### PR TITLE
fix: use green design token for card hover color on homepage

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -27,6 +27,8 @@ const { title } = Astro.props as Props;
 	</body>
 </html>
 <style>
+	@import '../styles/tokens.css';
+
 	:root {
 		--font-size-base: clamp(1rem, 0.34vw + 0.91rem, 1.19rem);
 		--font-size-lg: clamp(1.2rem, 0.7vw + 1.2rem, 1.5rem);
@@ -61,8 +63,8 @@ const { title } = Astro.props as Props;
 		--inverse-accent-bg: #b22222;
 
 		--primary-link-default-text-color: #111111;
-		--primary-link-hover-text-color: #b22222;
-		--primary-link-focus-text-color: #b22222;
+		--primary-link-hover-text-color: var(--color-secondary);
+		--primary-link-focus-text-color: var(--color-secondary);
 
 		--inverse-link-default-text-color: #dddddd;
 		--inverse-link-hover-text-color: #b22222;


### PR DESCRIPTION
Replace hardcoded red (#b22222) hover/focus text color with
var(--color-secondary) design token (#2e8743, TheLeague Green).
Import tokens.css to make the design token available.

https://claude.ai/code/session_01W4yR9aLyHizbpdnC4RUSSd