### PR TITLE
Remove cancel logic and oldYears===newYears validation

### DIFF
--- a/src/pages/theleague/rosters.astro
+++ b/src/pages/theleague/rosters.astro
@@ -8898,18 +8898,6 @@ const r = (path: string) => resolveLeaguePath(path, hideLeaguePrefix);
 
       const elig = cdmPlayerData.eligibility;
 
-      // If selecting the same years as current contract, cancel any pending declaration
-      if (cdmSelectedYears === elig?.currentYears) {
-        delete localDeclarations[cdmPlayerData.id];
-        delete declarationsByPlayer[cdmPlayerData.id];
-        cdmSubmitBtn.style.display = 'none';
-        cdmSuccess.style.display = 'flex';
-        updateView();
-        applyEligibilityStyling();
-        setTimeout(closeDeclarationModal, 1500);
-        return;
-      }
-
       // Demo mode: skip API call, show success immediately
       const isDemoPlayer = demoActive && String(cdmPlayerData.id).startsWith('DEMO_');
       if (isDemoPlayer) {

--- a/src/utils/contract-validation.ts
+++ b/src/utils/contract-validation.ts
@@ -169,14 +169,6 @@ export function validateContractSubmission(
     });
   }
 
-  // Validate that we're changing the contract
-  if (oldYears === newYears) {
-    errors.push({
-      field: 'contractYears',
-      message: 'New contract years must be different from current contract years',
-    });
-  }
-
   // Validate new contract years
   errors.push(...validateContractYears(newYears));
 


### PR DESCRIPTION
The client-side cancel logic was intercepting legitimate submissions when the pre-selected years matched the MFL current years (e.g., DJ Moore with an already-applied 2yr contract). Removed the cancel shortcut so all submissions go through the API. Also removed the server-side validation that blocked declarations with same years as current — owners should be able to declare any year within the deadline.

https://claude.ai/code/session_01C9Wrq8EyZ5jMivQ7BK7xNj