### PR TITLE
Add League Calendar to Popular section in side drawer

### DIFF
--- a/src/config/nav-config.json
+++ b/src/config/nav-config.json
@@ -55,6 +55,15 @@
           "path": "/playoffs",
           "external": false,
           "description": "Playoff bracket and results"
+        },
+        {
+          "id": "league-calendar",
+          "label": "League Calendar",
+          "icon": "calendar",
+          "path": "/calendar",
+          "external": false,
+          "leagueOnly": "theleague",
+          "description": "View upcoming league events and deadlines"
         }
       ]
     },
@@ -258,7 +267,8 @@
     "/draft-predictor": "/draft-predictor",
     "/icons": "/icons",
     "/assets": "/assets",
-    "/trade-builder": "/trade-builder"
+    "/trade-builder": "/trade-builder",
+    "/calendar": "/calendar"
   },
   "verifyTeamUrl": {
     "theleague": "https://{host}/{year}/home/{leagueId}?MODULE=MESSAGE20",


### PR DESCRIPTION
Adds a new navigation link for the League Calendar page under the
Popular section, visible only for TheLeague. Also adds the /calendar
route to the routeEquivalence map for active state detection.

https://claude.ai/code/session_01GcxbhVtbi2RBQpViMUT7H1