### PR TITLE
Fix editorial hero missing horizontal padding on mobile

### DIFF
--- a/src/components/theleague/HeroBanner.astro
+++ b/src/components/theleague/HeroBanner.astro
@@ -677,6 +677,7 @@ const imagePath = image ? `/assets/whats-new/${image}` : null;
     .hero-banner--editorial .hero-banner__content {
       flex-direction: column;
       gap: 1.5rem;
+      padding-inline: var(--spacing-sm, 0.5rem);
     }
 
     .hero-banner__editorial-image {


### PR DESCRIPTION
The editorial variant had zero horizontal padding on mobile (≤700px),
making its content appear closer to the screen edge than other card
components. Added padding-inline using the spacing-sm token to align
with the layout's container padding.

https://claude.ai/code/session_01DinSDBdLEWmqcZDzKjDpCs