### PR TITLE
Fix mobile alignment and padding on What's New page

### DIFF
--- a/src/pages/theleague/index.astro
+++ b/src/pages/theleague/index.astro
@@ -97,7 +97,7 @@ const pages = {
     display: flex;
     flex-direction: column;
     gap: 3rem;
-    padding: 2rem 0;
+    padding: 2rem var(--spacing-md, 1rem);
   }
 
   .home-header {

--- a/src/pages/theleague/whats-new.astro
+++ b/src/pages/theleague/whats-new.astro
@@ -117,7 +117,7 @@ const MULTICOLOR_ICONS = ['nfl'];
     display: flex;
     flex-direction: column;
     gap: var(--spacing-xl, 2rem);
-    padding: var(--spacing-xl, 2rem) 0;
+    padding: var(--spacing-xl, 2rem) var(--spacing-md, 1rem);
   }
 
   /* ── Page Header ── */


### PR DESCRIPTION
Add horizontal padding (1rem) to the whats-new-page container so
content doesn't sit flush against screen edges on mobile. The layout's
main element only provides 0.5rem inline padding, which was insufficient.

https://claude.ai/code/session_01UXE9dEZrwotdBymQXoGGLU