### PR TITLE
fix: recognize AUCTION_WON transactions for salary selection eligibility

### DIFF
--- a/src/components/theleague/ContractDeclarationModal.astro
+++ b/src/components/theleague/ContractDeclarationModal.astro
@@ -214,6 +214,7 @@
               <thead>
                 <tr>
                   <th>Season</th>
+                  <th class="cdm-projection-th--salary">Contract</th>
                   <th class="cdm-projection-th--salary">Committed</th>
                   <th class="cdm-projection-th--salary">Available</th>
                 </tr>
@@ -1221,12 +1222,17 @@
   }
 
   .cdm-cap-impact-table :global(td:nth-child(2)),
-  .cdm-cap-impact-table :global(td:nth-child(3)) {
+  .cdm-cap-impact-table :global(td:nth-child(3)),
+  .cdm-cap-impact-table :global(td:nth-child(4)) {
     text-align: right;
     font-weight: 600;
   }
 
-  .cdm-cap-impact-table :global(td:nth-child(3)) {
+  .cdm-cap-impact-table :global(td:nth-child(2)) {
+    color: var(--color-primary, #1e5fa8);
+  }
+
+  .cdm-cap-impact-table :global(td:nth-child(4)) {
     color: var(--color-success, #16a34a);
   }
 

--- a/src/components/theleague/ContractDeclarationModal.astro
+++ b/src/components/theleague/ContractDeclarationModal.astro
@@ -206,6 +206,25 @@
           </div>
         </div>
 
+        <!-- Team Cap Impact (shown alongside salary projection) -->
+        <div class="cdm-section" id="cdm-cap-impact-section" style="display: none;">
+          <h4 class="cdm-section__title">Team Cap Impact</h4>
+          <div class="cdm-projection-wrapper">
+            <table class="cdm-cap-impact-table">
+              <thead>
+                <tr>
+                  <th>Season</th>
+                  <th class="cdm-projection-th--salary">Committed</th>
+                  <th class="cdm-projection-th--salary">Available</th>
+                </tr>
+              </thead>
+              <tbody id="cdm-cap-impact-body">
+                <!-- Populated by JS -->
+              </tbody>
+            </table>
+          </div>
+        </div>
+
       </div><!-- /cdm-review-panel -->
     </div><!-- /cdm-body -->
 
@@ -1169,6 +1188,57 @@
   }
 
   .cdm-projection-table :global(tbody tr:hover) {
+    background: var(--color-gray-50, #f9fafb);
+  }
+
+  /* ================================================================
+     Team Cap Impact Table
+     ================================================================ */
+  .cdm-cap-impact-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.8125rem;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .cdm-cap-impact-table th {
+    background: var(--color-gray-50, #f9fafb);
+    color: var(--color-gray-400, #9ca3af);
+    font-weight: 600;
+    font-size: 0.625rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    padding: 0.4rem 0.75rem;
+    text-align: left;
+    border-bottom: 1px solid var(--content-border, #e2e8f0);
+  }
+
+  .cdm-cap-impact-table :global(td) {
+    padding: 0.4rem 0.75rem;
+    color: var(--color-gray-700, #374151);
+    border-bottom: 1px solid var(--color-gray-50, #f9fafb);
+    font-size: 0.8125rem;
+  }
+
+  .cdm-cap-impact-table :global(td:nth-child(2)),
+  .cdm-cap-impact-table :global(td:nth-child(3)) {
+    text-align: right;
+    font-weight: 600;
+  }
+
+  .cdm-cap-impact-table :global(td:nth-child(3)) {
+    color: var(--color-success, #16a34a);
+  }
+
+  .cdm-cap-impact-table :global(.cap-over) {
+    color: var(--color-error, #dc2626) !important;
+  }
+
+  .cdm-cap-impact-table :global(tr:last-child td) {
+    border-bottom: none;
+  }
+
+  .cdm-cap-impact-table :global(tbody tr:hover) {
     background: var(--color-gray-50, #f9fafb);
   }
 

--- a/src/config/nav-config.json
+++ b/src/config/nav-config.json
@@ -117,6 +117,14 @@
           "description": "Coach mode with matchups & odds"
         },
         {
+          "id": "contracts",
+          "label": "My Contracts",
+          "icon": "file-text",
+          "path": "/contracts/manage",
+          "external": false,
+          "description": "View and manage your contract declarations"
+        },
+        {
           "id": "trade-builder",
           "label": "Trade Builder",
           "icon": "transactions-2",
@@ -269,6 +277,7 @@
     "/draft-predictor": "/draft-predictor",
     "/icons": "/icons",
     "/assets": "/assets",
+    "/contracts/manage": "/contracts/manage",
     "/trade-builder": "/trade-builder",
     "/players": "/players",
     "/calendar": "/calendar",

--- a/src/pages/api/contracts/approve.ts
+++ b/src/pages/api/contracts/approve.ts
@@ -44,7 +44,7 @@ export const POST: APIRoute = async ({ request }) => {
       );
     }
 
-    const declaration = getDeclarationById(declarationId);
+    const declaration = await getDeclarationById(declarationId);
     if (!declaration) {
       return new Response(
         JSON.stringify({ error: 'Declaration not found' }),
@@ -61,7 +61,7 @@ export const POST: APIRoute = async ({ request }) => {
       );
     }
 
-    const updated = updateDeclaration(declarationId, {
+    const updated = await updateDeclaration(declarationId, {
       status: 'approved',
       reviewedBy: user.name || user.id,
       reviewedAt: new Date().toISOString(),
@@ -83,14 +83,14 @@ export const POST: APIRoute = async ({ request }) => {
     });
 
     if (mflResult.success) {
-      updateDeclaration(declarationId, {
+      await updateDeclaration(declarationId, {
         status: 'applied',
         mflSynced: true,
         mflSyncedAt: new Date().toISOString(),
       });
     } else {
       // Approved but MFL write failed — mark the error but keep approved status
-      updateDeclaration(declarationId, {
+      await updateDeclaration(declarationId, {
         mflError: mflResult.error,
       });
     }

--- a/src/pages/api/contracts/declare.ts
+++ b/src/pages/api/contracts/declare.ts
@@ -11,6 +11,7 @@ import { validateContractSubmission } from '../../../utils/contract-validation';
 import {
   generateDeclarationId,
   addDeclaration,
+  updateDeclaration,
   getPendingDeclarationForPlayer,
   getTeamFranchiseTag,
   getTeamExtension,
@@ -95,15 +96,25 @@ export const POST: APIRoute = async ({ request }) => {
       );
     }
 
-    // 5. Check for existing pending declaration on this player
+    // 5. Check for existing pending declaration — update it if found
     const existing = await getPendingDeclarationForPlayer(playerId, franchiseId);
-    if (existing) {
+    if (existing && existing.status === 'pending') {
+      await updateDeclaration(existing.id, {
+        requestedYears,
+        requestedSalary,
+        requestedContractInfo,
+        submittedAt: new Date().toISOString(),
+      });
+
       return new Response(
         JSON.stringify({
-          error: 'A pending declaration already exists for this player',
-          existingDeclarationId: existing.id,
+          success: true,
+          declarationId: existing.id,
+          status: 'pending',
+          updated: true,
+          message: 'Declaration updated',
         }),
-        { status: 409, headers: JSON_HEADERS },
+        { status: 200, headers: JSON_HEADERS },
       );
     }
 

--- a/src/pages/api/contracts/declare.ts
+++ b/src/pages/api/contracts/declare.ts
@@ -96,7 +96,7 @@ export const POST: APIRoute = async ({ request }) => {
     }
 
     // 5. Check for existing pending declaration on this player
-    const existing = getPendingDeclarationForPlayer(playerId, franchiseId);
+    const existing = await getPendingDeclarationForPlayer(playerId, franchiseId);
     if (existing) {
       return new Response(
         JSON.stringify({
@@ -109,7 +109,7 @@ export const POST: APIRoute = async ({ request }) => {
 
     // 6. Type-specific validations
     if (type === 'franchise-tag') {
-      const existingTag = getTeamFranchiseTag(franchiseId, new Date().getFullYear());
+      const existingTag = await getTeamFranchiseTag(franchiseId, new Date().getFullYear());
       if (existingTag) {
         return new Response(
           JSON.stringify({ error: 'Your team has already used its franchise tag this year' }),
@@ -120,7 +120,7 @@ export const POST: APIRoute = async ({ request }) => {
 
     // team-option counts as an extension (exercise or rookie extension both use the same limit)
     if (type === 'veteran-extension' || type === 'rookie-extension' || type === 'team-option') {
-      const existingExt = getTeamExtension(franchiseId, new Date().getFullYear());
+      const existingExt = await getTeamExtension(franchiseId, new Date().getFullYear());
       if (existingExt) {
         return new Response(
           JSON.stringify({ error: 'Your team has already used its extension this season' }),
@@ -152,7 +152,7 @@ export const POST: APIRoute = async ({ request }) => {
       acquisitionTimestamp,
     };
 
-    addDeclaration(declaration);
+    await addDeclaration(declaration);
 
     return new Response(
       JSON.stringify({

--- a/src/pages/api/contracts/declare.ts
+++ b/src/pages/api/contracts/declare.ts
@@ -165,8 +165,9 @@ export const POST: APIRoute = async ({ request }) => {
     );
   } catch (error) {
     console.error('Contract declaration error:', error);
+    const message = error instanceof Error ? error.message : 'Internal server error';
     return new Response(
-      JSON.stringify({ error: 'Internal server error' }),
+      JSON.stringify({ error: message }),
       { status: 500, headers: JSON_HEADERS },
     );
   }

--- a/src/pages/api/contracts/pending.ts
+++ b/src/pages/api/contracts/pending.ts
@@ -28,7 +28,7 @@ export const GET: APIRoute = async ({ request }) => {
       );
     }
 
-    const pending = getPendingDeclarations();
+    const pending = await getPendingDeclarations();
 
     return new Response(
       JSON.stringify({ declarations: pending }),

--- a/src/pages/api/contracts/reject.ts
+++ b/src/pages/api/contracts/reject.ts
@@ -44,7 +44,7 @@ export const POST: APIRoute = async ({ request }) => {
       );
     }
 
-    const declaration = getDeclarationById(declarationId);
+    const declaration = await getDeclarationById(declarationId);
     if (!declaration) {
       return new Response(
         JSON.stringify({ error: 'Declaration not found' }),
@@ -61,7 +61,7 @@ export const POST: APIRoute = async ({ request }) => {
       );
     }
 
-    const updated = updateDeclaration(declarationId, {
+    const updated = await updateDeclaration(declarationId, {
       status: 'rejected',
       reviewedBy: user.name || user.id,
       reviewedAt: new Date().toISOString(),

--- a/src/pages/theleague/contracts/franchise-tags.astro
+++ b/src/pages/theleague/contracts/franchise-tags.astro
@@ -12,7 +12,7 @@ if (!user || !isAdminFranchise(user.franchiseId)) {
 }
 
 const leagueYear = getCurrentLeagueYear();
-const tags = getFranchiseTagsByYear(leagueYear);
+const tags = await getFranchiseTagsByYear(leagueYear);
 
 // Sort: pending first, then approved, then by submission date
 const sorted = [...tags].sort((a, b) => {

--- a/src/pages/theleague/contracts/manage.astro
+++ b/src/pages/theleague/contracts/manage.astro
@@ -3,8 +3,8 @@ import TheLeagueLayout from '../../../layouts/TheLeagueLayout.astro';
 import { getPendingDeclarations, getDeclarations } from '../../../utils/contract-storage';
 
 // Load declaration data at build/request time
-const pending = getPendingDeclarations();
-const allDeclarations = getDeclarations();
+const pending = await getPendingDeclarations();
+const allDeclarations = await getDeclarations();
 const recentDecisions = allDeclarations
   .filter(d => d.status === 'approved' || d.status === 'rejected' || d.status === 'applied')
   .slice(0, 20);

--- a/src/pages/theleague/rosters.astro
+++ b/src/pages/theleague/rosters.astro
@@ -3920,6 +3920,11 @@ const r = (path: string) => resolveLeaguePath(path, hideLeaguePrefix);
     font-style: italic;
   }
 
+  :global(.salary-cell--declared) {
+    color: var(--color-primary, #1e5fa8) !important;
+    font-style: italic;
+  }
+
   :global(.actions-cell) {
     text-align: center;
     vertical-align: middle;
@@ -6526,12 +6531,17 @@ const r = (path: string) => resolveLeaguePath(path, hideLeaguePrefix);
             ? player.nflLogo
             : player.headshot ?? getPlayerHeadshot(player.id, player.espnId);
 
+          // Check for declared contract years (pending or approved)
+          const decl = localDeclarations[player.id] || declarationsByPlayer[player.id];
+          const declaredYears = decl ? (decl.years ?? decl.requestedYears ?? null) : null;
+          const effectiveYears = declaredYears ?? parseInt(displayYears, 10) || 0;
+
           const salaryCells = salaryYears
             .map((year, index) => {
               const columnKey = `year${index + 1}`;
-              const isUfa = !(parseInt(player.contractYears, 10) > index);
-              const isFirstYearUfa = isUfa && parseInt(player.contractYears, 10) === index;
-              const isFutureUfa = isUfa && parseInt(player.contractYears, 10) < index;
+              const isUfa = !(effectiveYears > index);
+              const isFirstYearUfa = isUfa && effectiveYears === index;
+              const isFutureUfa = isUfa && effectiveYears < index;
 
               let value;
               let cellClass = 'salary-cell gm-col';
@@ -6564,6 +6574,8 @@ const r = (path: string) => resolveLeaguePath(path, hideLeaguePrefix);
                 value = '—';
                 cellClass += ' salary-cell--future-ufa';
               } else {
+                const originalYears = parseInt(player.contractYears, 10) || 0;
+                const isDeclaredYear = declaredYears && index >= originalYears;
                 if (action && action.type === 'extension' && action.salaryBreakdown) {
                   cellClass += ' salary-cell--simulated';
                   const yearKey = `year${index}`;
@@ -6573,6 +6585,7 @@ const r = (path: string) => resolveLeaguePath(path, hideLeaguePrefix);
                   const baseSalary = Number(player.salary ?? 0);
                   const escalatedSalary = Math.round(baseSalary * Math.pow(1.1, index));
                   value = _capSpaceFmt.format(escalatedSalary);
+                  if (isDeclaredYear) cellClass += ' salary-cell--declared';
                 }
               }
 
@@ -6948,7 +6961,12 @@ const r = (path: string) => resolveLeaguePath(path, hideLeaguePrefix);
             return sum;
           }
 
-          if ((player.contractYears ?? 0) > index) {
+          // Use declared contract years if available
+          const decl = localDeclarations[player.id] || declarationsByPlayer[player.id];
+          const declYears = decl ? (decl.years ?? decl.requestedYears ?? null) : null;
+          const effectiveContractYears = declYears ?? (player.contractYears ?? 0);
+
+          if (effectiveContractYears > index) {
             const isCurrent = index === 0;
             const tagRaw = (player.displayTag ?? player.status ?? 'ACTIVE').toString().toUpperCase();
             const tag = tagRaw.includes('PRACTICE')

--- a/src/pages/theleague/rosters.astro
+++ b/src/pages/theleague/rosters.astro
@@ -6534,7 +6534,7 @@ const r = (path: string) => resolveLeaguePath(path, hideLeaguePrefix);
           // Check for declared contract years (pending or approved)
           const decl = localDeclarations[player.id] || declarationsByPlayer[player.id];
           const declaredYears = decl ? (decl.years ?? decl.requestedYears ?? null) : null;
-          const effectiveYears = declaredYears ?? parseInt(displayYears, 10) || 0;
+          const effectiveYears = declaredYears ?? (parseInt(displayYears, 10) || 0);
 
           const salaryCells = salaryYears
             .map((year, index) => {
@@ -6964,7 +6964,7 @@ const r = (path: string) => resolveLeaguePath(path, hideLeaguePrefix);
           // Use declared contract years if available
           const decl = localDeclarations[player.id] || declarationsByPlayer[player.id];
           const declYears = decl ? (decl.years ?? decl.requestedYears ?? null) : null;
-          const effectiveContractYears = declYears ?? (player.contractYears ?? 0);
+          const effectiveContractYears = declYears != null ? declYears : (player.contractYears ?? 0);
 
           if (effectiveContractYears > index) {
             const isCurrent = index === 0;

--- a/src/pages/theleague/rosters.astro
+++ b/src/pages/theleague/rosters.astro
@@ -7829,6 +7829,7 @@ const r = (path: string) => resolveLeaguePath(path, hideLeaguePrefix);
         document.getElementById('cdm-ext-current').textContent = formatSalaryCompact(elig.currentSalary);
         document.getElementById('cdm-ext-new').textContent = formatSalaryCompact(extSalary);
         updateProjectionTable(extSalary, extYears, null, config.salaryYears?.[0]);
+        updateCapImpact(extSalary, extYears, config.salaryYears?.[0]);
         cdmSelectedYears = extYears;
         cdmSelectedSalary = extSalary;
         cdmSubmitBtn.disabled = false;
@@ -7867,6 +7868,7 @@ const r = (path: string) => resolveLeaguePath(path, hideLeaguePrefix);
             cdmSelectedYears = yr;
             cdmSubmitBtn.disabled = false;
             updateProjectionTable(elig.currentSalary, yr, null, config.salaryYears?.[0]);
+            updateCapImpact(elig.currentSalary, yr, config.salaryYears?.[0]);
           });
           yearContainer.appendChild(btn);
         });
@@ -7879,6 +7881,7 @@ const r = (path: string) => resolveLeaguePath(path, hideLeaguePrefix);
             cdmSelectedYears = preSelectedYears;
             cdmSubmitBtn.disabled = false;
             updateProjectionTable(elig.currentSalary, preSelectedYears, null, config.salaryYears?.[0]);
+            updateCapImpact(elig.currentSalary, preSelectedYears, config.salaryYears?.[0]);
           }
         }
       }
@@ -7909,6 +7912,7 @@ const r = (path: string) => resolveLeaguePath(path, hideLeaguePrefix);
       document.getElementById('cdm-extension-section').style.display = 'none';
       document.getElementById('cdm-formula-section').style.display = 'none';
       document.getElementById('cdm-projection-section').style.display = 'none';
+      document.getElementById('cdm-cap-impact-section').style.display = 'none';
 
       // Clear year selection and disable submit
       document.querySelectorAll('.cdm-year-btn').forEach(b => b.classList.remove('selected'));
@@ -7953,6 +7957,57 @@ const r = (path: string) => resolveLeaguePath(path, hideLeaguePrefix);
         tr.appendChild(tdYear);
         tr.appendChild(tdAge);
         tr.appendChild(tdSalary);
+        tbody.appendChild(tr);
+      }
+      section.style.display = '';
+    };
+
+    /**
+     * Show team cap impact for each year of the proposed contract.
+     * Uses lastViewContext (current team's cap charges) to show
+     * committed salary and available cap space per season.
+     */
+    const updateCapImpact = (playerBaseSalary, years, startYear = null) => {
+      const section = document.getElementById('cdm-cap-impact-section');
+      const tbody = document.getElementById('cdm-cap-impact-body');
+      if (!section || !tbody) return;
+
+      const ctx = lastViewContext;
+      if (!ctx || !ctx.capChargesWithDead) {
+        section.style.display = 'none';
+        return;
+      }
+
+      const teamCapCharges = ctx.capChargesWithDead;
+      const capLimitForSeason = ctx.capLimitForSeason ?? capLimit ?? 45_000_000;
+      const salary = Number(playerBaseSalary) || 0;
+      const yr0 = startYear ?? (salaryYears[0] || 2026);
+
+      tbody.replaceChildren();
+      for (let i = 0; i < years; i++) {
+        const playerSalaryThisYear = Math.round(salary * Math.pow(ESCALATION_RATE, i));
+        const existingCharge = teamCapCharges[i] ?? 0;
+        const newCommitted = existingCharge + playerSalaryThisYear;
+        const available = capLimitForSeason - newCommitted;
+
+        const tr = document.createElement('tr');
+
+        const tdYear = document.createElement('td');
+        tdYear.textContent = String(yr0 + i);
+
+        const tdCommitted = document.createElement('td');
+        tdCommitted.textContent = formatSalaryCompact(newCommitted);
+
+        const tdAvailable = document.createElement('td');
+        tdAvailable.textContent = formatSalaryCompact(Math.abs(available));
+        if (available < 0) {
+          tdAvailable.classList.add('cap-over');
+          tdAvailable.textContent = '-' + tdAvailable.textContent;
+        }
+
+        tr.appendChild(tdYear);
+        tr.appendChild(tdCommitted);
+        tr.appendChild(tdAvailable);
         tbody.appendChild(tr);
       }
       section.style.display = '';
@@ -8044,6 +8099,7 @@ const r = (path: string) => resolveLeaguePath(path, hideLeaguePrefix);
 
           const playerAge = data.birthdate ? calculateAge(data.birthdate) : null;
           updateProjectionTable(newSalary, existingYears + yr, playerAge, config.salaryYears?.[0]);
+          updateCapImpact(newSalary, existingYears + yr, config.salaryYears?.[0]);
 
           if (formulaSection) {
             formulaSection.style.display = '';
@@ -8388,6 +8444,7 @@ const r = (path: string) => resolveLeaguePath(path, hideLeaguePrefix);
       document.getElementById('cdm-extension-section').style.display = 'none';
       document.getElementById('cdm-formula-section').style.display = 'none';
       document.getElementById('cdm-projection-section').style.display = 'none';
+      document.getElementById('cdm-cap-impact-section').style.display = 'none';
 
       const metricsEl = document.getElementById('cdm-metrics');
       if (metricsEl) metricsEl.style.display = 'none';
@@ -8450,6 +8507,7 @@ const r = (path: string) => resolveLeaguePath(path, hideLeaguePrefix);
 
       const playerAge = cdmPlayerData.birthdate ? calculateAge(cdmPlayerData.birthdate) : null;
       updateProjectionTable(tagSalary, 1, playerAge, config.salaryYears?.[0]);
+      updateCapImpact(tagSalary, 1, config.salaryYears?.[0]);
 
       const reviewPanel = document.getElementById('cdm-review-panel');
       if (reviewPanel) {
@@ -8514,6 +8572,7 @@ const r = (path: string) => resolveLeaguePath(path, hideLeaguePrefix);
       const playerAge = cdmPlayerData.birthdate ? calculateAge(cdmPlayerData.birthdate) : null;
       const ageAtOption = playerAge !== null ? playerAge + elig.currentYears : null;
       updateProjectionTable(optionSalary, 1, ageAtOption, teamOptionYear);
+      updateCapImpact(optionSalary, 1, teamOptionYear);
 
       const reviewPanel = document.getElementById('cdm-review-panel');
       if (reviewPanel) {
@@ -8631,6 +8690,7 @@ const r = (path: string) => resolveLeaguePath(path, hideLeaguePrefix);
 
       const playerAge = cdmPlayerData.birthdate ? calculateAge(cdmPlayerData.birthdate) : null;
       updateProjectionTable(newSalary, denominator, playerAge, config.salaryYears?.[0]);
+      updateCapImpact(newSalary, denominator, config.salaryYears?.[0]);
 
       const reviewPanel = document.getElementById('cdm-review-panel');
       if (reviewPanel) {
@@ -8689,6 +8749,7 @@ const r = (path: string) => resolveLeaguePath(path, hideLeaguePrefix);
       document.getElementById('cdm-extension-section').style.display = 'none';
       document.getElementById('cdm-formula-section').style.display = 'none';
       document.getElementById('cdm-projection-section').style.display = 'none';
+      document.getElementById('cdm-cap-impact-section').style.display = 'none';
 
       const yearSection = document.getElementById('cdm-year-section');
       if (yearSection) yearSection.style.display = '';

--- a/src/pages/theleague/rosters.astro
+++ b/src/pages/theleague/rosters.astro
@@ -7995,6 +7995,9 @@ const r = (path: string) => resolveLeaguePath(path, hideLeaguePrefix);
         const tdYear = document.createElement('td');
         tdYear.textContent = String(yr0 + i);
 
+        const tdContract = document.createElement('td');
+        tdContract.textContent = formatSalaryCompact(playerSalaryThisYear);
+
         const tdCommitted = document.createElement('td');
         tdCommitted.textContent = formatSalaryCompact(newCommitted);
 
@@ -8006,6 +8009,7 @@ const r = (path: string) => resolveLeaguePath(path, hideLeaguePrefix);
         }
 
         tr.appendChild(tdYear);
+        tr.appendChild(tdContract);
         tr.appendChild(tdCommitted);
         tr.appendChild(tdAvailable);
         tbody.appendChild(tr);

--- a/src/pages/theleague/rosters.astro
+++ b/src/pages/theleague/rosters.astro
@@ -1984,7 +1984,7 @@ if (testEligibility) {
 }
 
 // Load existing declarations for indicator display
-const allDeclarations = getDeclarations();
+const allDeclarations = await getDeclarations();
 const declarationsByPlayer: Record<string, { status: string; type: string; requestedYears: number }> = {};
 for (const decl of allDeclarations) {
   if (decl.status === 'pending' || decl.status === 'approved') {

--- a/src/utils/contract-eligibility.ts
+++ b/src/utils/contract-eligibility.ts
@@ -23,7 +23,7 @@ const IN_SEASON_DEADLINE_MS = 24 * 60 * 60 * 1000;  // 24 hours
 const OFFSEASON_DEADLINE_MS = 48 * 60 * 60 * 1000;   // 48 hours
 
 // Transaction types that represent new player acquisitions (not trades)
-const ACQUISITION_TYPES = ['BBID_WAIVER', 'FREE_AGENT'];
+const ACQUISITION_TYPES = ['BBID_WAIVER', 'FREE_AGENT', 'AUCTION_WON'];
 
 /**
  * Parse the MFL transaction string format into added/dropped player IDs.
@@ -33,6 +33,7 @@ const ACQUISITION_TYPES = ['BBID_WAIVER', 'FREE_AGENT'];
  *   "addId|dropId,"       -> add/drop swap
  *   "addId|,"             -> add only (no drop)
  *   "addId,|bbid|dropId," -> BBID add/drop with bid amount
+ *   "playerId|amount|"    -> auction won (AUCTION_WON)
  *   ""                    -> empty (batch marker like BBID_AUTO_PROCESS_WAIVERS)
  */
 export function parseTransactionString(txnString: string): {
@@ -75,6 +76,14 @@ export function parseTransactionString(txnString: string): {
       }
     }
     return { addedPlayerIds, droppedPlayerIds };
+  }
+
+  // Auction format: "playerId|amount|" (no commas, trailing pipe)
+  const auctionMatch = txnString.match(/^(\d+)\|(\d+)\|$/);
+  if (auctionMatch) {
+    addedPlayerIds.push(auctionMatch[1]);
+    bbidAmount = parseInt(auctionMatch[2], 10);
+    return { addedPlayerIds, droppedPlayerIds, bbidAmount };
   }
 
   // Add/drop swap: "addId|dropId," or "addId|,"

--- a/src/utils/contract-storage.ts
+++ b/src/utils/contract-storage.ts
@@ -1,41 +1,44 @@
 /**
  * Contract Declaration Storage
  *
- * Stores contract declarations in Upstash Redis (production/Vercel)
+ * Stores contract declarations in Vercel Blob (production/preview)
  * with filesystem fallback for local development.
- * Follows the same pattern as custom-rankings-storage / cr.ts.
  */
 
 import type { ContractDeclaration, DeclarationStatus } from '../types/contracts';
 
-const REDIS_KEY = 'contract-declarations';
+const BLOB_PATH = 'data/contract-declarations.json';
 
-type RedisClient = {
-  get: <T>(key: string) => Promise<T | null>;
-  set: (key: string, value: unknown) => Promise<unknown>;
-};
+// --- Vercel Blob helpers ---
 
-let _redis: RedisClient | null | undefined;
+async function readFromBlob(): Promise<ContractDeclaration[] | null> {
+  try {
+    const { list: listBlobs } = await import('@vercel/blob');
+    const { blobs } = await listBlobs({ prefix: BLOB_PATH, limit: 1 });
+    if (blobs.length === 0) return [];
 
-async function getRedis(): Promise<RedisClient | null> {
-  if (_redis !== undefined) return _redis;
-
-  const url = process.env.UPSTASH_REDIS_REST_URL || process.env.KV_REST_API_URL;
-  const token = process.env.UPSTASH_REDIS_REST_TOKEN || process.env.KV_REST_API_TOKEN;
-  if (!url || !token) {
-    console.warn('[contract-storage] Redis env vars missing. UPSTASH_REDIS_REST_URL:', !!process.env.UPSTASH_REDIS_REST_URL, 'KV_REST_API_URL:', !!process.env.KV_REST_API_URL);
-    _redis = null;
+    const res = await fetch(blobs[0].url);
+    if (!res.ok) return null;
+    const data = await res.json() as ContractDeclaration[];
+    return data;
+  } catch (err) {
+    console.error('[contract-storage] Blob read error:', err);
     return null;
   }
+}
 
+async function writeToBlob(declarations: ContractDeclaration[]): Promise<boolean> {
   try {
-    const { Redis } = await import('@upstash/redis');
-    _redis = new Redis({ url, token });
-    return _redis;
+    const { put } = await import('@vercel/blob');
+    await put(BLOB_PATH, JSON.stringify(declarations), {
+      access: 'public',
+      addRandomSuffix: false,
+      contentType: 'application/json',
+    });
+    return true;
   } catch (err) {
-    console.error('[contract-storage] Failed to import @upstash/redis:', err);
-    _redis = null;
-    return null;
+    console.error('[contract-storage] Blob write error:', err);
+    return false;
   }
 }
 
@@ -73,23 +76,18 @@ function writeDeclarationsFileSync(file: DeclarationsFile): void {
 // --- Unified async read/write ---
 
 async function readAllDeclarations(): Promise<ContractDeclaration[]> {
-  const redis = await getRedis();
-  if (redis) {
-    const data = await redis.get<ContractDeclaration[]>(REDIS_KEY);
+  if (process.env.VERCEL) {
+    const data = await readFromBlob();
     return data ?? [];
   }
   return readDeclarationsFileSync().declarations;
 }
 
 async function writeAllDeclarations(declarations: ContractDeclaration[]): Promise<void> {
-  const redis = await getRedis();
-  if (redis) {
-    await redis.set(REDIS_KEY, declarations);
-    return;
-  }
-  // On Vercel the filesystem is read-only — don't attempt file writes
   if (process.env.VERCEL) {
-    throw new Error('Storage not configured: Upstash Redis credentials are missing');
+    const ok = await writeToBlob(declarations);
+    if (!ok) throw new Error('Failed to write declarations to Vercel Blob');
+    return;
   }
   writeDeclarationsFileSync({
     version: '1.0',

--- a/src/utils/contract-storage.ts
+++ b/src/utils/contract-storage.ts
@@ -85,6 +85,10 @@ async function writeAllDeclarations(declarations: ContractDeclaration[]): Promis
     await redis.set(REDIS_KEY, declarations);
     return;
   }
+  // On Vercel the filesystem is read-only — don't attempt file writes
+  if (process.env.VERCEL) {
+    throw new Error('Storage not configured: Upstash Redis credentials are missing');
+  }
   writeDeclarationsFileSync({
     version: '1.0',
     lastUpdated: new Date().toISOString(),

--- a/src/utils/contract-storage.ts
+++ b/src/utils/contract-storage.ts
@@ -1,13 +1,45 @@
 /**
  * Contract Declaration Storage
  *
- * Reads and writes contract declarations to a JSON file.
- * Follows the existing codebase pattern of JSON file caching in data/theleague/.
+ * Stores contract declarations in Upstash Redis (production/Vercel)
+ * with filesystem fallback for local development.
+ * Follows the same pattern as custom-rankings-storage / cr.ts.
  */
 
+import type { ContractDeclaration, DeclarationStatus } from '../types/contracts';
+
+const REDIS_KEY = 'contract-declarations';
+
+type RedisClient = {
+  get: <T>(key: string) => Promise<T | null>;
+  set: (key: string, value: unknown) => Promise<unknown>;
+};
+
+let _redis: RedisClient | null | undefined;
+
+async function getRedis(): Promise<RedisClient | null> {
+  if (_redis !== undefined) return _redis;
+
+  const url = process.env.UPSTASH_REDIS_REST_URL || process.env.KV_REST_API_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN || process.env.KV_REST_API_TOKEN;
+  if (!url || !token) {
+    _redis = null;
+    return null;
+  }
+
+  try {
+    const { Redis } = await import('@upstash/redis');
+    _redis = new Redis({ url, token });
+    return _redis;
+  } catch {
+    _redis = null;
+    return null;
+  }
+}
+
+// --- Filesystem fallback for local dev ---
 import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
 import { join, dirname } from 'node:path';
-import type { ContractDeclaration, DeclarationStatus } from '../types/contracts';
 
 const DECLARATIONS_PATH = join(
   process.cwd(),
@@ -20,31 +52,47 @@ interface DeclarationsFile {
   declarations: ContractDeclaration[];
 }
 
-function ensureDirectoryExists(filePath: string): void {
-  const dir = dirname(filePath);
-  if (!existsSync(dir)) {
-    mkdirSync(dir, { recursive: true });
-  }
-}
-
-function readDeclarationsFile(): DeclarationsFile {
+function readDeclarationsFileSync(): DeclarationsFile {
   try {
     const data = readFileSync(DECLARATIONS_PATH, 'utf-8');
     return JSON.parse(data);
   } catch {
-    return {
-      version: '1.0',
-      lastUpdated: new Date().toISOString(),
-      declarations: [],
-    };
+    return { version: '1.0', lastUpdated: new Date().toISOString(), declarations: [] };
   }
 }
 
-function writeDeclarationsFile(file: DeclarationsFile): void {
-  ensureDirectoryExists(DECLARATIONS_PATH);
+function writeDeclarationsFileSync(file: DeclarationsFile): void {
+  const dir = dirname(DECLARATIONS_PATH);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
   file.lastUpdated = new Date().toISOString();
   writeFileSync(DECLARATIONS_PATH, JSON.stringify(file, null, 2), 'utf-8');
 }
+
+// --- Unified async read/write ---
+
+async function readAllDeclarations(): Promise<ContractDeclaration[]> {
+  const redis = await getRedis();
+  if (redis) {
+    const data = await redis.get<ContractDeclaration[]>(REDIS_KEY);
+    return data ?? [];
+  }
+  return readDeclarationsFileSync().declarations;
+}
+
+async function writeAllDeclarations(declarations: ContractDeclaration[]): Promise<void> {
+  const redis = await getRedis();
+  if (redis) {
+    await redis.set(REDIS_KEY, declarations);
+    return;
+  }
+  writeDeclarationsFileSync({
+    version: '1.0',
+    lastUpdated: new Date().toISOString(),
+    declarations,
+  });
+}
+
+// --- Public API (all async) ---
 
 /** Generate a unique declaration ID */
 export function generateDeclarationId(): string {
@@ -54,61 +102,65 @@ export function generateDeclarationId(): string {
 }
 
 /** Get all declarations */
-export function getDeclarations(): ContractDeclaration[] {
-  return readDeclarationsFile().declarations;
+export async function getDeclarations(): Promise<ContractDeclaration[]> {
+  return readAllDeclarations();
 }
 
 /** Get declarations filtered by status */
-export function getDeclarationsByStatus(status: DeclarationStatus): ContractDeclaration[] {
-  return getDeclarations().filter(d => d.status === status);
+export async function getDeclarationsByStatus(status: DeclarationStatus): Promise<ContractDeclaration[]> {
+  const all = await readAllDeclarations();
+  return all.filter(d => d.status === status);
 }
 
 /** Get pending declarations (for commissioner dashboard) */
-export function getPendingDeclarations(): ContractDeclaration[] {
+export async function getPendingDeclarations(): Promise<ContractDeclaration[]> {
   return getDeclarationsByStatus('pending');
 }
 
 /** Get declarations for a specific franchise */
-export function getDeclarationsByFranchise(franchiseId: string): ContractDeclaration[] {
-  return getDeclarations().filter(d => d.franchiseId === franchiseId);
+export async function getDeclarationsByFranchise(franchiseId: string): Promise<ContractDeclaration[]> {
+  const all = await readAllDeclarations();
+  return all.filter(d => d.franchiseId === franchiseId);
 }
 
 /** Get a single declaration by ID */
-export function getDeclarationById(id: string): ContractDeclaration | undefined {
-  return getDeclarations().find(d => d.id === id);
+export async function getDeclarationById(id: string): Promise<ContractDeclaration | undefined> {
+  const all = await readAllDeclarations();
+  return all.find(d => d.id === id);
 }
 
 /** Add a new declaration */
-export function addDeclaration(declaration: ContractDeclaration): ContractDeclaration {
-  const file = readDeclarationsFile();
-  file.declarations.unshift(declaration); // Newest first
-  writeDeclarationsFile(file);
+export async function addDeclaration(declaration: ContractDeclaration): Promise<ContractDeclaration> {
+  const all = await readAllDeclarations();
+  all.unshift(declaration); // Newest first
+  await writeAllDeclarations(all);
   return declaration;
 }
 
 /** Update an existing declaration */
-export function updateDeclaration(
+export async function updateDeclaration(
   id: string,
   updates: Partial<ContractDeclaration>,
-): ContractDeclaration | null {
-  const file = readDeclarationsFile();
-  const index = file.declarations.findIndex(d => d.id === id);
+): Promise<ContractDeclaration | null> {
+  const all = await readAllDeclarations();
+  const index = all.findIndex(d => d.id === id);
   if (index === -1) return null;
 
-  file.declarations[index] = { ...file.declarations[index], ...updates };
-  writeDeclarationsFile(file);
-  return file.declarations[index];
+  all[index] = { ...all[index], ...updates };
+  await writeAllDeclarations(all);
+  return all[index];
 }
 
 /**
  * Check if a team has already used their franchise tag for a given league year.
  * Returns the existing tag declaration if found.
  */
-export function getTeamFranchiseTag(
+export async function getTeamFranchiseTag(
   franchiseId: string,
   leagueYear: number,
-): ContractDeclaration | undefined {
-  return getDeclarations().find(
+): Promise<ContractDeclaration | undefined> {
+  const all = await readAllDeclarations();
+  return all.find(
     d =>
       d.franchiseId === franchiseId &&
       d.type === 'franchise-tag' &&
@@ -122,8 +174,9 @@ export function getTeamFranchiseTag(
  * Get all active franchise tags for a given league year (all teams).
  * Used for the franchise tags listing page.
  */
-export function getFranchiseTagsByYear(leagueYear: number): ContractDeclaration[] {
-  return getDeclarations().filter(
+export async function getFranchiseTagsByYear(leagueYear: number): Promise<ContractDeclaration[]> {
+  const all = await readAllDeclarations();
+  return all.filter(
     d =>
       d.type === 'franchise-tag' &&
       d.status !== 'rejected' &&
@@ -136,11 +189,12 @@ export function getFranchiseTagsByYear(leagueYear: number): ContractDeclaration[
  * Check if a team has already used their extension for a given league year.
  * Returns the existing extension declaration if found.
  */
-export function getTeamExtension(
+export async function getTeamExtension(
   franchiseId: string,
   leagueYear: number,
-): ContractDeclaration | undefined {
-  return getDeclarations().find(
+): Promise<ContractDeclaration | undefined> {
+  const all = await readAllDeclarations();
+  return all.find(
     d =>
       d.franchiseId === franchiseId &&
       (d.type === 'veteran-extension' || d.type === 'rookie-extension' || d.type === 'team-option') &&
@@ -154,11 +208,12 @@ export function getTeamExtension(
  * Get pending declaration for a specific player (to support optimistic UI).
  * Returns the most recent non-rejected declaration for this player.
  */
-export function getPendingDeclarationForPlayer(
+export async function getPendingDeclarationForPlayer(
   playerId: string,
   franchiseId: string,
-): ContractDeclaration | undefined {
-  return getDeclarations().find(
+): Promise<ContractDeclaration | undefined> {
+  const all = await readAllDeclarations();
+  return all.find(
     d =>
       d.playerId === playerId &&
       d.franchiseId === franchiseId &&

--- a/src/utils/contract-storage.ts
+++ b/src/utils/contract-storage.ts
@@ -23,6 +23,7 @@ async function getRedis(): Promise<RedisClient | null> {
   const url = process.env.UPSTASH_REDIS_REST_URL || process.env.KV_REST_API_URL;
   const token = process.env.UPSTASH_REDIS_REST_TOKEN || process.env.KV_REST_API_TOKEN;
   if (!url || !token) {
+    console.warn('[contract-storage] Redis env vars missing. UPSTASH_REDIS_REST_URL:', !!process.env.UPSTASH_REDIS_REST_URL, 'KV_REST_API_URL:', !!process.env.KV_REST_API_URL);
     _redis = null;
     return null;
   }
@@ -31,7 +32,8 @@ async function getRedis(): Promise<RedisClient | null> {
     const { Redis } = await import('@upstash/redis');
     _redis = new Redis({ url, token });
     return _redis;
-  } catch {
+  } catch (err) {
+    console.error('[contract-storage] Failed to import @upstash/redis:', err);
     _redis = null;
     return null;
   }

--- a/src/utils/contract-storage.ts
+++ b/src/utils/contract-storage.ts
@@ -33,6 +33,7 @@ async function writeToBlob(declarations: ContractDeclaration[]): Promise<boolean
     await put(BLOB_PATH, JSON.stringify(declarations), {
       access: 'public',
       addRandomSuffix: false,
+      allowOverwrite: true,
       contentType: 'application/json',
     });
     return true;

--- a/tests/contract-declaration-api.test.ts
+++ b/tests/contract-declaration-api.test.ts
@@ -71,57 +71,57 @@ describe('contract-storage', () => {
   });
 
   describe('getDeclarations', () => {
-    it('returns empty array when file does not exist', () => {
+    it('returns empty array when file does not exist', async () => {
       vi.mocked(readFileSync).mockImplementation(() => {
         throw new Error('ENOENT');
       });
-      expect(getDeclarations()).toEqual([]);
+      expect(await getDeclarations()).toEqual([]);
     });
 
-    it('returns declarations from file', () => {
+    it('returns declarations from file', async () => {
       const decl = mockDeclaration();
       setupMockFile([decl]);
-      const result = getDeclarations();
+      const result = await getDeclarations();
       expect(result).toHaveLength(1);
       expect(result[0].id).toBe('DECL_123_abc');
     });
   });
 
   describe('getPendingDeclarations', () => {
-    it('filters to only pending status', () => {
+    it('filters to only pending status', async () => {
       setupMockFile([
         mockDeclaration({ id: '1', status: 'pending' }),
         mockDeclaration({ id: '2', status: 'approved' }),
         mockDeclaration({ id: '3', status: 'pending' }),
         mockDeclaration({ id: '4', status: 'rejected' }),
       ]);
-      const result = getPendingDeclarations();
+      const result = await getPendingDeclarations();
       expect(result).toHaveLength(2);
       expect(result.map(d => d.id)).toEqual(['1', '3']);
     });
   });
 
   describe('getDeclarationById', () => {
-    it('returns matching declaration', () => {
+    it('returns matching declaration', async () => {
       setupMockFile([
         mockDeclaration({ id: 'DECL_A' }),
         mockDeclaration({ id: 'DECL_B' }),
       ]);
-      const result = getDeclarationById('DECL_B');
+      const result = await getDeclarationById('DECL_B');
       expect(result?.id).toBe('DECL_B');
     });
 
-    it('returns undefined for missing ID', () => {
+    it('returns undefined for missing ID', async () => {
       setupMockFile([mockDeclaration({ id: 'DECL_A' })]);
-      expect(getDeclarationById('DECL_MISSING')).toBeUndefined();
+      expect(await getDeclarationById('DECL_MISSING')).toBeUndefined();
     });
   });
 
   describe('addDeclaration', () => {
-    it('writes declaration to file', () => {
+    it('writes declaration to file', async () => {
       setupMockFile([]);
       const decl = mockDeclaration();
-      addDeclaration(decl);
+      await addDeclaration(decl);
 
       expect(writeFileSync).toHaveBeenCalledTimes(1);
       const written = JSON.parse(vi.mocked(writeFileSync).mock.calls[0][1] as string);
@@ -129,9 +129,9 @@ describe('contract-storage', () => {
       expect(written.declarations[0].id).toBe('DECL_123_abc');
     });
 
-    it('prepends new declaration (newest first)', () => {
+    it('prepends new declaration (newest first)', async () => {
       setupMockFile([mockDeclaration({ id: 'OLD' })]);
-      addDeclaration(mockDeclaration({ id: 'NEW' }));
+      await addDeclaration(mockDeclaration({ id: 'NEW' }));
 
       const written = JSON.parse(vi.mocked(writeFileSync).mock.calls[0][1] as string);
       expect(written.declarations[0].id).toBe('NEW');
@@ -140,10 +140,10 @@ describe('contract-storage', () => {
   });
 
   describe('updateDeclaration', () => {
-    it('updates matching declaration fields', () => {
+    it('updates matching declaration fields', async () => {
       setupMockFile([mockDeclaration({ id: 'DECL_A', status: 'pending' })]);
 
-      const result = updateDeclaration('DECL_A', {
+      const result = await updateDeclaration('DECL_A', {
         status: 'approved',
         reviewedBy: 'commish',
         reviewedAt: '2026-02-28T12:00:00.000Z',
@@ -156,26 +156,26 @@ describe('contract-storage', () => {
       expect(written.declarations[0].status).toBe('approved');
     });
 
-    it('returns null for missing declaration', () => {
+    it('returns null for missing declaration', async () => {
       setupMockFile([]);
-      expect(updateDeclaration('MISSING', { status: 'approved' })).toBeNull();
+      expect(await updateDeclaration('MISSING', { status: 'approved' })).toBeNull();
     });
   });
 
   describe('getDeclarationsByFranchise', () => {
-    it('filters by franchiseId', () => {
+    it('filters by franchiseId', async () => {
       setupMockFile([
         mockDeclaration({ id: '1', franchiseId: '0001' }),
         mockDeclaration({ id: '2', franchiseId: '0002' }),
         mockDeclaration({ id: '3', franchiseId: '0001' }),
       ]);
-      const result = getDeclarationsByFranchise('0001');
+      const result = await getDeclarationsByFranchise('0001');
       expect(result).toHaveLength(2);
     });
   });
 
   describe('getTeamFranchiseTag', () => {
-    it('finds existing non-rejected franchise tag for the year', () => {
+    it('finds existing non-rejected franchise tag for the year', async () => {
       setupMockFile([
         mockDeclaration({
           id: 'TAG_1',
@@ -185,11 +185,11 @@ describe('contract-storage', () => {
           submittedAt: '2026-03-01T10:00:00.000Z',
         }),
       ]);
-      const result = getTeamFranchiseTag('0001', 2026);
+      const result = await getTeamFranchiseTag('0001', 2026);
       expect(result?.id).toBe('TAG_1');
     });
 
-    it('ignores rejected tags', () => {
+    it('ignores rejected tags', async () => {
       setupMockFile([
         mockDeclaration({
           id: 'TAG_1',
@@ -199,10 +199,10 @@ describe('contract-storage', () => {
           submittedAt: '2026-03-01T10:00:00.000Z',
         }),
       ]);
-      expect(getTeamFranchiseTag('0001', 2026)).toBeUndefined();
+      expect(await getTeamFranchiseTag('0001', 2026)).toBeUndefined();
     });
 
-    it('ignores tags from different years', () => {
+    it('ignores tags from different years', async () => {
       setupMockFile([
         mockDeclaration({
           id: 'TAG_1',
@@ -212,12 +212,12 @@ describe('contract-storage', () => {
           submittedAt: '2025-03-01T10:00:00.000Z',
         }),
       ]);
-      expect(getTeamFranchiseTag('0001', 2026)).toBeUndefined();
+      expect(await getTeamFranchiseTag('0001', 2026)).toBeUndefined();
     });
   });
 
   describe('getTeamExtension', () => {
-    it('finds existing veteran extension', () => {
+    it('finds existing veteran extension', async () => {
       setupMockFile([
         mockDeclaration({
           id: 'EXT_1',
@@ -227,10 +227,10 @@ describe('contract-storage', () => {
           submittedAt: '2026-02-20T10:00:00.000Z',
         }),
       ]);
-      expect(getTeamExtension('0002', 2026)?.id).toBe('EXT_1');
+      expect((await getTeamExtension('0002', 2026))?.id).toBe('EXT_1');
     });
 
-    it('finds existing rookie extension', () => {
+    it('finds existing rookie extension', async () => {
       setupMockFile([
         mockDeclaration({
           id: 'EXT_2',
@@ -240,10 +240,10 @@ describe('contract-storage', () => {
           submittedAt: '2026-02-20T10:00:00.000Z',
         }),
       ]);
-      expect(getTeamExtension('0003', 2026)?.id).toBe('EXT_2');
+      expect((await getTeamExtension('0003', 2026))?.id).toBe('EXT_2');
     });
 
-    it('ignores expired extensions', () => {
+    it('ignores expired extensions', async () => {
       setupMockFile([
         mockDeclaration({
           id: 'EXT_1',
@@ -253,12 +253,12 @@ describe('contract-storage', () => {
           submittedAt: '2026-02-20T10:00:00.000Z',
         }),
       ]);
-      expect(getTeamExtension('0002', 2026)).toBeUndefined();
+      expect(await getTeamExtension('0002', 2026)).toBeUndefined();
     });
   });
 
   describe('getPendingDeclarationForPlayer', () => {
-    it('finds pending declaration for player on franchise', () => {
+    it('finds pending declaration for player on franchise', async () => {
       setupMockFile([
         mockDeclaration({
           id: 'D1',
@@ -267,11 +267,11 @@ describe('contract-storage', () => {
           status: 'pending',
         }),
       ]);
-      const result = getPendingDeclarationForPlayer('14056', '0001');
+      const result = await getPendingDeclarationForPlayer('14056', '0001');
       expect(result?.id).toBe('D1');
     });
 
-    it('finds approved (not yet synced) declaration', () => {
+    it('finds approved (not yet synced) declaration', async () => {
       setupMockFile([
         mockDeclaration({
           id: 'D2',
@@ -280,10 +280,10 @@ describe('contract-storage', () => {
           status: 'approved',
         }),
       ]);
-      expect(getPendingDeclarationForPlayer('14056', '0001')?.id).toBe('D2');
+      expect((await getPendingDeclarationForPlayer('14056', '0001'))?.id).toBe('D2');
     });
 
-    it('does not return rejected declarations', () => {
+    it('does not return rejected declarations', async () => {
       setupMockFile([
         mockDeclaration({
           id: 'D3',
@@ -292,10 +292,10 @@ describe('contract-storage', () => {
           status: 'rejected',
         }),
       ]);
-      expect(getPendingDeclarationForPlayer('14056', '0001')).toBeUndefined();
+      expect(await getPendingDeclarationForPlayer('14056', '0001')).toBeUndefined();
     });
 
-    it('does not match different franchise', () => {
+    it('does not match different franchise', async () => {
       setupMockFile([
         mockDeclaration({
           id: 'D4',
@@ -304,7 +304,7 @@ describe('contract-storage', () => {
           status: 'pending',
         }),
       ]);
-      expect(getPendingDeclarationForPlayer('14056', '0001')).toBeUndefined();
+      expect(await getPendingDeclarationForPlayer('14056', '0001')).toBeUndefined();
     });
   });
 });

--- a/tests/contract-eligibility.test.ts
+++ b/tests/contract-eligibility.test.ts
@@ -99,6 +99,13 @@ describe('parseTransactionString', () => {
     expect(result.addedPlayerIds).toEqual([]);
     expect(result.droppedPlayerIds).toContain('13604');
   });
+
+  it('parses auction format (playerId|amount|)', () => {
+    const result = parseTransactionString('13592|3250000|');
+    expect(result.addedPlayerIds).toEqual(['13592']);
+    expect(result.droppedPlayerIds).toEqual([]);
+    expect(result.bbidAmount).toBe(3250000);
+  });
 });
 
 // --- parseTransactions ---
@@ -160,6 +167,21 @@ describe('parseTransactions', () => {
     ];
     const result = parseTransactions(raw);
     expect(result).toHaveLength(0);
+  });
+
+  it('includes AUCTION_WON transactions', () => {
+    const raw: MFLRawTransaction[] = [
+      {
+        type: 'AUCTION_WON',
+        franchise: '0001',
+        timestamp: '1774060150',
+        transaction: '13592|3250000|',
+      },
+    ];
+    const result = parseTransactions(raw);
+    expect(result).toHaveLength(1);
+    expect(result[0].addedPlayerIds).toEqual(['13592']);
+    expect(result[0].bbidAmount).toBe(3250000);
   });
 
   it('includes FREE_AGENT transactions that have adds', () => {
@@ -299,6 +321,27 @@ describe('getPlayerEligibility', () => {
       const playerInfo = makePlayerInfo();
 
       const result = getPlayerEligibility('14867', '0009', roster, transactions, playerInfo, currentYear, now);
+      expect(result.eligible).toBe(true);
+      expect(result.declarationType).toBe('new-acquisition');
+      expect(result.yearOptions).toEqual([2, 3, 4, 5]);
+      expect(result.isExpired).toBe(false);
+    });
+
+    it('marks a recent auction acquisition as eligible with 2-5 year options', () => {
+      const acquisitionTime = Math.floor(now.getTime() / 1000) - 3600;
+      const rawTxns: MFLRawTransaction[] = [
+        {
+          type: 'AUCTION_WON',
+          franchise: '0001',
+          timestamp: String(acquisitionTime),
+          transaction: '13592|3250000|',
+        },
+      ];
+      const transactions = parseTransactions(rawTxns);
+      const roster = makeRosterPlayer({ id: '13592', contractYear: '1', contractInfo: '' });
+      const playerInfo = makePlayerInfo({ id: '13592' });
+
+      const result = getPlayerEligibility('13592', '0001', roster, transactions, playerInfo, currentYear, now);
       expect(result.eligible).toBe(true);
       expect(result.declarationType).toBe('new-acquisition');
       expect(result.yearOptions).toEqual([2, 3, 4, 5]);


### PR DESCRIPTION
The contract eligibility engine only recognized BBID_WAIVER and FREE_AGENT
as acquisition types, but the league's offseason auction produces AUCTION_WON
transactions with a different format (playerId|amount|). Added AUCTION_WON to
ACQUISITION_TYPES and parsing support for the auction transaction format so
newly auctioned players correctly show the salary selection chip.

https://claude.ai/code/session_01VAsPPPqZoS3vwTFVorR5de