### PR TITLE
Fix mobile horizontal scroll on League Planner page

### DIFF
--- a/src/components/theleague/FreeAgentNeedsCard.astro
+++ b/src/components/theleague/FreeAgentNeedsCard.astro
@@ -87,6 +87,10 @@ const hasNeeds = needs.length > 0;
 </ChartCard>
 
 <style>
+  .fa-needs {
+    min-width: 0;
+  }
+
   .fa-needs__tabs {
     display: flex;
     gap: 0.25rem;
@@ -114,6 +118,10 @@ const hasNeeds = needs.length > 0;
   .fa-needs__tab--active {
     color: var(--primary-color, #1c497c);
     border-bottom-color: var(--primary-color, #1c497c);
+  }
+
+  .fa-needs__panel {
+    overflow-x: auto;
   }
 
   .fa-needs__list {

--- a/src/pages/theleague/rosters.astro
+++ b/src/pages/theleague/rosters.astro
@@ -3017,6 +3017,11 @@ const r = (path: string) => resolveLeaguePath(path, hideLeaguePrefix);
   .planner-layout {
     display: grid;
     gap: 1.5rem;
+    min-width: 0;
+  }
+
+  .planner-layout > * {
+    min-width: 0;
   }
 
   .planner-section__title {


### PR DESCRIPTION
Break CSS Grid min-width:auto propagation chain that caused the
dynamically-injected ranking columns in Potential Targets to expand
the entire page beyond viewport width on mobile.

- Add min-width:0 to .planner-layout and its children
- Add min-width:0 to .fa-needs container
- Add overflow-x:auto to .fa-needs__panel so ranking columns scroll
  within the card instead of the page

https://claude.ai/code/session_01JGyU9VS7UkRrnVwUfuyJLF