### PR TITLE
Fix contract duration selector bug

### DIFF
--- a/src/pages/theleague/rosters.astro
+++ b/src/pages/theleague/rosters.astro
@@ -1903,10 +1903,10 @@ if (testEligibility) {
 
   // --- Eligibility data for the 3 scenarios ---
   eligibilityByTeam[testTeamId] = {
-    // Hopkins: free agent BBID pickup, 18h deadline, can declare 2-5 years
+    // Hopkins: free agent BBID pickup, 18h deadline, can declare 1-5 years
     '11232': {
       type: 'new-acquisition',
-      yearOptions: [2, 3, 4, 5],
+      yearOptions: [1, 2, 3, 4, 5],
       deadlineTimestamp: Math.floor((now + 18 * 60 * 60 * 1000) / 1000),
       isExpired: false,
       currentYears: 1,
@@ -8896,6 +8896,20 @@ const r = (path: string) => resolveLeaguePath(path, hideLeaguePrefix);
       cdmSubmitBtn.textContent = 'Submitting...';
       cdmError.style.display = 'none';
 
+      const elig = cdmPlayerData.eligibility;
+
+      // If selecting the same years as current contract, cancel any pending declaration
+      if (cdmSelectedYears === elig?.currentYears) {
+        delete localDeclarations[cdmPlayerData.id];
+        delete declarationsByPlayer[cdmPlayerData.id];
+        cdmSubmitBtn.style.display = 'none';
+        cdmSuccess.style.display = 'flex';
+        updateView();
+        applyEligibilityStyling();
+        setTimeout(closeDeclarationModal, 1500);
+        return;
+      }
+
       // Demo mode: skip API call, show success immediately
       const isDemoPlayer = demoActive && String(cdmPlayerData.id).startsWith('DEMO_');
       if (isDemoPlayer) {
@@ -8910,8 +8924,6 @@ const r = (path: string) => resolveLeaguePath(path, hideLeaguePrefix);
         setTimeout(closeDeclarationModal, 1500);
         return;
       }
-
-      const elig = cdmPlayerData.eligibility;
       const franchiseId = config.authUser?.franchiseId ?? currentTeam;
       const franchiseName = config.teams?.[franchiseId]?.name ?? franchiseId;
       const leagueId = config.authUser?.leagueId ?? '13522';
@@ -9520,7 +9532,7 @@ const r = (path: string) => resolveLeaguePath(path, hideLeaguePrefix);
       eligibilityByTeam[currentTeam] = {};
       eligibilityByTeam[currentTeam]['DEMO_HOPKINS'] = {
         type: 'new-acquisition',
-        yearOptions: [2, 3, 4, 5],
+        yearOptions: [1, 2, 3, 4, 5],
         deadlineTimestamp: Math.floor((now + 18 * 60 * 60 * 1000) / 1000),
         isExpired: false,
         currentYears: 1,

--- a/src/utils/contract-eligibility.ts
+++ b/src/utils/contract-eligibility.ts
@@ -259,8 +259,8 @@ export function getPlayerEligibility(
     const nowMs = now.getTime();
     const isExpired = nowMs > deadlineMs;
 
-    // If still within deadline and contract is at default 1 year, player can declare
-    if (!isExpired && currentYears === 1 && !isRC) {
+    // If still within deadline, player can declare (regardless of current contract years)
+    if (!isExpired && !isRC) {
       return {
         ...base,
         eligible: true,

--- a/src/utils/contract-eligibility.ts
+++ b/src/utils/contract-eligibility.ts
@@ -268,7 +268,7 @@ export function getPlayerEligibility(
         acquisitionTimestamp: acquisition.timestamp,
         deadlineTimestamp: Math.floor(deadlineMs / 1000),
         isExpired: false,
-        yearOptions: [2, 3, 4, 5],
+        yearOptions: [1, 2, 3, 4, 5],
       };
     }
   }

--- a/tests/contract-eligibility.test.ts
+++ b/tests/contract-eligibility.test.ts
@@ -369,7 +369,7 @@ describe('getPlayerEligibility', () => {
       expect(result.declarationType).not.toBe('new-acquisition');
     });
 
-    it('does not mark players with existing multi-year contracts as new-acquisition eligible', () => {
+    it('allows acquired players with multi-year contracts to change within deadline', () => {
       const acquisitionTime = Math.floor(now.getTime() / 1000) - 3600;
       const rawTxns: MFLRawTransaction[] = [
         {
@@ -384,8 +384,10 @@ describe('getPlayerEligibility', () => {
       const playerInfo = makePlayerInfo();
 
       const result = getPlayerEligibility('14867', '0009', roster, transactions, playerInfo, currentYear, now);
-      // Should not be new-acquisition since they already have 3 years
-      expect(result.declarationType).not.toBe('new-acquisition');
+      // Within deadline, owner can always change contract regardless of current years
+      expect(result.eligible).toBe(true);
+      expect(result.declarationType).toBe('new-acquisition');
+      expect(result.yearOptions).toEqual([1, 2, 3, 4, 5]);
     });
   });
 

--- a/tests/contract-eligibility.test.ts
+++ b/tests/contract-eligibility.test.ts
@@ -323,11 +323,11 @@ describe('getPlayerEligibility', () => {
       const result = getPlayerEligibility('14867', '0009', roster, transactions, playerInfo, currentYear, now);
       expect(result.eligible).toBe(true);
       expect(result.declarationType).toBe('new-acquisition');
-      expect(result.yearOptions).toEqual([2, 3, 4, 5]);
+      expect(result.yearOptions).toEqual([1, 2, 3, 4, 5]);
       expect(result.isExpired).toBe(false);
     });
 
-    it('marks a recent auction acquisition as eligible with 2-5 year options', () => {
+    it('marks a recent auction acquisition as eligible with 1-5 year options', () => {
       const acquisitionTime = Math.floor(now.getTime() / 1000) - 3600;
       const rawTxns: MFLRawTransaction[] = [
         {
@@ -344,7 +344,7 @@ describe('getPlayerEligibility', () => {
       const result = getPlayerEligibility('13592', '0001', roster, transactions, playerInfo, currentYear, now);
       expect(result.eligible).toBe(true);
       expect(result.declarationType).toBe('new-acquisition');
-      expect(result.yearOptions).toEqual([2, 3, 4, 5]);
+      expect(result.yearOptions).toEqual([1, 2, 3, 4, 5]);
       expect(result.isExpired).toBe(false);
     });
 


### PR DESCRIPTION
## Summary
- Added 1-year option to the contract length selector for new acquisitions (was only showing 2-5 years)
- Removed the `currentYears === 1` restriction so owners can change their contract declaration anytime within the deadline, even after a previous declaration was approved/applied
- Selecting 1 year (same as current contract) cancels any pending declaration

## Test plan
- [x] All 50 contract eligibility tests pass
- [ ] Verify new-acquisition modal shows [1, 2, 3, 4, 5] year options
- [ ] Verify owner can change an already-applied contract within the deadline (e.g. DJ Moore scenario)
- [ ] Verify selecting 1 year reverts/cancels a pending declaration
- [ ] Verify expired deadlines still block changes