### PR TITLE
Link trade deadline event to internal trade builder page

### DIFF
--- a/src/data/theleague/league-events.ts
+++ b/src/data/theleague/league-events.ts
@@ -219,9 +219,9 @@ export const THE_LEAGUE_EVENTS: LeagueEventDefinition[] = [
     startDate: { type: 'computed', rule: 'friday-before-week-11' },
     actionLinks: [
       {
-        label: 'Trade Center',
-        url: 'https://{mflHost}/{year}/options?L={leagueId}&O=03',
-        external: true,
+        label: 'Trade Builder',
+        url: '/theleague/trade-builder',
+        external: false,
       },
     ],
     urgencyDays: 7,


### PR DESCRIPTION
Change the Trading Deadline calendar event action link from the
external MFL Trade Center to the internal /theleague/trade-builder page.

https://claude.ai/code/session_01JackGqurtAd6ynbwwTpbWk