### PR TITLE
Fix contract duration: add 1-year option to new-acquisition declarations

### DIFF
--- a/src/pages/theleague/rosters.astro
+++ b/src/pages/theleague/rosters.astro
@@ -1903,10 +1903,10 @@ if (testEligibility) {
 
   // --- Eligibility data for the 3 scenarios ---
   eligibilityByTeam[testTeamId] = {
-    // Hopkins: free agent BBID pickup, 18h deadline, can declare 2-5 years
+    // Hopkins: free agent BBID pickup, 18h deadline, can declare 1-5 years
     '11232': {
       type: 'new-acquisition',
-      yearOptions: [2, 3, 4, 5],
+      yearOptions: [1, 2, 3, 4, 5],
       deadlineTimestamp: Math.floor((now + 18 * 60 * 60 * 1000) / 1000),
       isExpired: false,
       currentYears: 1,
@@ -8896,6 +8896,20 @@ const r = (path: string) => resolveLeaguePath(path, hideLeaguePrefix);
       cdmSubmitBtn.textContent = 'Submitting...';
       cdmError.style.display = 'none';
 
+      const elig = cdmPlayerData.eligibility;
+
+      // If selecting the same years as current contract, cancel any pending declaration
+      if (cdmSelectedYears === elig?.currentYears) {
+        delete localDeclarations[cdmPlayerData.id];
+        delete declarationsByPlayer[cdmPlayerData.id];
+        cdmSubmitBtn.style.display = 'none';
+        cdmSuccess.style.display = 'flex';
+        updateView();
+        applyEligibilityStyling();
+        setTimeout(closeDeclarationModal, 1500);
+        return;
+      }
+
       // Demo mode: skip API call, show success immediately
       const isDemoPlayer = demoActive && String(cdmPlayerData.id).startsWith('DEMO_');
       if (isDemoPlayer) {
@@ -8910,8 +8924,6 @@ const r = (path: string) => resolveLeaguePath(path, hideLeaguePrefix);
         setTimeout(closeDeclarationModal, 1500);
         return;
       }
-
-      const elig = cdmPlayerData.eligibility;
       const franchiseId = config.authUser?.franchiseId ?? currentTeam;
       const franchiseName = config.teams?.[franchiseId]?.name ?? franchiseId;
       const leagueId = config.authUser?.leagueId ?? '13522';
@@ -9520,7 +9532,7 @@ const r = (path: string) => resolveLeaguePath(path, hideLeaguePrefix);
       eligibilityByTeam[currentTeam] = {};
       eligibilityByTeam[currentTeam]['DEMO_HOPKINS'] = {
         type: 'new-acquisition',
-        yearOptions: [2, 3, 4, 5],
+        yearOptions: [1, 2, 3, 4, 5],
         deadlineTimestamp: Math.floor((now + 18 * 60 * 60 * 1000) / 1000),
         isExpired: false,
         currentYears: 1,

--- a/src/utils/contract-eligibility.ts
+++ b/src/utils/contract-eligibility.ts
@@ -268,7 +268,7 @@ export function getPlayerEligibility(
         acquisitionTimestamp: acquisition.timestamp,
         deadlineTimestamp: Math.floor(deadlineMs / 1000),
         isExpired: false,
-        yearOptions: [2, 3, 4, 5],
+        yearOptions: [1, 2, 3, 4, 5],
       };
     }
   }

--- a/tests/contract-eligibility.test.ts
+++ b/tests/contract-eligibility.test.ts
@@ -323,11 +323,11 @@ describe('getPlayerEligibility', () => {
       const result = getPlayerEligibility('14867', '0009', roster, transactions, playerInfo, currentYear, now);
       expect(result.eligible).toBe(true);
       expect(result.declarationType).toBe('new-acquisition');
-      expect(result.yearOptions).toEqual([2, 3, 4, 5]);
+      expect(result.yearOptions).toEqual([1, 2, 3, 4, 5]);
       expect(result.isExpired).toBe(false);
     });
 
-    it('marks a recent auction acquisition as eligible with 2-5 year options', () => {
+    it('marks a recent auction acquisition as eligible with 1-5 year options', () => {
       const acquisitionTime = Math.floor(now.getTime() / 1000) - 3600;
       const rawTxns: MFLRawTransaction[] = [
         {
@@ -344,7 +344,7 @@ describe('getPlayerEligibility', () => {
       const result = getPlayerEligibility('13592', '0001', roster, transactions, playerInfo, currentYear, now);
       expect(result.eligible).toBe(true);
       expect(result.declarationType).toBe('new-acquisition');
-      expect(result.yearOptions).toEqual([2, 3, 4, 5]);
+      expect(result.yearOptions).toEqual([1, 2, 3, 4, 5]);
       expect(result.isExpired).toBe(false);
     });
 


### PR DESCRIPTION
The contract length selector for new acquisitions only showed [2,3,4,5] year
options, preventing owners from reverting back to the default 1-year contract.
Now includes 1 year as an option. Selecting 1 year (same as current) cancels
any pending declaration.

https://claude.ai/code/session_01C9Wrq8EyZ5jMivQ7BK7xNj