### PR TITLE
Fix commissioner access for contract approve/reject and rename nav link

### DIFF
--- a/src/config/nav-config.json
+++ b/src/config/nav-config.json
@@ -118,7 +118,7 @@
         },
         {
           "id": "contracts",
-          "label": "My Contracts",
+          "label": "Contracts",
           "icon": "file-text",
           "path": "/contracts/manage",
           "external": false,

--- a/src/pages/api/contracts/approve.ts
+++ b/src/pages/api/contracts/approve.ts
@@ -7,7 +7,7 @@
  */
 
 import type { APIRoute } from 'astro';
-import { getAuthUser } from '../../../utils/auth';
+import { getAuthUser, isCommissionerOrAdmin } from '../../../utils/auth';
 import { getDeclarationById, updateDeclaration } from '../../../utils/contract-storage';
 import { writeContractToMFL } from '../../../utils/mfl-contract-writer';
 
@@ -27,7 +27,7 @@ export const POST: APIRoute = async ({ request }) => {
       );
     }
 
-    if (user.role !== 'commissioner' && user.role !== 'admin') {
+    if (!isCommissionerOrAdmin(user)) {
       return new Response(
         JSON.stringify({ error: 'Commissioner access required' }),
         { status: 403, headers: JSON_HEADERS },

--- a/src/pages/api/contracts/pending.ts
+++ b/src/pages/api/contracts/pending.ts
@@ -6,7 +6,7 @@
  */
 
 import type { APIRoute } from 'astro';
-import { getAuthUser } from '../../../utils/auth';
+import { getAuthUser, isCommissionerOrAdmin } from '../../../utils/auth';
 import { getPendingDeclarations } from '../../../utils/contract-storage';
 
 const JSON_HEADERS = { 'Content-Type': 'application/json' };
@@ -21,7 +21,7 @@ export const GET: APIRoute = async ({ request }) => {
       );
     }
 
-    if (user.role !== 'commissioner' && user.role !== 'admin') {
+    if (!isCommissionerOrAdmin(user)) {
       return new Response(
         JSON.stringify({ error: 'Commissioner access required' }),
         { status: 403, headers: JSON_HEADERS },

--- a/src/pages/api/contracts/reject.ts
+++ b/src/pages/api/contracts/reject.ts
@@ -7,7 +7,7 @@
  */
 
 import type { APIRoute } from 'astro';
-import { getAuthUser } from '../../../utils/auth';
+import { getAuthUser, isCommissionerOrAdmin } from '../../../utils/auth';
 import { getDeclarationById, updateDeclaration } from '../../../utils/contract-storage';
 
 const JSON_HEADERS = { 'Content-Type': 'application/json' };
@@ -27,7 +27,7 @@ export const POST: APIRoute = async ({ request }) => {
       );
     }
 
-    if (user.role !== 'commissioner' && user.role !== 'admin') {
+    if (!isCommissionerOrAdmin(user)) {
       return new Response(
         JSON.stringify({ error: 'Commissioner access required' }),
         { status: 403, headers: JSON_HEADERS },

--- a/src/pages/theleague/contracts/manage.astro
+++ b/src/pages/theleague/contracts/manage.astro
@@ -1,6 +1,11 @@
 ---
 import TheLeagueLayout from '../../../layouts/TheLeagueLayout.astro';
 import { getPendingDeclarations, getDeclarations } from '../../../utils/contract-storage';
+import { getAuthUser, isCommissionerOrAdmin } from '../../../utils/auth';
+
+// Check if current user is a commissioner
+const user = getAuthUser(Astro.request);
+const isCommish = !!user && isCommissionerOrAdmin(user);
 
 // Load declaration data at build/request time
 const pending = await getPendingDeclarations();
@@ -32,7 +37,7 @@ function formatSalary(cents: number): string {
     <!-- Page header -->
     <header class="page-header">
       <h1 class="page-title">Contract Declarations</h1>
-      <p class="page-subtitle">Commissioner review and approval workflow</p>
+      <p class="page-subtitle">Contract declaration status and history</p>
     </header>
 
     <div class="page-grid">
@@ -100,24 +105,26 @@ function formatSalary(cents: number): string {
                   )}
                 </div>
 
-                <div class="decl-card__actions">
-                  <button
-                    class="action-btn action-btn--approve"
-                    data-action="approve"
-                    data-id={d.id}
-                    data-player={d.playerName}
-                  >
-                    Approve
-                  </button>
-                  <button
-                    class="action-btn action-btn--reject"
-                    data-action="reject"
-                    data-id={d.id}
-                    data-player={d.playerName}
-                  >
-                    Reject
-                  </button>
-                </div>
+                {isCommish && (
+                  <div class="decl-card__actions">
+                    <button
+                      class="action-btn action-btn--approve"
+                      data-action="approve"
+                      data-id={d.id}
+                      data-player={d.playerName}
+                    >
+                      Approve
+                    </button>
+                    <button
+                      class="action-btn action-btn--reject"
+                      data-action="reject"
+                      data-id={d.id}
+                      data-player={d.playerName}
+                    >
+                      Reject
+                    </button>
+                  </div>
+                )}
               </article>
             ))}
           </div>
@@ -218,20 +225,22 @@ function formatSalary(cents: number): string {
     </div>
   </main>
 
-  <!-- Rejection reason modal -->
-  <dialog id="rejectModal" class="reject-dialog">
-    <form method="dialog" class="reject-dialog__form">
-      <h3 class="reject-dialog__title">Reject Declaration</h3>
-      <p id="rejectModalPlayer" class="reject-dialog__player"></p>
-      <label for="rejectReason" class="reject-dialog__label">Reason (optional)</label>
-      <textarea id="rejectReason" class="reject-dialog__textarea" rows="3" placeholder="Enter reason for rejection..."></textarea>
-      <input type="hidden" id="rejectDeclarationId" />
-      <div class="reject-dialog__actions">
-        <button type="button" class="action-btn action-btn--cancel" id="rejectModalCancel">Cancel</button>
-        <button type="button" class="action-btn action-btn--reject" id="rejectModalConfirm">Reject</button>
-      </div>
-    </form>
-  </dialog>
+  {isCommish && (
+    <!-- Rejection reason modal -->
+    <dialog id="rejectModal" class="reject-dialog">
+      <form method="dialog" class="reject-dialog__form">
+        <h3 class="reject-dialog__title">Reject Declaration</h3>
+        <p id="rejectModalPlayer" class="reject-dialog__player"></p>
+        <label for="rejectReason" class="reject-dialog__label">Reason (optional)</label>
+        <textarea id="rejectReason" class="reject-dialog__textarea" rows="3" placeholder="Enter reason for rejection..."></textarea>
+        <input type="hidden" id="rejectDeclarationId" />
+        <div class="reject-dialog__actions">
+          <button type="button" class="action-btn action-btn--cancel" id="rejectModalCancel">Cancel</button>
+          <button type="button" class="action-btn action-btn--reject" id="rejectModalConfirm">Reject</button>
+        </div>
+      </form>
+    </dialog>
+  )}
 
   <script type="module">
     const pendingList = document.getElementById('pendingList');

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -5,6 +5,7 @@
  */
 
 import { getSessionTokenFromCookie, validateSessionToken } from './session';
+import { isAdminFranchise } from '../config/nav-config';
 
 export interface AuthUser {
   id: string;
@@ -106,6 +107,19 @@ export function requireAuth(user: AuthUser | null): user is AuthUser {
  */
 export function isFranchiseOwner(user: AuthUser, franchiseId: string): boolean {
   return user.franchiseId === franchiseId;
+}
+
+/**
+ * Verify that user has commissioner-level access.
+ * Checks both the JWT role AND the admin franchise list from nav config,
+ * so commissioners are recognized even if MFL didn't set the commish cookie at login.
+ */
+export function isCommissionerOrAdmin(user: AuthUser): boolean {
+  if (user.role === 'commissioner' || user.role === 'admin') return true;
+
+  // Fallback: check admin franchise IDs from nav config
+  // This handles cases where MFL login didn't return the MFL_IS_COMMISH cookie
+  return isAdminFranchise(user.franchiseId);
 }
 
 /**


### PR DESCRIPTION
The approve/reject/pending API endpoints only checked the JWT session
role, which depends on MFL returning the MFL_IS_COMMISH cookie at login.
When that cookie wasn't set, commissioners got "Commissioner access
required" errors. Now also checks the adminFranchiseIds list from
nav-config as a fallback. Renamed "My Contracts" to "Contracts" in nav.

https://claude.ai/code/session_01Sz58Tyg5NQB5EsDWAd4VPH