### PR TITLE
feat: new homepage prototype with compact feed and reply system

### DIFF
--- a/src/components/shared/ScheftnerFeed.astro
+++ b/src/components/shared/ScheftnerFeed.astro
@@ -15,11 +15,14 @@ import ScheftnerPostCard from './ScheftnerPostCard.astro';
 interface Props {
   posts: ScheftnerPost[];
   isAuthenticated?: boolean;
+  userFranchiseId?: string;
+  userTeamName?: string;
+  userTeamIcon?: string;
   /** Max posts to show initially (for pagination) */
   initialLimit?: number;
 }
 
-const { posts, isAuthenticated = false, initialLimit = 25 } = Astro.props;
+const { posts, isAuthenticated = false, userFranchiseId, userTeamName, userTeamIcon, initialLimit = 25 } = Astro.props;
 const now = new Date();
 ---
 
@@ -35,6 +38,9 @@ const now = new Date();
         <ScheftnerPostCard
           post={post}
           isAuthenticated={isAuthenticated}
+          userFranchiseId={userFranchiseId}
+          userTeamName={userTeamName}
+          userTeamIcon={userTeamIcon}
           now={now}
         />
       </div>

--- a/src/components/shared/ScheftnerFeedCompact.astro
+++ b/src/components/shared/ScheftnerFeedCompact.astro
@@ -1,0 +1,103 @@
+---
+/**
+ * ScheftnerFeedCompact — Compact feed for sidebar usage.
+ *
+ * Shows 10 posts initially with "Show more" pagination.
+ * Section header with editorial left-border accent.
+ */
+import type { ScheftnerPost } from '../../types/scheftner';
+import ScheftnerPostCardCompact from './ScheftnerPostCardCompact.astro';
+
+interface Props {
+  posts: ScheftnerPost[];
+  isAuthenticated?: boolean;
+  userFranchiseId?: string;
+  userTeamName?: string;
+  userTeamIcon?: string;
+  initialLimit?: number;
+}
+
+const {
+  posts,
+  isAuthenticated = false,
+  userFranchiseId,
+  userTeamName,
+  userTeamIcon,
+  initialLimit = 10,
+} = Astro.props;
+
+const now = new Date();
+---
+
+<section class="sfc-feed" aria-label="Latest league news">
+  <div class="sfc-feed__header">
+    <h2 class="sfc-feed__title">Scheftner Report</h2>
+    <a href="/theleague/news" class="sfc-feed__view-all">View all <span aria-hidden="true">→</span></a>
+  </div>
+
+  {posts.length === 0 ? (
+    <div class="sfc-empty">No news yet. Schefter is on assignment.</div>
+  ) : (
+    <div class="sfc-feed__list" data-initial-limit={initialLimit}>
+      {posts.map((post, i) => (
+        <div class:list={['sfc-feed__item', { 'sfc-feed__item--hidden': i >= initialLimit }]} data-feed-index={i}>
+          <ScheftnerPostCardCompact
+            post={post}
+            isAuthenticated={isAuthenticated}
+            userFranchiseId={userFranchiseId}
+            userTeamName={userTeamName}
+            userTeamIcon={userTeamIcon}
+            now={now}
+          />
+        </div>
+      ))}
+    </div>
+  )}
+
+  {posts.length > initialLimit && (
+    <div class="sfc-load-more">
+      <button class="sfc-load-more__btn" data-sfc-load-more>
+        Show more
+      </button>
+    </div>
+  )}
+</section>
+
+<script>
+  function initCompactLoadMore() {
+    const feed = document.querySelector('.sfc-feed');
+    if (!feed) return;
+
+    const btn = feed.querySelector('[data-sfc-load-more]') as HTMLButtonElement | null;
+    if (!btn) return;
+
+    const list = feed.querySelector('.sfc-feed__list');
+    if (!list) return;
+
+    const PAGE_SIZE = 5;
+    const initialLimit = parseInt(list.getAttribute('data-initial-limit') ?? '10', 10);
+    let showing = initialLimit;
+
+    btn.addEventListener('click', () => {
+      const items = list.querySelectorAll('.sfc-feed__item');
+      const nextLimit = showing + PAGE_SIZE;
+
+      items.forEach((item, i) => {
+        if (i < nextLimit) {
+          item.classList.remove('sfc-feed__item--hidden');
+        }
+      });
+
+      showing = nextLimit;
+
+      if (showing >= items.length) {
+        // Focus the first newly-revealed item before removing button
+        const firstNew = items[nextLimit - PAGE_SIZE];
+        if (firstNew instanceof HTMLElement) firstNew.focus({ preventScroll: true });
+        btn.parentElement?.remove();
+      }
+    });
+  }
+
+  document.addEventListener('astro:page-load', initCompactLoadMore);
+</script>

--- a/src/components/shared/ScheftnerPostCard.astro
+++ b/src/components/shared/ScheftnerPostCard.astro
@@ -17,14 +17,18 @@ import type { ScheftnerPost } from '../../types/scheftner';
 import { getAuthor, getAuthorAvatar } from '../../types/scheftner';
 import { formatRelativeTime } from '../../utils/scheftner-feed';
 import ScheftnerReactionBar from './ScheftnerReactionBar.tsx';
+import ScheftnerReplyThread from './ScheftnerReplyThread.tsx';
 
 interface Props {
   post: ScheftnerPost;
   isAuthenticated?: boolean;
+  userFranchiseId?: string;
+  userTeamName?: string;
+  userTeamIcon?: string;
   now?: Date;
 }
 
-const { post, isAuthenticated = false, now } = Astro.props;
+const { post, isAuthenticated = false, userFranchiseId, userTeamName, userTeamIcon, now } = Astro.props;
 const relTime = formatRelativeTime(post.timestamp, now);
 const author = getAuthor(post.authorId);
 const avatarSrc = getAuthorAvatar(author);
@@ -79,10 +83,22 @@ const tierClass = `sf-post ${isArticle ? 'sf-post--article' : isExternal ? 'sf-p
       </a>
     )}
 
-    <ScheftnerReactionBar
-      client:visible
-      postId={post.id}
-      isAuthenticated={isAuthenticated}
-    />
+    <div class="sfc-post__actions">
+      <ScheftnerReplyThread
+        client:idle
+        postId={post.id}
+        postHeadline={post.headline}
+        postAuthorId={post.authorId}
+        isAuthenticated={isAuthenticated}
+        userFranchiseId={userFranchiseId}
+        userTeamName={userTeamName}
+        userTeamIcon={userTeamIcon}
+      />
+      <ScheftnerReactionBar
+        client:visible
+        postId={post.id}
+        isAuthenticated={isAuthenticated}
+      />
+    </div>
   </div>
 </article>

--- a/src/components/shared/ScheftnerPostCardCompact.astro
+++ b/src/components/shared/ScheftnerPostCardCompact.astro
@@ -1,0 +1,81 @@
+---
+/**
+ * ScheftnerPostCardCompact — Compact post card for sidebar feed.
+ *
+ * Smaller text, 3-line body clamp, no analysis blocks or article images.
+ * Renders reactions + reply thread toggle.
+ */
+import type { ScheftnerPost } from '../../types/scheftner';
+import { getAuthor, getAuthorAvatar } from '../../types/scheftner';
+import { formatRelativeTime } from '../../utils/scheftner-feed';
+import ScheftnerReactionBar from './ScheftnerReactionBar.tsx';
+import ScheftnerReplyThread from './ScheftnerReplyThread.tsx';
+
+interface Props {
+  post: ScheftnerPost;
+  isAuthenticated?: boolean;
+  userFranchiseId?: string;
+  userTeamName?: string;
+  userTeamIcon?: string;
+  now?: Date;
+}
+
+const {
+  post,
+  isAuthenticated = false,
+  userFranchiseId,
+  userTeamName,
+  userTeamIcon,
+  now,
+} = Astro.props;
+
+const relTime = formatRelativeTime(post.timestamp, now);
+const author = getAuthor(post.authorId);
+const avatarSrc = getAuthorAvatar(author);
+const isExternal = post.type === 'external';
+const tierClass = `sfc-post${post.tier === 'breaking' ? ' sfc-post--breaking' : ''}`;
+---
+
+<article class={tierClass} data-post-id={post.id} aria-label={`${author.name}: ${post.headline ?? post.body?.replace(/<[^>]+>/g, '').slice(0, 80) ?? 'Post'}`}>
+  <img class="sfc-avatar" src={avatarSrc} alt="" aria-hidden="true" width="32" height="32" loading="lazy" />
+
+  <div class="sfc-post__content">
+    <div class="sfc-post__header">
+      <span class="sfc-post__name">{author.name}</span>
+      <span class="sfc-post__handle">{author.handle}</span>
+      <time class="sfc-post__time" datetime={post.timestamp}>{relTime}</time>
+    </div>
+
+    <div class="sfc-post__body" set:html={post.body} />
+
+    {post.link && (
+      <a
+        href={post.link}
+        class="sfc-post__link"
+        {...(isExternal ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
+      >
+        {post.linkLabel ?? (isExternal ? 'Read on ESPN →' : 'Read more')}
+        {isExternal && <span style="position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0">(opens in new tab)</span>}
+      </a>
+    )}
+
+    <div class="sfc-post__actions">
+      <ScheftnerReactionBar
+        client:visible
+        postId={post.id}
+        isAuthenticated={isAuthenticated}
+      />
+    </div>
+
+    <ScheftnerReplyThread
+      client:idle
+      postId={post.id}
+      postHeadline={post.headline}
+      postAuthorId={post.authorId}
+      isAuthenticated={isAuthenticated}
+      userFranchiseId={userFranchiseId}
+      userTeamName={userTeamName}
+      userTeamIcon={userTeamIcon}
+    />
+  </div>
+</article>

--- a/src/components/shared/ScheftnerPostCardCompact.astro
+++ b/src/components/shared/ScheftnerPostCardCompact.astro
@@ -60,22 +60,21 @@ const tierClass = `sfc-post${post.tier === 'breaking' ? ' sfc-post--breaking' : 
     )}
 
     <div class="sfc-post__actions">
+      <ScheftnerReplyThread
+        client:idle
+        postId={post.id}
+        postHeadline={post.headline}
+        postAuthorId={post.authorId}
+        isAuthenticated={isAuthenticated}
+        userFranchiseId={userFranchiseId}
+        userTeamName={userTeamName}
+        userTeamIcon={userTeamIcon}
+      />
       <ScheftnerReactionBar
         client:visible
         postId={post.id}
         isAuthenticated={isAuthenticated}
       />
     </div>
-
-    <ScheftnerReplyThread
-      client:idle
-      postId={post.id}
-      postHeadline={post.headline}
-      postAuthorId={post.authorId}
-      isAuthenticated={isAuthenticated}
-      userFranchiseId={userFranchiseId}
-      userTeamName={userTeamName}
-      userTeamIcon={userTeamIcon}
-    />
   </div>
 </article>

--- a/src/components/shared/ScheftnerReplyThread.tsx
+++ b/src/components/shared/ScheftnerReplyThread.tsx
@@ -30,7 +30,7 @@ function formatRelTime(iso: string): string {
 }
 
 const CHAT_ICON = (
-  <svg className="sfc-reply-toggle__icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+  <svg className="sfc-reply-toggle__icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
     <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
   </svg>
 );
@@ -62,7 +62,7 @@ export default function ScheftnerReplyThread({
   const repliesRegionRef = useRef<HTMLDivElement>(null);
   const toggleRef = useRef<HTMLButtonElement>(null);
 
-  // Fetch replies when thread is first expanded
+  // Fetch replies on mount so count badge shows immediately
   const fetchReplies = useCallback(async () => {
     try {
       const res = await fetch(`/api/scheftner-replies/${postId}`);
@@ -77,10 +77,8 @@ export default function ScheftnerReplyThread({
   }, [postId]);
 
   useEffect(() => {
-    if (isExpanded && !loaded) {
-      fetchReplies();
-    }
-  }, [isExpanded, loaded, fetchReplies]);
+    fetchReplies();
+  }, [fetchReplies]);
 
   const toggleExpanded = () => {
     setIsExpanded(prev => !prev);

--- a/src/components/shared/ScheftnerReplyThread.tsx
+++ b/src/components/shared/ScheftnerReplyThread.tsx
@@ -1,0 +1,307 @@
+/**
+ * ScheftnerReplyThread — Interactive reply thread for feed posts.
+ *
+ * Renders as a collapsible thread below each post. Owners reply with
+ * their team icon as avatar. AI characters (Claude Schefter / Ask Roger)
+ * respond in real-time via Haiku.
+ */
+import { useState, useRef, useCallback, useEffect } from 'react';
+import type { ScheftnerReply } from '../../types/scheftner-replies';
+
+interface Props {
+  postId: string;
+  postHeadline: string;
+  postAuthorId?: string;
+  isAuthenticated: boolean;
+  userFranchiseId?: string;
+  userTeamName?: string;
+  userTeamIcon?: string;
+}
+
+function formatRelTime(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return 'now';
+  if (mins < 60) return `${mins}m`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h`;
+  const days = Math.floor(hours / 24);
+  return `${days}d`;
+}
+
+const CHAT_ICON = (
+  <svg className="sfc-reply-toggle__icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+    <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+  </svg>
+);
+
+export default function ScheftnerReplyThread({
+  postId,
+  postHeadline,
+  postAuthorId,
+  isAuthenticated,
+  userFranchiseId,
+  userTeamName,
+  userTeamIcon,
+}: Props) {
+  const isRogerPost = postAuthorId === 'roger';
+  const defaultAiName = isRogerPost ? 'Ask Roger' : 'Claude Schefter';
+  const defaultAiAvatar = isRogerPost ? '/assets/commissioner-avatar.webp' : '/assets/claude-schefter-avatar.webp';
+
+  const [replies, setReplies] = useState<ScheftnerReply[]>([]);
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [aiTyping, setAiTyping] = useState(false);
+  const [aiTypingName, setAiTypingName] = useState(defaultAiName);
+  const [aiTypingAvatar, setAiTypingAvatar] = useState(defaultAiAvatar);
+  const [inputValue, setInputValue] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [loaded, setLoaded] = useState(false);
+
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const repliesRegionRef = useRef<HTMLDivElement>(null);
+  const toggleRef = useRef<HTMLButtonElement>(null);
+
+  // Fetch replies when thread is first expanded
+  const fetchReplies = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/scheftner-replies/${postId}`);
+      if (res.ok) {
+        const data = await res.json();
+        setReplies(data.replies ?? []);
+      }
+    } catch {
+      // Silently fail — replies are supplementary
+    }
+    setLoaded(true);
+  }, [postId]);
+
+  useEffect(() => {
+    if (isExpanded && !loaded) {
+      fetchReplies();
+    }
+  }, [isExpanded, loaded, fetchReplies]);
+
+  const toggleExpanded = () => {
+    setIsExpanded(prev => !prev);
+  };
+
+  const handleSubmit = async () => {
+    const body = inputValue.trim();
+    if (!body || isSubmitting) return;
+
+    setError(null);
+    setIsSubmitting(true);
+
+    // Optimistic insert
+    const tempId = `temp-${Date.now()}`;
+    const optimisticReply: ScheftnerReply = {
+      id: tempId,
+      postId,
+      parentId: null,
+      body,
+      author: {
+        type: 'owner',
+        franchiseId: userFranchiseId,
+        name: userTeamName ?? 'My Team',
+        avatar: userTeamIcon ?? '',
+      },
+      createdAt: new Date().toISOString(),
+    };
+
+    setReplies(prev => [...prev, optimisticReply]);
+    setInputValue('');
+
+    try {
+      // 1. Submit user reply
+      const replyRes = await fetch(`/api/scheftner-replies/${postId}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ body }),
+      });
+
+      if (!replyRes.ok) {
+        const err = await replyRes.json().catch(() => ({ error: 'Failed to post reply' }));
+        throw new Error(err.error);
+      }
+
+      const { reply: savedReply } = await replyRes.json();
+
+      // Replace optimistic reply with server reply
+      setReplies(prev => prev.map(r => r.id === tempId ? savedReply : r));
+
+      // 2. Trigger AI reply — show typing indicator with pre-resolved character
+      setAiTypingName(defaultAiName);
+      setAiTypingAvatar(defaultAiAvatar);
+      setAiTyping(true);
+
+      const aiRes = await fetch(`/api/scheftner-replies/${postId}/ai-reply`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ userReplyId: savedReply.id }),
+      });
+
+      if (aiRes.ok) {
+        const { reply: aiReply } = await aiRes.json();
+        setReplies(prev => [...prev, aiReply]);
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Failed to post reply';
+      setError(msg);
+      // Remove optimistic reply on failure
+      setReplies(prev => prev.filter(r => r.id !== tempId));
+    } finally {
+      setIsSubmitting(false);
+      setAiTyping(false);
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+      e.preventDefault();
+      handleSubmit();
+    }
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      setIsExpanded(false);
+      toggleRef.current?.focus();
+    }
+  };
+
+  const handleRegionKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      setIsExpanded(false);
+      toggleRef.current?.focus();
+    }
+  };
+
+  const replyCount = replies.length;
+
+  return (
+    <div className="sfc-reply-thread">
+      <button
+        ref={toggleRef}
+        className="sfc-reply-toggle"
+        onClick={toggleExpanded}
+        aria-expanded={isExpanded}
+        aria-controls={`replies-${postId}`}
+        aria-label={isExpanded ? 'Hide replies' : `Show replies${replyCount > 0 ? ` (${replyCount})` : ''}`}
+      >
+        {CHAT_ICON}
+        {replyCount > 0 && (
+          <span className="sfc-reply-toggle__count">{replyCount}</span>
+        )}
+      </button>
+
+      {isExpanded && (
+        <div
+          id={`replies-${postId}`}
+          className="sfc-replies"
+          role="region"
+          aria-label="Replies to this post"
+          ref={repliesRegionRef}
+          onKeyDown={handleRegionKeyDown}
+        >
+          {/* Reply list */}
+          <div aria-live="polite" aria-relevant="additions" aria-atomic="false">
+            {replies.map(reply => (
+              <div
+                key={reply.id}
+                className={`sfc-reply${reply.author.type === 'ai' ? ` sfc-reply--ai${reply.author.aiCharacter === 'roger' ? ' sfc-reply--roger' : ''}` : ' sfc-reply--owner'}`}
+              >
+                <img
+                  className="sfc-reply__avatar"
+                  src={reply.author.avatar}
+                  alt=""
+                  width="24"
+                  height="24"
+                  loading="lazy"
+                />
+                <div className="sfc-reply__content">
+                  <div className="sfc-reply__header">
+                    <span className="sfc-reply__name">{reply.author.name}</span>
+                    {reply.author.handle && (
+                      <span className="sfc-reply__handle">{reply.author.handle}</span>
+                    )}
+                    <time className="sfc-reply__time" dateTime={reply.createdAt}>
+                      {formatRelTime(reply.createdAt)}
+                    </time>
+                  </div>
+                  <div className="sfc-reply__body">{reply.body}</div>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {/* Typing indicator */}
+          {aiTyping && (
+            <div className="sfc-typing" role="status" aria-live="polite">
+              <img
+                className="sfc-reply__avatar"
+                src={aiTypingAvatar}
+                alt=""
+                width="24"
+                height="24"
+              />
+              <div className="sfc-typing__content">
+                <span className="sfc-typing__text">{aiTypingName} is typing</span>
+                <span className="sfc-typing__dots" aria-hidden="true">
+                  <span className="sfc-typing__dot" />
+                  <span className="sfc-typing__dot" />
+                  <span className="sfc-typing__dot" />
+                </span>
+              </div>
+            </div>
+          )}
+
+          {/* Error message */}
+          {error && (
+            <div className="sfc-reply-error" role="alert" style={{
+              fontSize: '0.75rem',
+              color: 'var(--color-error, #dc2626)',
+              padding: '0.25rem 0',
+            }}>
+              {error}
+            </div>
+          )}
+
+          {/* Composer */}
+          {isAuthenticated && (
+            <div className="sfc-composer">
+              {userTeamIcon && (
+                <img
+                  className="sfc-reply__avatar"
+                  src={userTeamIcon}
+                  alt=""
+                  width="24"
+                  height="24"
+                />
+              )}
+              <textarea
+                ref={textareaRef}
+                className="sfc-composer__input"
+                placeholder="Reply..."
+                aria-label="Write a reply to this post. Press Ctrl+Enter to submit."
+                value={inputValue}
+                onChange={e => setInputValue(e.target.value)}
+                onKeyDown={handleKeyDown}
+                rows={1}
+                maxLength={500}
+                disabled={isSubmitting}
+              />
+              <button
+                className="sfc-composer__submit"
+                onClick={handleSubmit}
+                disabled={!inputValue.trim() || isSubmitting}
+                aria-label="Submit reply"
+              >
+                {isSubmitting ? '...' : 'Reply'}
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/data/page-directory.json
+++ b/src/data/page-directory.json
@@ -1,5 +1,16 @@
 [
   {
+    "id": "new-hp",
+    "title": "Homepage Prototype",
+    "description": "Experimental 2-column homepage with interactive Scheftner feed and AI-powered reply threads",
+    "path": "/theleague/new-hp",
+    "icon": "home",
+    "category": "tools",
+    "tags": ["prototype", "homepage", "new", "experimental", "feed", "replies", "scheftner", "chat", "smack talk", "interactive", "ai"],
+    "visibility": "admin",
+    "popularity": 1
+  },
+  {
     "id": "news",
     "title": "The Scheftner Report",
     "description": "League news feed with AI-generated transaction reports, trade analysis, and hot takes from Claude Schefter",

--- a/src/pages/api/scheftner-replies/[postId].ts
+++ b/src/pages/api/scheftner-replies/[postId].ts
@@ -1,0 +1,77 @@
+/**
+ * Scheftner Feed — Replies API
+ *
+ * GET  /api/scheftner-replies/{postId}  — Get all replies for a post
+ * POST /api/scheftner-replies/{postId}  — Create a reply (auth required)
+ */
+
+import type { APIRoute } from 'astro';
+import { getAuthUser } from '../../../utils/auth';
+import type { ScheftnerReply, CreateReplyRequest } from '../../../types/scheftner-replies';
+import {
+  getRepliesForPost,
+  saveReply,
+  generateReplyId,
+  checkReplyRateLimit,
+  resolveTeamInfo,
+} from '../../../utils/scheftner-replies-storage';
+
+function json(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+export const GET: APIRoute = async ({ params }) => {
+  const postId = params.postId;
+  if (!postId) return json({ error: 'postId required' }, 400);
+
+  const replies = await getRepliesForPost(postId);
+  return json({ replies });
+};
+
+export const POST: APIRoute = async ({ params, request }) => {
+  const user = getAuthUser(request);
+  if (!user?.franchiseId) return json({ error: 'Authentication required' }, 401);
+
+  const postId = params.postId;
+  if (!postId) return json({ error: 'postId required' }, 400);
+
+  let body: CreateReplyRequest;
+  try {
+    body = await request.json();
+  } catch {
+    return json({ error: 'Invalid request body' }, 400);
+  }
+
+  const replyBody = body.body?.trim() ?? '';
+  if (!replyBody) return json({ error: 'Reply cannot be empty' }, 400);
+  if (replyBody.length > 500) return json({ error: 'Reply must be under 500 characters' }, 400);
+
+  const { allowed } = await checkReplyRateLimit(user.franchiseId);
+  if (!allowed) {
+    return json({ error: 'Slow down — you\'re limited to 10 replies per hour.' }, 429);
+  }
+
+  const teamInfo = await resolveTeamInfo(user.franchiseId);
+
+  const reply: ScheftnerReply = {
+    id: generateReplyId(),
+    postId,
+    parentId: body.parentId ?? null,
+    body: replyBody,
+    author: {
+      type: 'owner',
+      franchiseId: user.franchiseId,
+      name: teamInfo.name,
+      avatar: teamInfo.icon,
+    },
+    createdAt: new Date().toISOString(),
+  };
+
+  const saved = await saveReply(reply);
+  if (!saved) return json({ error: 'Failed to save reply' }, 500);
+
+  return json({ reply }, 201);
+};

--- a/src/pages/api/scheftner-replies/[postId]/ai-reply.ts
+++ b/src/pages/api/scheftner-replies/[postId]/ai-reply.ts
@@ -1,0 +1,163 @@
+/**
+ * Scheftner Feed — AI Reply Generator
+ *
+ * POST /api/scheftner-replies/{postId}/ai-reply
+ *
+ * Generates a reply from Claude Schefter or Ask Roger using Haiku.
+ * Called after a user posts a reply to trigger an AI response.
+ */
+
+import type { APIRoute } from 'astro';
+import { getAuthUser } from '../../../../utils/auth';
+import type { ScheftnerReply, AiReplyRequest } from '../../../../types/scheftner-replies';
+import {
+  getReplyById,
+  saveReply,
+  generateReplyId,
+} from '../../../../utils/scheftner-replies-storage';
+import { getAuthor, getAuthorAvatar } from '../../../../types/scheftner';
+import type { ScheftnerPost } from '../../../../types/scheftner';
+
+function json(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+const CLAUDE_SYSTEM = `You are Claude Schefter, the league's beat reporter and insider for a dynasty fantasy football league called TheLeague. You're responding to league owners in the comments of your news feed.
+
+Personality:
+- Channel Adam Schefter's breaking-news energy but with more humor and edge
+- Play along with smack talk — roast owners when they deserve it
+- Be entertaining, witty, and slightly sarcastic but never mean-spirited
+- Use sports metaphors, insider lingo, and league-specific references
+- Reference the post content for context when relevant
+- Encourage banter and rivalry between owners
+
+Rules:
+- Keep replies under 100 words
+- Never break character — you ARE Claude Schefter
+- Never mention being an AI or language model
+- Be opinionated — take sides, make predictions, call out bad takes`;
+
+const ROGER_SYSTEM = `You are Ask Roger, the commissioner's AI assistant for a dynasty fantasy football league called TheLeague. You're responding to league owners in the comments of the news feed.
+
+Personality:
+- You're the league's rule enforcer and deadline reminder, but with dry wit
+- Deadpan humor — like a seasoned bureaucrat who's seen everything
+- You've read the constitution so they don't have to
+- Slightly exasperated but always professional
+- Reference rules and deadlines when relevant, but keep it conversational
+- Play along with smack talk but from an authority position
+
+Rules:
+- Keep replies under 100 words
+- Never break character — you ARE Ask Roger
+- Never mention being an AI or language model
+- Be the voice of reason, but make it entertaining`;
+
+/** Find the original post from the feed data */
+async function findPost(postId: string): Promise<ScheftnerPost | null> {
+  try {
+    const feedModule = await import('../../../../data/theleague/scheftner-feed.json');
+    const feed = feedModule.default ?? feedModule;
+    return (feed.posts ?? []).find((p: ScheftnerPost) => p.id === postId) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/** Decide which AI character responds */
+function chooseCharacter(post: ScheftnerPost | null): 'claude' | 'roger' {
+  if (post?.authorId === 'roger') return 'roger';
+  if (post?.type === 'ask-roger') return 'roger';
+  return 'claude';
+}
+
+export const POST: APIRoute = async ({ params, request }) => {
+  const user = getAuthUser(request);
+  if (!user?.franchiseId) return json({ error: 'Authentication required' }, 401);
+
+  const postId = params.postId;
+  if (!postId) return json({ error: 'postId required' }, 400);
+
+  let body: AiReplyRequest;
+  try {
+    body = await request.json();
+  } catch {
+    return json({ error: 'Invalid request body' }, 400);
+  }
+
+  if (!body.userReplyId) return json({ error: 'userReplyId required' }, 400);
+
+  // Load context
+  const [userReply, post] = await Promise.all([
+    getReplyById(postId, body.userReplyId),
+    findPost(postId),
+  ]);
+
+  if (!userReply) return json({ error: 'User reply not found' }, 404);
+
+  const character = chooseCharacter(post);
+  const systemPrompt = character === 'roger' ? ROGER_SYSTEM : CLAUDE_SYSTEM;
+
+  // Build context for the AI
+  const contextParts: string[] = [];
+  if (post) {
+    contextParts.push(`Original post: "${post.headline}"`);
+    if (post.body) {
+      const bodyText = post.body.replace(/<[^>]+>/g, '').slice(0, 200);
+      contextParts.push(`Post body: "${bodyText}"`);
+    }
+  }
+  contextParts.push(`${userReply.author.name} replied: "${userReply.body}"`);
+
+  const userMessage = contextParts.join('\n\n');
+
+  try {
+    const { default: Anthropic } = await import('@anthropic-ai/sdk');
+    const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+
+    const response = await client.messages.create({
+      model: 'claude-haiku-4-5-20251001',
+      max_tokens: 200,
+      temperature: 0.8,
+      system: systemPrompt,
+      messages: [{ role: 'user', content: userMessage }],
+    });
+
+    const aiText = response.content
+      .filter((b): b is { type: 'text'; text: string } => b.type === 'text')
+      .map(b => b.text)
+      .join('');
+
+    if (!aiText) return json({ error: 'AI generated empty response' }, 500);
+
+    const author = getAuthor(character);
+    const avatarUrl = getAuthorAvatar(author);
+
+    const aiReply: ScheftnerReply = {
+      id: generateReplyId(),
+      postId,
+      parentId: userReply.id,
+      body: aiText,
+      author: {
+        type: 'ai',
+        name: author.name,
+        avatar: avatarUrl,
+        handle: author.handle,
+        aiCharacter: character,
+      },
+      createdAt: new Date().toISOString(),
+    };
+
+    const saved = await saveReply(aiReply);
+    if (!saved) return json({ error: 'Failed to save AI reply' }, 500);
+
+    return json({ reply: aiReply }, 201);
+  } catch (err) {
+    console.error('[ai-reply] Anthropic API error:', err);
+    return json({ error: 'AI reply generation failed' }, 500);
+  }
+};

--- a/src/pages/api/scheftner-replies/[postId]/ai-reply.ts
+++ b/src/pages/api/scheftner-replies/[postId]/ai-reply.ts
@@ -36,7 +36,7 @@ Personality:
 - Encourage banter and rivalry between owners
 
 Rules:
-- Keep replies under 100 words
+- Keep replies under 140 characters — old-school Twitter length, punchy and tight
 - Never break character — you ARE Claude Schefter
 - Never mention being an AI or language model
 - Be opinionated — take sides, make predictions, call out bad takes`;
@@ -52,7 +52,7 @@ Personality:
 - Play along with smack talk but from an authority position
 
 Rules:
-- Keep replies under 100 words
+- Keep replies under 140 characters — old-school Twitter length, punchy and tight
 - Never break character — you ARE Ask Roger
 - Never mention being an AI or language model
 - Be the voice of reason, but make it entertaining`;
@@ -121,7 +121,7 @@ export const POST: APIRoute = async ({ params, request }) => {
 
     const response = await client.messages.create({
       model: 'claude-haiku-4-5-20251001',
-      max_tokens: 200,
+      max_tokens: 100,
       temperature: 0.8,
       system: systemPrompt,
       messages: [{ role: 'user', content: userMessage }],

--- a/src/pages/theleague/new-hp.astro
+++ b/src/pages/theleague/new-hp.astro
@@ -1,0 +1,134 @@
+---
+/**
+ * New Homepage Prototype
+ *
+ * 2-column layout: flexible left column + 380px right sidebar with compact feed.
+ * Admin-only, accessible at /theleague/new-hp by direct URL.
+ */
+export const prerender = false;
+
+import TheLeagueLayout from '../../layouts/TheLeagueLayout.astro';
+import ScheftnerFeedCompact from '../../components/shared/ScheftnerFeedCompact.astro';
+import { getAuthUser } from '../../utils/auth';
+import type { ScheftnerFeed as FeedType } from '../../types/scheftner';
+import feedData from '../../data/theleague/scheftner-feed.json';
+import '../../styles/scheftner-feed.css';
+import '../../styles/scheftner-feed-compact.css';
+
+const authUser = getAuthUser(Astro.request);
+const isAuthenticated = !!authUser;
+const userFranchiseId = authUser?.franchiseId;
+
+const feed = feedData as FeedType;
+const compactPosts = feed.posts.slice(0, 30);
+
+// Resolve team info for reply composer avatar
+let userTeamName: string | undefined;
+let userTeamIcon: string | undefined;
+
+if (userFranchiseId) {
+  try {
+    const config = await import('../../data/theleague.config.json');
+    const teams = config.default?.teams ?? config.teams ?? [];
+    const team = teams.find((t: { franchiseId: string }) => t.franchiseId === userFranchiseId);
+    if (team) {
+      userTeamName = team.name;
+      userTeamIcon = team.icon;
+    }
+  } catch { /* fallback gracefully */ }
+}
+---
+
+<TheLeagueLayout title="Home">
+  <div class="hp2">
+    <section class="hp2__main" aria-labelledby="hp2-dashboard-heading">
+      <h2 id="hp2-dashboard-heading" class="hp2__section-title">Dashboard</h2>
+      <div class="hp2__placeholder">
+        <p class="hp2__placeholder-text">Dashboard widgets coming soon.</p>
+      </div>
+    </section>
+
+    <aside class="hp2__sidebar" aria-label="Scheftner Report feed">
+      <ScheftnerFeedCompact
+        posts={compactPosts}
+        isAuthenticated={isAuthenticated}
+        userFranchiseId={userFranchiseId}
+        userTeamName={userTeamName}
+        userTeamIcon={userTeamIcon}
+      />
+    </aside>
+  </div>
+</TheLeagueLayout>
+
+<style>
+  .hp2 {
+    display: grid;
+    grid-template-columns: 1fr 380px;
+    gap: 1.5rem;
+    align-items: start;
+  }
+
+  .hp2__main {
+    min-width: 0;
+  }
+
+  .hp2__section-title {
+    font-size: 0.75rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--color-gray-900, #111827);
+    padding-left: 0.625rem;
+    border-left: 2px solid var(--color-primary, #1c497c);
+    margin: 0 0 1rem;
+    line-height: 1;
+  }
+
+  .hp2__placeholder {
+    background: var(--color-gray-50, #f9fafb);
+    border: 1px dashed var(--content-border, #e2e8f0);
+    border-radius: var(--radius-lg, 0.75rem);
+    padding: 3rem 2rem;
+    text-align: center;
+    min-height: 200px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .hp2__placeholder-text {
+    font-size: 0.875rem;
+    color: var(--color-gray-500, #6b7280);
+    margin: 0;
+  }
+
+  .hp2__sidebar {
+    position: sticky;
+    top: calc(var(--header-height, 3.5rem) + 1rem);
+    max-height: calc(100dvh - var(--header-height, 3.5rem) - 2rem);
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    scrollbar-width: thin;
+    scrollbar-color: var(--sf-border, #e5e7eb) transparent;
+  }
+
+  @media (max-width: 1024px) {
+    .hp2 {
+      grid-template-columns: 1fr 320px;
+      gap: 1rem;
+    }
+  }
+
+  @media (max-width: 640px) {
+    .hp2 {
+      grid-template-columns: 1fr;
+      gap: 1rem;
+    }
+
+    .hp2__sidebar {
+      position: static;
+      max-height: none;
+      overflow-y: visible;
+    }
+  }
+</style>

--- a/src/pages/theleague/news.astro
+++ b/src/pages/theleague/news.astro
@@ -19,10 +19,28 @@ import { getAuthor, getAuthorAvatar, SCHEFTNER_AUTHORS } from '../../types/schef
 import feedData from '../../data/theleague/scheftner-feed.json';
 import type { ScheftnerFeed as FeedType } from '../../types/scheftner';
 import '../../styles/scheftner-feed.css';
+import '../../styles/scheftner-feed-compact.css';
 
 const authUser = getAuthUser(Astro.request);
 const isAuthenticated = !!authUser;
+const userFranchiseId = authUser?.franchiseId;
 const feed = feedData as FeedType;
+
+// Resolve team info for reply composer avatar
+let userTeamName: string | undefined;
+let userTeamIcon: string | undefined;
+
+if (userFranchiseId) {
+  try {
+    const config = await import('../../data/theleague.config.json');
+    const teams = config.default?.teams ?? config.teams ?? [];
+    const team = teams.find((t: { franchiseId: string }) => t.franchiseId === userFranchiseId);
+    if (team) {
+      userTeamName = team.name;
+      userTeamIcon = team.icon;
+    }
+  } catch { /* fallback gracefully */ }
+}
 
 // Source filter via ?source=claude|nfl|events
 const sourceParam = Astro.url.searchParams.get('source');
@@ -104,6 +122,9 @@ const tabs = [
         <ScheftnerFeed
           posts={filteredPosts}
           isAuthenticated={isAuthenticated}
+          userFranchiseId={userFranchiseId}
+          userTeamName={userTeamName}
+          userTeamIcon={userTeamIcon}
           initialLimit={25}
         />
       </div>

--- a/src/styles/scheftner-feed-compact.css
+++ b/src/styles/scheftner-feed-compact.css
@@ -1,0 +1,472 @@
+/* ── Scheftner Feed Compact ──
+ * Compact variant for sidebar usage.
+ * CSS namespace: --sfc-*
+ * Extends --sf-* tokens from scheftner-feed.css
+ */
+
+:root {
+  --sfc-avatar-size: 2rem;
+  --sfc-body-size: 0.8125rem;
+  --sfc-name-size: 0.8125rem;
+  --sfc-handle-size: 0.75rem;
+  --sfc-time-size: 0.75rem;
+  --sfc-post-padding-x: 0.75rem;
+  --sfc-post-padding-y: 0.625rem;
+  --sfc-post-gap: 0.625rem;
+  --sfc-body-lines: 3;
+
+  --sfc-reply-indent: 2.625rem;
+  --sfc-reply-avatar-size: 1.5rem;
+  --sfc-reply-body-size: 0.8125rem;
+  --sfc-reply-thread-line: var(--sf-border, #e5e7eb);
+  --sfc-reply-ai-bg: var(--sf-analysis-bg, var(--color-gray-50, #f9fafb));
+  --sfc-reply-ai-accent: var(--sf-accent, var(--color-primary, #1c497c));
+  --sfc-typing-dot-color: var(--sf-text-secondary, #6b7280);
+}
+
+/* ── Feed Container ── */
+.sfc-feed {
+  background: var(--sf-bg, #fff);
+  border: 1px solid var(--sf-border, #e5e7eb);
+  border-radius: var(--radius-lg, 0.75rem);
+  overflow: hidden;
+}
+
+.sfc-feed__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem var(--sfc-post-padding-x);
+  border-bottom: 1px solid var(--sf-border, #e5e7eb);
+}
+
+.sfc-feed__title {
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-gray-900, #111827);
+  padding-left: 0.625rem;
+  border-left: 2px solid var(--color-primary, #1c497c);
+  margin: 0;
+  line-height: 1;
+}
+
+.sfc-feed__view-all {
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--sf-link-color, var(--color-primary, #1c497c));
+  text-decoration: none;
+}
+
+.sfc-feed__view-all:hover {
+  text-decoration: underline;
+}
+
+.sfc-feed__view-all:focus-visible {
+  outline: 2px solid var(--color-primary, #1c497c);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm, 0.25rem);
+}
+
+.sfc-feed__list {
+  display: flex;
+  flex-direction: column;
+}
+
+.sfc-feed__item {
+  border-bottom: 1px solid var(--sf-border, #e5e7eb);
+}
+
+.sfc-feed__item:last-child {
+  border-bottom: none;
+}
+
+.sfc-feed__item--hidden {
+  display: none;
+}
+
+/* ── Compact Post Card ── */
+.sfc-post {
+  display: flex;
+  gap: var(--sfc-post-gap);
+  padding: var(--sfc-post-padding-y) var(--sfc-post-padding-x);
+  transition: background 0.15s ease;
+}
+
+.sfc-post:hover {
+  background: var(--sf-hover-bg, var(--color-gray-50, #f9fafb));
+}
+
+.sfc-post--breaking {
+  border-left: 3px solid var(--sf-accent, var(--color-primary, #1c497c));
+}
+
+.sfc-avatar {
+  flex-shrink: 0;
+  width: var(--sfc-avatar-size);
+  height: var(--sfc-avatar-size);
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.sfc-post__content {
+  flex: 1;
+  min-width: 0;
+}
+
+.sfc-post__header {
+  display: flex;
+  align-items: baseline;
+  gap: 0.25rem;
+  flex-wrap: wrap;
+}
+
+.sfc-post__name {
+  font-size: var(--sfc-name-size);
+  font-weight: 600;
+  color: var(--sf-text-primary, #0f1419);
+  white-space: nowrap;
+}
+
+.sfc-post__handle {
+  font-size: var(--sfc-handle-size);
+  color: var(--sf-text-secondary, #6b7280);
+  white-space: nowrap;
+}
+
+.sfc-post__time {
+  font-size: var(--sfc-time-size);
+  color: var(--sf-text-secondary, #6b7280);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.sfc-post__time::before {
+  content: '·';
+  margin: 0 0.1875rem;
+}
+
+.sfc-post__body {
+  font-size: var(--sfc-body-size);
+  line-height: 1.45;
+  color: var(--sf-text-body, #1f2937);
+  margin-top: 0.1875rem;
+  display: -webkit-box;
+  -webkit-line-clamp: var(--sfc-body-lines);
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.sfc-post__link {
+  display: inline-block;
+  margin-top: 0.25rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--sf-link-color, var(--color-primary, #1c497c));
+  text-decoration: none;
+}
+
+.sfc-post__link:hover {
+  text-decoration: underline;
+}
+
+.sfc-post__link:focus-visible {
+  outline: 2px solid var(--color-primary, #1c497c);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm, 0.25rem);
+}
+
+/* ── Post Actions (reactions + reply toggle) ── */
+.sfc-post__actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 0.375rem;
+}
+
+/* ── Reply Toggle Button ── */
+.sfc-reply-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.1875rem 0.5rem;
+  border-radius: 999px;
+  border: 1px solid var(--sf-border, #e5e7eb);
+  background: transparent;
+  color: var(--sf-text-secondary, #6b7280);
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: color 0.15s, background 0.15s;
+  min-height: 2rem;
+}
+
+.sfc-reply-toggle:hover {
+  color: var(--sf-accent, #1c497c);
+  background: var(--sf-reaction-active-bg);
+}
+
+.sfc-reply-toggle:focus-visible {
+  outline: 2px solid var(--sf-accent, #1c497c);
+  outline-offset: 2px;
+}
+
+.sfc-reply-toggle__icon {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+}
+
+.sfc-reply-toggle__count {
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
+}
+
+/* ── Reply Thread ── */
+.sfc-replies {
+  position: relative;
+  margin-left: calc(var(--sfc-avatar-size) / 2);
+  padding-left: calc(var(--sfc-reply-indent) - var(--sfc-avatar-size) / 2);
+  padding-top: 0.25rem;
+  padding-bottom: 0.25rem;
+}
+
+/* Vertical thread connector line */
+.sfc-replies::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: var(--sfc-reply-thread-line);
+  border-radius: 1px;
+}
+
+/* ── Individual Reply ── */
+.sfc-reply {
+  display: flex;
+  gap: 0.5rem;
+  padding: 0.375rem 0;
+}
+
+.sfc-reply__avatar {
+  flex-shrink: 0;
+  width: var(--sfc-reply-avatar-size);
+  height: var(--sfc-reply-avatar-size);
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.sfc-reply__content {
+  flex: 1;
+  min-width: 0;
+}
+
+.sfc-reply__header {
+  display: flex;
+  align-items: baseline;
+  gap: 0.25rem;
+  flex-wrap: wrap;
+}
+
+.sfc-reply__name {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--sf-text-primary, #0f1419);
+  white-space: nowrap;
+}
+
+.sfc-reply__handle {
+  font-size: 0.75rem;
+  color: var(--sf-text-secondary, #6b7280);
+  white-space: nowrap;
+}
+
+.sfc-reply__time {
+  font-size: 0.75rem;
+  color: var(--sf-text-secondary, #6b7280);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.sfc-reply__time::before {
+  content: '·';
+  margin: 0 0.1875rem;
+}
+
+.sfc-reply__body {
+  font-size: var(--sfc-reply-body-size);
+  line-height: 1.4;
+  color: var(--sf-text-body, #1f2937);
+  margin-top: 0.125rem;
+}
+
+/* AI reply accent background */
+.sfc-reply--ai .sfc-reply__content {
+  background: var(--sfc-reply-ai-bg);
+  padding: 0.375rem 0.625rem;
+  border-radius: 0 var(--radius-sm, 0.25rem) var(--radius-sm, 0.25rem) 0;
+  border-left: 2px solid var(--sfc-reply-ai-accent);
+}
+
+.sfc-reply--roger .sfc-reply__content {
+  border-left-color: var(--color-secondary, #2e8743);
+}
+
+/* ── Typing Indicator ── */
+.sfc-typing {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.375rem 0;
+}
+
+.sfc-typing__content {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+}
+
+.sfc-typing__text {
+  font-size: 0.75rem;
+  color: var(--sf-text-secondary, #6b7280);
+  font-style: italic;
+}
+
+.sfc-typing__dots {
+  display: inline-flex;
+  gap: 0.1875rem;
+}
+
+.sfc-typing__dot {
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: var(--sfc-typing-dot-color);
+  animation: sfc-typing-bounce 1.4s infinite ease-in-out both;
+}
+
+.sfc-typing__dot:nth-child(2) {
+  animation-delay: 0.16s;
+}
+
+.sfc-typing__dot:nth-child(3) {
+  animation-delay: 0.32s;
+}
+
+@keyframes sfc-typing-bounce {
+  0%, 80%, 100% {
+    transform: scale(0.6);
+    opacity: 0.4;
+  }
+  40% {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+/* ── Reply Composer ── */
+.sfc-composer {
+  display: flex;
+  gap: 0.5rem;
+  padding: 0.5rem 0 0.25rem;
+  align-items: flex-start;
+}
+
+.sfc-composer__input {
+  flex: 1;
+  min-width: 0;
+  padding: 0.375rem 0.5rem;
+  border: 1px solid var(--sf-border, #e5e7eb);
+  border-radius: var(--radius-md, 0.5rem);
+  font-size: 0.8125rem;
+  font-family: inherit;
+  color: var(--sf-text-body, #1f2937);
+  background: var(--sf-bg, #fff);
+  resize: none;
+  line-height: 1.4;
+  max-height: 5rem;
+  overflow-y: auto;
+}
+
+.sfc-composer__input::placeholder {
+  color: var(--sf-text-secondary, #6b7280);
+}
+
+.sfc-composer__input:focus-visible {
+  outline: 2px solid var(--sf-accent, #1c497c);
+  outline-offset: 2px;
+  border-color: var(--sf-accent, #1c497c);
+  box-shadow: 0 0 0 2px rgba(28, 73, 124, 0.15);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--sf-accent, #1c497c) 15%, transparent);
+}
+
+.sfc-composer__submit {
+  flex-shrink: 0;
+  padding: 0.375rem 0.75rem;
+  background: var(--btn-primary-bg, #1c497c);
+  color: var(--btn-primary-text, #fff);
+  font-size: 0.75rem;
+  font-weight: 600;
+  border: none;
+  border-radius: var(--radius-md, 0.5rem);
+  cursor: pointer;
+  transition: background 0.15s ease;
+  min-height: 2rem;
+}
+
+.sfc-composer__submit:hover {
+  background: var(--btn-primary-bg-hover, #164066);
+}
+
+.sfc-composer__submit:focus-visible {
+  outline: 2px solid var(--color-primary, #1c497c);
+  outline-offset: 2px;
+}
+
+.sfc-composer__submit:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* ── Load More ── */
+.sfc-load-more {
+  padding: 0.5rem var(--sfc-post-padding-x);
+  text-align: center;
+  border-top: 1px solid var(--sf-border, #e5e7eb);
+}
+
+.sfc-load-more__btn {
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--sf-link-color, var(--color-primary, #1c497c));
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0.375rem 0.75rem;
+}
+
+.sfc-load-more__btn:hover {
+  text-decoration: underline;
+}
+
+.sfc-load-more__btn:focus-visible {
+  outline: 2px solid var(--color-primary, #1c497c);
+  outline-offset: 2px;
+}
+
+/* ── Empty State ── */
+.sfc-empty {
+  padding: 2rem 1rem;
+  text-align: center;
+  color: var(--sf-text-secondary, #6b7280);
+  font-size: 0.8125rem;
+}
+
+/* ── Reduced Motion ── */
+@media (prefers-reduced-motion: reduce) {
+  .sfc-typing__dot {
+    animation: none;
+  }
+}

--- a/src/styles/scheftner-feed-compact.css
+++ b/src/styles/scheftner-feed-compact.css
@@ -181,7 +181,7 @@
 .sfc-post__actions {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.375rem;
   margin-top: 0.375rem;
   flex-wrap: wrap;
 }
@@ -196,24 +196,26 @@
   order: 99;
 }
 
-/* ── Reply Toggle Button — matches sf-reaction-like style ── */
+/* ── Reply Toggle Button — matches sf-reaction-like / sf-reaction-pill pill style ── */
 .sfc-reply-toggle {
   display: inline-flex;
   align-items: center;
   gap: 0.25rem;
-  padding: 0.25rem 0.375rem;
-  border-radius: var(--radius-sm, 0.25rem);
-  border: none;
+  padding: 0.1875rem 0.625rem;
+  border-radius: 999px;
+  border: 1px solid var(--sf-border, #e5e7eb);
   background: transparent;
   color: var(--sf-text-secondary, #6b7280);
-  font-size: 0.75rem;
+  font-size: 0.8125rem;
+  line-height: 1.5;
   cursor: pointer;
-  transition: color 0.15s, background 0.15s;
+  transition: color 0.15s, background 0.15s, border-color 0.15s;
 }
 
 .sfc-reply-toggle:hover {
   color: var(--sf-accent, #1c497c);
-  background: var(--color-gray-100, #f3f4f6);
+  background: var(--sf-reaction-active-bg, color-mix(in srgb, var(--color-primary, #1c497c) 10%, transparent));
+  border-color: var(--sf-accent, #1c497c);
 }
 
 .sfc-reply-toggle:focus-visible {
@@ -222,12 +224,13 @@
 }
 
 .sfc-reply-toggle__icon {
-  width: 16px;
-  height: 16px;
+  width: 14px;
+  height: 14px;
   flex-shrink: 0;
 }
 
 .sfc-reply-toggle__count {
+  font-size: 0.75rem;
   font-weight: 500;
   font-variant-numeric: tabular-nums;
 }

--- a/src/styles/scheftner-feed-compact.css
+++ b/src/styles/scheftner-feed-compact.css
@@ -224,23 +224,10 @@
 
 /* ── Reply Thread ── */
 .sfc-replies {
-  position: relative;
-  margin-left: calc(var(--sfc-avatar-size) / 2);
-  padding-left: calc(var(--sfc-reply-indent) - var(--sfc-avatar-size) / 2);
   padding-top: 0.25rem;
   padding-bottom: 0.25rem;
-}
-
-/* Vertical thread connector line */
-.sfc-replies::before {
-  content: '';
-  position: absolute;
-  left: 0;
-  top: 0;
-  bottom: 0;
-  width: 2px;
-  background: var(--sfc-reply-thread-line);
-  border-radius: 1px;
+  border-top: 1px solid var(--sf-border, #e5e7eb);
+  margin-top: 0.375rem;
 }
 
 /* ── Individual Reply ── */

--- a/src/styles/scheftner-feed-compact.css
+++ b/src/styles/scheftner-feed-compact.css
@@ -196,25 +196,24 @@
   order: 99;
 }
 
-/* ── Reply Toggle Button ── */
+/* ── Reply Toggle Button — matches sf-reaction-like style ── */
 .sfc-reply-toggle {
   display: inline-flex;
   align-items: center;
   gap: 0.25rem;
-  padding: 0.1875rem 0.5rem;
-  border-radius: 999px;
-  border: 1px solid var(--sf-border, #e5e7eb);
+  padding: 0.25rem 0.375rem;
+  border-radius: var(--radius-sm, 0.25rem);
+  border: none;
   background: transparent;
   color: var(--sf-text-secondary, #6b7280);
   font-size: 0.75rem;
   cursor: pointer;
   transition: color 0.15s, background 0.15s;
-  min-height: 2rem;
 }
 
 .sfc-reply-toggle:hover {
   color: var(--sf-accent, #1c497c);
-  background: var(--sf-reaction-active-bg);
+  background: var(--color-gray-100, #f3f4f6);
 }
 
 .sfc-reply-toggle:focus-visible {
@@ -223,8 +222,8 @@
 }
 
 .sfc-reply-toggle__icon {
-  width: 14px;
-  height: 14px;
+  width: 16px;
+  height: 16px;
   flex-shrink: 0;
 }
 

--- a/src/styles/scheftner-feed-compact.css
+++ b/src/styles/scheftner-feed-compact.css
@@ -180,7 +180,7 @@
 /* ── Post Actions (reply toggle + reactions on same line) ── */
 .sfc-post__actions {
   display: flex;
-  align-items: flex-end;
+  align-items: center;
   gap: 0.375rem;
   margin-top: 0.375rem;
   flex-wrap: wrap;

--- a/src/styles/scheftner-feed-compact.css
+++ b/src/styles/scheftner-feed-compact.css
@@ -177,12 +177,23 @@
   border-radius: var(--radius-sm, 0.25rem);
 }
 
-/* ── Post Actions (reactions + reply toggle) ── */
+/* ── Post Actions (reply toggle + reactions on same line) ── */
 .sfc-post__actions {
   display: flex;
   align-items: center;
   gap: 0.5rem;
   margin-top: 0.375rem;
+  flex-wrap: wrap;
+}
+
+/* Reply thread wrapper — toggle stays inline, expanded content spans full width */
+.sfc-post__actions .sfc-reply-thread {
+  display: contents;
+}
+
+.sfc-post__actions .sfc-replies {
+  flex-basis: 100%;
+  order: 99;
 }
 
 /* ── Reply Toggle Button ── */

--- a/src/styles/scheftner-feed-compact.css
+++ b/src/styles/scheftner-feed-compact.css
@@ -180,10 +180,16 @@
 /* ── Post Actions (reply toggle + reactions on same line) ── */
 .sfc-post__actions {
   display: flex;
-  align-items: center;
+  align-items: flex-end;
   gap: 0.375rem;
   margin-top: 0.375rem;
   flex-wrap: wrap;
+}
+
+/* Strip inherited spacing from reactions bar inside compact actions */
+.sfc-post__actions .sf-reactions {
+  margin-top: 0;
+  padding-top: 0;
 }
 
 /* Reply thread wrapper — toggle stays inline, expanded content spans full width */

--- a/src/types/scheftner-replies.ts
+++ b/src/types/scheftner-replies.ts
@@ -1,0 +1,43 @@
+// ── Scheftner Reply Types ──
+
+/** A reply to a Scheftner feed post */
+export interface ScheftnerReply {
+  id: string;
+  postId: string;
+  parentId: string | null;
+  body: string;
+  author: ScheftnerReplyAuthor;
+  createdAt: string;
+}
+
+export type ScheftnerReplyAuthorType = 'owner' | 'ai';
+
+export interface ScheftnerReplyAuthor {
+  type: ScheftnerReplyAuthorType;
+  /** Franchise ID for owner replies */
+  franchiseId?: string;
+  /** Display name — team name for owners, character name for AI */
+  name: string;
+  /** Avatar URL — team icon for owners, character avatar for AI */
+  avatar: string;
+  /** AI character handle (e.g. @schefter) */
+  handle?: string;
+  /** Which AI character for AI replies */
+  aiCharacter?: 'claude' | 'roger';
+}
+
+/** Request body for creating a reply */
+export interface CreateReplyRequest {
+  body: string;
+  parentId?: string;
+}
+
+/** Response from the reply API */
+export interface ReplyListResponse {
+  replies: ScheftnerReply[];
+}
+
+/** Request body for AI reply generation */
+export interface AiReplyRequest {
+  userReplyId: string;
+}

--- a/src/utils/scheftner-replies-storage.ts
+++ b/src/utils/scheftner-replies-storage.ts
@@ -1,0 +1,127 @@
+/**
+ * Scheftner Reply Storage
+ *
+ * Stores replies in Upstash Redis using one hash per post.
+ * Key: scheftner:replies:{postId}
+ * Fields: replyId → JSON(ScheftnerReply)
+ *
+ * Follows the suggestions-storage.ts pattern.
+ */
+
+import type { ScheftnerReply } from '../types/scheftner-replies';
+
+type RedisClient = {
+  hget: <T>(key: string, field: string) => Promise<T | null>;
+  hgetall: <T>(key: string) => Promise<Record<string, T> | null>;
+  hset: (key: string, fieldValues: Record<string, unknown>) => Promise<number>;
+  hdel: (key: string, ...fields: string[]) => Promise<number>;
+  incr: (key: string) => Promise<number>;
+  expire: (key: string, seconds: number) => Promise<unknown>;
+};
+
+const KEYS = {
+  repliesPrefix: 'scheftner:replies:',
+  ratePrefix: 'scheftner:reply-rate:',
+} as const;
+
+let _redis: RedisClient | null | undefined;
+
+async function getRedis(): Promise<RedisClient | null> {
+  if (_redis !== undefined) return _redis;
+
+  const url = process.env.UPSTASH_REDIS_REST_URL || process.env.KV_REST_API_URL || process.env.STORAGE_REST_API_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN || process.env.KV_REST_API_TOKEN || process.env.STORAGE_REST_API_TOKEN;
+  if (!url || !token) {
+    _redis = null;
+    return null;
+  }
+
+  try {
+    const { Redis } = await import('@upstash/redis');
+    _redis = new Redis({ url, token }) as unknown as RedisClient;
+    return _redis;
+  } catch (err) {
+    console.warn('[scheftner-replies] Redis unavailable:', err);
+    _redis = null;
+    return null;
+  }
+}
+
+export function generateReplyId(): string {
+  return `sfr_${Math.random().toString(36).slice(2, 10)}${Date.now().toString(36)}`;
+}
+
+/** Get all replies for a post, sorted chronologically */
+export async function getRepliesForPost(postId: string): Promise<ScheftnerReply[]> {
+  const redis = await getRedis();
+  if (!redis) return [];
+
+  try {
+    const all = await redis.hgetall<ScheftnerReply>(`${KEYS.repliesPrefix}${postId}`);
+    if (!all || Object.keys(all).length === 0) return [];
+    const replies = Object.values(all);
+    replies.sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
+    return replies;
+  } catch (err) {
+    console.error('[scheftner-replies] Failed to read replies:', err);
+    return [];
+  }
+}
+
+/** Get a single reply by ID */
+export async function getReplyById(postId: string, replyId: string): Promise<ScheftnerReply | null> {
+  const redis = await getRedis();
+  if (!redis) return null;
+
+  try {
+    return await redis.hget<ScheftnerReply>(`${KEYS.repliesPrefix}${postId}`, replyId);
+  } catch (err) {
+    console.error('[scheftner-replies] Failed to read reply:', err);
+    return null;
+  }
+}
+
+/** Save a reply to Redis */
+export async function saveReply(reply: ScheftnerReply): Promise<boolean> {
+  const redis = await getRedis();
+  if (!redis) return false;
+
+  try {
+    await redis.hset(`${KEYS.repliesPrefix}${reply.postId}`, { [reply.id]: reply });
+    return true;
+  } catch (err) {
+    console.error('[scheftner-replies] Failed to save reply:', err);
+    return false;
+  }
+}
+
+/** Rate limit: 10 replies per hour per franchise */
+const RATE_LIMIT_MAX = 10;
+const RATE_LIMIT_WINDOW = 3600;
+
+export async function checkReplyRateLimit(franchiseId: string): Promise<{ allowed: boolean; count: number }> {
+  const redis = await getRedis();
+  if (!redis) return { allowed: true, count: 0 };
+
+  try {
+    const key = `${KEYS.ratePrefix}${franchiseId}`;
+    const count = await redis.incr(key);
+    if (count === 1) {
+      await redis.expire(key, RATE_LIMIT_WINDOW);
+    }
+    return { allowed: count <= RATE_LIMIT_MAX, count };
+  } catch {
+    return { allowed: true, count: 0 };
+  }
+}
+
+/** Resolve team name and icon from config */
+export async function resolveTeamInfo(franchiseId: string): Promise<{ name: string; icon: string }> {
+  try {
+    const config = await import('../data/theleague.config.json');
+    const team = (config.default?.teams ?? config.teams ?? [])
+      .find((t: { franchiseId: string; name: string; icon?: string }) => t.franchiseId === franchiseId);
+    if (team) return { name: team.name, icon: team.icon ?? '' };
+  } catch { /* use fallback */ }
+  return { name: 'Unknown Team', icon: '' };
+}


### PR DESCRIPTION
## Summary
- New homepage prototype at `/theleague/new-hp` (admin-only) with 2-column layout
- Compact Scheftner Report feed in 380px right sidebar with all league news authors
- Twitter-style reply threads where AI characters (Claude Schefter, Ask Roger) respond to owners in real-time via Haiku
- Redis-backed reply storage with rate limiting, optimistic UI, and typing indicators

## Test plan
- [ ] Visit `/theleague/new-hp` — verify 2-column layout with sticky sidebar
- [ ] Scroll the feed — verify compact cards render all authors (Claude, Adam Schefter, Ask Roger)
- [ ] Click reaction hearts — verify they toggle and persist
- [ ] Click reply chat bubble — verify thread expands
- [ ] Log in and post a reply — verify it appears with team icon avatar
- [ ] Verify AI response appears after posting (typing indicator then reply)
- [ ] Test mobile at 640px — verify single column stack
- [ ] Test Show more button reveals additional posts