### PR TITLE
fix(AuctionStrip): fix mobile layout so all nav links are visible

### DIFF
--- a/src/components/theleague/AuctionStrip.astro
+++ b/src/components/theleague/AuctionStrip.astro
@@ -238,13 +238,28 @@ const secondaryLinks: StripLink[] = [
 
   /* ── Responsive ── */
   @media (max-width: 767px) {
+    .auction-strip {
+      flex-direction: column;
+      align-items: stretch;
+      padding: 1rem 1.25rem;
+    }
+
     .auction-strip__row--primary {
       flex-wrap: wrap;
       gap: 0.5rem;
     }
 
+    .auction-strip__row--secondary {
+      flex-wrap: wrap;
+    }
+
     .auction-strip__title {
       flex: 1;
+    }
+
+    .auction-strip__cta {
+      align-self: stretch;
+      justify-content: center;
     }
   }
 


### PR DESCRIPTION
Stack the strip vertically on mobile, allow secondary links to wrap,
and stretch the CTA button full-width so it no longer overlaps or
clips the "Free Agents · Completed Auctions · Auction Summary" row.

https://claude.ai/code/session_0144Tkh1KXQjjgLRr4ZDnKfo