### PR TITLE
Increase mobile text size to .8rem and align reply text with post text

### DIFF
--- a/src/styles/schefter-feed-compact.css
+++ b/src/styles/schefter-feed-compact.css
@@ -470,6 +470,23 @@
   font-size: 0.8125rem;
 }
 
+/* ── Mobile Reply Adjustments ── */
+@media (max-width: 640px) {
+  :root {
+    --sfc-reply-avatar-size: 1.125rem;
+    --sfc-reply-body-size: 0.8rem;
+  }
+
+  .sfc-post__body,
+  .sf-post__body {
+    font-size: 0.8rem;
+  }
+
+  .sfc-reply {
+    gap: 0.375rem;
+  }
+}
+
 /* ── Reduced Motion ── */
 @media (prefers-reduced-motion: reduce) {
   .sfc-typing__dot {


### PR DESCRIPTION
Adds mobile media query to schefter-feed-compact.css:
- Post body and reply body text → 0.8rem on mobile
- Reply avatar shrunk to 1.125rem (18px) to signal replies visually
- Reduced reply gap for better text alignment with parent post

https://claude.ai/code/session_01LrtWrBuUg8Mo3eTaUVigGC