### PR TITLE
Add CSS Customization Guide and documentation

### DIFF
--- a/docs/CSS_CUSTOMIZATION_GUIDE.md
+++ b/docs/CSS_CUSTOMIZATION_GUIDE.md
@@ -1,0 +1,749 @@
+# MFL CSS Customization Guide
+
+This guide explains how to customize the dark theme CSS files (`dark_main.css` and `dark_din_main.css`) for your MFL league. You don't need to create a new stylesheet — just override specific CSS variables using a `<style>` block in an MFL Homepage Message.
+
+---
+
+## Table of Contents
+
+1. [How It Works](#how-it-works)
+2. [Getting Started — Override Variables in a Homepage Message](#getting-started)
+3. [Giving Claude the Context It Needs](#giving-claude-context)
+4. [Complete CSS Variable Reference](#variable-reference)
+5. [Common Customization Examples](#examples)
+6. [Using the SVG Icon Sprite](#icon-sprite)
+7. [Adding New Icons to the Sprite](#adding-icons)
+8. [Submitting New Icons via Pull Request](#submitting-icons-pr)
+9. [Font Differences Between the Two CSS Files](#font-differences)
+10. [Tips and Gotchas](#tips)
+
+---
+
+## <a id="how-it-works"></a>1. How It Works
+
+The CSS files (`dark_main.css` or `dark_din_main.css`) are loaded via the **Custom CSS URL** field in MFL:
+
+> **Setup > Franchise Setup > Images and Other URLs > Custom CSS**
+
+Every color, font, spacing value, and visual style in these files is controlled by **CSS custom properties** (also called CSS variables) defined in a `:root` block at the top of the stylesheet. Because CSS custom properties cascade, you can **override any of them** by adding a `<style>` block in an MFL Homepage Message — no need to edit or replace the base CSS file.
+
+**How the cascade works:**
+1. MFL loads your Custom CSS file (e.g., `dark_main.css`)
+2. MFL renders Homepage Messages, which can contain `<style>` blocks
+3. The `<style>` block's `:root` overrides win because they appear later in the page
+
+---
+
+## <a id="getting-started"></a>2. Getting Started — Override Variables in a Homepage Message
+
+Create (or edit) an MFL **Homepage Message** and add a `<style>` block like this:
+
+```html
+<style>
+:root {
+  /* === Brand Colors === */
+  --accent-color: #ff4500;           /* Change gold accent to orange-red */
+  --dark-accent-color: #cc3700;      /* Darker version for hover states */
+
+  /* === Text === */
+  --primary-text-color: #f0f0f0;     /* Slightly brighter body text */
+
+  /* === Backgrounds === */
+  --pagebody-bg: #0a0a0a;            /* Deeper black page background */
+
+  /* === Headings === */
+  --h1-color: #ff4500;               /* Match headings to new accent */
+  --h2-color: #ff4500;
+  --h3-color: #ff4500;
+
+  /* === Buttons === */
+  --button-bg-color: #ff4500;        /* Button background matches accent */
+  --button-bg-color-hover: #ff6030;  /* Lighter on hover */
+  --button-link-color: #ffffff;      /* White text on buttons */
+}
+</style>
+```
+
+**That's it.** Only list the variables you want to change. Everything else keeps its default value from the base CSS file.
+
+---
+
+## <a id="giving-claude-context"></a>3. Giving Claude the Context It Needs
+
+When you're working with Claude to customize your CSS, paste the following prompt at the start of your conversation so Claude understands the system:
+
+---
+
+**Copy this prompt to Claude:**
+
+> I'm customizing an MFL (MyFantasyLeague) league website. My league uses a dark theme CSS file loaded via MFL's Custom CSS URL field. I override specific CSS variables using a `<style>` block inside an MFL Homepage Message.
+>
+> The base CSS file defines all styles using CSS custom properties (variables) in a `:root` block. I can override any variable by redefining it in my Homepage Message's `<style>` block — the override wins because it appears later on the page.
+>
+> Here is the complete list of CSS variables I can override, with their current default values:
+>
+> ```css
+> :root {
+>   /* Colors */
+>   --primary-color: #cccccc;
+>   --secondary-color: #eeeeee;
+>   --accent-color: #c9a94e;
+>   --dark-accent-color: #a8893a;
+>   --primary-text-color: #e0e0e0;
+>   --secondary-text-color: #c0c0c0;
+>   --link-color: #bbbbbb;
+>   --link-color-hover: #c9a94e;
+>   --add-color: #4ade80;
+>   --drop-color: #f87171;
+>
+>   /* Alerts */
+>   --alert-danger-text: #fca5a5;
+>   --alert-danger-bg: rgba(220, 38, 38, 0.15);
+>   --alert-danger-border: rgba(220, 38, 38, 0.25);
+>   --alert-warning-text: #fcd34d;
+>   --alert-warning-bg: rgb(57, 36, 1);
+>   --alert-warning-border: rgb(216, 155, 49);
+>   --alert-success-text: #6ee7b7;
+>   --alert-success-bg: rgba(16, 185, 129, 0.12);
+>   --alert-success-border: rgba(16, 185, 129, 0.25);
+>   --alert-info-text: #93bbfd;
+>   --alert-info-bg: rgba(59, 130, 246, 0.12);
+>   --alert-info-border: rgba(59, 130, 246, 0.25);
+>
+>   /* Neutrals */
+>   --gray1: #d8d8d8;
+>   --gray2: #8a8a8a;
+>   --gray3: #6b6b6b;
+>   --offwhite: #2e2e2e;
+>   --offwhite2: #121212;
+>   --lightgray: #2e2e2e;
+>   --lightgray2: #3a3a3a;
+>   --lightgray3: #5a5a5a;
+>   --white: #2e2e2e;
+>   --codebg-color: #151515;
+>
+>   /* Tables */
+>   --oddtablerow: #2e2e2e;
+>   --eventablerow: #444444;
+>   --newposition-border-color: #3a3a3a;
+>   --table-header-color: #8a8a8a;
+>
+>   /* Page Backgrounds */
+>   --primary-bg-color: #2e2e2e;
+>   --pagebody-bg: #121212;
+>   --report-bg: #2e2e2e;
+>   --header-bg: #101010;
+>
+>   /* Footer */
+>   --footer-bg-color: #101010;
+>   --footer-text-color: #e0e0e0;
+>   --footer-header-text-color: #e0e0e0;
+>
+>   /* Borders */
+>   --border-color: #2e2e2e;
+>
+>   /* MFL Top Menu */
+>   --menu-bg-color: #101010;
+>   --menu-bg-hover-color: #1d1d1d;
+>   --menu-border-color: #1a1a1a;
+>   --menu-text-color: #e0e0e0;
+>
+>   /* Report Sub-Navigation */
+>   --secondary-menu-border-color: #c9a94e;
+>   --secondary-menu-bg-color: #8a7230;
+>   --secondary-menu-text-color: #e0e0e0;
+>   --secondary-menu-link-color: #e0e0e0;
+>   --secondary-menu-icon-color: #e0e0e0;
+>   --secondary-menu-icon-hover-color: #ededed;
+>   --secondary-menu-font-weight: normal;
+>
+>   /* Buttons */
+>   --button-bg-color: #c9a94e;
+>   --button-bg-color-hover: #d4b85e;
+>   --button-link-color: #121212;
+>
+>   /* Tabs */
+>   --tab-hover-color: #fff;
+>
+>   /* Scrollbar */
+>   --scrollbar-bg-color: #3a3a3a;
+>   --scrollbar-bg-hover-color: #4a4a4a;
+>
+>   /* Captions and Headings */
+>   --caption-color: #c9a94e;
+>   --headline-font-color: #c9a94e;
+>   --h1-color: #c9a94e;
+>   --h2-color: #c9a94e;
+>   --h3-color: #c9a94e;
+>   --h4-color: #c9a94e;
+>   --h5-color: #c9a94e;
+>   --h6-color: #c9a94e;
+>
+>   /* Icons */
+>   --icon-color: #c9a94e;
+>   --icon-color-hover: #d4b85e;
+>   --icon-text-color: #c9a94e;
+>
+>   /* Calendar */
+>   --calendar-bg-color: #282828;
+>   --calendar-eventablerow: #2e2e2e;
+>   --calendar-border-color: #444033;
+>   --calendar-text-color: #e0e0e0;
+>   --today-bg-color: #c9a94e;
+>   --today-border-color: #b89a42;
+>   --today-text-color: #121212;
+>
+>   /* Logo / SVG Crest */
+>   --logo-main-color: #c9a94e;
+>   --logo-secondary-color: #1d1d1d;
+>   --logo-3rd-color: #3a3a3a;
+>   --logo-4th-color: #c9a94e;
+>   --logo-text-color: #c9a94e;
+>   --logo-secondary-text-color: #1d1d1d;
+>
+>   /* Roster Page */
+>   --color-bg-base: #323232;
+>   --color-bg-subtle: #272727;
+>   --color-bg-practice: rgba(59, 130, 246, 0.1);
+>   --color-bg-practice-alt: rgba(59, 130, 246, 0.15);
+>   --color-bg-injured: rgba(220, 38, 38, 0.1);
+>   --color-bg-injured-alt: rgba(220, 38, 38, 0.15);
+>   --color-border-practice: rgba(59, 130, 246, 0.3);
+>   --color-border-injured: rgba(220, 38, 38, 0.3);
+>
+>   /* Header Icon Buttons */
+>   --header-icon-color: #666666;
+>   --header-icon-text-color: #eeeeee;
+>   --header-icon-hover-color: #dddddd;
+>
+>   /* Logo Name */
+>   --logo-name-primary-color: #c9a94e;
+>   --logo-name-secondary-color: #e0e0e0;
+>
+>   /* Division Headings */
+>   --division-heading-color: #e0e0e0;
+>   --division-subheading-color: #c9a94e;
+>   --division-border-color: #666666;
+>
+>   /* Typography */
+>   --headline-font: "UFC Sans Condensed", sans-serif;
+>   --headline-font-weight: 700;
+>   --body-font: "UFC Sans Condensed", sans-serif;
+>   --body-font-weight: 400;
+>   --svg-text-font-size: 11px;
+>
+>   /* Border Radius */
+>   --border-radius-sm: .25rem;
+>   --border-radius-default: .5rem;
+>   --border-radius-lg: 1rem;
+>   --border-radius-xl: 8rem;
+> }
+> ```
+>
+> When I ask you to change something, generate ONLY a `<style>` block containing the overridden variables. Do not regenerate the entire stylesheet. Only include variables that are changing.
+
+---
+
+That prompt gives Claude everything it needs. From there you can say things like:
+
+- "Change my accent color to red `#dc2626`"
+- "Make the page background pure black"
+- "Make the table headers match my accent color"
+- "Change my heading font to Arial"
+
+And Claude will respond with the correct `<style>` block.
+
+---
+
+## <a id="variable-reference"></a>4. Complete CSS Variable Reference
+
+Below is every variable available, grouped by what it controls. Default values shown are from `dark_main.css` (the UFC font version). The `dark_din_main.css` file uses identical values except for the font variables.
+
+### Brand / Accent Colors
+| Variable | Default | What it controls |
+|---|---|---|
+| `--primary-color` | `#cccccc` | Primary UI color (light gray in dark mode) |
+| `--secondary-color` | `#eeeeee` | Secondary UI color |
+| `--accent-color` | `#c9a94e` | Main accent / brand highlight (gold) |
+| `--dark-accent-color` | `#a8893a` | Darker accent for hover/active states |
+
+### Text Colors
+| Variable | Default | What it controls |
+|---|---|---|
+| `--primary-text-color` | `#e0e0e0` | Main body text |
+| `--secondary-text-color` | `#c0c0c0` | Muted / secondary text |
+| `--link-color` | `#bbbbbb` | Link text color |
+| `--link-color-hover` | `#c9a94e` | Link hover color |
+
+### Page Backgrounds
+| Variable | Default | What it controls |
+|---|---|---|
+| `--pagebody-bg` | `#121212` | Full page background |
+| `--primary-bg-color` | `#2e2e2e` | Content area / card backgrounds |
+| `--report-bg` | `#2e2e2e` | Report page backgrounds |
+| `--header-bg` | `#101010` | Site header background |
+| `--codebg-color` | `#151515` | Code block backgrounds |
+
+### Headings (h1–h6)
+| Variable | Default | What it controls |
+|---|---|---|
+| `--headline-font-color` | `#c9a94e` | General headline color |
+| `--caption-color` | `#c9a94e` | Caption text |
+| `--h1-color` through `--h6-color` | `#c9a94e` | Individual heading levels |
+
+### Typography / Fonts
+| Variable | Default | What it controls |
+|---|---|---|
+| `--headline-font` | `"UFC Sans Condensed", sans-serif` | Heading font family |
+| `--headline-font-weight` | `700` | Heading font weight |
+| `--body-font` | `"UFC Sans Condensed", sans-serif` | Body text font family |
+| `--body-font-weight` | `400` | Body text font weight |
+| `--svg-text-font-size` | `11px` | Font size inside SVG elements |
+
+### MFL Top Menu
+| Variable | Default | What it controls |
+|---|---|---|
+| `--menu-bg-color` | `#101010` | Menu background |
+| `--menu-bg-hover-color` | `#1d1d1d` | Menu item hover background |
+| `--menu-border-color` | `#1a1a1a` | Menu border |
+| `--menu-text-color` | `#e0e0e0` | Menu text |
+
+### Report Sub-Navigation
+| Variable | Default | What it controls |
+|---|---|---|
+| `--secondary-menu-bg-color` | `#8a7230` | Sub-nav background |
+| `--secondary-menu-border-color` | `#c9a94e` | Sub-nav border |
+| `--secondary-menu-text-color` | `#e0e0e0` | Sub-nav text |
+| `--secondary-menu-link-color` | `#e0e0e0` | Sub-nav links |
+| `--secondary-menu-icon-color` | `#e0e0e0` | Sub-nav icon fill |
+| `--secondary-menu-icon-hover-color` | `#ededed` | Sub-nav icon hover fill |
+| `--secondary-menu-font-weight` | `normal` | Sub-nav font weight |
+
+### Buttons
+| Variable | Default | What it controls |
+|---|---|---|
+| `--button-bg-color` | `#c9a94e` | Button background |
+| `--button-bg-color-hover` | `#d4b85e` | Button hover background |
+| `--button-link-color` | `#121212` | Button text color |
+
+### Tables
+| Variable | Default | What it controls |
+|---|---|---|
+| `--oddtablerow` | `#2e2e2e` | Odd row background |
+| `--eventablerow` | `#444444` | Even row background |
+| `--table-header-color` | `#8a8a8a` | Table header text |
+| `--newposition-border-color` | `#3a3a3a` | Position change indicator border |
+
+### Alerts
+| Variable | Default | What it controls |
+|---|---|---|
+| `--alert-danger-text` | `#fca5a5` | Danger alert text |
+| `--alert-danger-bg` | `rgba(220, 38, 38, 0.15)` | Danger alert background |
+| `--alert-danger-border` | `rgba(220, 38, 38, 0.25)` | Danger alert border |
+| `--alert-warning-text` | `#fcd34d` | Warning alert text |
+| `--alert-warning-bg` | `rgb(57, 36, 1)` | Warning alert background |
+| `--alert-warning-border` | `rgb(216, 155, 49)` | Warning alert border |
+| `--alert-success-text` | `#6ee7b7` | Success alert text |
+| `--alert-success-bg` | `rgba(16, 185, 129, 0.12)` | Success alert background |
+| `--alert-success-border` | `rgba(16, 185, 129, 0.25)` | Success alert border |
+| `--alert-info-text` | `#93bbfd` | Info alert text |
+| `--alert-info-bg` | `rgba(59, 130, 246, 0.12)` | Info alert background |
+| `--alert-info-border` | `rgba(59, 130, 246, 0.25)` | Info alert border |
+
+### Icons
+| Variable | Default | What it controls |
+|---|---|---|
+| `--icon-color` | `#c9a94e` | Default SVG icon fill |
+| `--icon-color-hover` | `#d4b85e` | Icon hover fill |
+| `--icon-text-color` | `#c9a94e` | Text labels next to icons |
+
+### Calendar
+| Variable | Default | What it controls |
+|---|---|---|
+| `--calendar-bg-color` | `#282828` | Calendar background |
+| `--calendar-eventablerow` | `#2e2e2e` | Calendar alternating rows |
+| `--calendar-border-color` | `#444033` | Calendar cell borders |
+| `--calendar-text-color` | `#e0e0e0` | Calendar text |
+| `--today-bg-color` | `#c9a94e` | Today highlight background |
+| `--today-border-color` | `#b89a42` | Today highlight border |
+| `--today-text-color` | `#121212` | Today highlight text |
+
+### Logo / SVG Crest
+| Variable | Default | What it controls |
+|---|---|---|
+| `--logo-main-color` | `#c9a94e` | Primary logo fill |
+| `--logo-secondary-color` | `#1d1d1d` | Secondary logo fill |
+| `--logo-3rd-color` | `#3a3a3a` | Third logo color |
+| `--logo-4th-color` | `#c9a94e` | Fourth logo color |
+| `--logo-text-color` | `#c9a94e` | Logo text fill |
+| `--logo-secondary-text-color` | `#1d1d1d` | Logo secondary text fill |
+| `--logo-name-primary-color` | `#c9a94e` | League name primary color |
+| `--logo-name-secondary-color` | `#e0e0e0` | League name secondary color |
+
+### Footer
+| Variable | Default | What it controls |
+|---|---|---|
+| `--footer-bg-color` | `#101010` | Footer background |
+| `--footer-text-color` | `#e0e0e0` | Footer text |
+| `--footer-header-text-color` | `#e0e0e0` | Footer section headers |
+
+### Neutrals / Grays
+| Variable | Default | What it controls |
+|---|---|---|
+| `--gray1` | `#d8d8d8` | Lightest gray |
+| `--gray2` | `#8a8a8a` | Medium gray |
+| `--gray3` | `#6b6b6b` | Darkest gray |
+| `--offwhite` | `#2e2e2e` | Off-white (dark mode: dark gray) |
+| `--offwhite2` | `#121212` | Deeper off-white |
+| `--lightgray` | `#2e2e2e` | Light gray |
+| `--lightgray2` | `#3a3a3a` | Medium light gray |
+| `--lightgray3` | `#5a5a5a` | Darker light gray |
+| `--white` | `#2e2e2e` | "White" (inverted for dark mode) |
+
+### Scrollbar
+| Variable | Default | What it controls |
+|---|---|---|
+| `--scrollbar-bg-color` | `#3a3a3a` | Scrollbar track |
+| `--scrollbar-bg-hover-color` | `#4a4a4a` | Scrollbar hover |
+
+### Roster Page
+| Variable | Default | What it controls |
+|---|---|---|
+| `--color-bg-base` | `#323232` | Roster card base background |
+| `--color-bg-subtle` | `#272727` | Subtle background areas |
+| `--color-bg-practice` | `rgba(59, 130, 246, 0.1)` | Practice squad row |
+| `--color-bg-injured` | `rgba(220, 38, 38, 0.1)` | IR row |
+
+### Division Headings
+| Variable | Default | What it controls |
+|---|---|---|
+| `--division-heading-color` | `#e0e0e0` | Division heading text |
+| `--division-subheading-color` | `#c9a94e` | Division subheading text |
+| `--division-border-color` | `#666666` | Division separator line |
+
+### Header Icon Buttons
+| Variable | Default | What it controls |
+|---|---|---|
+| `--header-icon-color` | `#666666` | Header icon fill |
+| `--header-icon-text-color` | `#eeeeee` | Header icon label text |
+| `--header-icon-hover-color` | `#dddddd` | Header icon hover fill |
+
+### Miscellaneous
+| Variable | Default | What it controls |
+|---|---|---|
+| `--add-color` | `#4ade80` | Waiver add / pickup indicator (green) |
+| `--drop-color` | `#f87171` | Waiver drop indicator (red) |
+| `--border-color` | `#2e2e2e` | General border color |
+| `--tab-hover-color` | `#fff` | Tab hover text |
+| `--border-radius-sm` | `.25rem` | Small border radius |
+| `--border-radius-default` | `.5rem` | Default border radius |
+| `--border-radius-lg` | `1rem` | Large border radius |
+| `--border-radius-xl` | `8rem` | Extra-large / pill border radius |
+
+---
+
+## <a id="examples"></a>5. Common Customization Examples
+
+### Change your brand accent from gold to red
+```html
+<style>
+:root {
+  --accent-color: #dc2626;
+  --dark-accent-color: #b91c1c;
+  --link-color-hover: #dc2626;
+  --button-bg-color: #dc2626;
+  --button-bg-color-hover: #ef4444;
+  --h1-color: #dc2626;
+  --h2-color: #dc2626;
+  --h3-color: #dc2626;
+  --h4-color: #dc2626;
+  --h5-color: #dc2626;
+  --h6-color: #dc2626;
+  --caption-color: #dc2626;
+  --headline-font-color: #dc2626;
+  --icon-color: #dc2626;
+  --icon-color-hover: #ef4444;
+  --icon-text-color: #dc2626;
+  --secondary-menu-border-color: #dc2626;
+  --secondary-menu-bg-color: #7f1d1d;
+  --today-bg-color: #dc2626;
+  --today-border-color: #b91c1c;
+  --logo-main-color: #dc2626;
+  --logo-4th-color: #dc2626;
+  --logo-text-color: #dc2626;
+  --logo-name-primary-color: #dc2626;
+  --division-subheading-color: #dc2626;
+}
+</style>
+```
+
+### Use a custom Google Font for headings
+```html
+<!-- Load the font first (also in a Homepage Message) -->
+<link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;700&display=swap" rel="stylesheet">
+
+<style>
+:root {
+  --headline-font: "Oswald", sans-serif;
+  --body-font: "Oswald", sans-serif;
+}
+</style>
+```
+
+### Make tables higher contrast
+```html
+<style>
+:root {
+  --oddtablerow: #1a1a1a;
+  --eventablerow: #2a2a2a;
+  --table-header-color: #e0e0e0;
+}
+</style>
+```
+
+### Softer border radius (more rounded)
+```html
+<style>
+:root {
+  --border-radius-sm: .5rem;
+  --border-radius-default: 1rem;
+  --border-radius-lg: 1.5rem;
+}
+</style>
+```
+
+---
+
+## <a id="icon-sprite"></a>6. Using the SVG Icon Sprite
+
+All icons in the CSS are served from a single SVG sprite file:
+
+```
+public/assets/icons/sprite.svg
+```
+
+This file contains 100+ icon symbols. Each icon is a `<symbol>` element with a unique `id`.
+
+### Browsing Available Icons
+
+We built an **Icon Gallery** page that lets you:
+- Browse all 100+ icons visually
+- Search by name or keyword (e.g., "money", "trade", "roster")
+- Filter by category (gameday, draft, scoring, standings, auction, waivers, playoffs, roster, etc.)
+- Test colors with a live color picker
+- Copy the full sprite SVG to your clipboard
+
+**The Icon Gallery is at:** `src/pages/theleague/icons.astro` in the repo (route: `/theleague/icons`).
+
+> **Note:** The link in the site footer to this page is currently returning a 404. This is a known issue being tracked. In the meantime, navigate directly to `/theleague/icons` in your browser if the site is running locally.
+
+### Using an Icon in HTML
+
+To display an icon from the sprite, use an inline SVG with a `<use>` tag:
+
+```html
+<svg width="38" height="38" viewBox="0 0 512 512">
+  <use href="/assets/icons/sprite.svg#icon-trophy"></use>
+</svg>
+```
+
+Replace `icon-trophy` with any icon `id` from the sprite. The `viewBox` for most icons is `0 0 512 512`, but check the gallery for the exact value.
+
+### Controlling Icon Colors
+
+Icons inherit their fill color from the CSS variables:
+
+| Variable | Controls |
+|---|---|
+| `--icon-color` | Default icon fill |
+| `--icon-color-hover` | Icon fill on hover |
+| `--icon-text-color` | Text labels next to icons |
+
+You can also override a specific icon's color inline:
+
+```html
+<svg width="38" height="38" viewBox="0 0 512 512" style="fill: #dc2626;">
+  <use href="/assets/icons/sprite.svg#icon-trophy"></use>
+</svg>
+```
+
+---
+
+## <a id="adding-icons"></a>7. Adding New Icons to the Sprite
+
+The sprite is a single SVG file with `<symbol>` elements. To add a new icon:
+
+### Step 1 — Get your SVG
+
+Get a clean SVG icon. Good sources:
+- [Heroicons](https://heroicons.com)
+- [Lucide](https://lucide.dev)
+- [Feather Icons](https://feathericons.com)
+- [SVG Repo](https://www.svgrepo.com)
+- Ask Claude to generate one
+
+Make sure the SVG is simple (single path, no embedded styles or transforms if possible).
+
+### Step 2 — Convert it to a `<symbol>`
+
+Take the raw SVG content and wrap it as a `<symbol>`. For example, if your raw SVG is:
+
+```xml
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <path d="M12 2L2 7v10l10 5 10-5V7L12 2z"/>
+</svg>
+```
+
+Convert it to a symbol entry:
+
+```xml
+<symbol id="icon-my-custom-icon" viewBox="0 0 24 24">
+  <path d="M12 2L2 7v10l10 5 10-5V7L12 2z"/>
+</symbol>
+```
+
+**Rules:**
+- The `id` must start with `icon-` (e.g., `icon-my-custom-icon`)
+- Copy the `viewBox` from the original SVG's `viewBox` attribute
+- Only include the inner elements (`<path>`, `<circle>`, `<rect>`, etc.) — not the outer `<svg>` wrapper
+- Remove any `fill="..."` attributes from the paths so the icon inherits the theme color
+
+### Step 3 — Add it to the sprite file
+
+Open `public/assets/icons/sprite.svg` and add your new `<symbol>` inside the root `<svg>` tag, before the closing `</svg>`:
+
+```xml
+<svg xmlns="http://www.w3.org/2000/svg" style="display: none;">
+  <!-- ... existing symbols ... -->
+
+  <symbol id="icon-my-custom-icon" viewBox="0 0 24 24">
+    <path d="M12 2L2 7v10l10 5 10-5V7L12 2z"/>
+  </symbol>
+
+</svg>
+```
+
+### Asking Claude to Help
+
+You can ask Claude to do this conversion for you. Here's a good prompt:
+
+> I need to add a new icon to my SVG sprite file. Here's the SVG I want to add:
+>
+> [paste your SVG here]
+>
+> Please convert this into a `<symbol>` element with the id `icon-my-name`. Remove any fill attributes so it inherits the theme color. Give me the `<symbol>` block I should paste into my sprite.svg file.
+
+---
+
+## <a id="submitting-icons-pr"></a>8. Submitting New Icons via Pull Request
+
+If you want to add new icons to the shared sprite so everyone benefits, submit a Pull Request (PR) to the repository.
+
+### Prerequisites
+
+1. A GitHub account
+2. Git installed on your computer
+3. Access to the `braven112/mfl.football.v2` repository
+
+### Step-by-Step
+
+**1. Fork or clone the repo:**
+```bash
+git clone https://github.com/braven112/mfl.football.v2.git
+cd mfl.football.v2
+```
+
+**2. Create a feature branch:**
+```bash
+git checkout -b add-icon-my-icon-name
+```
+
+**3. Edit the sprite file:**
+
+Open `public/assets/icons/sprite.svg` in a text editor and add your `<symbol>` (see Section 7 above).
+
+**4. (Optional) Update the icon gallery search data:**
+
+If you want your icon to be searchable in the gallery, you can add synonyms and category tags in `src/pages/theleague/icons.astro`:
+
+- Add an entry to the `synonyms` object (around line 28):
+  ```js
+  'icon-my-custom-icon': ['keyword1', 'keyword2', 'keyword3'],
+  ```
+
+- Add the icon id to relevant category arrays in the `categories` object (around line 118):
+  ```js
+  gameday: [
+    // ...existing icons...
+    'icon-my-custom-icon',
+  ],
+  ```
+
+**5. Commit and push:**
+```bash
+git add public/assets/icons/sprite.svg
+git add src/pages/theleague/icons.astro   # only if you updated synonyms/categories
+git commit -m "Add icon-my-custom-icon to SVG sprite"
+git push -u origin add-icon-my-icon-name
+```
+
+**6. Open a Pull Request:**
+```bash
+gh pr create --title "Add icon-my-custom-icon" --body "Adds a new icon for [describe what it's for]. Preview the icon in the gallery at /theleague/icons."
+```
+
+Or open the PR through GitHub's web interface.
+
+### Asking Claude to Help Write the PR
+
+You can paste your new SVG into Claude and ask:
+
+> I want to add this SVG icon to the mfl.football.v2 repo's sprite file at `public/assets/icons/sprite.svg`. The icon should be called `icon-my-name`.
+>
+> 1. Convert it to a `<symbol>` element
+> 2. Show me the search synonyms to add in `src/pages/theleague/icons.astro`
+> 3. Suggest which categories it belongs in
+> 4. Give me the git commands to commit and create a PR
+
+---
+
+## <a id="font-differences"></a>9. Font Differences Between the Two CSS Files
+
+| CSS File | Heading Font | Body Font | How it's loaded |
+|---|---|---|---|
+| `dark_main.css` | UFC Sans Condensed | UFC Sans Condensed | `@font-face` with local WOFF2 files (`/assets/fonts/UFCSans-CondensedMedium.woff2` and `UFCSans-CondensedBold.woff2`) |
+| `dark_din_main.css` | DIN (via Typekit) | DIN (via Typekit) | `@import url("https://use.typekit.net/wpa6ggf.css")` — loaded from Adobe Fonts |
+
+Both files share the **exact same CSS variables and component styles**. The only difference is the font. If you override `--headline-font` and `--body-font` in your Homepage Message, you can use any font you want regardless of which base file you chose.
+
+---
+
+## <a id="tips"></a>10. Tips and Gotchas
+
+### Only override what you need
+You don't need to copy all 80+ variables. Only include the ones you're changing. The base stylesheet handles everything else.
+
+### The accent color is used everywhere
+`--accent-color` (`#c9a94e` gold) is the most impactful single variable. It drives headings, icons, buttons, the sub-navigation, calendar "today" highlight, logo, and more. Changing it is the fastest way to rebrand.
+
+If you change `--accent-color`, you'll likely also want to update these related variables to match:
+- `--dark-accent-color` (darker shade for hover)
+- `--h1-color` through `--h6-color`
+- `--caption-color` / `--headline-font-color`
+- `--icon-color` / `--icon-color-hover` / `--icon-text-color`
+- `--button-bg-color` / `--button-bg-color-hover`
+- `--secondary-menu-border-color` / `--secondary-menu-bg-color`
+- `--today-bg-color` / `--today-border-color`
+- `--logo-main-color` / `--logo-text-color`
+
+### Dark mode contrast
+When picking custom colors, remember you're on a dark background (`#121212`). Use lighter colors for text and keep enough contrast for readability. The [WebAIM Contrast Checker](https://webaim.org/resources/contrastchecker/) is a good tool.
+
+### Test in multiple MFL reports
+MFL has many different report pages (rosters, standings, live scoring, draft, etc.). After making changes, spot-check a few different pages to make sure your overrides look good across the board.
+
+### CSS specificity
+Your `<style>` block in a Homepage Message overrides the base CSS because it comes later in the page. If something isn't overriding, make sure you're targeting `:root` — not a class or element selector.
+
+### Homepage Messages are per-league
+Your overrides apply to the league where you added the Homepage Message. Different leagues can have different overrides while sharing the same base CSS file.

--- a/docs/CSS_CUSTOMIZATION_GUIDE.md
+++ b/docs/CSS_CUSTOMIZATION_GUIDE.md
@@ -240,11 +240,26 @@ When you're working with Claude to customize your CSS, paste the following promp
 > }
 > ```
 >
+> The source code for these CSS files and the full project is on GitHub:
+> https://github.com/braven112/mfl.football.v2
+>
+> Key files in the repo:
+> - `src/assets/css/src/_variables-dark.scss` — all CSS variable definitions with defaults
+> - `src/assets/css/src/dark_main.scss` — main dark theme SCSS (UFC Sans Condensed font)
+> - `src/assets/css/src/dark_din_main.scss` — dark theme variant (DIN font via Typekit)
+> - `public/assets/css/dist/dark_main.css` — compiled CSS file (what MFL loads)
+> - `public/assets/css/dist/dark_din_main.css` — compiled DIN variant
+> - `public/assets/icons/sprite.svg` — SVG icon sprite with 100+ symbols
+> - `src/pages/theleague/icons.astro` — icon gallery page with search/categories
+> - `src/pages/theleague/css-customization.astro` — this customization guide page
+>
+> If you need to look up how a specific component is styled, check the SCSS partials in `src/assets/css/src/` (e.g., `_tables.scss`, `_buttons.scss`, `_mflmenu.scss`). Each file uses the CSS variables defined above.
+>
 > When I ask you to change something, generate ONLY a `<style>` block containing the overridden variables. Do not regenerate the entire stylesheet. Only include variables that are changing.
 
 ---
 
-That prompt gives Claude everything it needs. From there you can say things like:
+That prompt gives Claude everything it needs — including the GitHub repo URL so it can look up component styles if needed. From there you can say things like:
 
 - "Change my accent color to red `#dc2626`"
 - "Make the page background pure black"

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -25,6 +25,7 @@
 						<span class="footer-link-label">Assets</span>
 						<a href="/theleague/assets" class="footer-link">Team Assets</a>
 						<a href="/theleague/icons" class="footer-link">Sprite Icons</a>
+						<a href="/theleague/css-customization" class="footer-link">CSS Customization</a>
 					</div>
 					<a href="#" class="social-link">
 						<!-- Simple social icon placeholder -->

--- a/src/components/theleague/Footer.astro
+++ b/src/components/theleague/Footer.astro
@@ -77,6 +77,7 @@ const championIcon = championTeam?.assets?.icons?.[0]?.relativePath;
 				<ul>
 					<li><a href={resolveLeaguePath(isAFL ? "/afl-fantasy/assets" : "/theleague/assets", hideLeaguePrefix)}>Asset Library</a></li>
 					{!isAFL && <li><a href={resolveLeaguePath("/theleague/icons", hideLeaguePrefix)}>Sprite Icons</a></li>}
+					{!isAFL && <li><a href={resolveLeaguePath("/theleague/css-customization", hideLeaguePrefix)}>CSS Customization</a></li>}
 				</ul>
 			</div>
 			<div class="footer-column">

--- a/src/pages/theleague/css-customization.astro
+++ b/src/pages/theleague/css-customization.astro
@@ -1,0 +1,976 @@
+---
+import Layout from '../../layouts/Layout.astro';
+
+export const prerender = true;
+
+// Read the variables file at build time so the copy-to-clipboard prompt stays in sync
+import fs from 'fs';
+import path from 'path';
+
+const varsPath = path.join(process.cwd(), 'src/assets/css/src/_variables-dark.scss');
+const varsContent = fs.readFileSync(varsPath, 'utf-8');
+
+// Extract the :root block (lines between `:root {` and the closing `}`)
+const rootMatch = varsContent.match(/:root\s*\{([\s\S]*?)\n\}/);
+const rootBlock = rootMatch ? rootMatch[1] : '';
+
+// Parse variable declarations into an array of { name, value, comment }
+const varLines = rootBlock
+  .split('\n')
+  .map(l => l.trim())
+  .filter(l => l.startsWith('--'));
+
+const variables = varLines.map(line => {
+  const match = line.match(/^(--[\w-]+)\s*:\s*(.+?)\s*;/);
+  if (!match) return null;
+  return { name: match[1], value: match[2] };
+}).filter(Boolean) as { name: string; value: string }[];
+
+// Build the Claude prompt with all current variable values
+const claudePromptVars = variables.map(v => `  ${v.name}: ${v.value};`).join('\n');
+
+// Group variables by category for the reference table
+type VarGroup = { label: string; id: string; vars: { name: string; value: string; desc: string }[] };
+
+const groups: VarGroup[] = [
+  {
+    label: 'Brand / Accent Colors', id: 'brand',
+    vars: [
+      { name: '--primary-color', value: '', desc: 'Primary UI color (light gray in dark mode)' },
+      { name: '--secondary-color', value: '', desc: 'Secondary UI color' },
+      { name: '--accent-color', value: '', desc: 'Main accent / brand highlight (gold)' },
+      { name: '--dark-accent-color', value: '', desc: 'Darker accent for hover/active states' },
+    ]
+  },
+  {
+    label: 'Text Colors', id: 'text',
+    vars: [
+      { name: '--primary-text-color', value: '', desc: 'Main body text' },
+      { name: '--secondary-text-color', value: '', desc: 'Muted / secondary text' },
+      { name: '--link-color', value: '', desc: 'Link text color' },
+      { name: '--link-color-hover', value: '', desc: 'Link hover color' },
+    ]
+  },
+  {
+    label: 'Page Backgrounds', id: 'backgrounds',
+    vars: [
+      { name: '--pagebody-bg', value: '', desc: 'Full page background' },
+      { name: '--primary-bg-color', value: '', desc: 'Content area / card backgrounds' },
+      { name: '--report-bg', value: '', desc: 'Report page backgrounds' },
+      { name: '--header-bg', value: '', desc: 'Site header background' },
+      { name: '--codebg-color', value: '', desc: 'Code block backgrounds' },
+    ]
+  },
+  {
+    label: 'Headings', id: 'headings',
+    vars: [
+      { name: '--headline-font-color', value: '', desc: 'General headline color' },
+      { name: '--caption-color', value: '', desc: 'Caption text' },
+      { name: '--h1-color', value: '', desc: 'H1 heading color' },
+      { name: '--h2-color', value: '', desc: 'H2 heading color' },
+      { name: '--h3-color', value: '', desc: 'H3 heading color' },
+      { name: '--h4-color', value: '', desc: 'H4 heading color' },
+      { name: '--h5-color', value: '', desc: 'H5 heading color' },
+      { name: '--h6-color', value: '', desc: 'H6 heading color' },
+    ]
+  },
+  {
+    label: 'Typography / Fonts', id: 'fonts',
+    vars: [
+      { name: '--headline-font', value: '', desc: 'Heading font family' },
+      { name: '--headline-font-weight', value: '', desc: 'Heading font weight' },
+      { name: '--body-font', value: '', desc: 'Body text font family' },
+      { name: '--body-font-weight', value: '', desc: 'Body text font weight' },
+      { name: '--svg-text-font-size', value: '', desc: 'Font size inside SVG elements' },
+    ]
+  },
+  {
+    label: 'MFL Top Menu', id: 'menu',
+    vars: [
+      { name: '--menu-bg-color', value: '', desc: 'Menu background' },
+      { name: '--menu-bg-hover-color', value: '', desc: 'Menu item hover background' },
+      { name: '--menu-border-color', value: '', desc: 'Menu border' },
+      { name: '--menu-text-color', value: '', desc: 'Menu text' },
+    ]
+  },
+  {
+    label: 'Report Sub-Navigation', id: 'subnav',
+    vars: [
+      { name: '--secondary-menu-bg-color', value: '', desc: 'Sub-nav background' },
+      { name: '--secondary-menu-border-color', value: '', desc: 'Sub-nav border' },
+      { name: '--secondary-menu-text-color', value: '', desc: 'Sub-nav text' },
+      { name: '--secondary-menu-link-color', value: '', desc: 'Sub-nav links' },
+      { name: '--secondary-menu-icon-color', value: '', desc: 'Sub-nav icon fill' },
+      { name: '--secondary-menu-icon-hover-color', value: '', desc: 'Sub-nav icon hover fill' },
+      { name: '--secondary-menu-font-weight', value: '', desc: 'Sub-nav font weight' },
+    ]
+  },
+  {
+    label: 'Buttons', id: 'buttons',
+    vars: [
+      { name: '--button-bg-color', value: '', desc: 'Button background' },
+      { name: '--button-bg-color-hover', value: '', desc: 'Button hover background' },
+      { name: '--button-link-color', value: '', desc: 'Button text color' },
+    ]
+  },
+  {
+    label: 'Tables', id: 'tables',
+    vars: [
+      { name: '--oddtablerow', value: '', desc: 'Odd row background' },
+      { name: '--eventablerow', value: '', desc: 'Even row background' },
+      { name: '--table-header-color', value: '', desc: 'Table header text' },
+      { name: '--newposition-border-color', value: '', desc: 'Position change border' },
+    ]
+  },
+  {
+    label: 'Alerts', id: 'alerts',
+    vars: [
+      { name: '--alert-danger-text', value: '', desc: 'Danger alert text' },
+      { name: '--alert-danger-bg', value: '', desc: 'Danger alert background' },
+      { name: '--alert-danger-border', value: '', desc: 'Danger alert border' },
+      { name: '--alert-warning-text', value: '', desc: 'Warning alert text' },
+      { name: '--alert-warning-bg', value: '', desc: 'Warning alert background' },
+      { name: '--alert-warning-border', value: '', desc: 'Warning alert border' },
+      { name: '--alert-success-text', value: '', desc: 'Success alert text' },
+      { name: '--alert-success-bg', value: '', desc: 'Success alert background' },
+      { name: '--alert-success-border', value: '', desc: 'Success alert border' },
+      { name: '--alert-info-text', value: '', desc: 'Info alert text' },
+      { name: '--alert-info-bg', value: '', desc: 'Info alert background' },
+      { name: '--alert-info-border', value: '', desc: 'Info alert border' },
+    ]
+  },
+  {
+    label: 'Icons', id: 'icons',
+    vars: [
+      { name: '--icon-color', value: '', desc: 'Default SVG icon fill' },
+      { name: '--icon-color-hover', value: '', desc: 'Icon hover fill' },
+      { name: '--icon-text-color', value: '', desc: 'Text labels next to icons' },
+    ]
+  },
+  {
+    label: 'Calendar', id: 'calendar',
+    vars: [
+      { name: '--calendar-bg-color', value: '', desc: 'Calendar background' },
+      { name: '--calendar-eventablerow', value: '', desc: 'Calendar alternating rows' },
+      { name: '--calendar-border-color', value: '', desc: 'Calendar cell borders' },
+      { name: '--calendar-text-color', value: '', desc: 'Calendar text' },
+      { name: '--today-bg-color', value: '', desc: 'Today highlight background' },
+      { name: '--today-border-color', value: '', desc: 'Today highlight border' },
+      { name: '--today-text-color', value: '', desc: 'Today highlight text' },
+    ]
+  },
+  {
+    label: 'Logo / SVG Crest', id: 'logo',
+    vars: [
+      { name: '--logo-main-color', value: '', desc: 'Primary logo fill' },
+      { name: '--logo-secondary-color', value: '', desc: 'Secondary logo fill' },
+      { name: '--logo-3rd-color', value: '', desc: 'Third logo color' },
+      { name: '--logo-4th-color', value: '', desc: 'Fourth logo color' },
+      { name: '--logo-text-color', value: '', desc: 'Logo text fill' },
+      { name: '--logo-secondary-text-color', value: '', desc: 'Logo secondary text fill' },
+      { name: '--logo-name-primary-color', value: '', desc: 'League name primary color' },
+      { name: '--logo-name-secondary-color', value: '', desc: 'League name secondary color' },
+    ]
+  },
+  {
+    label: 'Footer', id: 'footer',
+    vars: [
+      { name: '--footer-bg-color', value: '', desc: 'Footer background' },
+      { name: '--footer-text-color', value: '', desc: 'Footer text' },
+      { name: '--footer-header-text-color', value: '', desc: 'Footer section headers' },
+    ]
+  },
+  {
+    label: 'Neutrals / Grays', id: 'neutrals',
+    vars: [
+      { name: '--gray1', value: '', desc: 'Lightest gray' },
+      { name: '--gray2', value: '', desc: 'Medium gray' },
+      { name: '--gray3', value: '', desc: 'Darkest gray' },
+      { name: '--offwhite', value: '', desc: 'Off-white (dark gray in dark mode)' },
+      { name: '--offwhite2', value: '', desc: 'Deeper off-white' },
+      { name: '--lightgray', value: '', desc: 'Light gray' },
+      { name: '--lightgray2', value: '', desc: 'Medium light gray' },
+      { name: '--lightgray3', value: '', desc: 'Darker light gray' },
+      { name: '--white', value: '', desc: '"White" (inverted for dark mode)' },
+    ]
+  },
+  {
+    label: 'Scrollbar', id: 'scrollbar',
+    vars: [
+      { name: '--scrollbar-bg-color', value: '', desc: 'Scrollbar track' },
+      { name: '--scrollbar-bg-hover-color', value: '', desc: 'Scrollbar hover' },
+    ]
+  },
+  {
+    label: 'Roster Page', id: 'roster',
+    vars: [
+      { name: '--color-bg-base', value: '', desc: 'Roster card base background' },
+      { name: '--color-bg-subtle', value: '', desc: 'Subtle background areas' },
+      { name: '--color-bg-practice', value: '', desc: 'Practice squad row' },
+      { name: '--color-bg-injured', value: '', desc: 'Injured Reserve row' },
+    ]
+  },
+  {
+    label: 'Division Headings', id: 'divisions',
+    vars: [
+      { name: '--division-heading-color', value: '', desc: 'Division heading text' },
+      { name: '--division-subheading-color', value: '', desc: 'Division subheading text' },
+      { name: '--division-border-color', value: '', desc: 'Division separator line' },
+    ]
+  },
+  {
+    label: 'Header Icon Buttons', id: 'header-icons',
+    vars: [
+      { name: '--header-icon-color', value: '', desc: 'Header icon fill' },
+      { name: '--header-icon-text-color', value: '', desc: 'Header icon label text' },
+      { name: '--header-icon-hover-color', value: '', desc: 'Header icon hover fill' },
+    ]
+  },
+  {
+    label: 'Miscellaneous', id: 'misc',
+    vars: [
+      { name: '--add-color', value: '', desc: 'Waiver add / pickup indicator (green)' },
+      { name: '--drop-color', value: '', desc: 'Waiver drop indicator (red)' },
+      { name: '--border-color', value: '', desc: 'General border color' },
+      { name: '--tab-hover-color', value: '', desc: 'Tab hover text' },
+      { name: '--border-radius-sm', value: '', desc: 'Small border radius' },
+      { name: '--border-radius-default', value: '', desc: 'Default border radius' },
+      { name: '--border-radius-lg', value: '', desc: 'Large border radius' },
+      { name: '--border-radius-xl', value: '', desc: 'Extra-large / pill border radius' },
+    ]
+  },
+];
+
+// Resolve actual default values from the parsed variables
+const varMap = new Map(variables.map(v => [v.name, v.value]));
+for (const group of groups) {
+  for (const v of group.vars) {
+    v.value = varMap.get(v.name) ?? '';
+  }
+}
+---
+
+<Layout title="MFL.football - CSS Customization Guide">
+  <main class="guide-page">
+    <section class="intro">
+      <h1>CSS Customization Guide</h1>
+      <p>
+        Customize the dark theme CSS files without editing the source.
+        Override any variable using a <code>&lt;style&gt;</code> block in an MFL Homepage Message.
+      </p>
+      <div class="cta-row">
+        <a class="cta-link" href="/theleague/icons">Browse Icons</a>
+        <a class="cta-link secondary" href="/theleague/instructions">Installation Guide</a>
+      </div>
+    </section>
+
+    <div class="guide-layout">
+      <div class="guide-content">
+
+        <!-- HOW IT WORKS -->
+        <section id="how-it-works" class="card">
+          <h2>How It Works</h2>
+          <p>
+            The CSS files (<code>dark_main.css</code> or <code>dark_din_main.css</code>) are loaded
+            via the <strong>Custom CSS URL</strong> field in MFL:
+          </p>
+          <ol>
+            <li>Go to <strong>Setup &gt; Franchise Setup &gt; Images and Other URLs</strong></li>
+            <li>Paste the stylesheet URL into the <strong>Custom CSS</strong> field</li>
+            <li>Save &mdash; MFL loads it across your league site</li>
+          </ol>
+          <p>
+            Every visual property in the stylesheet is driven by <strong>CSS custom properties</strong>
+            (variables) defined in a <code>:root</code> block. Because CSS cascades, you can override
+            any variable by adding a <code>&lt;style&gt;</code> block in an MFL <strong>Homepage Message</strong>.
+            The Homepage Message loads <em>after</em> the stylesheet, so your overrides win.
+          </p>
+        </section>
+
+        <!-- GETTING STARTED -->
+        <section id="getting-started" class="card">
+          <h2>Getting Started</h2>
+          <p>Create (or edit) an MFL <strong>Homepage Message</strong> and add a <code>&lt;style&gt;</code> block. Only include the variables you want to change:</p>
+          <pre><code>&lt;style&gt;
+:root {'{'}
+  /* Brand Colors */
+  --accent-color: #ff4500;
+  --dark-accent-color: #cc3700;
+
+  /* Headings */
+  --h1-color: #ff4500;
+  --h2-color: #ff4500;
+  --h3-color: #ff4500;
+
+  /* Buttons */
+  --button-bg-color: #ff4500;
+  --button-bg-color-hover: #ff6030;
+  --button-link-color: #ffffff;
+{'}'}
+&lt;/style&gt;</code></pre>
+          <p class="hint">Everything you don't override keeps its default value from the base CSS file.</p>
+        </section>
+
+        <!-- CLAUDE PROMPT -->
+        <section id="claude-prompt" class="card">
+          <h2>Using Claude to Help Customize</h2>
+          <p>
+            Copy the prompt below and paste it at the start of a Claude conversation. It gives Claude
+            all the context it needs &mdash; from there you can say things like <em>"Change my accent
+            color to red"</em> or <em>"Make the table headers white"</em> and Claude will respond
+            with the correct <code>&lt;style&gt;</code> block.
+          </p>
+          <div class="prompt-box">
+            <div class="prompt-header">
+              <strong>Claude Prompt</strong>
+              <button class="copy-btn" id="copy-prompt-btn" type="button">Copy</button>
+            </div>
+            <pre class="prompt-content" id="claude-prompt-text">{`I'm customizing an MFL (MyFantasyLeague) league website. My league uses a dark theme CSS file loaded via MFL's Custom CSS URL field. I override specific CSS variables using a <style> block inside an MFL Homepage Message.
+
+The base CSS file defines all styles using CSS custom properties (variables) in a :root block. I can override any variable by redefining it in my Homepage Message's <style> block — the override wins because it appears later on the page.
+
+Here is the complete list of CSS variables I can override, with their current default values:
+
+:root {
+${claudePromptVars}
+}
+
+When I ask you to change something, generate ONLY a <style> block containing the overridden variables. Do not regenerate the entire stylesheet. Only include variables that are changing.`}</pre>
+          </div>
+        </section>
+
+        <!-- VARIABLE REFERENCE -->
+        <section id="variable-reference" class="card">
+          <h2>CSS Variable Reference</h2>
+          <p>
+            Every variable available for override, grouped by what it controls.
+            Defaults shown are from <code>dark_main.css</code> (UFC font).
+            The <code>dark_din_main.css</code> file uses identical values except for the font variables.
+          </p>
+
+          {groups.map(group => (
+            <div class="var-group" id={`vars-${group.id}`}>
+              <h3>{group.label}</h3>
+              <div class="var-table-wrap">
+                <table class="var-table">
+                  <thead>
+                    <tr>
+                      <th>Variable</th>
+                      <th>Default</th>
+                      <th>Description</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {group.vars.map(v => (
+                      <tr>
+                        <td><code>{v.name}</code></td>
+                        <td>
+                          <span class="value-cell">
+                            {v.value.match(/^#[0-9a-fA-F]{3,8}$/) && (
+                              <span class="color-swatch" style={`background:${v.value}`}></span>
+                            )}
+                            <code>{v.value}</code>
+                          </span>
+                        </td>
+                        <td>{v.desc}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          ))}
+        </section>
+
+        <!-- EXAMPLES -->
+        <section id="examples" class="card">
+          <h2>Common Examples</h2>
+
+          <h3>Rebrand accent from gold to red</h3>
+          <pre><code>&lt;style&gt;
+:root {'{'}
+  --accent-color: #dc2626;
+  --dark-accent-color: #b91c1c;
+  --link-color-hover: #dc2626;
+  --button-bg-color: #dc2626;
+  --button-bg-color-hover: #ef4444;
+  --h1-color: #dc2626;
+  --h2-color: #dc2626;
+  --h3-color: #dc2626;
+  --h4-color: #dc2626;
+  --h5-color: #dc2626;
+  --h6-color: #dc2626;
+  --caption-color: #dc2626;
+  --headline-font-color: #dc2626;
+  --icon-color: #dc2626;
+  --icon-color-hover: #ef4444;
+  --secondary-menu-border-color: #dc2626;
+  --secondary-menu-bg-color: #7f1d1d;
+  --today-bg-color: #dc2626;
+  --logo-main-color: #dc2626;
+  --logo-name-primary-color: #dc2626;
+{'}'}
+&lt;/style&gt;</code></pre>
+
+          <h3>Custom Google Font for headings</h3>
+          <pre><code>&lt;!-- Load the font first --&gt;
+&lt;link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;700&amp;display=swap" rel="stylesheet"&gt;
+
+&lt;style&gt;
+:root {'{'}
+  --headline-font: "Oswald", sans-serif;
+  --body-font: "Oswald", sans-serif;
+{'}'}
+&lt;/style&gt;</code></pre>
+
+          <h3>Higher contrast tables</h3>
+          <pre><code>&lt;style&gt;
+:root {'{'}
+  --oddtablerow: #1a1a1a;
+  --eventablerow: #2a2a2a;
+  --table-header-color: #e0e0e0;
+{'}'}
+&lt;/style&gt;</code></pre>
+
+          <h3>Softer / more rounded corners</h3>
+          <pre><code>&lt;style&gt;
+:root {'{'}
+  --border-radius-sm: .5rem;
+  --border-radius-default: 1rem;
+  --border-radius-lg: 1.5rem;
+{'}'}
+&lt;/style&gt;</code></pre>
+        </section>
+
+        <!-- ICON SPRITE -->
+        <section id="icon-sprite" class="card">
+          <h2>Using the SVG Icon Sprite</h2>
+          <p>
+            All icons are served from a single SVG sprite file containing 100+ symbols.
+            Browse, search, and test colors in the
+            <a href="/theleague/icons"><strong>Icon Gallery</strong></a>.
+          </p>
+
+          <h3>Display an icon</h3>
+          <pre><code>&lt;svg width="38" height="38" viewBox="0 0 512 512"&gt;
+  &lt;use href="/assets/icons/sprite.svg#icon-trophy"&gt;&lt;/use&gt;
+&lt;/svg&gt;</code></pre>
+          <p>
+            Replace <code>icon-trophy</code> with any icon ID from the sprite. Check the
+            <a href="/theleague/icons">gallery</a> for available icons and their exact <code>viewBox</code> values.
+          </p>
+
+          <h3>Controlling icon colors</h3>
+          <p>Icons inherit fill from CSS variables:</p>
+          <table class="var-table compact">
+            <thead><tr><th>Variable</th><th>Controls</th></tr></thead>
+            <tbody>
+              <tr><td><code>--icon-color</code></td><td>Default icon fill</td></tr>
+              <tr><td><code>--icon-color-hover</code></td><td>Icon fill on hover</td></tr>
+              <tr><td><code>--icon-text-color</code></td><td>Text labels next to icons</td></tr>
+            </tbody>
+          </table>
+          <p>Override a single icon inline:</p>
+          <pre><code>&lt;svg width="38" height="38" viewBox="0 0 512 512" style="fill: #dc2626;"&gt;
+  &lt;use href="/assets/icons/sprite.svg#icon-trophy"&gt;&lt;/use&gt;
+&lt;/svg&gt;</code></pre>
+        </section>
+
+        <!-- ADDING ICONS -->
+        <section id="adding-icons" class="card">
+          <h2>Adding New Icons</h2>
+
+          <h3>1. Get a clean SVG</h3>
+          <p>
+            Sources: <a href="https://heroicons.com" target="_blank">Heroicons</a>,
+            <a href="https://lucide.dev" target="_blank">Lucide</a>,
+            <a href="https://feathericons.com" target="_blank">Feather Icons</a>,
+            <a href="https://www.svgrepo.com" target="_blank">SVG Repo</a>,
+            or ask Claude to generate one.
+          </p>
+
+          <h3>2. Convert to a <code>&lt;symbol&gt;</code></h3>
+          <p>Strip the outer <code>&lt;svg&gt;</code> wrapper and any <code>fill</code> attributes so the icon inherits the theme color:</p>
+          <pre><code>&lt;symbol id="icon-my-custom-icon" viewBox="0 0 24 24"&gt;
+  &lt;path d="M12 2L2 7v10l10 5 10-5V7L12 2z"/&gt;
+&lt;/symbol&gt;</code></pre>
+
+          <h3>3. Add to the sprite file</h3>
+          <p>
+            Open <code>public/assets/icons/sprite.svg</code> and paste your <code>&lt;symbol&gt;</code>
+            inside the root <code>&lt;svg&gt;</code> tag, before the closing <code>&lt;/svg&gt;</code>.
+          </p>
+
+          <h3>Ask Claude to help</h3>
+          <div class="prompt-box small">
+            <pre class="prompt-content">I need to add a new icon to my SVG sprite file. Here's the SVG:
+
+[paste your SVG here]
+
+Convert this into a &lt;symbol&gt; element with the id "icon-my-name".
+Remove any fill attributes so it inherits the theme color.
+Give me the &lt;symbol&gt; block to paste into sprite.svg.</pre>
+          </div>
+        </section>
+
+        <!-- SUBMITTING A PR -->
+        <section id="submit-pr" class="card">
+          <h2>Submitting New Icons via Pull Request</h2>
+          <p>To add icons to the shared sprite for everyone, submit a PR to the repository.</p>
+
+          <h3>Steps</h3>
+          <ol class="step-list">
+            <li>
+              <strong>Clone the repo:</strong>
+              <pre><code>git clone https://github.com/braven112/mfl.football.v2.git
+cd mfl.football.v2</code></pre>
+            </li>
+            <li>
+              <strong>Create a branch:</strong>
+              <pre><code>git checkout -b add-icon-my-icon-name</code></pre>
+            </li>
+            <li>
+              <strong>Edit the sprite:</strong> Add your <code>&lt;symbol&gt;</code> to
+              <code>public/assets/icons/sprite.svg</code>
+            </li>
+            <li>
+              <strong>(Optional) Update the gallery:</strong> In
+              <code>src/pages/theleague/icons.astro</code>, add search synonyms and category tags
+              so your icon shows up when people search.
+            </li>
+            <li>
+              <strong>Commit and push:</strong>
+              <pre><code>git add public/assets/icons/sprite.svg
+git commit -m "Add icon-my-custom-icon to SVG sprite"
+git push -u origin add-icon-my-icon-name</code></pre>
+            </li>
+            <li>
+              <strong>Open the PR:</strong>
+              <pre><code>gh pr create --title "Add icon-my-custom-icon" \
+  --body "Adds a new icon for [description]."</code></pre>
+              Or use the GitHub web interface.
+            </li>
+          </ol>
+        </section>
+
+        <!-- FONT DIFFERENCES -->
+        <section id="font-differences" class="card">
+          <h2>Font Differences</h2>
+          <table class="var-table">
+            <thead>
+              <tr><th>CSS File</th><th>Font</th><th>How it loads</th></tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><code>dark_main.css</code></td>
+                <td>UFC Sans Condensed</td>
+                <td><code>@font-face</code> with local WOFF2 files</td>
+              </tr>
+              <tr>
+                <td><code>dark_din_main.css</code></td>
+                <td>DIN (via Typekit)</td>
+                <td><code>@import</code> from Adobe Fonts</td>
+              </tr>
+            </tbody>
+          </table>
+          <p>
+            Both files share identical CSS variables and component styles. The only difference is the font.
+            If you override <code>--headline-font</code> and <code>--body-font</code>, you can use any
+            font regardless of which base file you chose.
+          </p>
+        </section>
+
+        <!-- TIPS -->
+        <section id="tips" class="card">
+          <h2>Tips &amp; Gotchas</h2>
+          <ul>
+            <li>
+              <strong>Only override what you need.</strong> Don't copy all 80+ variables.
+              The base stylesheet handles everything else.
+            </li>
+            <li>
+              <strong>The accent color is everywhere.</strong> <code>--accent-color</code> drives
+              headings, icons, buttons, sub-nav, calendar, and the logo. Changing it is the fastest
+              way to rebrand. See the <a href="#examples">red rebrand example</a> for all the related
+              variables you should update together.
+            </li>
+            <li>
+              <strong>Dark mode contrast.</strong> Your background is <code>#121212</code>. Use
+              lighter colors for text and check contrast with a tool like
+              <a href="https://webaim.org/resources/contrastchecker/" target="_blank">WebAIM Contrast Checker</a>.
+            </li>
+            <li>
+              <strong>Test multiple MFL pages.</strong> MFL has rosters, standings, live scoring,
+              draft pages, etc. Spot-check a few different pages after making changes.
+            </li>
+            <li>
+              <strong>Specificity.</strong> Target <code>:root</code> in your style block &mdash;
+              not a class or element selector. That's how the base CSS defines them and your override
+              needs to match.
+            </li>
+            <li>
+              <strong>Per-league overrides.</strong> Your Homepage Message applies only to the league
+              where you added it. Different leagues can share the same base CSS file but have different
+              overrides.
+            </li>
+          </ul>
+        </section>
+
+      </div>
+
+      <!-- SIDEBAR TOC -->
+      <aside class="toc" aria-label="On this page">
+        <strong>On this page</strong>
+        <ul>
+          <li><a href="#how-it-works">How It Works</a></li>
+          <li><a href="#getting-started">Getting Started</a></li>
+          <li><a href="#claude-prompt">Claude Prompt</a></li>
+          <li><a href="#variable-reference">Variable Reference</a></li>
+          <li><a href="#examples">Examples</a></li>
+          <li><a href="#icon-sprite">Icon Sprite</a></li>
+          <li><a href="#adding-icons">Adding Icons</a></li>
+          <li><a href="#submit-pr">Submitting a PR</a></li>
+          <li><a href="#font-differences">Font Differences</a></li>
+          <li><a href="#tips">Tips &amp; Gotchas</a></li>
+        </ul>
+      </aside>
+    </div>
+  </main>
+</Layout>
+
+<style>
+  :root {
+    --card-bg: rgba(255, 255, 255, 0.92);
+    --card-border: rgba(37, 99, 235, 0.2);
+    --card-shadow: 0 15px 45px -25px rgba(15, 23, 42, 0.45);
+  }
+
+  .guide-page {
+    max-width: 1280px;
+    margin: 0 auto;
+    padding: 2rem 1.5rem 4rem;
+    display: grid;
+    gap: 2.5rem;
+  }
+
+  /* ── Intro hero ── */
+  .intro {
+    text-align: center;
+    background: linear-gradient(135deg, rgba(37, 99, 235, 0.95), rgba(5, 150, 105, 0.95));
+    color: white;
+    padding: 3rem 2rem;
+    border-radius: 1.5rem;
+    box-shadow: var(--card-shadow);
+  }
+
+  .intro h1 { margin-bottom: 0.5rem; }
+  .intro p { margin: 0 auto; max-width: 640px; opacity: 0.92; }
+  .intro code {
+    background: rgba(255,255,255,0.18);
+    padding: 0.15rem 0.4rem;
+    border-radius: 0.3rem;
+  }
+
+  .cta-row {
+    margin-top: 1.5rem;
+    display: flex;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+  }
+
+  .cta-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    background: rgba(255, 255, 255, 0.18);
+    border: 1px solid rgba(255, 255, 255, 0.4);
+    color: white;
+    padding: 0.65rem 1.25rem;
+    border-radius: 999px;
+    text-decoration: none;
+    font-weight: 600;
+    font-size: 0.9rem;
+    transition: all 0.2s;
+  }
+
+  .cta-link.secondary { background: rgba(15, 23, 42, 0.55); }
+  .cta-link:hover { background: rgba(255, 255, 255, 0.3); transform: translateY(-1px); }
+
+  /* ── Two-column layout ── */
+  .guide-layout {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 260px;
+    gap: 2.5rem;
+    align-items: start;
+  }
+
+  .guide-content {
+    display: grid;
+    gap: 2.5rem;
+    min-width: 0;
+  }
+
+  /* ── Sidebar TOC ── */
+  .toc {
+    background: rgba(15, 23, 42, 0.04);
+    border-left: 4px solid rgba(37, 99, 235, 0.65);
+    padding: 1.25rem 1.5rem;
+    border-radius: 1rem;
+    box-shadow: var(--card-shadow);
+    position: sticky;
+    top: 2rem;
+    max-height: calc(100vh - 4rem);
+    overflow-y: auto;
+  }
+
+  .toc::-webkit-scrollbar { width: 8px; }
+  .toc::-webkit-scrollbar-thumb { background: rgba(37, 99, 235, 0.35); border-radius: 999px; }
+
+  .toc ul {
+    list-style: none;
+    padding-left: 0;
+    margin: 0.6rem 0 0;
+    display: grid;
+    gap: 0.45rem;
+  }
+
+  .toc a {
+    color: rgba(37, 99, 235, 0.95);
+    text-decoration: none;
+    font-weight: 600;
+    font-size: 0.85rem;
+  }
+
+  .toc a:hover { text-decoration: underline; }
+
+  /* ── Cards ── */
+  .card {
+    background: var(--card-bg);
+    border: 1px solid var(--card-border);
+    border-radius: 1.4rem;
+    padding: 2rem;
+    box-shadow: var(--card-shadow);
+    backdrop-filter: blur(3px);
+    scroll-margin-top: 2rem;
+  }
+
+  .card h2 {
+    margin-top: 0;
+    margin-bottom: 1rem;
+    color: rgba(15, 23, 42, 0.92);
+  }
+
+  .card h3 {
+    margin-top: 1.5rem;
+    margin-bottom: 0.5rem;
+    color: rgba(37, 99, 235, 0.9);
+    font-size: 1rem;
+  }
+
+  .card h3:first-child { margin-top: 0; }
+
+  .card p {
+    line-height: 1.7;
+    margin: 0 0 0.75rem;
+    color: #334155;
+  }
+
+  .card ul, .card ol {
+    margin: 0 0 0.75rem;
+    padding-left: 1.4rem;
+    line-height: 1.75;
+    color: #334155;
+  }
+
+  .card code {
+    background: rgba(15, 23, 42, 0.06);
+    padding: 0.15rem 0.4rem;
+    border-radius: 0.3rem;
+    font-size: 0.85em;
+  }
+
+  .card a { color: rgba(37, 99, 235, 0.95); }
+
+  .hint {
+    font-size: 0.85rem;
+    color: #64748b;
+    font-style: italic;
+  }
+
+  /* ── Code blocks ── */
+  pre {
+    background: #0f172a;
+    color: #e2e8f0;
+    border-radius: 0.75rem;
+    padding: 1rem 1.25rem;
+    overflow-x: auto;
+    font-size: 0.82rem;
+    line-height: 1.6;
+    margin: 0.75rem 0;
+  }
+
+  pre code {
+    background: none;
+    padding: 0;
+    font-size: inherit;
+    color: inherit;
+  }
+
+  /* ── Claude prompt box ── */
+  .prompt-box {
+    border: 2px solid rgba(37, 99, 235, 0.3);
+    border-radius: 0.75rem;
+    overflow: hidden;
+    margin: 0.75rem 0;
+  }
+
+  .prompt-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    background: rgba(37, 99, 235, 0.08);
+    padding: 0.5rem 1rem;
+    border-bottom: 1px solid rgba(37, 99, 235, 0.15);
+  }
+
+  .prompt-content {
+    margin: 0;
+    border-radius: 0;
+    font-size: 0.78rem;
+    max-height: 360px;
+    overflow-y: auto;
+  }
+
+  .prompt-box.small .prompt-content {
+    max-height: 180px;
+    font-size: 0.8rem;
+  }
+
+  .copy-btn {
+    padding: 0.3rem 0.85rem;
+    background: #0f172a;
+    color: #fff;
+    border: none;
+    border-radius: 6px;
+    font-size: 0.8rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.15s;
+  }
+
+  .copy-btn:hover { background: #1e293b; }
+
+  /* ── Variable reference tables ── */
+  .var-group { margin-top: 1.5rem; }
+  .var-group:first-child { margin-top: 0.5rem; }
+
+  .var-table-wrap { overflow-x: auto; }
+
+  .var-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.82rem;
+    margin: 0.5rem 0;
+  }
+
+  .var-table th {
+    text-align: left;
+    padding: 0.5rem 0.75rem;
+    background: rgba(15, 23, 42, 0.06);
+    border-bottom: 2px solid rgba(15, 23, 42, 0.1);
+    font-weight: 700;
+    color: #0f172a;
+    white-space: nowrap;
+  }
+
+  .var-table td {
+    padding: 0.4rem 0.75rem;
+    border-bottom: 1px solid rgba(15, 23, 42, 0.06);
+    vertical-align: middle;
+  }
+
+  .var-table.compact { max-width: 480px; }
+
+  .var-table tbody tr:hover { background: rgba(37, 99, 235, 0.04); }
+
+  .value-cell {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+  }
+
+  .color-swatch {
+    display: inline-block;
+    width: 16px;
+    height: 16px;
+    border-radius: 3px;
+    border: 1px solid rgba(0,0,0,0.15);
+    flex-shrink: 0;
+  }
+
+  /* ── Step list ── */
+  .step-list li {
+    margin-bottom: 1rem;
+  }
+
+  .step-list pre {
+    margin-top: 0.5rem;
+  }
+
+  /* ── Responsive ── */
+  @media (max-width: 1024px) {
+    .guide-layout { grid-template-columns: minmax(0, 1fr) 220px; }
+  }
+
+  @media (max-width: 767px) {
+    .guide-page { padding: 1rem 1rem 3rem; }
+
+    .guide-layout { grid-template-columns: 1fr; }
+
+    .toc {
+      position: static;
+      max-height: none;
+      box-shadow: none;
+    }
+
+    .card { padding: 1.5rem 1.25rem; }
+    .cta-row { flex-direction: column; }
+    .intro { padding: 2rem 1.25rem; }
+
+    .var-table { font-size: 0.78rem; }
+    .var-table th, .var-table td { padding: 0.35rem 0.5rem; }
+  }
+</style>
+
+<script>
+  // Copy Claude prompt button
+  const copyBtn = document.getElementById('copy-prompt-btn') as HTMLButtonElement;
+  const promptEl = document.getElementById('claude-prompt-text') as HTMLPreElement;
+
+  copyBtn?.addEventListener('click', async () => {
+    try {
+      await navigator.clipboard.writeText(promptEl.textContent || '');
+      const original = copyBtn.textContent;
+      copyBtn.textContent = 'Copied!';
+      setTimeout(() => { copyBtn.textContent = original; }, 2000);
+    } catch {
+      copyBtn.textContent = 'Failed';
+      setTimeout(() => { copyBtn.textContent = 'Copy'; }, 2000);
+    }
+  });
+
+  // Smooth scroll for TOC links
+  document.querySelectorAll('.toc a[href^="#"]').forEach(link => {
+    link.addEventListener('click', (e) => {
+      const href = (link as HTMLAnchorElement).getAttribute('href');
+      if (!href) return;
+      const target = document.querySelector(href);
+      if (target) {
+        e.preventDefault();
+        target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        history.pushState(null, '', href);
+      }
+    });
+  });
+</script>

--- a/src/pages/theleague/css-customization.astro
+++ b/src/pages/theleague/css-customization.astro
@@ -285,6 +285,21 @@ for (const group of groups) {
             any variable by adding a <code>&lt;style&gt;</code> block in an MFL <strong>Homepage Message</strong>.
             The Homepage Message loads <em>after</em> the stylesheet, so your overrides win.
           </p>
+          <div class="repo-callout">
+            <strong>Source Repository</strong>
+            <p>
+              The full source code is on GitHub at
+              <a href="https://github.com/braven112/mfl.football.v2" target="_blank">braven112/mfl.football.v2</a>.
+              If you're using Claude to help customize, point it at this repo so it can reference
+              the SCSS partials, variable definitions, and component styles directly.
+            </p>
+            <p class="repo-files">
+              Key files:
+              <code>src/assets/css/src/_variables-dark.scss</code> (all variable defaults) &middot;
+              <code>public/assets/icons/sprite.svg</code> (icon sprite) &middot;
+              <code>src/assets/css/src/</code> (component SCSS files)
+            </p>
+          </div>
         </section>
 
         <!-- GETTING STARTED -->
@@ -334,6 +349,21 @@ Here is the complete list of CSS variables I can override, with their current de
 :root {
 ${claudePromptVars}
 }
+
+The source code for these CSS files and the full project is on GitHub:
+https://github.com/braven112/mfl.football.v2
+
+Key files in the repo:
+- src/assets/css/src/_variables-dark.scss — all CSS variable definitions with defaults
+- src/assets/css/src/dark_main.scss — main dark theme SCSS (UFC Sans Condensed font)
+- src/assets/css/src/dark_din_main.scss — dark theme variant (DIN font via Typekit)
+- public/assets/css/dist/dark_main.css — compiled CSS file (what MFL loads)
+- public/assets/css/dist/dark_din_main.css — compiled DIN variant
+- public/assets/icons/sprite.svg — SVG icon sprite with 100+ symbols
+- src/pages/theleague/icons.astro — icon gallery page with search/categories
+- src/pages/theleague/css-customization.astro — this customization guide page
+
+If you need to look up how a specific component is styled, check the SCSS partials in src/assets/css/src/ (e.g., _tables.scss, _buttons.scss, _mflmenu.scss). Each file uses the CSS variables defined above.
 
 When I ask you to change something, generate ONLY a <style> block containing the overridden variables. Do not regenerate the entire stylesheet. Only include variables that are changing.`}</pre>
           </div>
@@ -791,6 +821,38 @@ git push -u origin add-icon-my-icon-name</code></pre>
   }
 
   .card a { color: rgba(37, 99, 235, 0.95); }
+
+  /* ── Repo callout ── */
+  .repo-callout {
+    margin-top: 1.25rem;
+    padding: 1rem 1.25rem;
+    background: rgba(37, 99, 235, 0.06);
+    border: 1px solid rgba(37, 99, 235, 0.2);
+    border-left: 4px solid rgba(37, 99, 235, 0.65);
+    border-radius: 0.5rem;
+  }
+
+  .repo-callout strong {
+    display: block;
+    margin-bottom: 0.4rem;
+    color: #0f172a;
+  }
+
+  .repo-callout p {
+    margin: 0 0 0.5rem;
+    font-size: 0.88rem;
+  }
+
+  .repo-callout p:last-child { margin-bottom: 0; }
+
+  .repo-files {
+    font-size: 0.82rem !important;
+    color: #64748b !important;
+  }
+
+  .repo-files code {
+    font-size: 0.78rem;
+  }
 
   .hint {
     font-size: 0.85rem;


### PR DESCRIPTION
## Summary
This PR adds comprehensive documentation and an interactive guide for customizing the MFL dark theme CSS files without editing the source stylesheets. Users can now override CSS variables via MFL Homepage Messages, with full reference documentation and Claude AI integration support.

## Key Changes

- **New CSS Customization Guide Page** (`src/pages/theleague/css-customization.astro`)
  - Interactive Astro page that reads CSS variables from `_variables-dark.scss` at build time
  - Displays 80+ CSS custom properties organized into 18 logical groups (brand colors, typography, buttons, tables, alerts, etc.)
  - Includes live color swatches for hex values
  - Provides copy-to-clipboard Claude prompt with all current variable defaults
  - Contains 5 detailed code examples (red rebrand, custom fonts, table contrast, border radius, etc.)
  - Sections on icon sprite usage, adding new icons, and submitting PRs
  - Sidebar table of contents for easy navigation
  - Comprehensive tips and gotchas section

- **Markdown Documentation** (`docs/CSS_CUSTOMIZATION_GUIDE.md`)
  - Standalone markdown version of the guide for offline reference
  - Complete variable reference tables
  - Step-by-step instructions for customization
  - Claude prompt ready to copy-paste
  - Examples and troubleshooting

- **Footer Navigation Updates**
  - Added "CSS Customization" link to both `Footer.astro` and `theleague/Footer.astro`
  - Links to the new guide from the Assets section

## Implementation Details

- The Astro page uses `fs` and `path` modules to parse the SCSS variables file at build time, ensuring the Claude prompt and reference tables stay in sync with actual defaults
- Variables are grouped by functional category (brand colors, text, backgrounds, headings, typography, menus, buttons, tables, alerts, icons, calendar, logo, footer, neutrals, scrollbar, roster, divisions, header icons, misc)
- Color swatches are rendered for hex color values using inline SVG spans
- The Claude prompt is pre-formatted with all 80+ variables so users can immediately ask Claude to generate customization code
- Both CSS files (`dark_main.css` and `dark_din_main.css`) are documented, with notes on font differences

https://claude.ai/code/session_01YDenyfLaVsthaqPrNHzhyW