### PR TITLE
Add toggle to filter calendar events by All, Upcoming, or Past

### DIFF
--- a/src/components/theleague/CalendarEventCard.astro
+++ b/src/components/theleague/CalendarEventCard.astro
@@ -29,6 +29,8 @@ const category = event.definition.category;
 const MULTICOLOR_ICONS = ['nfl'];
 const isMulticolor = event.definition.icon ? MULTICOLOR_ICONS.includes(event.definition.icon) : false;
 
+const eventStatus = event.isActive ? 'active' : event.isPast ? 'past' : 'upcoming';
+
 const cardClasses = [
   'calendar-card',
   `calendar-card--${category}`,
@@ -38,7 +40,7 @@ const cardClasses = [
 ].filter(Boolean).join(' ');
 ---
 
-<article class={cardClasses}>
+<article class={cardClasses} data-event-status={eventStatus}>
   {(event.isPast || event.isActive) && (
     <span class="calendar-card__badge">{statusText}</span>
   )}

--- a/src/pages/theleague/calendar.astro
+++ b/src/pages/theleague/calendar.astro
@@ -40,12 +40,22 @@ const nextYearGroups = groupByCategory(nextYearEvents);
     <header class="calendar-hero">
       <h1 class="calendar-hero__title">League Calendar</h1>
       <div class="calendar-hero__controls">
-        <label for="year-select" class="calendar-hero__label">Year</label>
-        <select id="year-select" class="calendar-hero__select">
-          <option value="prev">{prevCalendarYear}</option>
-          <option value="current" selected>{calendarYear}</option>
-          <option value="next">{nextCalendarYear}</option>
-        </select>
+        <div class="calendar-hero__control-group">
+          <label class="calendar-hero__label">Show</label>
+          <div class="calendar-toggle" role="radiogroup" aria-label="Filter events by status">
+            <button class="calendar-toggle__btn calendar-toggle__btn--active" data-filter="all" role="radio" aria-checked="true">All</button>
+            <button class="calendar-toggle__btn" data-filter="upcoming" role="radio" aria-checked="false">Upcoming</button>
+            <button class="calendar-toggle__btn" data-filter="past" role="radio" aria-checked="false">Past</button>
+          </div>
+        </div>
+        <div class="calendar-hero__control-group">
+          <label for="year-select" class="calendar-hero__label">Year</label>
+          <select id="year-select" class="calendar-hero__select">
+            <option value="prev">{prevCalendarYear}</option>
+            <option value="current" selected>{calendarYear}</option>
+            <option value="next">{nextCalendarYear}</option>
+          </select>
+        </div>
       </div>
     </header>
 
@@ -149,14 +159,61 @@ const nextYearGroups = groupByCategory(nextYearEvents);
     });
   }
 
+  /**
+   * Event status filter — toggle between All, Upcoming, and Past events.
+   * Hides cards that don't match the filter and hides empty category sections.
+   */
+  function initEventFilter() {
+    const buttons = document.querySelectorAll<HTMLButtonElement>('.calendar-toggle__btn');
+    if (!buttons.length) return;
+
+    function applyFilter(filter: string) {
+      // Update button states
+      buttons.forEach((btn) => {
+        const isSelected = btn.dataset.filter === filter;
+        btn.classList.toggle('calendar-toggle__btn--active', isSelected);
+        btn.setAttribute('aria-checked', String(isSelected));
+      });
+
+      // Filter cards across all year containers
+      const cards = document.querySelectorAll<HTMLElement>('.calendar-card');
+      cards.forEach((card) => {
+        const status = card.dataset.eventStatus;
+        if (filter === 'all') {
+          card.style.display = '';
+        } else if (filter === 'upcoming') {
+          card.style.display = status === 'past' ? 'none' : '';
+        } else if (filter === 'past') {
+          card.style.display = status === 'past' ? '' : 'none';
+        }
+      });
+
+      // Hide category sections that have no visible cards
+      const sections = document.querySelectorAll<HTMLElement>('.calendar-section');
+      sections.forEach((section) => {
+        const visibleCards = section.querySelectorAll('.calendar-card:not([style*="display: none"])');
+        section.style.display = visibleCards.length === 0 ? 'none' : '';
+      });
+    }
+
+    buttons.forEach((btn) => {
+      btn.addEventListener('click', () => {
+        const filter = btn.dataset.filter || 'all';
+        applyFilter(filter);
+      });
+    });
+  }
+
   // Run after DOM is ready
   if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', () => {
       initYearSelect();
+      initEventFilter();
       resolveCalendarLinks();
     });
   } else {
     initYearSelect();
+    initEventFilter();
     resolveCalendarLinks();
   }
 </script>
@@ -189,7 +246,49 @@ const nextYearGroups = groupByCategory(nextYearEvents);
   .calendar-hero__controls {
     display: flex;
     align-items: center;
+    gap: 1.25rem;
+  }
+
+  .calendar-hero__control-group {
+    display: flex;
+    align-items: center;
     gap: 0.5rem;
+  }
+
+  /* Toggle button group */
+  .calendar-toggle {
+    display: flex;
+    border: 1px solid var(--color-gray-300, #d1d5db);
+    border-radius: 0.375rem;
+    overflow: hidden;
+  }
+
+  .calendar-toggle__btn {
+    font-size: 0.85rem;
+    font-weight: 600;
+    padding: 0.4rem 0.75rem;
+    border: none;
+    background: var(--content-bg, #fff);
+    color: var(--text-secondary-color, #64748b);
+    cursor: pointer;
+    transition: background 0.15s ease, color 0.15s ease;
+  }
+
+  .calendar-toggle__btn:not(:last-child) {
+    border-right: 1px solid var(--color-gray-300, #d1d5db);
+  }
+
+  .calendar-toggle__btn:hover {
+    background: var(--color-gray-50, #f9fafb);
+  }
+
+  .calendar-toggle__btn--active {
+    background: var(--color-primary, #1c497c);
+    color: #fff;
+  }
+
+  .calendar-toggle__btn--active:hover {
+    background: var(--color-primary, #1c497c);
   }
 
   .calendar-hero__label {
@@ -253,6 +352,11 @@ const nextYearGroups = groupByCategory(nextYearEvents);
 
     .calendar-hero__title {
       font-size: 1.5rem;
+    }
+
+    .calendar-hero__controls {
+      flex-direction: column;
+      gap: 0.75rem;
     }
 
     .calendar-section__grid {


### PR DESCRIPTION
Adds a segmented toggle control to the League Calendar hero area that
lets users filter events by status. "All" shows everything (current
behavior), "Upcoming" hides past events, and "Past" shows only completed
events. Category sections with no visible cards are automatically hidden.

https://claude.ai/code/session_01VfzrxpoiVKVG5cEQawUPUg