### PR TITLE
Reduce minimum width of year options grid in contract modal

### DIFF
--- a/src/components/theleague/ContractDeclarationModal.astro
+++ b/src/components/theleague/ContractDeclarationModal.astro
@@ -747,7 +747,7 @@
      ================================================================ */
   .cdm-year-options {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(4.5rem, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(3.5rem, 1fr));
     gap: 0.5rem;
   }
 


### PR DESCRIPTION
## Summary
Adjusted the grid layout styling for year options in the ContractDeclarationModal component to use a smaller minimum column width, allowing for more compact spacing.

## Key Changes
- Reduced `minmax()` minimum width from `4.5rem` to `3.5rem` in `.cdm-year-options` grid layout
- This change allows year option buttons to display in a tighter grid when space is constrained

## Implementation Details
The modification affects the CSS Grid template for the year selection options, making the grid more responsive to smaller viewport widths or container sizes by reducing the minimum column width by 1rem.

https://claude.ai/code/session_01VZsaJdwZ82F38MxjeuAGs1