### PR TITLE
Fix defense tab showing no players in trade builder

### DIFF
--- a/src/pages/theleague/trade-builder.astro
+++ b/src/pages/theleague/trade-builder.astro
@@ -271,7 +271,8 @@ const teams = franchises.map((franchise: any) => {
     const contractInfo = rp.contractInfo ?? '';
     const status = rp.status ?? 'ROSTER';
     const norm = normalizeStatus(status);
-    const position = pData?.position ?? 'N/A';
+    const rawPos = pData?.position ?? 'N/A';
+    const position = rawPos === 'Def' ? 'DEF' : rawPos;
     const nflTeam = normalizeTeamCode(pData?.team ?? '');
 
     return {


### PR DESCRIPTION
MFL returns "Def" for defense positions but the PlayerSelector filter
tab expects "DEF" (uppercase). Normalize the position during roster
data mapping, matching the pattern used elsewhere in the codebase.

https://claude.ai/code/session_016K4DKZWcnebq3AB8Tn9Kyv