### PR TITLE
Add day-of-week abbreviation to event calendar dates

### DIFF
--- a/src/utils/event-date-formatter.ts
+++ b/src/utils/event-date-formatter.ts
@@ -4,15 +4,21 @@
  * Formatting helpers for league event dates and countdowns.
  */
 
+const DAY_NAMES = [
+  'Sun', 'Mon', 'Tue', 'Wed',
+  'Thu', 'Fri', 'Sat',
+];
+
 const MONTH_NAMES = [
   'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
   'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
 ];
 
 /**
- * Format a date as "Feb 14" or "Feb 14, 8:45 PM PT" if time is set.
+ * Format a date as "Thu, Mar 19" or "Thu, Mar 19, 8:45 PM PT" if time is set.
  */
 export function formatEventDate(date: Date): string {
+  const dayName = DAY_NAMES[date.getDay()];
   const month = MONTH_NAMES[date.getMonth()];
   const day = date.getDate();
 
@@ -21,20 +27,20 @@ export function formatEventDate(date: Date): string {
 
   // If time is midnight (0:00), treat as date-only
   if (hours === 0 && minutes === 0) {
-    return `${month} ${day}`;
+    return `${dayName}, ${month} ${day}`;
   }
 
   const period = hours >= 12 ? 'PM' : 'AM';
   const displayHours = hours % 12 || 12;
   const displayMinutes = minutes.toString().padStart(2, '0');
 
-  return `${month} ${day}, ${displayHours}:${displayMinutes} ${period} PT`;
+  return `${dayName}, ${month} ${day}, ${displayHours}:${displayMinutes} ${period} PT`;
 }
 
 /**
  * Format a date range:
- * - Same month: "Feb 1 - 14"
- * - Cross month: "Feb 15 - Mar 7"
+ * - Same month: "Sun, Feb 1 - 14"
+ * - Cross month: "Sun, Feb 15 - Mar 7"
  * - Same day: just the single date
  */
 export function formatEventDateRange(start: Date, end: Date): string {
@@ -42,14 +48,15 @@ export function formatEventDateRange(start: Date, end: Date): string {
     return formatEventDate(start);
   }
 
+  const startDay = DAY_NAMES[start.getDay()];
   const startMonth = MONTH_NAMES[start.getMonth()];
   const endMonth = MONTH_NAMES[end.getMonth()];
 
   if (start.getMonth() === end.getMonth()) {
-    return `${startMonth} ${start.getDate()} - ${end.getDate()}`;
+    return `${startDay}, ${startMonth} ${start.getDate()} - ${end.getDate()}`;
   }
 
-  return `${startMonth} ${start.getDate()} - ${endMonth} ${end.getDate()}`;
+  return `${startDay}, ${startMonth} ${start.getDate()} - ${endMonth} ${end.getDate()}`;
 }
 
 /**

--- a/tests/event-date-formatter.test.ts
+++ b/tests/event-date-formatter.test.ts
@@ -9,46 +9,46 @@ import {
 describe('formatEventDate', () => {
   it('should format a date without time', () => {
     const date = new Date(2026, 1, 15, 0, 0); // Feb 15 at midnight
-    expect(formatEventDate(date)).toBe('Feb 15');
+    expect(formatEventDate(date)).toBe('Sun, Feb 15');
   });
 
   it('should format a date with evening time', () => {
     const date = new Date(2026, 1, 14, 20, 45); // Feb 14 at 8:45 PM
-    expect(formatEventDate(date)).toBe('Feb 14, 8:45 PM PT');
+    expect(formatEventDate(date)).toBe('Sat, Feb 14, 8:45 PM PT');
   });
 
   it('should format a date with morning time', () => {
     const date = new Date(2026, 2, 19, 7, 0); // Mar 19 at 7:00 AM
-    expect(formatEventDate(date)).toBe('Mar 19, 7:00 AM PT');
+    expect(formatEventDate(date)).toBe('Thu, Mar 19, 7:00 AM PT');
   });
 
   it('should format noon correctly', () => {
     const date = new Date(2026, 5, 1, 12, 0); // Jun 1 at noon
-    expect(formatEventDate(date)).toBe('Jun 1, 12:00 PM PT');
+    expect(formatEventDate(date)).toBe('Mon, Jun 1, 12:00 PM PT');
   });
 
   it('should zero-pad minutes', () => {
     const date = new Date(2026, 8, 10, 9, 5); // Sep 10 at 9:05 AM
-    expect(formatEventDate(date)).toBe('Sep 10, 9:05 AM PT');
+    expect(formatEventDate(date)).toBe('Thu, Sep 10, 9:05 AM PT');
   });
 });
 
 describe('formatEventDateRange', () => {
-  it('should format same-month range as "Feb 1 - 14"', () => {
+  it('should format same-month range as "Sun, Feb 1 - 14"', () => {
     const start = new Date(2026, 1, 1);
     const end = new Date(2026, 1, 14);
-    expect(formatEventDateRange(start, end)).toBe('Feb 1 - 14');
+    expect(formatEventDateRange(start, end)).toBe('Sun, Feb 1 - 14');
   });
 
-  it('should format cross-month range as "Feb 15 - Mar 7"', () => {
+  it('should format cross-month range as "Sun, Feb 15 - Mar 7"', () => {
     const start = new Date(2026, 1, 15);
     const end = new Date(2026, 2, 7);
-    expect(formatEventDateRange(start, end)).toBe('Feb 15 - Mar 7');
+    expect(formatEventDateRange(start, end)).toBe('Sun, Feb 15 - Mar 7');
   });
 
   it('should format same day as single date', () => {
     const date = new Date(2026, 1, 15);
-    expect(formatEventDateRange(date, date)).toBe('Feb 15');
+    expect(formatEventDateRange(date, date)).toBe('Sun, Feb 15');
   });
 });
 


### PR DESCRIPTION
Display 3-letter day abbreviations (e.g. "Thu, Mar 19") on calendar event dates and date ranges for better context at a glance.

https://claude.ai/code/session_01Fa1BJupfq2RPfWNMreQns2