### PR TITLE
docs: add Claude Code session summaries for project history

### DIFF
--- a/docs/claude/session-summaries.md
+++ b/docs/claude/session-summaries.md
@@ -1,0 +1,483 @@
+# Claude Code Session Summaries
+
+> Last updated: 2026-03-23
+> This file tracks all Claude Code sessions for the mfl.football.v2 project.
+> Use Ctrl+F to search by feature, date, PR number, or session ID.
+
+---
+
+## Session Index (Newest First)
+
+| Date | Session ID | PR(s) | Summary |
+|------|-----------|-------|---------|
+| 2026-03-23 | `session_01TkF8kz7c3odRCkmToMfhsq` | — | Session summary creation & project documentation |
+| 2026-03-23 | `session_0149YRoxywYwaZdrSATE7ahY` | #63 | Fix Pacific Time deadline display & contract eligibility |
+| 2026-03-23 | `session_01LjmsMdfMu1Z9XdQHKJt8k5` | #62 | Fix /login 404 redirect |
+| 2026-03-23 | `session_01MkgVNack1TZn8QUYyMqTMx` | #61 | Division champions dynamic computation |
+| 2026-03-23 | — | — | `feat: add owner activity tracking with Redis-backed visit logging` (no PR, direct commit `8ba52af`) |
+| 2026-03-22 | `session_01KDwrmpoGYAgX3tm2f4mX2B` | #60 | Fix nav logged-in state from ?myteam= query param |
+| 2026-03-22 | `session_01VvVtZ7sBMnEqgu8WGeLd4m` | #59 (OPEN) | Power Rankings page |
+| 2026-03-22 | — | #58 | Contract system: Redis storage + commish management (multi-session work) |
+| 2026-03-22 | `session_01GFYfFizzTd5ja9gt3N4cSi` | #57 | Fix contract submit window & batch submit for offseason |
+| 2026-03-22 | — | — | `feat: redesign applied contracts with year grouping, team icons, and mobile layout` (direct commit `a7fb54b`) |
+| 2026-03-21 | `session_01C9Wrq8EyZ5jMivQ7BK7xNj` | #55, #53 | Remove cancel logic, fix contract duration (1-year option) |
+| 2026-03-21 | `session_0197vFiwJqoEFRvHxUt4wGzt` | #52, #51, #49 | Contract manager: unified auth, commish toggle, design tokens |
+| 2026-03-21 | `session_01Sz58Tyg5NQB5EsDWAd4VPH` | #46 | Fix commissioner access for contract approve/reject |
+| 2026-03-21 | `session_01VbTGoiL1uE3zi288ocHyDi` | #45 | Use auctionBidTime as anchor for auction timer |
+| 2026-03-21 | `session_01VAsPPPqZoS3vwTFVorR5de` | #43 | Fix AUCTION_WON transactions for salary eligibility |
+| 2026-03-21 | `session_0142wLbrTS8tEteBgpmc6N8X` | #42 | Fix auction winners missing from salary file on roster page |
+| 2026-03-21 | `session_01Txn3tMseHnkoqCgM6zCnix` | #40 | Consolidate auction What's New articles |
+| 2026-03-20 | `session_01U4AAXxqfwHazKFQLvPTCzE` | #39 | Auction view on free agents page with live bid tracking |
+| 2026-03-20 | `session_01VZsaJdwZ82F38MxjeuAGs1` | #38 | Reduce min width of year options grid in contract modal |
+| 2026-03-16 | `session_01CgJXc5S68Gz2HyNBH19uCN` | #37 | Add SVG favicon to all layout templates |
+| 2026-03-15 | `session_014sAPL7Rc3wHk11kvmA2FGY` | #36 | Calculate rookie salary reserve from actual draft picks |
+| 2026-03-14 | `session_014RTuZunqp1bgMUkJBhhnqA` | #35 | Update side nav: add Rules link, remove Franchise Tags |
+| 2026-03-12 | `session_013VNZG12D8fFjGhpeyk8tKr` | #33 (OPEN) | News feed sidebar for league homepage |
+| 2026-03-11 | `session_01VfzrxpoiVKVG5cEQawUPUg` | #32, #31 | Calendar event filter toggle (All/Upcoming/Past) |
+| 2026-03-04 | `session_013WBbvh59NsGS6ab4aGYHGe` | #30 | Fix hero CTA link for PWA app entry |
+| 2026-03-02 | `session_01LSaLnCEDmBnbZTmcewEpLA` | #29 | Gate franchise tag feature behind admin flag |
+| 2026-02-28 | `session_01XBPZaXXeDaUF5wJrjuxHdt` | #28 | Screenshot requirements & validation for What's New |
+| 2026-02-28 | `session_01NJR2r8CFRLoh3SMZGpS47h` | #27 | Migrate MFL page enhancements from global.js to modular script |
+| 2026-02-28 | `session_01YDenyfLaVsthaqPrNHzhyW` | #26 | CSS Customization Guide & documentation |
+| 2026-02-28 | `session_01BAwDDDNptfdkxXXfAbbyFs` | #25 | Fix mobile clear button pushing GM/Coach tabs |
+| 2026-02-26 | `session_01LLiF8nUpHLYJ4PBe8yrcsf` | #24 | Phase 1 login integration plan with MFL auth flow |
+| 2026-02-24 | `session_01VnTg4w3PMi15hWKBrE3SQU` | #22 | Fix unranked players in average/composite calculations |
+| 2026-02-24 | `session_01JGyU9VS7UkRrnVwUfuyJLF` | #21 | Fix mobile horizontal scroll on League Planner |
+| 2026-02-21 | `session_01W4yR9aLyHizbpdnC4RUSSd` | #20 | Fix green design token for card hover color |
+| 2026-02-17 | `session_01RN6Kx7BmYqezN8Us7FmXAe` | #19 | Free Agents player research tool with sorting/filtering |
+| 2026-02-17 | `session_01UXE9dEZrwotdBymQXoGGLU` | #17 | Fix mobile alignment/padding on What's New page |
+| 2026-02-16 | `session_01Bek3PzS1xMatFxzhcmQ14Z` | #15 | Fix MFL Trade Bait link (O=133) |
+| 2026-02-16 | `session_01Xjj3UnTTsmVxHWe4Fsq6JN` | #12 | Add spacing above League Summary table |
+| 2026-02-16 | `session_018aiGQ7ZFFPmDb2WTZbTq45` | #11 | Fix draft picks: load from previous year's MFL feed |
+| 2026-02-15 | `session_01Fa1BJupfq2RPfWNMreQns2` | #7 | Add day-of-week abbreviation to calendar dates |
+| 2026-02-15 | `session_01JackGqurtAd6ynbwwTpbWk` | #5 | Link trade deadline event to trade builder page |
+| 2026-02-15 | `session_016N2mRfLKWDc9bZQpqLtwKu` | #4 | Remove 'blind bid' terminology from calendar |
+| 2026-02-15 | `session_012QERBMqTcR8PoVFJrmrBvF` | #3 | Add white background to league summary page |
+| 2026-02-15 | `session_01GcxbhVtbi2RBQpViMUT7H1` | #2 | Add League Calendar to Popular section in side drawer |
+| 2025-12-20 | — | #1 | Feature/rules page (initial PR, no session URL) |
+
+---
+
+## Detailed Session Notes
+
+### 2026-03-23: Fix Pacific Time Deadlines
+**Session:** `session_0149YRoxywYwaZdrSATE7ahY` | **PR:** #63 (merged, then reverted)
+
+Three interconnected fixes in one session:
+1. **Deadline display**: All dates on contract manage page now use `America/Los_Angeles` timezone. Client-side deadline text re-rendered in PT to match server.
+2. **Contract window boundaries**: Offseason window (Feb 15 - Aug cutdown), in-season window (Sept 1 - Feb 14), and rookie cutdown date all shifted by 7-8 hours on UTC servers (Vercel). Fixed by constructing UTC instants with explicit PT offset.
+3. **Eligibility chips disappearing**: `fs.readFileSync` for transactions.json failed on Vercel serverless. Migrated to `import.meta.glob` which bundles at build time.
+
+**Key files touched:** Contract window logic, eligibility engine, contract manage page
+**Note:** This PR was later reverted (commit `9ed0445`) — may need re-application with fixes.
+
+---
+
+### 2026-03-23: Fix /login 404
+**Session:** `session_01LjmsMdfMu1Z9XdQHKJt8k5` | **PR:** #62
+
+Simple fix: Added 301 permanent redirect from `/login` to `/theleague/login`.
+
+---
+
+### 2026-03-23: Dynamic Division Champions
+**Session:** `session_01MkgVNack1TZn8QUYyMqTMx` | **PR:** #61
+
+Iterative session with 3 commits:
+1. Initially updated hardcoded 2025 champions (wrong data)
+2. Corrected based on overall record vs division record
+3. **Final solution**: Replaced ~100 lines of hardcoded `championsByYear` map with dynamic `getDivisionChampions()` function using existing `divisionTiebreaker` logic
+
+**Key insight:** Division champs determined by overall record, not division record.
+
+---
+
+### 2026-03-23: Owner Activity Tracking
+**No session URL** | Direct commit `8ba52af`
+
+New feature: `/theleague/activity` page with Redis-backed (Upstash) owner visit logging. Added What's New entry.
+
+---
+
+### 2026-03-22: Nav Logged-in State Bug
+**Session:** `session_01KDwrmpoGYAgX3tm2f4mX2B` | **PR:** #60
+
+Fixed bug where navigation showed logged-in state when `?myteam=` query param was present in URL.
+
+---
+
+### 2026-03-22: Power Rankings Page (IN PROGRESS)
+**Session:** `session_01VvVtZ7sBMnEqgu8WGeLd4m` | **PR:** #59 (OPEN)
+
+New Power Rankings page feature — still open, not yet merged.
+
+---
+
+### 2026-03-22: Contract System - Redis Migration
+**PR:** #58 (no session URL — likely multi-session work)
+
+Major infrastructure change:
+- **Redis storage migration**: Contract declarations moved to Upstash Redis (atomic per-declaration writes via HSET), replacing Vercel Blob (had CDN caching race conditions)
+- **Commish contract management**: Apply All, Reapply, MFL verification, reconciliation tools
+- **Contract declaration fixes**: 1-year option, 48hr re-submission window, cap impact display
+- **Env var fix**: Added `STORAGE_` prefix fallback for Upstash integration
+
+---
+
+### 2026-03-22: Contract Submit Window Fix
+**Session:** `session_01GFYfFizzTd5ja9gt3N4cSi` | **PR:** #57
+
+Fixed contract submit window and batch submit to work during offseason period.
+
+---
+
+### 2026-03-22: Applied Contracts Redesign
+**No session URL** | Direct commit `a7fb54b`
+
+Redesigned applied contracts display with year grouping, team icons, CSS grid for mobile responsiveness, and inline team icons with year indicators.
+
+---
+
+### 2026-03-21: Contract Duration & Cancel Logic
+**Session:** `session_01C9Wrq8EyZ5jMivQ7BK7xNj` | **PRs:** #55, #53
+
+Two PRs from same session:
+- **#53**: Added 1-year option to new-acquisition contract declarations
+- **#55**: Removed cancel logic and `oldYears===newYears` validation
+
+---
+
+### 2026-03-21: Contract Manager Overhaul
+**Session:** `session_0197vFiwJqoEFRvHxUt4wGzt` | **PRs:** #52, #51, #49
+
+Large session producing 3 PRs:
+- **#49**: Updated contract manager buttons to design system tokens
+- **#51**: Simplified contract manager — Apply button, MFL cookie storage, removed complexity
+- **#52**: Unified auth, commish toggle, real-time counts
+
+---
+
+### 2026-03-21: Commissioner Access Fix
+**Session:** `session_01Sz58Tyg5NQB5EsDWAd4VPH` | **PR:** #46
+
+Fixed commissioner access for contract approve/reject operations. Renamed nav link.
+
+---
+
+### 2026-03-21: Auction Timer Fix
+**Session:** `session_01VbTGoiL1uE3zi288ocHyDi` | **PR:** #45
+
+Changed auction timer calculations to use `auctionBidTime` as the anchor point instead of previous logic.
+
+---
+
+### 2026-03-21: Auction Salary Eligibility
+**Session:** `session_01VAsPPPqZoS3vwTFVorR5de` | **PR:** #43
+
+Fixed: `AUCTION_WON` transactions were not recognized for salary selection eligibility, causing incorrect contract options.
+
+---
+
+### 2026-03-21: Missing Auction Winners on Roster
+**Session:** `session_0142wLbrTS8tEteBgpmc6N8X` | **PR:** #42
+
+Fixed auction winners not appearing on roster page because they were missing from the salary file.
+
+---
+
+### 2026-03-21: Consolidate Auction Articles
+**Session:** `session_01Txn3tMseHnkoqCgM6zCnix` | **PR:** #40
+
+Merged two separate auction What's New articles into a single, cleaner entry.
+
+---
+
+### 2026-03-20: Auction View Feature
+**Session:** `session_01U4AAXxqfwHazKFQLvPTCzE` | **PR:** #39
+
+Major feature: Added Auction view tab to the free agents page with live bid tracking. Allows owners to see current auction status inline with free agent data.
+
+---
+
+### 2026-03-20: Contract Modal Width Fix
+**Session:** `session_01VZsaJdwZ82F38MxjeuAGs1` | **PR:** #38
+
+Reduced minimum width of year options grid in contract modal for better mobile display.
+
+---
+
+### 2026-03-16: SVG Favicon
+**Session:** `session_01CgJXc5S68Gz2HyNBH19uCN` | **PR:** #37
+
+Added SVG favicon to all layout templates across the app.
+
+---
+
+### 2026-03-15: Rookie Salary Reserve
+**Session:** `session_014sAPL7Rc3wHk11kvmA2FGY` | **PR:** #36
+
+Changed rookie salary reserve calculation to be based on actual draft picks owned rather than a fixed estimate.
+
+---
+
+### 2026-03-14: Side Nav Update
+**Session:** `session_014RTuZunqp1bgMUkJBhhnqA` | **PR:** #35
+
+Updated side navigation: added Rules link, removed Franchise Tags link.
+
+---
+
+### 2026-03-12: News Feed Sidebar (IN PROGRESS)
+**Session:** `session_013VNZG12D8fFjGhpeyk8tKr` | **PR:** #33 (OPEN)
+
+New feature: News feed sidebar for the league homepage. Still open/in progress.
+
+---
+
+### 2026-03-11: Calendar Event Filters
+**Session:** `session_01VfzrxpoiVKVG5cEQawUPUg` | **PRs:** #32, #31
+
+Two PRs from same session:
+- **#31**: Added toggle to filter calendar events by All, Upcoming, or Past
+- **#32**: Aligned the event filter toggle with the design system chip pattern
+
+---
+
+### 2026-03-04: PWA Hero CTA Fix
+**Session:** `session_013WBbvh59NsGS6ab4aGYHGe` | **PR:** #30
+
+Fixed hero CTA link for PWA app entry — was incorrectly pointing to homepage instead of the appropriate landing page.
+
+---
+
+### 2026-03-02: Franchise Tag Admin Gate
+**Session:** `session_01LSaLnCEDmBnbZTmcewEpLA` | **PR:** #29
+
+Gated the franchise tag feature behind an admin flag so it's not visible to regular users until ready.
+
+---
+
+### 2026-02-28: What's New Screenshot Requirements
+**Session:** `session_01XBPZaXXeDaUF5wJrjuxHdt` | **PR:** #28
+
+Added screenshot requirements and validation for What's New changelog entries. Ensures 16:9 aspect ratio screenshots are provided for new features/pages.
+
+---
+
+### 2026-02-28: MFL Script Modularization
+**Session:** `session_01NJR2r8CFRLoh3SMZGpS47h` | **PR:** #27
+
+Migrated MFL page enhancements from monolithic `global.js` to a modular script architecture.
+
+---
+
+### 2026-02-28: CSS Customization Guide
+**Session:** `session_01YDenyfLaVsthaqPrNHzhyW` | **PR:** #26
+
+Created comprehensive CSS Customization Guide documentation.
+
+---
+
+### 2026-02-28: Mobile Tab Alignment Fix
+**Session:** `session_01BAwDDDNptfdkxXXfAbbyFs` | **PR:** #25
+
+Fixed mobile clear button pushing GM/Coach tabs out of alignment on roster-related pages.
+
+---
+
+### 2026-02-26: Login Integration Plan
+**Session:** `session_01LLiF8nUpHLYJ4PBe8yrcsf` | **PR:** #24
+
+Documentation/planning session: Created Phase 1 login integration plan documenting the MFL auth flow.
+
+---
+
+### 2026-02-24: Rankings Calculation Fix
+**Session:** `session_01VnTg4w3PMi15hWKBrE3SQU` | **PR:** #22
+
+Fixed bug where unranked players were treated as rank 0 instead of max rank + 1 in average/composite calculations, skewing results.
+
+---
+
+### 2026-02-24: League Planner Mobile Scroll
+**Session:** `session_01JGyU9VS7UkRrnVwUfuyJLF` | **PR:** #21
+
+Fixed mobile horizontal scroll issue on the League Planner page.
+
+---
+
+### 2026-02-21: Design Token Fix
+**Session:** `session_01W4yR9aLyHizbpdnC4RUSSd` | **PR:** #20
+
+Fixed card hover color on homepage to use the correct green design token instead of a hardcoded value.
+
+---
+
+### 2026-02-17: Free Agents Research Tool
+**Session:** `session_01RN6Kx7BmYqezN8Us7FmXAe` | **PR:** #19
+
+Major feature: Built a Free Agents player research tool with sorting and filtering capabilities.
+
+---
+
+### 2026-02-17: What's New Mobile Fix
+**Session:** `session_01UXE9dEZrwotdBymQXoGGLU` | **PR:** #17
+
+Fixed mobile alignment and padding issues on the What's New page.
+
+---
+
+### 2026-02-16: Trade Bait Link Fix
+**Session:** `session_01Bek3PzS1xMatFxzhcmQ14Z` | **PR:** #15
+
+Fixed MFL Trade Bait link to point to the correct page (`O=133`).
+
+---
+
+### 2026-02-16: League Summary Spacing
+**Session:** `session_01Xjj3UnTTsmVxHWe4Fsq6JN` | **PR:** #12
+
+Added more spacing above the League Summary table for better visual hierarchy.
+
+---
+
+### 2026-02-16: Draft Picks Feed Fix
+**Session:** `session_018aiGQ7ZFFPmDb2WTZbTq45` | **PR:** #11
+
+Fixed draft picks display showing 0 for 2026 — needed to load from previous year's MFL feed for current draft year.
+
+---
+
+### 2026-02-16: Trade Bait Integration
+**No session URL** | **PRs:** #8, #9, #10
+
+Multi-PR effort to integrate trade bait functionality. Three PRs with branch names like `claude/trade-bait-integration-*`.
+
+---
+
+### 2026-02-15: Calendar Day Abbreviation
+**Session:** `session_01Fa1BJupfq2RPfWNMreQns2` | **PR:** #7
+
+Added day-of-week abbreviation (Mon, Tue, etc.) to event calendar dates for better readability.
+
+---
+
+### 2026-02-15: Trade Deadline Builder Link
+**Session:** `session_01JackGqurtAd6ynbwwTpbWk` | **PR:** #5
+
+Linked trade deadline calendar event to the internal trade builder page instead of external MFL.
+
+---
+
+### 2026-02-15: Calendar Terminology Fix
+**Session:** `session_016N2mRfLKWDc9bZQpqLtwKu` | **PR:** #4
+
+Removed 'blind bid' terminology from calendar event descriptions (replaced with correct wording).
+
+---
+
+### 2026-02-15: League Summary Background
+**Session:** `session_012QERBMqTcR8PoVFJrmrBvF` | **PR:** #3
+
+Added white background to the league summary page container for better readability.
+
+---
+
+### 2026-02-15: Side Drawer Calendar Link
+**Session:** `session_01GcxbhVtbi2RBQpViMUT7H1` | **PR:** #2
+
+Added League Calendar to the "Popular" section in the side drawer navigation.
+
+---
+
+### 2025-12-20: Rules Page (Project Genesis)
+**No session URL** | **PR:** #1
+
+The first PR — created the Rules page. Predates session URL tracking in commits.
+
+---
+
+## Sessions by Feature Area
+
+### Contract System
+- `session_0149YRoxywYwaZdrSATE7ahY` — Pacific Time deadline fix (#63)
+- `session_01GFYfFizzTd5ja9gt3N4cSi` — Submit window & batch fix (#57)
+- `session_01C9Wrq8EyZ5jMivQ7BK7xNj` — Duration & cancel logic (#55, #53)
+- `session_0197vFiwJqoEFRvHxUt4wGzt` — Manager overhaul (#52, #51, #49)
+- `session_01Sz58Tyg5NQB5EsDWAd4VPH` — Commissioner access (#46)
+- PR #58 (no session) — Redis migration & commish tools
+- `session_01VZsaJdwZ82F38MxjeuAGs1` — Modal width fix (#38)
+- `session_014sAPL7Rc3wHk11kvmA2FGY` — Rookie salary reserve (#36)
+- Commit `a7fb54b` — Applied contracts redesign
+
+### Auction System
+- `session_01U4AAXxqfwHazKFQLvPTCzE` — Auction view feature (#39)
+- `session_01VbTGoiL1uE3zi288ocHyDi` — Auction timer fix (#45)
+- `session_01VAsPPPqZoS3vwTFVorR5de` — AUCTION_WON eligibility (#43)
+- `session_0142wLbrTS8tEteBgpmc6N8X` — Missing auction winners (#42)
+- `session_01Txn3tMseHnkoqCgM6zCnix` — Consolidate articles (#40)
+
+### Navigation & Layout
+- `session_01KDwrmpoGYAgX3tm2f4mX2B` — Nav logged-in state bug (#60)
+- `session_014RTuZunqp1bgMUkJBhhnqA` — Side nav update (#35)
+- `session_01GcxbhVtbi2RBQpViMUT7H1` — Side drawer calendar (#2)
+- `session_01CgJXc5S68Gz2HyNBH19uCN` — SVG favicon (#37)
+
+### Mobile Fixes
+- `session_01BAwDDDNptfdkxXXfAbbyFs` — Tab alignment (#25)
+- `session_01JGyU9VS7UkRrnVwUfuyJLF` — League Planner scroll (#21)
+- `session_01UXE9dEZrwotdBymQXoGGLU` — What's New padding (#17)
+
+### Calendar & Events
+- `session_01VfzrxpoiVKVG5cEQawUPUg` — Event filters (#32, #31)
+- `session_01Fa1BJupfq2RPfWNMreQns2` — Day abbreviation (#7)
+- `session_016N2mRfLKWDc9bZQpqLtwKu` — Terminology fix (#4)
+
+### Free Agents & Rankings
+- `session_01RN6Kx7BmYqezN8Us7FmXAe` — Free Agents tool (#19)
+- `session_01VnTg4w3PMi15hWKBrE3SQU` — Rankings calculation fix (#22)
+- `session_01VvVtZ7sBMnEqgu8WGeLd4m` — Power Rankings page (#59, OPEN)
+
+### Trade System
+- `session_01JackGqurtAd6ynbwwTpbWk` — Trade builder link (#5)
+- `session_01Bek3PzS1xMatFxzhcmQ14Z` — Trade Bait link fix (#15)
+- PRs #8-10 — Trade Bait integration
+
+### Documentation & Planning
+- `session_01LLiF8nUpHLYJ4PBe8yrcsf` — Login integration plan (#24)
+- `session_01XBPZaXXeDaUF5wJrjuxHdt` — Screenshot requirements (#28)
+- `session_01YDenyfLaVsthaqPrNHzhyW` — CSS customization guide (#26)
+- `session_01NJR2r8CFRLoh3SMZGpS47h` — Script modularization (#27)
+
+### Design System & Tokens
+- `session_01W4yR9aLyHizbpdnC4RUSSd` — Green hover token (#20)
+- `session_01LSaLnCEDmBnbZTmcewEpLA` — Franchise tag admin gate (#29)
+
+### Homepage & General
+- `session_01MkgVNack1TZn8QUYyMqTMx` — Division champions (#61)
+- `session_01LjmsMdfMu1Z9XdQHKJt8k5` — Login redirect (#62)
+- `session_013WBbvh59NsGS6ab4aGYHGe` — PWA hero CTA fix (#30)
+- `session_013VNZG12D8fFjGhpeyk8tKr` — News feed sidebar (#33, OPEN)
+- `session_01Xjj3UnTTsmVxHWe4Fsq6JN` — League Summary spacing (#12)
+- `session_012QERBMqTcR8PoVFJrmrBvF` — Summary background (#3)
+- `session_018aiGQ7ZFFPmDb2WTZbTq45` — Draft picks fix (#11)
+- Commit `8ba52af` — Owner activity tracking
+
+---
+
+## Open Work (Unmerged)
+
+| PR | Session | Feature | Status |
+|----|---------|---------|--------|
+| #59 | `session_01VvVtZ7sBMnEqgu8WGeLd4m` | Power Rankings page | OPEN |
+| #33 | `session_013VNZG12D8fFjGhpeyk8tKr` | News feed sidebar | OPEN |
+
+---
+
+## Stats
+
+- **Total unique sessions tracked:** 38
+- **Total PRs:** 63 (61 merged, 2 open)
+- **Project start:** 2025-12-20 (PR #1)
+- **Most active day:** 2026-03-21 (8 PRs merged across 5 sessions — contract & auction sprint)
+- **Busiest feature area:** Contract system (9+ sessions)


### PR DESCRIPTION
## Summary

- Comprehensive index of all 38 Claude Code sessions with session IDs, PR links, dates, and one-line summaries
- Detailed notes for each session documenting what was done, key files, and important context
- Feature-area groupings (Contract System, Auction, Navigation, Mobile, Calendar, etc.) for quick lookup
- Open work tracker for unmerged PRs (#59, #33)

## Test plan
- [ ] Verify markdown renders correctly on GitHub
- [ ] Spot-check session URLs resolve correctly

https://claude.ai/code/session_01TkF8kz7c3odRCkmToMfhsq