### PR TITLE
feat: gate franchise tag feature behind admin flag

### DIFF
--- a/src/config/nav-config.json
+++ b/src/config/nav-config.json
@@ -48,6 +48,7 @@
           "path": "/contracts/franchise-tags",
           "external": false,
           "leagueOnly": "theleague",
+          "visibility": "admin",
           "description": "View all franchise tag declarations for the current offseason"
         },
         {

--- a/src/pages/theleague/contracts/franchise-tags.astro
+++ b/src/pages/theleague/contracts/franchise-tags.astro
@@ -2,6 +2,14 @@
 import TheLeagueLayout from '../../../layouts/TheLeagueLayout.astro';
 import { getFranchiseTagsByYear } from '../../../utils/contract-storage';
 import { getCurrentLeagueYear } from '../../../utils/league-year';
+import { getAuthUser } from '../../../utils/auth';
+import { isAdminFranchise } from '../../../config/nav-config';
+
+// Auth gate: admin only
+const user = getAuthUser(Astro.request);
+if (!user || !isAdminFranchise(user.franchiseId)) {
+  return Astro.redirect('/theleague');
+}
 
 const leagueYear = getCurrentLeagueYear();
 const tags = getFranchiseTagsByYear(leagueYear);

--- a/src/pages/theleague/rosters.astro
+++ b/src/pages/theleague/rosters.astro
@@ -49,6 +49,7 @@ import {
   getFrozenSalaryAveragesYear,
 } from '../../utils/salary-calculations';
 import { getAuthUser } from '../../utils/auth';
+import { isAdminFranchise } from '../../config/nav-config';
 import fs from 'fs';
 import path from 'path';
 import espnNewsData from '../../../data/theleague/nfl-news-week15.json';
@@ -1277,6 +1278,7 @@ const knownTeamIds = new Set([
 // Get authenticated user and set default team to their franchise if logged in
 const authUser = getAuthUser(Astro.request);
 const isLoggedIn = !!authUser;
+const isAdmin = isAdminFranchise(authUser?.franchiseId);
 const userFranchiseId = normalizeFranchiseId(authUser?.franchiseId);
 
 // Get URL parameters for team preference
@@ -1609,8 +1611,10 @@ if (Array.isArray(eligFranchises)) {
       new Date(), frozenSalaryAverages,
     );
     const playerMap: Record<string, any> = {};
+    const adminOnlyTypes = ['franchise-tag', 'veteran-extension', 'rookie-extension'];
     for (const p of teamResult.players) {
       if (!p.eligible) continue;
+      if (!isAdmin && adminOnlyTypes.includes(p.declarationType)) continue;
       const entry: Record<string, any> = {
         type: p.declarationType,
         yearOptions: p.yearOptions,
@@ -1956,12 +1960,14 @@ const r = (path: string) => resolveLeaguePath(path, hideLeaguePrefix);
             Clear All Tags
           </button>
 
-          <button class="submit-franchise-tags-btn" id="submitFranchiseTagsBtn" style="display: none;" title="Submit franchise tag declarations for commissioner approval">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-              <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/>
-            </svg>
-            Submit Franchise Tags
-          </button>
+          {isAdmin && (
+            <button class="submit-franchise-tags-btn" id="submitFranchiseTagsBtn" style="display: none;" title="Submit franchise tag declarations for commissioner approval">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/>
+              </svg>
+              Submit Franchise Tags
+            </button>
+          )}
 
           <div class="mode-toggle">
             <button class="mode-btn active" data-mode="gm" title="GM Mode: Contracts & Salary Cap">


### PR DESCRIPTION
Hide franchise tag submit flow, listing page, and extension/tag eligibility types from non-admin users until the feature is ready for general availability.

- Nav link: add visibility: admin to franchise-tags
- Listing page: redirect non-admin users to /theleague
- Rosters: filter out franchise-tag, veteran-extension, and rookie-extension eligibility types for non-admin users
- Rosters: conditionally render Submit Franchise Tags button

https://claude.ai/code/session_01LSaLnCEDmBnbZTmcewEpLA