### PR TITLE
feat: add save draft trades to trade builder

### DIFF
--- a/data/theleague/live-starting-lineups-week-22.json
+++ b/data/theleague/live-starting-lineups-week-22.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-09T04:23:32.473Z",
+  "generatedAt": "2026-04-10T03:45:35.213Z",
   "week": 22,
   "year": 2025,
   "leagueId": "13522",

--- a/src/components/theleague/trade-builder/PendingTradesPanel.tsx
+++ b/src/components/theleague/trade-builder/PendingTradesPanel.tsx
@@ -1,8 +1,10 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import type {
   PendingTrade,
+  DraftTrade,
   TradeBuilderTeam,
   TradeBuilderAuthUser,
+  TradeSide,
 } from '../../../types/trade-builder';
 import PendingTradeCard from './PendingTradeCard';
 
@@ -12,9 +14,52 @@ interface Props {
   isOpen: boolean;
   onClose: () => void;
   onLoadIntoBuilder: (trade: PendingTrade, mode: 'counter' | 'view') => void;
+  drafts: DraftTrade[];
+  onLoadDraft: (draft: DraftTrade) => void;
+  onDeleteDraft: (draftId: string) => void;
+  onRenameDraft: (draftId: string, name: string) => void;
 }
 
 type LoadingState = 'loading' | 'loaded' | 'error';
+
+function formatRelativeTime(ts: number): string {
+  const diff = Date.now() - ts;
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return 'Just now';
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d ago`;
+  return new Date(ts).toLocaleDateString();
+}
+
+function DraftSideSummary({
+  side,
+  teams,
+}: {
+  side: TradeSide;
+  teams: TradeBuilderTeam[];
+}) {
+  const team = teams.find(t => t.franchiseId === side.franchiseId);
+  if (!team) return <span className="ptp-draft-no-team">No team</span>;
+
+  const playerCount = side.playerIds.length;
+  const pickCount = side.draftPicks.length;
+  const parts: string[] = [];
+  if (playerCount > 0) parts.push(`${playerCount} player${playerCount > 1 ? 's' : ''}`);
+  if (pickCount > 0) parts.push(`${pickCount} pick${pickCount > 1 ? 's' : ''}`);
+
+  return (
+    <span className="ptp-draft-side">
+      {team.icon && <img src={team.icon} alt="" className="ptp-draft-icon" />}
+      <span className="ptp-draft-team">{team.abbrev}</span>
+      {parts.length > 0 && (
+        <span className="ptp-draft-assets">({parts.join(', ')})</span>
+      )}
+    </span>
+  );
+}
 
 export default function PendingTradesPanel({
   authUser,
@@ -22,6 +67,10 @@ export default function PendingTradesPanel({
   isOpen,
   onClose,
   onLoadIntoBuilder,
+  drafts,
+  onLoadDraft,
+  onDeleteDraft,
+  onRenameDraft,
 }: Props) {
   const [trades, setTrades] = useState<PendingTrade[]>([]);
   const [loadingState, setLoadingState] = useState<LoadingState>('loading');
@@ -29,6 +78,9 @@ export default function PendingTradesPanel({
   const panelRef = useRef<HTMLDivElement>(null);
   const closeRef = useRef<HTMLButtonElement>(null);
   const triggerRef = useRef<HTMLElement | null>(null);
+  const [editingDraftId, setEditingDraftId] = useState<string | null>(null);
+  const [editDraftName, setEditDraftName] = useState('');
+  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
 
   const fetchTrades = useCallback(async () => {
     setLoadingState('loading');
@@ -129,6 +181,28 @@ export default function PendingTradesPanel({
   const handleViewDetails = (trade: PendingTrade) => {
     onClose();
     onLoadIntoBuilder(trade, 'view');
+  };
+
+  const handleStartDraftRename = (draft: DraftTrade) => {
+    setEditingDraftId(draft.id);
+    setEditDraftName(draft.name);
+  };
+
+  const handleCommitDraftRename = () => {
+    if (editingDraftId && editDraftName.trim()) {
+      onRenameDraft(editingDraftId, editDraftName.trim());
+    }
+    setEditingDraftId(null);
+    setEditDraftName('');
+  };
+
+  const handleDeleteDraft = (id: string) => {
+    if (confirmDeleteId === id) {
+      onDeleteDraft(id);
+      setConfirmDeleteId(null);
+    } else {
+      setConfirmDeleteId(id);
+    }
   };
 
   if (!isOpen) return null;
@@ -237,6 +311,78 @@ export default function PendingTradesPanel({
               </div>
             </>
           )}
+
+          {/* Draft Trades — always shown, sourced from localStorage */}
+          <div className="ptp-section ptp-drafts-section">
+            <div className="ptp-section-header">
+              <h3 className="ptp-section-title">Drafts</h3>
+              <p className="ptp-section-sub">Saved trade templates</p>
+            </div>
+            {drafts.length > 0 ? (
+              <div className="ptp-card-list">
+                {[...drafts].sort((a, b) => b.updatedAt - a.updatedAt).map(draft => {
+                  const isEditing = editingDraftId === draft.id;
+                  const isConfirmingDelete = confirmDeleteId === draft.id;
+                  return (
+                    <div key={draft.id} className="ptp-draft-card">
+                      <div className="ptp-draft-header">
+                        {isEditing ? (
+                          <input
+                            className="ptp-draft-rename"
+                            value={editDraftName}
+                            onChange={e => setEditDraftName(e.target.value)}
+                            onBlur={handleCommitDraftRename}
+                            onKeyDown={e => {
+                              if (e.key === 'Enter') handleCommitDraftRename();
+                              if (e.key === 'Escape') { setEditingDraftId(null); setEditDraftName(''); }
+                            }}
+                            autoFocus
+                            maxLength={60}
+                          />
+                        ) : (
+                          <button
+                            className="ptp-draft-name"
+                            onClick={() => handleStartDraftRename(draft)}
+                            title="Click to rename"
+                          >
+                            {draft.name}
+                          </button>
+                        )}
+                        <span className="ptp-draft-time">{formatRelativeTime(draft.updatedAt)}</span>
+                      </div>
+                      <div className="ptp-draft-trade">
+                        <DraftSideSummary side={draft.teamA} teams={teams} />
+                        <span className="ptp-draft-arrow">&#8644;</span>
+                        <DraftSideSummary side={draft.teamB} teams={teams} />
+                      </div>
+                      <div className="ptp-draft-actions">
+                        <button
+                          className="ptp-draft-btn ptp-draft-btn--load"
+                          onClick={() => {
+                            onLoadDraft(draft);
+                            onClose();
+                          }}
+                        >
+                          Load
+                        </button>
+                        <button
+                          className={`ptp-draft-btn ptp-draft-btn--delete ${isConfirmingDelete ? 'ptp-draft-btn--confirm-del' : ''}`}
+                          onClick={() => handleDeleteDraft(draft.id)}
+                          onBlur={() => setConfirmDeleteId(null)}
+                        >
+                          {isConfirmingDelete ? 'Confirm' : 'Delete'}
+                        </button>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            ) : (
+              <div className="ptp-empty">
+                No saved drafts. Build a trade and click "Save Draft" to reuse it later.
+              </div>
+            )}
+          </div>
         </div>
       </aside>
 
@@ -385,6 +531,137 @@ export default function PendingTradesPanel({
           clip: rect(0, 0, 0, 0);
           white-space: nowrap;
           border-width: 0;
+        }
+        /* Draft trades section */
+        .ptp-drafts-section {
+          border-top: 1px solid var(--content-border, #e2e8f0);
+          padding-top: 1.5rem;
+        }
+        .ptp-draft-card {
+          border: 1px solid var(--content-border, #e2e8f0);
+          border-radius: var(--radius-md, 0.5rem);
+          padding: 0.875rem;
+          background: var(--content-bg, #fff);
+        }
+        .ptp-draft-header {
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          gap: 0.5rem;
+          margin-bottom: 0.5rem;
+        }
+        .ptp-draft-name {
+          background: none;
+          border: none;
+          padding: 0;
+          font-size: 0.875rem;
+          font-weight: 600;
+          color: var(--color-gray-900, #111827);
+          cursor: pointer;
+          text-align: left;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+          max-width: 70%;
+        }
+        .ptp-draft-name:hover { color: var(--color-primary, #1c497c); }
+        .ptp-draft-name:focus-visible {
+          outline: 2px solid var(--color-primary, #1c497c);
+          outline-offset: 2px;
+        }
+        .ptp-draft-rename {
+          font-size: 0.875rem;
+          font-weight: 600;
+          color: var(--color-gray-900, #111827);
+          border: 1px solid var(--color-primary, #1c497c);
+          border-radius: var(--radius-sm, 0.25rem);
+          padding: 0.125rem 0.375rem;
+          flex: 1;
+          max-width: 70%;
+          background: var(--color-white, #fff);
+        }
+        .ptp-draft-rename:focus {
+          outline: 2px solid var(--color-primary, #1c497c);
+          outline-offset: 1px;
+        }
+        .ptp-draft-time {
+          font-size: 0.75rem;
+          color: var(--color-gray-400, #9ca3af);
+          white-space: nowrap;
+        }
+        .ptp-draft-trade {
+          display: flex;
+          align-items: center;
+          gap: 0.5rem;
+          font-size: 0.8125rem;
+          color: var(--color-gray-700, #374151);
+          margin-bottom: 0.625rem;
+          flex-wrap: wrap;
+        }
+        .ptp-draft-side {
+          display: inline-flex;
+          align-items: center;
+          gap: 0.25rem;
+        }
+        .ptp-draft-icon {
+          width: 18px;
+          height: 18px;
+          border-radius: 2px;
+        }
+        .ptp-draft-team { font-weight: 600; }
+        .ptp-draft-assets {
+          color: var(--color-gray-500, #6b7280);
+          font-size: 0.75rem;
+        }
+        .ptp-draft-no-team {
+          color: var(--color-gray-400, #9ca3af);
+          font-style: italic;
+        }
+        .ptp-draft-arrow {
+          color: var(--color-gray-400, #9ca3af);
+          font-size: 1rem;
+        }
+        .ptp-draft-actions {
+          display: flex;
+          gap: 0.5rem;
+        }
+        .ptp-draft-btn {
+          padding: 0.375rem 0.75rem;
+          border-radius: var(--radius-sm, 0.25rem);
+          font-size: 0.75rem;
+          font-weight: 600;
+          cursor: pointer;
+          border: 1px solid var(--content-border, #e2e8f0);
+          transition: all 0.15s ease;
+        }
+        .ptp-draft-btn:focus-visible {
+          outline: 2px solid var(--color-primary, #1c497c);
+          outline-offset: 2px;
+        }
+        .ptp-draft-btn--load {
+          background: var(--btn-primary-bg, #1c497c);
+          color: #fff;
+          border-color: var(--btn-primary-bg, #1c497c);
+        }
+        .ptp-draft-btn--load:hover {
+          background: var(--btn-primary-bg-hover, #164066);
+        }
+        .ptp-draft-btn--delete {
+          background: var(--content-bg, #fff);
+          color: var(--color-gray-600, #4b5563);
+        }
+        .ptp-draft-btn--delete:hover {
+          border-color: var(--color-error, #dc2626);
+          color: var(--color-error, #dc2626);
+        }
+        .ptp-draft-btn--confirm-del {
+          background: var(--color-error, #dc2626);
+          color: #fff;
+          border-color: var(--color-error, #dc2626);
+        }
+        .ptp-draft-btn--confirm-del:hover {
+          background: #b91c1c;
+          border-color: #b91c1c;
         }
         @media (max-width: 640px) {
           .ptp-panel { width: 100%; }

--- a/src/components/theleague/trade-builder/PendingTradesPanel.tsx
+++ b/src/components/theleague/trade-builder/PendingTradesPanel.tsx
@@ -18,6 +18,7 @@ interface Props {
   onLoadDraft: (draft: DraftTrade) => void;
   onDeleteDraft: (draftId: string) => void;
   onRenameDraft: (draftId: string, name: string) => void;
+  onCopyDraftLink: (draft: DraftTrade) => void;
 }
 
 type LoadingState = 'loading' | 'loaded' | 'error';
@@ -71,6 +72,7 @@ export default function PendingTradesPanel({
   onLoadDraft,
   onDeleteDraft,
   onRenameDraft,
+  onCopyDraftLink,
 }: Props) {
   const [trades, setTrades] = useState<PendingTrade[]>([]);
   const [loadingState, setLoadingState] = useState<LoadingState>('loading');
@@ -81,6 +83,7 @@ export default function PendingTradesPanel({
   const [editingDraftId, setEditingDraftId] = useState<string | null>(null);
   const [editDraftName, setEditDraftName] = useState('');
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+  const [copiedDraftId, setCopiedDraftId] = useState<string | null>(null);
 
   const fetchTrades = useCallback(async () => {
     setLoadingState('loading');
@@ -366,12 +369,41 @@ export default function PendingTradesPanel({
                           Load
                         </button>
                         <button
-                          className={`ptp-draft-btn ptp-draft-btn--delete ${isConfirmingDelete ? 'ptp-draft-btn--confirm-del' : ''}`}
-                          onClick={() => handleDeleteDraft(draft.id)}
-                          onBlur={() => setConfirmDeleteId(null)}
+                          className="ptp-draft-btn ptp-draft-btn--copy"
+                          onClick={() => {
+                            onCopyDraftLink(draft);
+                            setCopiedDraftId(draft.id);
+                            setTimeout(() => setCopiedDraftId(null), 2000);
+                          }}
                         >
-                          {isConfirmingDelete ? 'Confirm' : 'Delete'}
+                          {copiedDraftId === draft.id ? 'Copied!' : 'Copy Link'}
                         </button>
+                      </div>
+                      <div className="ptp-draft-meta-row">
+                        {isConfirmingDelete ? (
+                          <>
+                            <span className="ptp-draft-delete-prompt">Delete this draft?</span>
+                            <button
+                              className="ptp-draft-link ptp-draft-link--danger"
+                              onClick={() => { onDeleteDraft(draft.id); setConfirmDeleteId(null); }}
+                            >
+                              Yes, delete
+                            </button>
+                            <button
+                              className="ptp-draft-link"
+                              onClick={() => setConfirmDeleteId(null)}
+                            >
+                              Cancel
+                            </button>
+                          </>
+                        ) : (
+                          <button
+                            className="ptp-draft-link"
+                            onClick={() => setConfirmDeleteId(draft.id)}
+                          >
+                            Delete
+                          </button>
+                        )}
                       </div>
                     </div>
                   );
@@ -646,22 +678,43 @@ export default function PendingTradesPanel({
         .ptp-draft-btn--load:hover {
           background: var(--btn-primary-bg-hover, #164066);
         }
-        .ptp-draft-btn--delete {
+        .ptp-draft-btn--copy {
           background: var(--content-bg, #fff);
-          color: var(--color-gray-600, #4b5563);
+          color: var(--color-gray-700, #374151);
         }
-        .ptp-draft-btn--delete:hover {
-          border-color: var(--color-error, #dc2626);
+        .ptp-draft-btn--copy:hover {
+          border-color: var(--color-primary, #1c497c);
+          color: var(--color-primary, #1c497c);
+        }
+        .ptp-draft-meta-row {
+          display: flex;
+          align-items: center;
+          gap: 0.5rem;
+          margin-top: 0.5rem;
+          padding-top: 0.5rem;
+          border-top: 1px solid var(--color-gray-100, #f3f4f6);
+        }
+        .ptp-draft-delete-prompt {
+          font-size: 0.75rem;
           color: var(--color-error, #dc2626);
+          font-weight: 500;
         }
-        .ptp-draft-btn--confirm-del {
-          background: var(--color-error, #dc2626);
-          color: #fff;
-          border-color: var(--color-error, #dc2626);
+        .ptp-draft-link {
+          background: none;
+          border: none;
+          padding: 0;
+          font-size: 0.6875rem;
+          color: var(--color-gray-400, #9ca3af);
+          cursor: pointer;
+          text-decoration: underline;
+          text-underline-offset: 2px;
         }
-        .ptp-draft-btn--confirm-del:hover {
-          background: #b91c1c;
-          border-color: #b91c1c;
+        .ptp-draft-link:hover { color: var(--color-gray-600, #4b5563); }
+        .ptp-draft-link--danger { color: var(--color-error, #dc2626); font-weight: 600; }
+        .ptp-draft-link--danger:hover { color: #b91c1c; }
+        .ptp-draft-link:focus-visible {
+          outline: 2px solid var(--color-primary, #1c497c);
+          outline-offset: 2px;
         }
         @media (max-width: 640px) {
           .ptp-panel { width: 100%; }

--- a/src/components/theleague/trade-builder/TradeBuilder.tsx
+++ b/src/components/theleague/trade-builder/TradeBuilder.tsx
@@ -5,6 +5,7 @@ import type {
   TradeAction,
   TradeSide,
   DraftPickKey,
+  DraftTrade,
   TradeBuilderAuthUser,
   TradeSubmissionState,
   PendingTrade,
@@ -125,6 +126,12 @@ function tradeReducer(state: TradeState, action: TradeAction): TradeState {
       return {
         teamA: { ...EMPTY_SIDE, franchiseId: state.teamA.franchiseId },
         teamB: { ...EMPTY_SIDE, franchiseId: state.teamB.franchiseId },
+        rookieModalTarget: null,
+      };
+    case 'LOAD_DRAFT':
+      return {
+        teamA: action.teamA,
+        teamB: action.teamB,
         rookieModalTarget: null,
       };
     case 'START_TRADE_FOR_PLAYER': {
@@ -453,6 +460,82 @@ export default function TradeBuilder({ pageData, defaultTeamId, authUser: authUs
     }
   }, [authUser, defaultTeamId, state.teamA, state.teamB, teamA, teamB]);
 
+  // ---------------------------------------------------------------------------
+  // Draft Trades (server-persisted via /api/trades/drafts)
+  // ---------------------------------------------------------------------------
+  const [drafts, setDrafts] = useState<DraftTrade[]>([]);
+
+  // Fetch drafts from server when panel opens or auth changes
+  const fetchDrafts = useCallback(async () => {
+    if (!authUser) { setDrafts([]); return; }
+    try {
+      const res = await fetch('/api/trades/drafts', { credentials: 'include' });
+      const json = await res.json();
+      if (json.drafts) setDrafts(json.drafts);
+    } catch { /* silent — drafts are non-critical */ }
+  }, [authUser]);
+
+  useEffect(() => { fetchDrafts(); }, [fetchDrafts]);
+
+  const handleSaveDraft = useCallback(async () => {
+    if (!authUser) {
+      setShowLoginModal(true);
+      return;
+    }
+    const teamAData = data.teams.find(t => t.franchiseId === state.teamA.franchiseId);
+    const teamBData = data.teams.find(t => t.franchiseId === state.teamB.franchiseId);
+    const nameA = teamAData?.abbrev ?? 'Team A';
+    const nameB = teamBData?.abbrev ?? 'Team B';
+    const now = Date.now();
+    const draft: DraftTrade = {
+      id: `draft-${now}-${Math.random().toString(36).slice(2, 8)}`,
+      name: `${nameA} / ${nameB}`,
+      createdAt: now,
+      updatedAt: now,
+      teamA: { ...state.teamA },
+      teamB: { ...state.teamB },
+    };
+    try {
+      const res = await fetch('/api/trades/drafts', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(draft),
+      });
+      const json = await res.json();
+      if (json.drafts) setDrafts(json.drafts);
+    } catch { /* silent */ }
+  }, [authUser, state.teamA, state.teamB, data.teams]);
+
+  const handleLoadDraft = useCallback((draft: DraftTrade) => {
+    setSubmissionStatus({ status: 'idle', errorMessage: null });
+    dispatch({ type: 'LOAD_DRAFT', teamA: draft.teamA, teamB: draft.teamB });
+  }, []);
+
+  const handleDeleteDraft = useCallback(async (draftId: string) => {
+    try {
+      const res = await fetch(`/api/trades/drafts?id=${encodeURIComponent(draftId)}`, {
+        method: 'DELETE',
+        credentials: 'include',
+      });
+      const json = await res.json();
+      if (json.drafts) setDrafts(json.drafts);
+    } catch { /* silent */ }
+  }, []);
+
+  const handleRenameDraft = useCallback(async (draftId: string, name: string) => {
+    try {
+      const res = await fetch('/api/trades/drafts', {
+        method: 'PATCH',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id: draftId, name }),
+      });
+      const json = await res.json();
+      if (json.drafts) setDrafts(json.drafts);
+    } catch { /* silent */ }
+  }, []);
+
   // Load a pending trade into the builder
   const handleLoadTradeIntoBuilder = useCallback((trade: PendingTrade, _mode: 'counter' | 'view') => {
     // Reset any prior submission state
@@ -500,10 +583,18 @@ export default function TradeBuilder({ pageData, defaultTeamId, authUser: authUs
           >
             Copy Link
           </button>
+          {hasTrade && (
+            <button
+              className="btn btn--secondary"
+              onClick={handleSaveDraft}
+            >
+              Save Draft
+            </button>
+          )}
           {authUser && (
             <button
               className="btn btn--secondary"
-              onClick={() => setShowPendingPanel(true)}
+              onClick={() => { fetchDrafts(); setShowPendingPanel(true); }}
             >
               My Trades
             </button>
@@ -664,6 +755,10 @@ export default function TradeBuilder({ pageData, defaultTeamId, authUser: authUs
           isOpen={showPendingPanel}
           onClose={() => setShowPendingPanel(false)}
           onLoadIntoBuilder={handleLoadTradeIntoBuilder}
+          drafts={drafts}
+          onLoadDraft={handleLoadDraft}
+          onDeleteDraft={handleDeleteDraft}
+          onRenameDraft={handleRenameDraft}
         />
       )}
 

--- a/src/components/theleague/trade-builder/TradeBuilder.tsx
+++ b/src/components/theleague/trade-builder/TradeBuilder.tsx
@@ -342,20 +342,6 @@ export default function TradeBuilder({ pageData, defaultTeamId, authUser: authUs
     return null;
   }, [authUser, state.teamA.franchiseId, state.teamB.franchiseId]);
 
-  // Copy share link
-  const handleCopyLink = useCallback(() => {
-    const params = serializeTradeToParams({
-      teamAId: state.teamA.franchiseId,
-      teamBId: state.teamB.franchiseId,
-      teamAPlayerIds: state.teamA.playerIds,
-      teamBPlayerIds: state.teamB.playerIds,
-      teamADraftPicks: state.teamA.draftPicks,
-      teamBDraftPicks: state.teamB.draftPicks,
-    });
-    const url = `${window.location.origin}${window.location.pathname}?${params.toString()}`;
-    navigator.clipboard.writeText(url);
-  }, [state]);
-
   // Update URL when trade changes
   useEffect(() => {
     if (!hasTrade) return;
@@ -576,13 +562,6 @@ export default function TradeBuilder({ pageData, defaultTeamId, authUser: authUs
           >
             Reset
           </button>
-          <button
-            className="btn btn--secondary"
-            onClick={handleCopyLink}
-            disabled={!hasTrade}
-          >
-            Copy Link
-          </button>
           {hasTrade && (
             <button
               className="btn btn--secondary"
@@ -759,6 +738,18 @@ export default function TradeBuilder({ pageData, defaultTeamId, authUser: authUs
           onLoadDraft={handleLoadDraft}
           onDeleteDraft={handleDeleteDraft}
           onRenameDraft={handleRenameDraft}
+          onCopyDraftLink={(draft) => {
+            const params = serializeTradeToParams({
+              teamAId: draft.teamA.franchiseId,
+              teamBId: draft.teamB.franchiseId,
+              teamAPlayerIds: draft.teamA.playerIds,
+              teamBPlayerIds: draft.teamB.playerIds,
+              teamADraftPicks: draft.teamA.draftPicks,
+              teamBDraftPicks: draft.teamB.draftPicks,
+            });
+            const url = `${window.location.origin}${window.location.pathname}?${params.toString()}`;
+            navigator.clipboard.writeText(url);
+          }}
         />
       )}
 

--- a/src/pages/api/trades/drafts.ts
+++ b/src/pages/api/trades/drafts.ts
@@ -1,0 +1,145 @@
+/**
+ * Draft Trades API Endpoint
+ *
+ * GET    /api/trades/drafts           — Load all saved draft trades
+ * POST   /api/trades/drafts           — Save a new draft trade
+ * PATCH  /api/trades/drafts           — Rename a draft trade  { id, name }
+ * DELETE /api/trades/drafts?id={id}   — Delete a draft trade
+ *
+ * Auth: Any authenticated franchise owner.
+ * Storage: Upstash Redis hash, keyed by dt:{franchiseId}.
+ * Each franchise can store up to 20 drafts.
+ */
+
+import type { APIRoute } from 'astro';
+import { getAuthUser } from '../../../utils/auth';
+import type { DraftTrade } from '../../../types/trade-builder';
+
+type RedisClient = {
+  get: <T>(key: string) => Promise<T | null>;
+  set: (key: string, value: unknown) => Promise<unknown>;
+  del: (key: string) => Promise<unknown>;
+};
+
+let loggedMissingRedisModule = false;
+
+async function getRedis(): Promise<RedisClient | null> {
+  const url = process.env.UPSTASH_REDIS_REST_URL || process.env.KV_REST_API_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN || process.env.KV_REST_API_TOKEN;
+  if (!url || !token) return null;
+
+  try {
+    const { Redis } = await import('@upstash/redis');
+    return new Redis({ url, token });
+  } catch (error) {
+    if (!loggedMissingRedisModule) {
+      loggedMissingRedisModule = true;
+      console.warn('Draft trades KV unavailable: @upstash/redis is not installed.', error);
+    }
+    return null;
+  }
+}
+
+const MAX_DRAFTS = 20;
+
+function makeKey(franchiseId: string): string {
+  return `dt:${franchiseId}`;
+}
+
+function jsonResponse(data: unknown, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+export const GET: APIRoute = async ({ request }) => {
+  const user = getAuthUser(request);
+  if (!user) return jsonResponse({ error: 'Unauthorized' }, 401);
+
+  const redis = await getRedis();
+  if (!redis) return jsonResponse({ drafts: [] });
+
+  try {
+    const drafts = await redis.get<DraftTrade[]>(makeKey(user.franchiseId));
+    return jsonResponse({ drafts: drafts ?? [] });
+  } catch (err) {
+    console.error('Failed to load draft trades from KV:', err);
+    return jsonResponse({ drafts: [], error: 'Read failed' });
+  }
+};
+
+export const POST: APIRoute = async ({ request }) => {
+  const user = getAuthUser(request);
+  if (!user) return jsonResponse({ error: 'Unauthorized' }, 401);
+
+  const redis = await getRedis();
+  if (!redis) return jsonResponse({ success: false, error: 'Storage not configured' }, 503);
+
+  try {
+    const draft = (await request.json()) as DraftTrade;
+    if (!draft.id || !draft.name) {
+      return jsonResponse({ success: false, error: 'Missing id or name' }, 400);
+    }
+
+    const key = makeKey(user.franchiseId);
+    const existing = (await redis.get<DraftTrade[]>(key)) ?? [];
+    const updated = [draft, ...existing].slice(0, MAX_DRAFTS);
+    await redis.set(key, updated);
+    return jsonResponse({ success: true, drafts: updated });
+  } catch (err) {
+    console.error('Failed to save draft trade to KV:', err);
+    return jsonResponse({ success: false, error: 'Write failed' }, 500);
+  }
+};
+
+export const PATCH: APIRoute = async ({ request }) => {
+  const user = getAuthUser(request);
+  if (!user) return jsonResponse({ error: 'Unauthorized' }, 401);
+
+  const redis = await getRedis();
+  if (!redis) return jsonResponse({ success: false, error: 'Storage not configured' }, 503);
+
+  try {
+    const { id, name } = (await request.json()) as { id: string; name: string };
+    if (!id || !name?.trim()) {
+      return jsonResponse({ success: false, error: 'Missing id or name' }, 400);
+    }
+
+    const key = makeKey(user.franchiseId);
+    const existing = (await redis.get<DraftTrade[]>(key)) ?? [];
+    const updated = existing.map(d =>
+      d.id === id ? { ...d, name: name.trim(), updatedAt: Date.now() } : d
+    );
+    await redis.set(key, updated);
+    return jsonResponse({ success: true, drafts: updated });
+  } catch (err) {
+    console.error('Failed to rename draft trade in KV:', err);
+    return jsonResponse({ success: false, error: 'Write failed' }, 500);
+  }
+};
+
+export const DELETE: APIRoute = async ({ request }) => {
+  const user = getAuthUser(request);
+  if (!user) return jsonResponse({ error: 'Unauthorized' }, 401);
+
+  const redis = await getRedis();
+  if (!redis) return jsonResponse({ success: false, error: 'Storage not configured' }, 503);
+
+  try {
+    const url = new URL(request.url);
+    const id = url.searchParams.get('id');
+    if (!id) {
+      return jsonResponse({ success: false, error: 'Missing draft id' }, 400);
+    }
+
+    const key = makeKey(user.franchiseId);
+    const existing = (await redis.get<DraftTrade[]>(key)) ?? [];
+    const updated = existing.filter(d => d.id !== id);
+    await redis.set(key, updated);
+    return jsonResponse({ success: true, drafts: updated });
+  } catch (err) {
+    console.error('Failed to delete draft trade from KV:', err);
+    return jsonResponse({ success: false, error: 'Delete failed' }, 500);
+  }
+};

--- a/src/types/trade-builder.ts
+++ b/src/types/trade-builder.ts
@@ -133,7 +133,8 @@ export type TradeAction =
   | { type: 'HIDE_ROOKIE_MODAL' }
   | { type: 'RESET' }
   | { type: 'SWAP_TEAMS' }
-  | { type: 'START_TRADE_FOR_PLAYER'; franchiseId: string; playerId: string };
+  | { type: 'START_TRADE_FOR_PLAYER'; franchiseId: string; playerId: string }
+  | { type: 'LOAD_DRAFT'; teamA: TradeSide; teamB: TradeSide };
 
 /** Computed cap impact for one team in a trade */
 export interface TeamTradeImpact {
@@ -199,3 +200,17 @@ export type TradeActionExtended =
   | { type: 'SUBMIT_TRADE_SUCCESS' }
   | { type: 'SUBMIT_TRADE_ERROR'; message: string }
   | { type: 'SUBMIT_TRADE_RESET' };
+
+// ---------------------------------------------------------------------------
+// Draft Trades (localStorage persistence)
+// ---------------------------------------------------------------------------
+
+/** A saved draft trade */
+export interface DraftTrade {
+  id: string;
+  name: string;
+  createdAt: number;
+  updatedAt: number;
+  teamA: TradeSide;
+  teamB: TradeSide;
+}


### PR DESCRIPTION
Adds the ability to save trade configurations as drafts for later reuse.
Drafts are stored server-side in Redis (keyed by franchise ID) so they
persist across devices and sessions. Users can save, load, rename, and
delete drafts from the "My Trades" slide-out panel.

- New /api/trades/drafts endpoint (GET/POST/PATCH/DELETE)
- DraftTrade type and LOAD_DRAFT reducer action
- Drafts section in PendingTradesPanel with inline rename and confirm-delete
- "Save Draft" button in trade builder header (visible when trade has assets)
- Max 20 drafts per franchise

https://claude.ai/code/session_01FmUS9f5YxJKCsj4AfDtzBh