### PR TITLE
fix: carry forward freeze state for offseason weekly snapshots

### DIFF
--- a/scripts/update-salary-averages.mjs
+++ b/scripts/update-salary-averages.mjs
@@ -743,9 +743,46 @@ const run = async () => {
   const stateIsCurrentSeason = state?.season === season;
   let lockedWeek = stateIsCurrentSeason ? state?.frozenWeek ?? null : null;
 
+  // Cross-year offseason detection: when the league year has advanced (e.g. 2025→2026)
+  // but the previous season had a freeze, we're in the offseason of the new league year.
+  // Carry forward the freeze info so weekly offseason snapshots continue to be generated.
+  let crossYearOffseason = false;
+  if (!lockedWeek && !stateIsCurrentSeason && state?.frozenWeek && state?.frozenAt && detectedWeek === 0) {
+    const prevSeason = state.season;
+    const prevFrozenWeek = state.frozenWeek;
+    console.log(
+      `[salary-averages] New league year ${season} — previous season ${prevSeason} ` +
+      `was frozen at week ${prevFrozenWeek}. Continuing offseason snapshots.`
+    );
+    lockedWeek = prevFrozenWeek;
+    crossYearOffseason = true;
+    // Persist the freeze state for the new season so subsequent runs don't need to re-derive it
+    await writeSeasonState({
+      season,
+      frozenWeek: prevFrozenWeek,
+      frozenAt: state.frozenAt,
+      carriedFrom: prevSeason,
+    });
+  }
+
   // Safety check: if the season is "frozen" but detectedWeek is 0 (no real scores),
   // the freeze was likely triggered erroneously by stale MFL data. Clear it.
-  if (lockedWeek && detectedWeek === 0) {
+  // Skip this check during cross-year offseason — detectedWeek is expected to be 0
+  // (either detected this run via crossYearOffseason, or persisted via carriedFrom).
+  const isCarriedForwardFreeze = crossYearOffseason || !!state?.carriedFrom;
+
+  // When real games are detected in the new season, clear the carried-forward freeze
+  // so normal week-by-week tracking resumes from week 1.
+  if (lockedWeek && detectedWeek > 0 && isCarriedForwardFreeze) {
+    console.log(
+      `[salary-averages] New season ${season} has real scores (week ${detectedWeek}) — ` +
+      `clearing carried-forward freeze. Normal tracking resumes.`
+    );
+    lockedWeek = null;
+    await writeSeasonState({ season, frozenWeek: null, clearedAt: new Date().toISOString() });
+  }
+
+  if (lockedWeek && detectedWeek === 0 && !isCarriedForwardFreeze) {
     console.warn(
       `[salary-averages] Season ${season} is frozen at week ${lockedWeek} but no scored ` +
       `matchups detected — clearing stale freeze state.`

--- a/src/data/mfl-season-state-theleague.json
+++ b/src/data/mfl-season-state-theleague.json
@@ -1,5 +1,6 @@
 {
-  "season": "2025",
+  "season": "2026",
   "frozenWeek": 14,
-  "frozenAt": "2025-12-15T00:00:00.000Z"
+  "frozenAt": "2025-12-15T00:00:00.000Z",
+  "carriedFrom": "2025"
 }


### PR DESCRIPTION
## Summary

- **Root cause**: When the league year advances (2025→2026 on Feb 14), the season state file still referenced "2025". The script checked `state.season === currentSeason` and got `false`, so `lockedWeek` was always `null` — causing the post-freeze weekly snapshot code to never execute during the offseason.
- **Fix**: Detects cross-year offseason condition and carries forward the freeze state with a `carriedFrom` marker. This prevents the safety check from clearing it on subsequent runs.
- **Lifecycle**: When real game scores are detected in the new season, the carried-forward freeze is automatically cleared and normal week-by-week tracking resumes.

## Test plan

- [x] Verified first-run cross-year detection: script logs "New league year 2026 — previous season 2025 was frozen at week 14. Continuing offseason snapshots."
- [x] Verified state file is updated with `carriedFrom: "2025"` marker
- [x] Verified second run correctly uses carried-forward state without clearing it
- [ ] After merge, verify the next CI roster-sync run generates a `summary-week-off-N.json` file with a current `generatedAt` timestamp
- [ ] In September when games start, verify the carried freeze is cleared and normal tracking resumes

https://claude.ai/code/session_01QQVa4BKN8bWQn1TcosBjCe