### PR TITLE
Add more spacing above League Summary table

### DIFF
--- a/src/components/theleague/LeagueSummaryTable.astro
+++ b/src/components/theleague/LeagueSummaryTable.astro
@@ -428,7 +428,7 @@ const serializedData = JSON.stringify({ teams, years, categories });
     left: 0;
     z-index: 3;
     min-width: 160px;
-    padding-left: 1.5rem;
+    padding-left: 1.125rem;
   }
 
   .league-summary__th--year {
@@ -436,7 +436,7 @@ const serializedData = JSON.stringify({ teams, years, categories });
   }
 
   .league-summary__th:last-child {
-    padding-right: 1.5rem;
+    padding-right: 1.125rem;
   }
 
   .league-summary__row {
@@ -467,7 +467,7 @@ const serializedData = JSON.stringify({ teams, years, categories });
     background: #fff;
     z-index: 1;
     border-right: 1px solid var(--primary-content-border-color, #e2e8f0);
-    padding-left: 1.5rem;
+    padding-left: 1.125rem;
   }
 
   .league-summary__td--value {
@@ -477,7 +477,7 @@ const serializedData = JSON.stringify({ teams, years, categories });
   }
 
   .league-summary__td:last-child {
-    padding-right: 1.5rem;
+    padding-right: 1.125rem;
   }
 
   .league-summary__team-cell {
@@ -556,19 +556,19 @@ const serializedData = JSON.stringify({ teams, years, categories });
 
     .league-summary__td--team {
       padding: 0.375rem 0.375rem;
-      padding-left: 1rem;
+      padding-left: 0.75rem;
     }
 
     .league-summary__th--team {
-      padding-left: 1rem;
+      padding-left: 0.75rem;
     }
 
     .league-summary__th:last-child {
-      padding-right: 1rem;
+      padding-right: 0.75rem;
     }
 
     .league-summary__td:last-child {
-      padding-right: 1rem;
+      padding-right: 0.75rem;
     }
 
     .league-summary__team-icon {

--- a/src/components/theleague/LeagueSummaryTable.astro
+++ b/src/components/theleague/LeagueSummaryTable.astro
@@ -384,11 +384,7 @@ const serializedData = JSON.stringify({ teams, years, categories });
     border-radius: 0.5rem;
     box-shadow: var(--shadow-sm, 0.5px 1px 1px hsl(220deg 3% 15% / 0.1));
     box-sizing: border-box;
-    max-width: none;
-    margin-inline: -1.5rem;
-    border-radius: 0;
-    border-left: none;
-    border-right: none;
+    max-width: 100%;
   }
 
   .league-summary__table {

--- a/src/components/theleague/LeagueSummaryTable.astro
+++ b/src/components/theleague/LeagueSummaryTable.astro
@@ -428,7 +428,7 @@ const serializedData = JSON.stringify({ teams, years, categories });
     left: 0;
     z-index: 3;
     min-width: 160px;
-    padding-left: 1.125rem;
+    padding-left: 1.5rem;
   }
 
   .league-summary__th--year {
@@ -467,7 +467,7 @@ const serializedData = JSON.stringify({ teams, years, categories });
     background: #fff;
     z-index: 1;
     border-right: 1px solid var(--primary-content-border-color, #e2e8f0);
-    padding-left: 1.125rem;
+    padding-left: 1.5rem;
   }
 
   .league-summary__td--value {
@@ -556,11 +556,11 @@ const serializedData = JSON.stringify({ teams, years, categories });
 
     .league-summary__td--team {
       padding: 0.375rem 0.375rem;
-      padding-left: 0.75rem;
+      padding-left: 1rem;
     }
 
     .league-summary__th--team {
-      padding-left: 0.75rem;
+      padding-left: 1rem;
     }
 
     .league-summary__th:last-child {

--- a/src/components/theleague/LeagueSummaryTable.astro
+++ b/src/components/theleague/LeagueSummaryTable.astro
@@ -384,7 +384,11 @@ const serializedData = JSON.stringify({ teams, years, categories });
     border-radius: 0.5rem;
     box-shadow: var(--shadow-sm, 0.5px 1px 1px hsl(220deg 3% 15% / 0.1));
     box-sizing: border-box;
-    max-width: 100%;
+    max-width: none;
+    margin-inline: -1.5rem;
+    border-radius: 0;
+    border-left: none;
+    border-right: none;
   }
 
   .league-summary__table {

--- a/src/components/theleague/LeagueSummaryTable.astro
+++ b/src/components/theleague/LeagueSummaryTable.astro
@@ -384,9 +384,9 @@ const serializedData = JSON.stringify({ teams, years, categories });
     border-radius: 0;
     box-shadow: var(--shadow-sm, 0.5px 1px 1px hsl(220deg 3% 15% / 0.1));
     box-sizing: border-box;
-    margin-left: -1.5rem;
-    margin-right: -1.5rem;
-    width: calc(100% + 3rem);
+    margin-left: -1.125rem;
+    margin-right: -1.125rem;
+    width: calc(100% + 2.25rem);
     border-left: none;
     border-right: none;
   }

--- a/src/components/theleague/LeagueSummaryTable.astro
+++ b/src/components/theleague/LeagueSummaryTable.astro
@@ -296,7 +296,7 @@ const serializedData = JSON.stringify({ teams, years, categories });
   .league-summary {
     font-family: system-ui, -apple-system, sans-serif;
     max-width: 100%;
-    overflow: hidden;
+    overflow: visible;
   }
 
   .league-summary__controls {

--- a/src/components/theleague/LeagueSummaryTable.astro
+++ b/src/components/theleague/LeagueSummaryTable.astro
@@ -386,6 +386,7 @@ const serializedData = JSON.stringify({ teams, years, categories });
     box-sizing: border-box;
     margin-left: -1.5rem;
     margin-right: -1.5rem;
+    width: calc(100% + 3rem);
     border-left: none;
     border-right: none;
   }

--- a/src/components/theleague/LeagueSummaryTable.astro
+++ b/src/components/theleague/LeagueSummaryTable.astro
@@ -428,10 +428,15 @@ const serializedData = JSON.stringify({ teams, years, categories });
     left: 0;
     z-index: 3;
     min-width: 160px;
+    padding-left: 1.5rem;
   }
 
   .league-summary__th--year {
     min-width: 100px;
+  }
+
+  .league-summary__th:last-child {
+    padding-right: 1.5rem;
   }
 
   .league-summary__row {
@@ -462,12 +467,17 @@ const serializedData = JSON.stringify({ teams, years, categories });
     background: #fff;
     z-index: 1;
     border-right: 1px solid var(--primary-content-border-color, #e2e8f0);
+    padding-left: 1.5rem;
   }
 
   .league-summary__td--value {
     text-align: right;
     font-variant-numeric: tabular-nums;
     transition: color 0.2s ease;
+  }
+
+  .league-summary__td:last-child {
+    padding-right: 1.5rem;
   }
 
   .league-summary__team-cell {
@@ -546,6 +556,19 @@ const serializedData = JSON.stringify({ teams, years, categories });
 
     .league-summary__td--team {
       padding: 0.375rem 0.375rem;
+      padding-left: 1rem;
+    }
+
+    .league-summary__th--team {
+      padding-left: 1rem;
+    }
+
+    .league-summary__th:last-child {
+      padding-right: 1rem;
+    }
+
+    .league-summary__td:last-child {
+      padding-right: 1rem;
     }
 
     .league-summary__team-icon {

--- a/src/components/theleague/LeagueSummaryTable.astro
+++ b/src/components/theleague/LeagueSummaryTable.astro
@@ -381,10 +381,13 @@ const serializedData = JSON.stringify({ teams, years, categories });
   .league-summary__table-wrapper {
     overflow-x: auto;
     border: 1px solid var(--primary-content-border-color, #e2e8f0);
-    border-radius: 0.5rem;
+    border-radius: 0;
     box-shadow: var(--shadow-sm, 0.5px 1px 1px hsl(220deg 3% 15% / 0.1));
     box-sizing: border-box;
-    max-width: 100%;
+    margin-left: -1.5rem;
+    margin-right: -1.5rem;
+    border-left: none;
+    border-right: none;
   }
 
   .league-summary__table {

--- a/src/pages/theleague/league-summary.astro
+++ b/src/pages/theleague/league-summary.astro
@@ -165,7 +165,7 @@ const teamsForDisplay = teamSummaries.map((team) => {
     width: 100%;
     max-width: 1400px;
     margin: 0 auto;
-    padding: 2rem 0.5rem;
+    padding: 4rem 0.5rem 2rem;
     background-color: var(--content-bg);
     border-radius: var(--radius-md);
     overflow-x: hidden;
@@ -182,6 +182,6 @@ const teamsForDisplay = teamSummaries.map((team) => {
   .subtitle {
     font-size: 1rem;
     color: #64748b;
-    margin-bottom: 2rem;
+    margin-bottom: 5rem;
   }
 </style>

--- a/src/pages/theleague/league-summary.astro
+++ b/src/pages/theleague/league-summary.astro
@@ -165,7 +165,7 @@ const teamsForDisplay = teamSummaries.map((team) => {
     width: 100%;
     max-width: 1400px;
     margin: 0 auto;
-    padding: 2rem 0.5rem;
+    padding: 2rem 1.5rem;
     background-color: var(--content-bg);
     border-radius: var(--radius-md);
     overflow-x: hidden;
@@ -177,13 +177,11 @@ const teamsForDisplay = teamSummaries.map((team) => {
     font-weight: 700;
     margin-bottom: 0.5rem;
     color: #1a1a1a;
-    padding-inline: 1.5rem;
   }
 
   .subtitle {
     font-size: 1rem;
     color: #64748b;
     margin-bottom: 5rem;
-    padding-inline: 1.5rem;
   }
 </style>

--- a/src/pages/theleague/league-summary.astro
+++ b/src/pages/theleague/league-summary.astro
@@ -168,7 +168,7 @@ const teamsForDisplay = teamSummaries.map((team) => {
     padding: 2rem 1.5rem;
     background-color: var(--content-bg);
     border-radius: var(--radius-md);
-    overflow-x: hidden;
+    overflow: visible;
     box-sizing: border-box;
   }
 

--- a/src/pages/theleague/league-summary.astro
+++ b/src/pages/theleague/league-summary.astro
@@ -165,7 +165,7 @@ const teamsForDisplay = teamSummaries.map((team) => {
     width: 100%;
     max-width: 1400px;
     margin: 0 auto;
-    padding: 2rem 2rem;
+    padding: 2rem 0.5rem;
     background-color: var(--content-bg);
     border-radius: var(--radius-md);
     overflow-x: hidden;
@@ -177,11 +177,13 @@ const teamsForDisplay = teamSummaries.map((team) => {
     font-weight: 700;
     margin-bottom: 0.5rem;
     color: #1a1a1a;
+    padding-inline: 1.5rem;
   }
 
   .subtitle {
     font-size: 1rem;
     color: #64748b;
     margin-bottom: 5rem;
+    padding-inline: 1.5rem;
   }
 </style>

--- a/src/pages/theleague/league-summary.astro
+++ b/src/pages/theleague/league-summary.astro
@@ -165,7 +165,7 @@ const teamsForDisplay = teamSummaries.map((team) => {
     width: 100%;
     max-width: 1400px;
     margin: 0 auto;
-    padding: 2rem 1.5rem;
+    padding: 2rem 1.125rem;
     background-color: var(--content-bg);
     border-radius: var(--radius-md);
     overflow: visible;

--- a/src/pages/theleague/league-summary.astro
+++ b/src/pages/theleague/league-summary.astro
@@ -165,7 +165,7 @@ const teamsForDisplay = teamSummaries.map((team) => {
     width: 100%;
     max-width: 1400px;
     margin: 0 auto;
-    padding: 4rem 0.5rem 2rem;
+    padding: 2rem 2rem;
     background-color: var(--content-bg);
     border-radius: var(--radius-md);
     overflow-x: hidden;


### PR DESCRIPTION
Increase top padding inside the card container and add more margin
below the subtitle for better visual separation from the table.

https://claude.ai/code/session_01Xjj3UnTTsmVxHWe4Fsq6JN