### PR TITLE
Calculate rookie salary reserve based on actual draft picks

### DIFF
--- a/src/utils/draft-pick-cap-impact.ts
+++ b/src/utils/draft-pick-cap-impact.ts
@@ -66,6 +66,47 @@ export interface PositionalNeed {
 }
 
 /**
+ * Calculates the average rookie salary across all positions for a given draft slot.
+ * Used when we don't know which position will be drafted (e.g., for cap reserve estimates).
+ */
+export function calculateAveragePickSalary(round: number, pickInRound: number): number {
+  if (round >= 3) {
+    const vals = Object.values(ROUND_3_FLAT_RATE);
+    return vals.reduce((s, v) => s + v, 0) / vals.length;
+  }
+
+  // Convert pick-in-round to overall pick number for salary table lookup
+  const overallPick = round === 2 ? 17 + pickInRound : pickInRound;
+
+  const roundSalaries = ROOKIE_SALARIES_2026[round];
+  if (!roundSalaries) {
+    const vals = Object.values(ROUND_3_FLAT_RATE);
+    return vals.reduce((s, v) => s + v, 0) / vals.length;
+  }
+
+  const salaryRow = roundSalaries[overallPick];
+  if (!salaryRow) {
+    const vals = Object.values(ROUND_3_FLAT_RATE);
+    return vals.reduce((s, v) => s + v, 0) / vals.length;
+  }
+
+  const vals = Object.values(salaryRow);
+  return vals.reduce((s, v) => s + v, 0) / vals.length;
+}
+
+/**
+ * Calculates the total estimated rookie reserve for a team based on their actual draft picks,
+ * using position-averaged slotted salaries.
+ */
+export function calculateTeamRookieReserve(
+  picks: { round: number; pickInRound: number }[]
+): number {
+  return picks.reduce((total, pick) => {
+    return total + calculateAveragePickSalary(pick.round, pick.pickInRound);
+  }, 0);
+}
+
+/**
  * Calculates the salary for a specific draft pick slot and position
  */
 export function calculateDraftPickSalary(round: number, pick: number, position: string): number {

--- a/src/utils/draft-pick-cap-impact.ts
+++ b/src/utils/draft-pick-cap-impact.ts
@@ -65,13 +65,16 @@ export interface PositionalNeed {
   targetAcquisitions: number;
 }
 
+// Positions to include in average salary calculations (exclude PK/DEF — rarely drafted)
+const DRAFTABLE_POSITIONS = ['QB', 'RB', 'WR', 'TE'] as const;
+
 /**
- * Calculates the average rookie salary across all positions for a given draft slot.
- * Used when we don't know which position will be drafted (e.g., for cap reserve estimates).
+ * Calculates the average rookie salary across draftable positions (QB/RB/WR/TE) for a given slot.
+ * Excludes PK and DEF since they are almost never drafted.
  */
 export function calculateAveragePickSalary(round: number, pickInRound: number): number {
   if (round >= 3) {
-    const vals = Object.values(ROUND_3_FLAT_RATE);
+    const vals = DRAFTABLE_POSITIONS.map((p) => ROUND_3_FLAT_RATE[p]);
     return vals.reduce((s, v) => s + v, 0) / vals.length;
   }
 
@@ -80,17 +83,17 @@ export function calculateAveragePickSalary(round: number, pickInRound: number): 
 
   const roundSalaries = ROOKIE_SALARIES_2026[round];
   if (!roundSalaries) {
-    const vals = Object.values(ROUND_3_FLAT_RATE);
+    const vals = DRAFTABLE_POSITIONS.map((p) => ROUND_3_FLAT_RATE[p]);
     return vals.reduce((s, v) => s + v, 0) / vals.length;
   }
 
   const salaryRow = roundSalaries[overallPick];
   if (!salaryRow) {
-    const vals = Object.values(ROUND_3_FLAT_RATE);
+    const vals = DRAFTABLE_POSITIONS.map((p) => ROUND_3_FLAT_RATE[p]);
     return vals.reduce((s, v) => s + v, 0) / vals.length;
   }
 
-  const vals = Object.values(salaryRow);
+  const vals = DRAFTABLE_POSITIONS.map((p) => salaryRow[p]);
   return vals.reduce((s, v) => s + v, 0) / vals.length;
 }
 

--- a/src/utils/future-draft-picks-utils.ts
+++ b/src/utils/future-draft-picks-utils.ts
@@ -141,8 +141,8 @@ export function getDraftCapitalSummary(
  */
 export function getDraftCapitalFromDraftResults(
   data: any
-): Map<string, { total: number; byRound: Map<number, number> }> {
-  const summary = new Map<string, { total: number; byRound: Map<number, number> }>();
+): Map<string, { total: number; byRound: Map<number, number>; picks: { round: number; pickInRound: number }[] }> {
+  const summary = new Map<string, { total: number; byRound: Map<number, number>; picks: { round: number; pickInRound: number }[] }>();
 
   const picks = data?.draftResults?.draftUnit?.draftPick;
   if (!Array.isArray(picks)) return summary;
@@ -152,15 +152,17 @@ export function getDraftCapitalFromDraftResults(
     if (!franchiseId) continue;
 
     const round = parseInt(pick.round, 10);
+    const pickInRound = parseInt(pick.pick, 10);
 
     let entry = summary.get(franchiseId);
     if (!entry) {
-      entry = { total: 0, byRound: new Map() };
+      entry = { total: 0, byRound: new Map(), picks: [] };
       summary.set(franchiseId, entry);
     }
 
     entry.total++;
     entry.byRound.set(round, (entry.byRound.get(round) || 0) + 1);
+    entry.picks.push({ round, pickInRound });
   }
 
   return summary;

--- a/src/utils/league-summary-utils.ts
+++ b/src/utils/league-summary-utils.ts
@@ -17,8 +17,9 @@ import {
   type CapPlayer,
   type DeadMoneyAdjustment,
 } from './salary-calculations';
+import { calculateTeamRookieReserve } from './draft-pick-cap-impact';
 import { parseNumber } from './formatters';
-export type DraftCapitalMap = Map<string, { total: number; byRound: Map<number, number> }>;
+export type DraftCapitalMap = Map<string, { total: number; byRound: Map<number, number>; picks: { round: number; pickInRound: number }[] }>;
 
 // ---------------------------------------------------------------------------
 // Types
@@ -108,7 +109,7 @@ export const CATEGORY_DEFINITIONS: CategoryDefinition[] = [
   {
     id: 'effectiveCapSpace',
     name: 'Effective Cap Space',
-    description: 'Cap space minus $5M rookie reserve',
+    description: 'Cap space minus estimated rookie salary obligations based on draft picks owned',
     milestone: 1,
     format: 'compactCurrency',
     direction: 'asc',
@@ -344,8 +345,12 @@ export function computeLeagueSummary(
       // 2. Dead money
       deadMoneyArr.push(deadMoney[i] ?? 0);
 
-      // 3. Effective cap space
-      effectiveCapSpaceArr.push(cs - RESERVE_FOR_ROOKIES);
+      // 3. Effective cap space — reserve based on team's actual draft picks
+      const teamDraftData = draftCapitalMap.get(team.franchiseId);
+      const rookieReserve = (i === 0 && teamDraftData?.picks?.length)
+        ? calculateTeamRookieReserve(teamDraftData.picks)
+        : RESERVE_FOR_ROOKIES;
+      effectiveCapSpaceArr.push(cs - rookieReserve);
 
       // 4. Average age of players still under contract
       const ages = underContract

--- a/tests/league-summary-utils.test.ts
+++ b/tests/league-summary-utils.test.ts
@@ -300,6 +300,7 @@ describe('computeLeagueSummary draft capital', () => {
       ['0001', {
         total: 4,
         byRound: new Map([[1, 1], [2, 2], [3, 1]]),
+        picks: [{ round: 1, pickInRound: 1 }, { round: 2, pickInRound: 1 }, { round: 2, pickInRound: 2 }, { round: 3, pickInRound: 1 }],
       }],
     ]);
     const teams = [makeTeam()];


### PR DESCRIPTION
## Summary
Replace the fixed $5M rookie reserve with a dynamic calculation based on a team's actual draft picks and their slotted salaries. This provides a more accurate representation of rookie salary obligations.

## Key Changes
- **New utility functions in `draft-pick-cap-impact.ts`**:
  - `calculateAveragePickSalary()`: Computes the average rookie salary across draftable positions (QB/RB/WR/TE) for a given draft slot, excluding PK and DEF which are rarely drafted
  - `calculateTeamRookieReserve()`: Aggregates the estimated rookie salary obligations for all of a team's draft picks

- **Updated `DraftCapitalMap` type** in `league-summary-utils.ts`:
  - Extended to include a `picks` array containing round and pick-in-round information for each team's draft selections

- **Modified effective cap space calculation** in `league-summary-utils.ts`:
  - Now uses `calculateTeamRookieReserve()` with actual draft picks instead of the fixed `RESERVE_FOR_ROOKIES` constant
  - Updated category description to reflect the new calculation method

- **Enhanced `getDraftCapitalFromDraftResults()`** in `future-draft-picks-utils.ts`:
  - Now captures individual pick details (round and pick-in-round) and stores them in the summary map
  - Enables accurate salary calculations based on actual draft slot positions

- **Updated test** in `league-summary-utils.test.ts`:
  - Added `picks` array to test fixture to match new `DraftCapitalMap` structure

## Implementation Details
- The salary calculation uses position-averaged slotted salaries from the `ROOKIE_SALARIES_2026` table
- For Round 3+, falls back to `ROUND_3_FLAT_RATE` averages
- Gracefully handles missing salary data by defaulting to Round 3+ rates

https://claude.ai/code/session_014sAPL7Rc3wHk11kvmA2FGY