### PR TITLE
Fix 404 on /login by adding redirect to /theleague/login

### DIFF
--- a/src/pages/login.astro
+++ b/src/pages/login.astro
@@ -1,0 +1,3 @@
+---
+return Astro.redirect('/theleague/login', 301);
+---


### PR DESCRIPTION
The login page lives at /theleague/login but /login was returning a 404.
Added a permanent redirect (301) from /login to /theleague/login.

https://claude.ai/code/session_01LjmsMdfMu1Z9XdQHKJt8k5