### PR TITLE
Fix mobile clear button pushing GM/Coach tabs out of alignment

### DIFF
--- a/src/pages/theleague/rosters.astro
+++ b/src/pages/theleague/rosters.astro
@@ -4347,6 +4347,11 @@ const r = (path: string) => resolveLeaguePath(path, hideLeaguePrefix);
     .clear-all-tags-btn {
       width: 100%;
       justify-content: center;
+      order: 2;
+    }
+
+    .mode-toggle {
+      order: 1;
     }
   }
 </style>


### PR DESCRIPTION
Use CSS order to place the "Clear All Tags" button below the mode toggle
tabs on mobile instead of above them.

https://claude.ai/code/session_01BAwDDDNptfdkxXXfAbbyFs