### PR TITLE
Fix hero CTA link for PWA app entry pointing to homepage instead of a…

### DIFF
--- a/src/data/whats-new.json
+++ b/src/data/whats-new.json
@@ -81,8 +81,8 @@
       "Here's what the app does right now: it logs you in, remembers who you are for 90 days, defaults every roster page to your team, and highlights your franchise across the site. That's it. That's the app. We built an entire installable application so you could stop scrolling through a dropdown to find your own team. In the future, this is where lineup submissions, free agent bidding, and other MFL actions will live — but for now, it's a very fancy, very persistent bookmark that knows your name. Install it anyway. You know you want to."
     ],
     "category": "new-feature",
-    "link": "/theleague",
-    "linkLabel": "Open The League",
+    "link": "/theleague/whats-new/pwa-app",
+    "linkLabel": "Read more",
     "icon": "home",
     "image": "pwa-app.webp",
     "imageAlt": "The League installed as a Progressive Web App on a mobile home screen"


### PR DESCRIPTION
…rticle

The "pwa-app" entry in whats-new.json had its link set to "/theleague" (the homepage), so the hero CTA would navigate back to the same page. Changed to "/theleague/whats-new/pwa-app" to link to the article detail page.

https://claude.ai/code/session_013WBbvh59NsGS6ab4aGYHGe