### PR TITLE
Use auctionBidTime as anchor for auction timer calculations

### DIFF
--- a/src/pages/theleague/players.astro
+++ b/src/pages/theleague/players.astro
@@ -1224,11 +1224,11 @@ const isAdmin = isAdminFranchise(authUser?.franchiseId);
   }
 
   // ── Auction view helpers ──
-  function getTimeLeftMs(initTime) {
-    if (initTime == null) return null;
-    // initTime from API is Unix seconds — convert to ms
-    const initMs = initTime > 1e12 ? initTime : initTime * 1000;
-    const deadline = initMs + BID_WINDOW_MS;
+  function getTimeLeftMs(anchorTime) {
+    if (anchorTime == null) return null;
+    // anchorTime from API is Unix seconds — convert to ms
+    const anchorMs = anchorTime > 1e12 ? anchorTime : anchorTime * 1000;
+    const deadline = anchorMs + BID_WINDOW_MS;
     const remaining = deadline - Date.now();
     return remaining > 0 ? remaining : 0;
   }
@@ -2224,6 +2224,12 @@ const isAdmin = isAdminFranchise(authUser?.franchiseId);
           p.auctionBidTime = newBidTime;
           p.auctionFranchise = newFranchise;
           p.auctionInitTime = newInitTime;
+          // Patch the DOM timer attribute so tickAuctionTimers uses the updated anchor
+          const timerCell = document.querySelector(`tr[data-player-id="${p.id}"] .col-auction-timeleft[data-bid-time]`);
+          if (timerCell) {
+            const newAnchor = newBidTime ?? newInitTime;
+            if (newAnchor != null) timerCell.setAttribute('data-bid-time', String(newAnchor));
+          }
         }
       }
 

--- a/src/pages/theleague/players.astro
+++ b/src/pages/theleague/players.astro
@@ -1415,8 +1415,8 @@ const isAdmin = isAdminFranchise(authUser?.franchiseId);
         }
         case 'auctionTimeLeft': {
           // Active bids first (sorted by time remaining asc), won second, no bid last
-          const aTime = getTimeLeftMs(a.auctionInitTime);
-          const bTime = getTimeLeftMs(b.auctionInitTime);
+          const aTime = getTimeLeftMs(a.auctionBidTime ?? a.auctionInitTime);
+          const bTime = getTimeLeftMs(b.auctionBidTime ?? b.auctionInitTime);
           if (a.auctionStatus === 'won' && b.auctionStatus !== 'won') return 1;
           if (b.auctionStatus === 'won' && a.auctionStatus !== 'won') return -1;
           aVal = aTime != null ? aTime : (a.auctionStatus === 'won' ? Infinity - 1 : Infinity);
@@ -1751,12 +1751,13 @@ const isAdmin = isAdminFranchise(authUser?.franchiseId);
         // Time Left
         if (p.auctionStatus === 'won') {
           html += `<td class="cell-num col-group--auction col-auction-timeleft col-auction-timeleft--won">Won</td>`;
-        } else if (p.auctionInitTime != null) {
-          const tlMs = getTimeLeftMs(p.auctionInitTime);
+        } else if (p.auctionBidTime != null || p.auctionInitTime != null) {
+          const timerStart = p.auctionBidTime ?? p.auctionInitTime;
+          const tlMs = getTimeLeftMs(timerStart);
           const tier = getTimeLeftTier(tlMs);
           const tlText = tlMs != null && tlMs > 0 ? formatTimeLeft(tlMs, tier) : 'Ended';
           const tierCls = tier === 'none' ? '' : ` col-auction-timeleft--${tier}`;
-          html += `<td class="cell-num col-group--auction col-auction-timeleft${tierCls}" aria-label="Time left: ${tlText}" data-init-time="${p.auctionInitTime}">${tlText}</td>`;
+          html += `<td class="cell-num col-group--auction col-auction-timeleft${tierCls}" aria-label="Time left: ${tlText}" data-bid-time="${timerStart}">${tlText}</td>`;
         } else {
           html += `<td class="cell-num col-group--auction col-auction-timeleft"><span class="na">&mdash;</span></td>`;
         }
@@ -2133,12 +2134,12 @@ const isAdmin = isAdminFranchise(authUser?.franchiseId);
   }
 
   function tickAuctionTimers() {
-    const cells = document.querySelectorAll('.col-auction-timeleft[data-init-time]');
+    const cells = document.querySelectorAll('.col-auction-timeleft[data-bid-time]');
     let hasCritical = false;
     cells.forEach(cell => {
-      const initTime = parseInt(cell.getAttribute('data-init-time'), 10);
-      if (!initTime) return;
-      const ms = getTimeLeftMs(initTime);
+      const bidTime = parseInt(cell.getAttribute('data-bid-time'), 10);
+      if (!bidTime) return;
+      const ms = getTimeLeftMs(bidTime);
       const tier = getTimeLeftTier(ms);
       const text = ms != null && ms > 0 ? formatTimeLeft(ms, tier) : 'Ended';
       cell.textContent = text;


### PR DESCRIPTION
## Summary
Updated auction timer logic to use the most recent bid time as the anchor point for countdown calculations, falling back to the initial auction time when no bid has been placed. This ensures timers accurately reflect the actual deadline based on the latest bidding activity.

## Key Changes
- Renamed `initTime` parameter to `anchorTime` in `getTimeLeftMs()` function for clarity, since it now represents either a bid time or init time
- Updated auction sorting by time remaining to use `auctionBidTime` (with fallback to `auctionInitTime`) instead of always using `auctionInitTime`
- Modified timer display logic to check for `auctionBidTime` first, then fall back to `auctionInitTime`
- Changed DOM attribute from `data-init-time` to `data-bid-time` to reflect the new anchor point
- Updated `tickAuctionTimers()` to read from the new `data-bid-time` attribute
- Added DOM patching in the bid update handler to update the timer cell's `data-bid-time` attribute when a new bid is placed

## Implementation Details
The changes ensure that when a bid is placed on an auction, the countdown timer resets based on the new bid time rather than the original auction start time. This is achieved by:
1. Preferring `auctionBidTime` over `auctionInitTime` throughout the timer calculation pipeline
2. Maintaining backward compatibility by falling back to `auctionInitTime` when no bid exists
3. Synchronizing the DOM attribute with the data model when bids are updated via WebSocket

https://claude.ai/code/session_01VbTGoiL1uE3zi288ocHyDi