### PR TITLE
feat: unified player identity map — single source of truth for player…

### DIFF
--- a/src/components/theleague/season-heroes/MatchupPreviewHero.astro
+++ b/src/components/theleague/season-heroes/MatchupPreviewHero.astro
@@ -8,6 +8,7 @@
  */
 import type { HeroState } from '../../../types/hero-state';
 import { getCurrentSeasonYear } from '../../../utils/league-year';
+import { getPlayerMap } from '../../../utils/player-map';
 import { normalizeTeamCode } from '../../../utils/nfl-logo';
 import GameDayPreviewHeroStub from '../hero-stubs/GameDayPreviewHeroStub.astro';
 import broadcastData from '../../../../data/theleague/broadcast-mappings.json';
@@ -49,11 +50,19 @@ const weekGames = (weekIdx >= 0 && weekIdx < rawSchedule.length)
   ? (rawSchedule[weekIdx]?.matchup ?? [])
   : [];
 
-// Build player → NFL team lookup
+// Build player → NFL team lookup (using unified identity map as primary, feed as fallback)
+const heroPlayerIdentityMap = getPlayerMap(year);
 const allPlayers = playersData?.players?.player ?? playersData?.default?.players?.player ?? [];
 const playerTeamMap = new Map<string, string>();
+// Pre-populate from identity map (normalized team codes)
+for (const [id, identity] of heroPlayerIdentityMap) {
+  playerTeamMap.set(id, identity.nflTeam);
+}
+// Fill in any missing from raw feed (non-fantasy positions may be needed)
 for (const p of allPlayers) {
-  playerTeamMap.set(p.id, p.team ?? '');
+  if (!playerTeamMap.has(p.id)) {
+    playerTeamMap.set(p.id, p.team ?? '');
+  }
 }
 
 // Build projection lookup

--- a/src/components/theleague/season-heroes/WaiverWireHero.astro
+++ b/src/components/theleague/season-heroes/WaiverWireHero.astro
@@ -8,6 +8,7 @@
  */
 import type { HeroState } from '../../../types/hero-state';
 import { getCurrentSeasonYear } from '../../../utils/league-year';
+import { getPlayerMap as getUnifiedPlayerMap } from '../../../utils/player-map';
 import PlayerCell from '../PlayerCell.astro';
 import WaiverWireHeroStub from '../hero-stubs/WaiverWireHeroStub.astro';
 
@@ -34,7 +35,8 @@ try {
 const rawScores = projData?.projectedScores?.playerScore ?? projData?.default?.projectedScores?.playerScore;
 const hasData = Array.isArray(rawScores) && rawScores.length > 0;
 
-// Build lookups
+// Build lookups — use unified player identity map for canonical team/name/position
+const waiverPlayerIdentityMap = getUnifiedPlayerMap(year);
 const playerMap = new Map<string, any>();
 const allPlayers = playersData?.players?.player ?? playersData?.default?.players?.player ?? [];
 for (const p of allPlayers) {
@@ -72,17 +74,19 @@ if (hasData) {
   for (const s of scored) {
     const player = playerMap.get(s.id);
     if (!player) continue;
-    // Parse "Last, First" name format
-    const [last, first] = (player.name ?? '').split(', ');
-    const displayName = first ? `${first} ${last}` : player.name;
-    const position = player.position?.replace(/^TM/, 'DEF') ?? '';
+    const identity = waiverPlayerIdentityMap.get(s.id);
+    const displayName = identity?.name ?? (() => {
+      const [last, first] = (player.name ?? '').split(', ');
+      return first ? `${first} ${last}` : player.name;
+    })();
+    const position = identity?.position ?? player.position?.replace(/^TM/, 'DEF') ?? '';
 
     freeAgents.push({
       id: s.id,
       name: displayName,
       position,
-      nflTeam: player.team ?? '',
-      headshot: `https://sleepercdn.com/content/nfl/players/thumb/${player.stats_global_id}.jpg`,
+      nflTeam: identity?.nflTeam ?? player.team ?? '',
+      headshot: identity?.headshot ?? `https://sleepercdn.com/content/nfl/players/thumb/${player.stats_global_id}.jpg`,
       projection: s.score,
       projDisplay: s.score.toFixed(1),
     });

--- a/src/pages/api/trades/pending.ts
+++ b/src/pages/api/trades/pending.ts
@@ -13,8 +13,7 @@ import { mflFetch } from '../../../utils/mfl-fetch';
 import { parseAssets } from '../../../utils/trade-asset-parsing';
 import type { PendingTrade } from '../../../types/trade-builder';
 import leagueConfig from '../../../data/theleague.config.json';
-import fs from 'node:fs';
-import path from 'node:path';
+import { getPlayerMap } from '../../../utils/player-map';
 
 /** Resolved asset for the trade alert modal (avoids needing full player data on client) */
 interface ResolvedAsset {
@@ -26,28 +25,17 @@ interface ResolvedAsset {
   espnId?: string;
 }
 
-/** Build a player lookup map from the static players.json feed */
+/** Build a player lookup map using the unified player identity map */
 function loadPlayerMap(year: number): Map<string, { name: string; position: string; team: string; espnId: string }> {
+  const identityMap = getPlayerMap(year);
   const map = new Map<string, { name: string; position: string; team: string; espnId: string }>();
-  try {
-    const feedPath = path.resolve(process.cwd(), `data/theleague/mfl-feeds/${year}/players.json`);
-    if (!fs.existsSync(feedPath)) return map;
-    const raw = JSON.parse(fs.readFileSync(feedPath, 'utf-8'));
-    const players = raw?.players?.player;
-    if (!players) return map;
-    const list = Array.isArray(players) ? players : [players];
-    for (const p of list) {
-      if (p.id) {
-        map.set(p.id, {
-          name: p.name ? p.name.replace(/,\s*/, ', ') : `Player ${p.id}`,
-          position: p.position || '',
-          team: p.team || '',
-          espnId: p.espn_id || '',
-        });
-      }
-    }
-  } catch {
-    // Non-fatal — assets will show as "Unknown Player"
+  for (const [id, identity] of identityMap) {
+    map.set(id, {
+      name: identity.name,
+      position: identity.position,
+      team: identity.nflTeam,
+      espnId: identity.espnId || '',
+    });
   }
   return map;
 }

--- a/src/pages/theleague/contracts/manage.astro
+++ b/src/pages/theleague/contracts/manage.astro
@@ -1,12 +1,10 @@
 ---
-import fs from 'node:fs';
-import path from 'node:path';
 import TheLeagueLayout from '../../../layouts/TheLeagueLayout.astro';
 import PlayerCell from '../../../components/theleague/PlayerCell.astro';
 import { getPendingDeclarations, getDeclarations } from '../../../utils/contract-storage';
 import { getAuthUser, isCommissionerOrAdmin } from '../../../utils/auth';
 import { getCurrentLeagueYear } from '../../../utils/league-year';
-import { normalizeTeamCode } from '../../../utils/nfl-logo';
+import { getPlayerMap } from '../../../utils/player-map';
 import leagueConfig from '../../../data/theleague.config.json';
 
 // Commissioner actions (Apply button) only show when commish-mode toggle is ON
@@ -44,29 +42,23 @@ const declarationTypeLabels: Record<string, string> = {
 
 const appliedCount = allDeclarations.filter(d => d.status === 'applied').length;
 
-// Load player data for headshots/positions in applied contracts
+// Load player identity data for headshots/positions
 const leagueYear = getCurrentLeagueYear();
-const playersPath = path.resolve(process.cwd(), `data/theleague/mfl-feeds/${leagueYear}/players.json`);
-let playerLookup: Record<string, { position: string; team: string; espnId?: string }> = {};
-try {
-  if (fs.existsSync(playersPath)) {
-    const playersData = JSON.parse(fs.readFileSync(playersPath, 'utf8'));
-    const players = playersData?.players?.player ?? [];
-    for (const p of players) {
-      playerLookup[p.id] = {
-        position: p.position === 'Def' ? 'DEF' : p.position,
-        team: normalizeTeamCode(p.team || ''),
-        espnId: p.espn_id,
-      };
-    }
-  }
-} catch (e) {
-  console.warn('Failed to load players.json for contract manage page:', e);
+const managePlayerMap = getPlayerMap(leagueYear);
+const playerLookup: Record<string, { position: string; team: string; espnId?: string }> = {};
+for (const [id, identity] of managePlayerMap) {
+  playerLookup[id] = {
+    position: identity.position,
+    team: identity.nflTeam,
+    espnId: identity.espnId ?? undefined,
+  };
 }
 
 const getHeadshot = (playerId: string, espnId?: string) => {
-  if (espnId) return `https://a.espncdn.com/i/headshots/nfl/players/full/${espnId}.png`;
-  return `https://www49.myfantasyleague.com/player_photos_big_2014/${playerId}_thumb.jpg`;
+  const identity = managePlayerMap.get(playerId);
+  return identity?.headshot ?? (espnId
+    ? `https://a.espncdn.com/i/headshots/nfl/players/full/${espnId}.png`
+    : `https://www49.myfantasyleague.com/player_photos_big_2014/${playerId}_thumb.jpg`);
 };
 ---
 

--- a/src/pages/theleague/cr.astro
+++ b/src/pages/theleague/cr.astro
@@ -9,6 +9,7 @@
 import TheLeagueLayout from '../../layouts/TheLeagueLayout.astro';
 import CustomRankingsPage from '../../components/theleague/custom-rankings/CustomRankingsPage';
 import { getCurrentLeagueYear } from '../../utils/league-year';
+import { getPlayerMap } from '../../utils/player-map';
 import '../../styles/player-cell.css';
 import '../../styles/custom-rankings.css';
 import { getAuthUser, isCommissionerOrAdmin } from '../../utils/auth';
@@ -53,16 +54,20 @@ for (const [filepath, mod] of Object.entries(playersFeeds)) {
 }
 
 // Build player array with headshot info for client-side enrichment
+const crPlayerIdentityMap = getPlayerMap(leagueYear);
 const rawPlayers = playersData?.players?.player ?? [];
 const mflPlayers = rawPlayers
   .filter((p: any) => p.name && p.position)
-  .map((p: any) => ({
-    id: p.id,
-    name: p.name,
-    position: p.position === 'Def' ? 'DEF' : p.position,
-    team: p.team || '',
-    espnId: p.espn_id || (espnCollegeIds as any).players?.[p.id]?.espnCollegeId || null,
-  }));
+  .map((p: any) => {
+    const identity = crPlayerIdentityMap.get(p.id);
+    return {
+      id: p.id,
+      name: identity?.name ?? p.name,
+      position: identity?.position ?? (p.position === 'Def' ? 'DEF' : p.position),
+      team: identity?.nflTeam ?? p.team ?? '',
+      espnId: identity?.espnId ?? (p.espn_id || (espnCollegeIds as any).players?.[p.id]?.espnCollegeId || null),
+    };
+  });
 
 // ---------------------------------------------------------------------------
 // Load projected scores + rosters for VORP calculation

--- a/src/pages/theleague/draft-predictor.astro
+++ b/src/pages/theleague/draft-predictor.astro
@@ -17,6 +17,7 @@ import type { DraftPrediction, ToiletBowlResult } from '../../types/standings';
 import { getTheLeaguePreference, setTheLeaguePreference, resolveTeamSelection } from '../../utils/team-preferences';
 import { getAuthUser } from '../../utils/auth';
 import { getCurrentSeasonYear, getNextDraftYear } from '../../utils/league-year';
+import { getPlayerMap } from '../../utils/player-map';
 import { resolveConfigForYear, resolvePreferredTeamIdForYear } from '../../utils/team-names';
 import espnCollegeIds from '../../../data/theleague/espn-college-ids.json';
 
@@ -223,7 +224,8 @@ const resolvePlayersDataForYear = (year: number | string) => {
 
 const historyPlayersData = resolvePlayersDataForYear(historyYear);
 
-const buildPlayerLookup = (playersData: any) => {
+const buildPlayerLookup = (playersData: any, year: number) => {
+  const identityMap = getPlayerMap(year);
   const lookup = new Map<
     string,
     { name: string; position?: string; nflTeam?: string; espnId?: string }
@@ -232,11 +234,12 @@ const buildPlayerLookup = (playersData: any) => {
   const list = Array.isArray(players) ? players : players ? [players] : [];
   list.forEach((p: any) => {
     if (!p?.id) return;
+    const identity = identityMap.get(p.id);
     lookup.set(p.id, {
-      name: p.name || '',
-      position: p.position || '',
-      nflTeam: p.team || p.draft_team || '',
-      espnId: p.espn_id || (espnCollegeIds as any).players?.[p.id]?.espnCollegeId || '',
+      name: identity?.name ?? p.name ?? '',
+      position: identity?.position ?? p.position ?? '',
+      nflTeam: identity?.nflTeam ?? p.team ?? p.draft_team ?? '',
+      espnId: identity?.espnId ?? p.espn_id ?? (espnCollegeIds as any).players?.[p.id]?.espnCollegeId ?? '',
     });
   });
   return lookup;
@@ -272,7 +275,7 @@ const normalizeNflTeamCode = (code = '') => {
   return map[upper] || upper;
 };
 
-const historyPlayerLookup = buildPlayerLookup(historyPlayersData);
+const historyPlayerLookup = buildPlayerLookup(historyPlayersData, parseInt(historyYear) || getNextDraftYear());
 
 // Team personalization: URL params + cookie integration
 const myTeamParam = Astro.url.searchParams.get('myteam');

--- a/src/pages/theleague/draft-room.astro
+++ b/src/pages/theleague/draft-room.astro
@@ -12,6 +12,7 @@ import { getCurrentLeagueYear } from '../../utils/league-year';
 import { getTheLeaguePreference, resolveTeamSelection } from '../../utils/team-preferences';
 import { getAuthUser } from '../../utils/auth';
 import { getPlayerHeadshot, getCollegeHeadshot } from '../../constants/roster-constants';
+import { getPlayerMap } from '../../utils/player-map';
 import { parseTradeFromComment } from '../../utils/draft-utils';
 import type { DraftRoomPageData, DraftRoomPick, DraftRoomPlayer, DraftRoomTeam } from '../../types/draft-room';
 import espnCollegeIds from '../../../data/theleague/espn-college-ids.json';
@@ -104,33 +105,37 @@ const formatName = (mflName: string): string => {
 };
 
 const espnCollegeMap = (espnCollegeIds as any)?.players || {};
+const draftPlayerIdentityMap = getPlayerMap(leagueYear);
 
 const players: DraftRoomPlayer[] = playerArray.map((p: any) => {
-  const nflEspnId = p.espn_id || '';
-  const collegeEspnId = espnCollegeMap[p.id]?.espnCollegeId || '';
-  const espnId = nflEspnId || collegeEspnId;
+  const identity = draftPlayerIdentityMap.get(p.id);
 
-  // Use college headshot URL when only a college ID is available —
-  // the ESPN combiner returns a broken placeholder (not a 404) for
-  // missing NFL headshots, so onerror fallback never fires.
+  // Use identity map for headshot (handles college fallback internally)
+  // But for rookies without NFL espn_id, prefer college headshot directly
   let headshot: string;
-  if (nflEspnId) {
-    headshot = getPlayerHeadshot(p.id, nflEspnId);
-  } else if (collegeEspnId) {
-    headshot = getCollegeHeadshot(collegeEspnId);
+  if (identity) {
+    headshot = identity.headshot;
   } else {
-    headshot = getPlayerHeadshot(p.id);
+    const nflEspnId = p.espn_id || '';
+    const collegeEspnId = espnCollegeMap[p.id]?.espnCollegeId || '';
+    if (nflEspnId) {
+      headshot = getPlayerHeadshot(p.id, nflEspnId);
+    } else if (collegeEspnId) {
+      headshot = getCollegeHeadshot(collegeEspnId);
+    } else {
+      headshot = getPlayerHeadshot(p.id);
+    }
   }
 
   return {
     id: p.id,
-    name: formatName(p.name || ''),
-    position: normPos(p.position || ''),
-    nflTeam: (p.team || '').toUpperCase(),
+    name: identity?.name ?? formatName(p.name || ''),
+    position: identity?.position ?? normPos(p.position || ''),
+    nflTeam: identity?.nflTeam ?? (p.team || '').toUpperCase(),
     headshot,
     isRookie: p.status === 'R' || p.draft_year === leagueYearStr,
     mflId: p.id,
-    espnId: espnId || undefined,
+    espnId: identity?.espnId ?? (p.espn_id || espnCollegeMap[p.id]?.espnCollegeId || undefined),
   };
 }).filter((p: DraftRoomPlayer) => {
   // Filter to draftable positions

--- a/src/pages/theleague/import-rankings.astro
+++ b/src/pages/theleague/import-rankings.astro
@@ -9,6 +9,7 @@
 import TheLeagueLayout from '../../layouts/TheLeagueLayout.astro';
 import RankingsImportPage from '../../components/theleague/rankings-import/RankingsImportPage';
 import { getCurrentLeagueYear } from '../../utils/league-year';
+import { getPlayerMap } from '../../utils/player-map';
 import bookmarkletManifest from '../../data/bookmarklet-manifest.json';
 import { getAuthUser, isCommissionerOrAdmin } from '../../utils/auth';
 
@@ -44,16 +45,20 @@ for (const [filepath, mod] of Object.entries(playersFeeds)) {
   }
 }
 
-// Build simplified player array for client-side matching
+// Build simplified player array for client-side matching using unified identity map
+const irPlayerIdentityMap = getPlayerMap(leagueYear);
 const rawPlayers = playersData?.players?.player ?? [];
 const mflPlayers = rawPlayers
   .filter((p: any) => p.name && p.position)
-  .map((p: any) => ({
-    id: p.id,
-    name: p.name,
-    position: p.position,
-    team: p.team || '',
-  }));
+  .map((p: any) => {
+    const identity = irPlayerIdentityMap.get(p.id);
+    return {
+      id: p.id,
+      name: identity?.name ?? p.name,
+      position: identity?.position ?? p.position,
+      team: identity?.nflTeam ?? p.team ?? '',
+    };
+  });
 
 // ---------------------------------------------------------------------------
 // Site configurations for bookmarklet cards

--- a/src/pages/theleague/index.astro
+++ b/src/pages/theleague/index.astro
@@ -21,6 +21,7 @@ import { resolveHeroState, parseTestDate, isAuctionStripPeriod, isPostDraftPerio
 import { enrichHeroState, isDraftComplete } from '../../utils/offseason-hero-data';
 import { getWhatsNextTimeline } from '../../utils/league-event-resolver';
 import { getCurrentLeagueYear, getCurrentSeasonYear } from '../../utils/league-year';
+import { getPlayerMap } from '../../utils/player-map';
 import { normalizePlayoffBracket, buildSeedMaps } from '../../utils/playoffs';
 import { isEliminated, buildBracketSummary } from '../../utils/playoff-hero-helpers';
 import { resolveLeaguePath } from '../../utils/nav-utils';
@@ -139,26 +140,28 @@ const rawTransactions: MFLRawTransaction[] = transactionEntries[0]?.data?.transa
     : [transactionEntries[0].data.transactions.transaction]
   : [];
 
+const hpPlayerIdentityMap = getPlayerMap(parseInt(currentSalaryYear) || getCurrentLeagueYear());
 const playerMetaById = new Map<string, { name: string; position: string }>();
 const eligibilityPlayersById = new Map<string, MFLPlayerInfo>();
 const playerDisplayById = new Map<string, DashboardPlayerContext>();
 for (const p of Array.isArray(rawPlayerFeed) ? rawPlayerFeed : [rawPlayerFeed]) {
   if (!p?.id) continue;
-  playerMetaById.set(p.id, { name: p.name ?? `Player ${p.id}`, position: p.position ?? '' });
+  const identity = hpPlayerIdentityMap.get(p.id);
+  playerMetaById.set(p.id, { name: identity?.name ?? p.name ?? `Player ${p.id}`, position: identity?.position ?? p.position ?? '' });
   eligibilityPlayersById.set(p.id, {
     id: p.id,
-    name: p.name ?? `Player ${p.id}`,
-    position: p.position ?? '',
-    team: p.team ?? '',
+    name: identity?.name ?? p.name ?? `Player ${p.id}`,
+    position: identity?.position ?? p.position ?? '',
+    team: identity?.nflTeam ?? p.team ?? '',
     status: p.status,
     draft_year: p.draft_year,
   });
   if (!playerDisplayById.has(p.id)) {
     playerDisplayById.set(p.id, {
       id: p.id,
-      name: p.name ?? `Player ${p.id}`,
-      position: p.position ?? '',
-      nflTeam: p.team ?? '',
+      name: identity?.name ?? p.name ?? `Player ${p.id}`,
+      position: identity?.position ?? p.position ?? '',
+      nflTeam: identity?.nflTeam ?? p.team ?? '',
     });
   }
 }

--- a/src/pages/theleague/league-summary.astro
+++ b/src/pages/theleague/league-summary.astro
@@ -13,6 +13,7 @@ import {
 import { getDraftCapitalFromDraftResults } from '../../utils/future-draft-picks-utils';
 import { chooseTeamName } from '../../utils/team-names';
 import { parseNumber } from '../../utils/formatters';
+import { getPlayerMap } from '../../utils/player-map';
 import { getCachedRosters } from '../../utils/mfl-roster-cache';
 
 export const prerender = false;
@@ -99,13 +100,14 @@ const playerFeedEntries = Object.entries(playerFeeds)
   .filter((item) => item.season === currentYear && item.data);
 
 const rawPlayerFeed = playerFeedEntries[0]?.data?.players?.player ?? [];
+const lsPlayerIdentityMap = getPlayerMap(parseInt(currentYear) || 2026);
 const playerMetaById = new Map<string, { name: string; position: string }>();
 for (const p of Array.isArray(rawPlayerFeed) ? rawPlayerFeed : [rawPlayerFeed]) {
   if (p?.id) {
-    // MFL names are "Last, First" — normalize to "Last, First" (matches salary file)
+    const identity = lsPlayerIdentityMap.get(p.id);
     playerMetaById.set(p.id, {
-      name: p.name ?? `Player ${p.id}`,
-      position: p.position ?? '',
+      name: identity?.name ?? p.name ?? `Player ${p.id}`,
+      position: identity?.position ?? p.position ?? '',
     });
   }
 }

--- a/src/pages/theleague/lineup.astro
+++ b/src/pages/theleague/lineup.astro
@@ -17,6 +17,7 @@ import { getAuthUser } from '../../utils/auth';
 import { getCurrentLeagueYear } from '../../utils/league-year';
 import { getCurrentWeekForYear } from '../../utils/current-week';
 import { normalizeTeamCode } from '../../utils/nfl-logo';
+import { getPlayerMap } from '../../utils/player-map';
 import { getPlayerHeadshot, nflByeWeeks } from '../../constants/roster-constants';
 import { loadLiveOdds, getFPAStats, parseSpread, processWeeklyScores, computeStreak } from '../../utils/coach-data';
 
@@ -121,23 +122,8 @@ const SLOT_ELIGIBILITY: Record<string, string[]> = {
   DEF: ['DEF'],
 };
 
-// ESPN ID sources — feed file has espn_id for ~1800 players, college IDs covers ~90 rookies
-import espnCollegeIds from '../../../data/theleague/espn-college-ids.json';
-const espnCollegeMap = (espnCollegeIds as any)?.players ?? {};
-
-// Build ESPN ID lookup from local player feed (the full MFL export, not the league-scoped API
-// which strips espn_id). This is the same source rosters.astro and trade-builder.astro use.
-const playerFeeds = import.meta.glob('../../../data/theleague/mfl-feeds/*/players.json', { eager: true });
-const espnIdByMflId = new Map<string, string>();
-for (const [path, mod] of Object.entries(playerFeeds)) {
-  const year = path.match(/mfl-feeds\/(\d{4})\//)?.[1];
-  if (year !== String(leagueYear)) continue;
-  const list = (mod as any)?.default?.players?.player ?? (mod as any)?.players?.player ?? [];
-  const arr = Array.isArray(list) ? list : [list];
-  for (const p of arr) {
-    if (p.id && p.espn_id) espnIdByMflId.set(p.id, p.espn_id);
-  }
-}
+// Player identity map — provides ESPN IDs, headshots, and team data from synced MFL feed
+const lineupPlayerIdentityMap = getPlayerMap(leagueYear);
 
 // ---------------------------------------------------------------------------
 // Build LineupPlayer array
@@ -219,11 +205,11 @@ schedule.forEach((g, i) => {
 // Build roster
 const roster: LineupPlayer[] = rosterPlayers.map((rp: any) => {
   const pd = playerMap.get(rp.id);
-  const nflTeam = normalizeTeamCode(pd?.team || '');
-  const position = (pd?.position || 'N/A').replace(/^Def$/i, 'DEF').replace(/^K$/i, 'PK');
-  const feedEspnId = espnIdByMflId.get(rp.id) ?? null;
-  const espnId = feedEspnId || espnCollegeMap[rp.id]?.espnCollegeId || null;
-  const headshot = getPlayerHeadshot(rp.id, espnId);
+  const identity = lineupPlayerIdentityMap.get(rp.id);
+  const nflTeam = identity?.nflTeam ?? normalizeTeamCode(pd?.team || '');
+  const position = identity?.position ?? (pd?.position || 'N/A').replace(/^Def$/i, 'DEF').replace(/^K$/i, 'PK');
+  const espnId = identity?.espnId ?? null;
+  const headshot = identity?.headshot ?? getPlayerHeadshot(rp.id, espnId);
   const proj = projMap.get(rp.id) ?? null;
   const isBye = nflByeWeeks[nflTeam] === week;
 

--- a/src/pages/theleague/mock-draft/[sessionId].astro
+++ b/src/pages/theleague/mock-draft/[sessionId].astro
@@ -14,6 +14,7 @@ import { getCurrentLeagueYear } from '../../../utils/league-year';
 import { getTheLeaguePreference, resolveTeamSelection } from '../../../utils/team-preferences';
 import { getAuthUser } from '../../../utils/auth';
 import { getPlayerHeadshot, getCollegeHeadshot } from '../../../constants/roster-constants';
+import { getPlayerMap } from '../../../utils/player-map';
 import espnCollegeIds from '../../../../data/theleague/espn-college-ids.json';
 import type { DraftRoomPageData, DraftRoomPick, DraftRoomPlayer, DraftRoomTeam } from '../../../types/draft-room';
 
@@ -90,33 +91,35 @@ const formatName = (mflName: string): string => {
 };
 
 const espnCollegeMap = (espnCollegeIds as any)?.players || {};
+const mockDraftPlayerIdentityMap = getPlayerMap(leagueYear);
 
 const players: DraftRoomPlayer[] = playerArray.map((p: any) => {
-  const nflEspnId = p.espn_id || '';
-  const collegeEspnId = espnCollegeMap[p.id]?.espnCollegeId || '';
-  const espnId = nflEspnId || collegeEspnId;
+  const identity = mockDraftPlayerIdentityMap.get(p.id);
 
-  // Use college headshot URL when only a college ID is available —
-  // the ESPN combiner returns a broken placeholder (not a 404) for
-  // missing NFL headshots, so onerror fallback never fires.
   let headshot: string;
-  if (nflEspnId) {
-    headshot = getPlayerHeadshot(p.id, nflEspnId);
-  } else if (collegeEspnId) {
-    headshot = getCollegeHeadshot(collegeEspnId);
+  if (identity) {
+    headshot = identity.headshot;
   } else {
-    headshot = getPlayerHeadshot(p.id);
+    const nflEspnId = p.espn_id || '';
+    const collegeEspnId = espnCollegeMap[p.id]?.espnCollegeId || '';
+    if (nflEspnId) {
+      headshot = getPlayerHeadshot(p.id, nflEspnId);
+    } else if (collegeEspnId) {
+      headshot = getCollegeHeadshot(collegeEspnId);
+    } else {
+      headshot = getPlayerHeadshot(p.id);
+    }
   }
 
   return {
     id: p.id,
-    name: formatName(p.name || ''),
-    position: normPos(p.position || ''),
-    nflTeam: (p.team || '').toUpperCase(),
+    name: identity?.name ?? formatName(p.name || ''),
+    position: identity?.position ?? normPos(p.position || ''),
+    nflTeam: identity?.nflTeam ?? (p.team || '').toUpperCase(),
     headshot,
     isRookie: p.status === 'R' || p.draft_year === leagueYearStr,
     mflId: p.id,
-    espnId: espnId || undefined,
+    espnId: identity?.espnId ?? (p.espn_id || espnCollegeMap[p.id]?.espnCollegeId || undefined),
   };
 }).filter((p: DraftRoomPlayer) => {
   const pos = p.position;

--- a/src/pages/theleague/players.astro
+++ b/src/pages/theleague/players.astro
@@ -11,6 +11,7 @@ import TheLeagueLayout from '../../layouts/TheLeagueLayout.astro';
 import PlayerDetailsModal from '../../components/theleague/PlayerDetailsModal.astro';
 import { positionOrder } from '../../constants/roster-constants';
 import { getCurrentLeagueYear, getCurrentSeasonYear } from '../../utils/league-year';
+import { getPlayerMap } from '../../utils/player-map';
 import { getNthDayOfMonth } from '../../utils/league-event-resolver';
 import { buildWeeklyPlayerResults } from '../../utils/weekly-player-results';
 import { getFrozenSalaryAveragesYear } from '../../utils/salary-calculations';
@@ -422,6 +423,7 @@ interface PlayerRow {
 
 const allPlayers = playersData?.players?.player;
 const playerList: PlayerRow[] = [];
+const playerIdentityMap = getPlayerMap(currentYear);
 
 if (Array.isArray(allPlayers)) {
   const now = Date.now() / 1000;
@@ -444,11 +446,12 @@ if (Array.isArray(allPlayers)) {
       }
     }
 
-    const pos = p.position === 'Def' ? 'DEF' : p.position;
-    const nameParts = p.name.split(', ');
-    const displayName = nameParts.length === 2
-      ? `${nameParts[1]} ${nameParts[0]}`
-      : p.name;
+    const identity = playerIdentityMap.get(p.id);
+    const pos = identity?.position ?? (p.position === 'Def' ? 'DEF' : p.position);
+    const displayName = identity?.name ?? (() => {
+      const nameParts = p.name.split(', ');
+      return nameParts.length === 2 ? `${nameParts[1]} ${nameParts[0]}` : p.name;
+    })();
 
     // Experience (years in NFL)
     const draftYr = p.draft_year ? parseInt(p.draft_year, 10) : null;
@@ -479,9 +482,9 @@ if (Array.isArray(allPlayers)) {
       id: p.id,
       name: displayName,
       position: pos,
-      team: normalizeMflTeam(p.team || ''),
+      team: identity?.nflTeam ?? normalizeMflTeam(p.team || ''),
       age: pos === 'DEF' ? 25 : age,
-      espnId: p.espn_id || (espnCollegeIds as any).players?.[p.id]?.espnCollegeId || null,
+      espnId: identity?.espnId ?? (p.espn_id || (espnCollegeIds as any).players?.[p.id]?.espnCollegeId || null),
       projected,
       rostered: isRostered,
       exp: pos === 'DEF' ? 5 : exp,

--- a/src/pages/theleague/projected-free-agents.astro
+++ b/src/pages/theleague/projected-free-agents.astro
@@ -14,6 +14,7 @@ import TheLeagueLayout from '../../layouts/TheLeagueLayout.astro';
 import PlayerDetailsModal from '../../components/theleague/PlayerDetailsModal.astro';
 import { positionOrder } from '../../constants/roster-constants';
 import { getCurrentLeagueYear, getCurrentSeasonYear } from '../../utils/league-year';
+import { getPlayerMap } from '../../utils/player-map';
 import { buildWeeklyPlayerResults } from '../../utils/weekly-player-results';
 import { getCachedRosters } from '../../utils/mfl-roster-cache';
 import { chooseTeamName } from '../../utils/team-names';
@@ -177,16 +178,21 @@ interface ProjectedFARow {
   draftYear: number | null;
 }
 
+const pfaPlayerIdentityMap = getPlayerMap(currentYear);
+
 function buildPlayerRow(
   playerId: string,
   info: any,
   salary: number,
   franchiseId: string,
 ): ProjectedFARow | null {
-  const pos = info.position === 'Def' ? 'DEF' : info.position;
-  const nameParts = info.name.split(', ');
-  const displayName = nameParts.length === 2 ? `${nameParts[1]} ${nameParts[0]}` : info.name;
-  const team = normalizeMflTeam(info.team || '');
+  const identity = pfaPlayerIdentityMap.get(playerId);
+  const pos = identity?.position ?? (info.position === 'Def' ? 'DEF' : info.position);
+  const displayName = identity?.name ?? (() => {
+    const nameParts = info.name.split(', ');
+    return nameParts.length === 2 ? `${nameParts[1]} ${nameParts[0]}` : info.name;
+  })();
+  const team = identity?.nflTeam ?? normalizeMflTeam(info.team || '');
 
   let age: number | null = null;
   if (info.birthdate && pos !== 'DEF') {
@@ -204,9 +210,9 @@ function buildPlayerRow(
 
   const fInfo = franchiseMap.get(franchiseId);
 
-  const headshot = info.espn_id
+  const headshot = identity?.headshot ?? (info.espn_id
     ? `https://a.espncdn.com/i/headshots/nfl/players/full/${info.espn_id}.png`
-    : `https://www49.myfantasyleague.com/player_photos_big_2014/${playerId}_thumb.jpg`;
+    : `https://www49.myfantasyleague.com/player_photos_big_2014/${playerId}_thumb.jpg`);
 
   return {
     id: playerId,
@@ -214,7 +220,7 @@ function buildPlayerRow(
     position: pos,
     nflTeam: team,
     headshot,
-    espnId: info.espn_id || null,
+    espnId: identity?.espnId ?? info.espn_id ?? null,
     franchiseId,
     franchiseName: fInfo?.nameShort || franchiseId,
     franchiseIcon: fInfo?.icon || '',

--- a/src/pages/theleague/rosters.astro
+++ b/src/pages/theleague/rosters.astro
@@ -60,6 +60,7 @@ import {
   resolveTeamSelection,
 } from '../../utils/team-preferences';
 import { getCurrentLeagueYear, getCurrentSeasonYear } from '../../utils/league-year';
+import { getPlayerMap } from '../../utils/player-map';
 import { getCachedRosters } from '../../utils/mfl-roster-cache';
 import { buildWeeklyPlayerResults } from '../../utils/weekly-player-results';
 import liveOddsFallbackData from '../../data/nfl/live-odds.json';
@@ -971,6 +972,7 @@ const buildDisplayRows = (teamData) => {
 
 const buildSeasonPayload = (season, rawData, tradeBaitPlayerIds = new Set()) => {
   const feedPlayers = playersFeedBySeason[season] ?? {};
+  const playerIdentityMap = getPlayerMap(Number(season));
   const liveRosterData = liveRosterDataByPlayerId[season] ?? {};
 
   // Projections Map — use the season's projected scores data
@@ -992,12 +994,13 @@ const buildSeasonPayload = (season, rawData, tradeBaitPlayerIds = new Set()) => 
     ? Object.entries(liveRosterData).map(([id, liveData]) => {
         const salaryPlayer = salaryDataById.get(id) ?? {};
         const feed = feedPlayers[id] ?? {};
+        const identity = playerIdentityMap.get(id);
         return {
           ...salaryPlayer,
           id,
-          name: salaryPlayer.name ?? feed.name ?? `Player ${id}`,
-          position: (salaryPlayer.position ?? feed.position ?? 'N/A').replace(/^Def$/i, 'DEF'),
-          team: salaryPlayer.team ?? feed.team ?? '',
+          name: identity?.name ?? salaryPlayer.name ?? feed.name ?? `Player ${id}`,
+          position: identity?.position ?? (salaryPlayer.position ?? feed.position ?? 'N/A').replace(/^Def$/i, 'DEF'),
+          team: identity?.nflTeam ?? salaryPlayer.team ?? feed.team ?? '',
           salary: liveData.salary ?? salaryPlayer.salary ?? '0',
           contractYear: liveData.contractYear ?? salaryPlayer.contractYear ?? '1',
           status: liveData.status ?? salaryPlayer.status ?? 'ROSTER',
@@ -1106,8 +1109,9 @@ const buildSeasonPayload = (season, rawData, tradeBaitPlayerIds = new Set()) => 
       : '-';
 
     const feedPlayer = feedPlayers[player.id] ?? null;
-    const resolvedEspnId = feedPlayer?.espn_id || (espnCollegeIds as any).players?.[player.id]?.espnCollegeId || null;
-    const headshot = getPlayerHeadshot(player.id, resolvedEspnId);
+    const identity = playerIdentityMap.get(player.id);
+    const resolvedEspnId = identity?.espnId ?? feedPlayer?.espn_id ?? (espnCollegeIds as any).players?.[player.id]?.espnCollegeId ?? null;
+    const headshot = identity?.headshot ?? getPlayerHeadshot(player.id, resolvedEspnId);
     const collegeName = player.sleeper?.college ?? player.college ?? null;
     const collegeAssets = getCollegeAssets(collegeName);
     const parseDraft = (val) => {
@@ -1594,11 +1598,13 @@ teamsList.forEach((team) => {
 });
 
 // Enrich FA players with headshot URLs for PlayerCell rendering
+const faPlayerIdentityMap = getPlayerMap(Number(faNeedsLeagueYear));
 for (const needs of Object.values(freeAgentNeedsByTeam)) {
   for (const need of needs) {
     for (const fa of need.topFreeAgents) {
+      const faIdentity = faPlayerIdentityMap.get(fa.id);
       const feedPlayer = faPlayerFeed[fa.id];
-      fa.headshot = getPlayerHeadshot(fa.id, feedPlayer?.espn_id || (espnCollegeIds as any).players?.[fa.id]?.espnCollegeId);
+      fa.headshot = faIdentity?.headshot ?? getPlayerHeadshot(fa.id, feedPlayer?.espn_id || (espnCollegeIds as any).players?.[fa.id]?.espnCollegeId);
       if (feedPlayer?.birthdate) fa.birthdate = Number(feedPlayer.birthdate);
     }
   }

--- a/src/pages/theleague/trade-builder.astro
+++ b/src/pages/theleague/trade-builder.astro
@@ -27,6 +27,8 @@ import { getCurrentLeagueYear } from '../../utils/league-year';
 import { chooseTeamName } from '../../utils/team-names';
 import { calculatePlayerCapHitByYear } from '../../utils/trade-calculations';
 import { getPlayerHeadshot, getNflLogoUrl, DEFAULT_HEADSHOT_URL } from '../../constants/roster-constants';
+import { normalizeTeamCode } from '../../utils/nfl-logo';
+import { getPlayerMap } from '../../utils/player-map';
 import espnCollegeIds from '../../../data/theleague/espn-college-ids.json';
 import { getAuthUser, isCommissionerOrAdmin } from '../../utils/auth';
 import { calculateAllSurplusValues } from '../../utils/surplus-value';
@@ -143,17 +145,8 @@ const teamConfigMap = new Map(
   (leagueConfigData.teams ?? []).map((t: any) => [t.franchiseId, t])
 );
 
-// Normalize NFL team codes
-const normalizeTeamCode = (team: string) => {
-  const map: Record<string, string> = {
-    NEP: 'NE', CLV: 'CLE', JAC: 'JAX', KCC: 'KC', LVR: 'LV', OAK: 'LV',
-    SD: 'LAC', ARZ: 'ARI', SFO: 'SF', STL: 'LAR', LA: 'LAR', GBP: 'GB',
-    NOR: 'NO', NOS: 'NO', TBB: 'TB', WSH: 'WAS',
-  };
-  if (!team) return '';
-  const upper = team.toUpperCase();
-  return map[upper] ?? upper;
-};
+// Player identity map for canonical team codes, names, headshots
+const tradePlayerIdentityMap = getPlayerMap(leagueYear);
 
 // Salary adjustments
 const rawAdjustments = salaryAdjData?.salaryAdjustments?.salaryAdjustment ?? [];
@@ -266,18 +259,19 @@ const teams = franchises.map((franchise: any) => {
   const tradeBaitSet = teamHasCurrentBait ? currentTradeBaitIds : prevTradeBaitIds;
   const players = rawRosterPlayers.map((rp: any) => {
     const pData = playerMap.get(rp.id);
+    const identity = tradePlayerIdentityMap.get(rp.id);
     const salary = parseNumber(rp.salary);
     const contractYears = parseInt(rp.contractYear ?? '0', 10) || 0;
     const contractInfo = rp.contractInfo ?? '';
     const status = rp.status ?? 'ROSTER';
     const norm = normalizeStatus(status);
-    const rawPos = pData?.position ?? 'N/A';
-    const position = rawPos === 'Def' ? 'DEF' : rawPos;
-    const nflTeam = normalizeTeamCode(pData?.team ?? '');
+    const position = identity?.position ?? pData?.position ?? 'N/A';
+    const nflTeam = identity?.nflTeam ?? normalizeTeamCode(pData?.team ?? '');
+
 
     return {
       id: rp.id,
-      name: pData?.name ?? `Player ${rp.id}`,
+      name: identity?.name ?? pData?.name ?? `Player ${rp.id}`,
       position,
       salary,
       contractYears,
@@ -285,7 +279,7 @@ const teams = franchises.map((franchise: any) => {
       status,
       normalizedStatus: norm,
       nflTeam,
-      headshot: getPlayerHeadshot(rp.id, pData?.espn_id || (espnCollegeIds as any).players?.[rp.id]?.espnCollegeId),
+      headshot: identity?.headshot ?? getPlayerHeadshot(rp.id, pData?.espn_id || (espnCollegeIds as any).players?.[rp.id]?.espnCollegeId),
       nflLogo: getNflLogoUrl(nflTeam),
       isRookie: contractInfo.startsWith('R'),
       isFranchiseTagged: contractInfo === 'F',

--- a/src/utils/offseason-hero-data.ts
+++ b/src/utils/offseason-hero-data.ts
@@ -327,22 +327,27 @@ export function isDraftComplete(leagueYear: number): boolean {
 }
 
 // ── Player Lookup ──
+import { getPlayerMap as getUnifiedPlayerMap } from './player-map';
 
 function getPlayerMap(leagueYear: number): Map<string, { name: string; position: string; team: string }> {
-  const data = readJsonFile(`data/theleague/mfl-feeds/${leagueYear}/players.json`);
-  if (!data?.players?.player) return new Map();
-
-  const players = Array.isArray(data.players.player)
-    ? data.players.player
-    : [data.players.player];
-
+  const identityMap = getUnifiedPlayerMap(leagueYear);
   const map = new Map<string, { name: string; position: string; team: string }>();
-  for (const p of players) {
-    map.set(p.id, {
-      name: p.name || 'Unknown',
-      position: p.position || '',
-      team: p.team || '',
+  for (const [id, identity] of identityMap) {
+    map.set(id, {
+      name: identity.name,
+      position: identity.position,
+      team: identity.nflTeam,
     });
+  }
+  // Also load non-fantasy-position players from raw feed (coaches, etc. may appear in transactions)
+  const data = readJsonFile(`data/theleague/mfl-feeds/${leagueYear}/players.json`);
+  if (data?.players?.player) {
+    const players = Array.isArray(data.players.player) ? data.players.player : [data.players.player];
+    for (const p of players) {
+      if (!map.has(p.id)) {
+        map.set(p.id, { name: p.name || 'Unknown', position: p.position || '', team: p.team || '' });
+      }
+    }
   }
   return map;
 }

--- a/src/utils/player-map.ts
+++ b/src/utils/player-map.ts
@@ -1,0 +1,158 @@
+/**
+ * Unified Player Identity Map
+ *
+ * Single source of truth for player identity data (name, position, NFL team, headshot).
+ * Reads from the MFL feed JSON on disk (synced every 5 min via GitHub Actions).
+ *
+ * @example
+ * ```typescript
+ * import { getPlayerMap, getPlayer } from '../utils/player-map';
+ *
+ * const players = getPlayerMap(2026);
+ * const mahomes = players.get('13116');
+ * // => { mflId: '13116', name: 'Patrick Mahomes', position: 'QB', nflTeam: 'KC', headshot: '...', espnId: '3139477' }
+ *
+ * // Convenience single lookup
+ * const player = getPlayer(2026, '13116');
+ * ```
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { normalizeTeamCode } from './nfl-logo';
+import { getPlayerHeadshot, resolveEspnId } from '../constants/roster-constants';
+
+export interface PlayerIdentity {
+  mflId: string;
+  name: string;
+  position: string;
+  nflTeam: string;
+  headshot: string;
+  espnId: string | null;
+}
+
+/** Fantasy-relevant positions to include */
+const FANTASY_POSITIONS = new Set(['QB', 'RB', 'WR', 'TE', 'PK', 'Def']);
+
+/** Module-level cache: year → player map */
+const cache = new Map<number, Map<string, PlayerIdentity>>();
+
+/** College ID mapping (loaded once) */
+let collegeIdMap: Record<string, { espnCollegeId?: string }> | null = null;
+
+function loadCollegeIds(): Record<string, { espnCollegeId?: string }> {
+  if (collegeIdMap) return collegeIdMap;
+  try {
+    const filePath = join(process.cwd(), 'data/theleague/espn-college-ids.json');
+    const raw = JSON.parse(readFileSync(filePath, 'utf-8'));
+    collegeIdMap = raw.players || {};
+  } catch {
+    collegeIdMap = {};
+  }
+  return collegeIdMap!;
+}
+
+/**
+ * Convert MFL name format to display format.
+ * Regular players: "Last, First" → "First Last"
+ * DEF/Team entries: "Bills, Buffalo" → "Buffalo Bills"
+ */
+function formatName(mflName: string, position: string): string {
+  const commaIndex = mflName.indexOf(',');
+  if (commaIndex === -1) return mflName;
+
+  const part1 = mflName.slice(0, commaIndex).trim();
+  const part2 = mflName.slice(commaIndex + 1).trim();
+
+  // For team defenses, format as "City Team" (e.g., "Buffalo Bills")
+  if (position === 'Def' || position === 'DEF') {
+    return `${part2} ${part1}`;
+  }
+
+  // Regular players: "Last, First" → "First Last"
+  return `${part2} ${part1}`;
+}
+
+/**
+ * Normalize position codes from MFL format.
+ * 'Def' → 'DEF', everything else stays uppercase as-is.
+ */
+function normalizePosition(pos: string): string {
+  if (pos === 'Def') return 'DEF';
+  return pos;
+}
+
+/**
+ * Get the complete player identity map for a given year.
+ * Results are cached in memory — multiple calls with the same year return the same Map instance.
+ *
+ * @param year - The league year (e.g., 2026)
+ * @returns Map of MFL player ID → PlayerIdentity
+ */
+export function getPlayerMap(year: number): Map<string, PlayerIdentity> {
+  const cached = cache.get(year);
+  if (cached) return cached;
+
+  const playerMap = new Map<string, PlayerIdentity>();
+
+  try {
+    const filePath = join(process.cwd(), `data/theleague/mfl-feeds/${year}/players.json`);
+    const raw = JSON.parse(readFileSync(filePath, 'utf-8'));
+    const players: Array<Record<string, string>> = raw?.players?.player || [];
+    const collegeIds = loadCollegeIds();
+
+    for (const p of players) {
+      const position = p.position || '';
+      if (!FANTASY_POSITIONS.has(position)) continue;
+
+      const mflId = p.id;
+      const normalizedPosition = normalizePosition(position);
+      const nflTeam = normalizeTeamCode(p.team || '');
+      const espnId = resolveEspnId(mflId, p as { espn_id?: string }, collegeIds);
+      const headshot = getPlayerHeadshot(mflId, espnId || undefined);
+      const name = formatName(p.name || '', position);
+
+      playerMap.set(mflId, {
+        mflId,
+        name,
+        position: normalizedPosition,
+        nflTeam,
+        headshot,
+        espnId,
+      });
+    }
+  } catch {
+    // Feed file missing for this year — return empty map
+  }
+
+  cache.set(year, playerMap);
+  return playerMap;
+}
+
+/**
+ * Get a single player's identity by MFL ID.
+ * Convenience wrapper around getPlayerMap().
+ *
+ * @param year - The league year
+ * @param mflId - MFL player ID
+ * @returns PlayerIdentity or undefined if not found
+ */
+export function getPlayer(year: number, mflId: string): PlayerIdentity | undefined {
+  return getPlayerMap(year).get(mflId);
+}
+
+/**
+ * Clear the player map cache. Useful for testing or when feed files are updated.
+ */
+export function clearPlayerMapCache(): void {
+  cache.clear();
+  collegeIdMap = null;
+}
+
+// Vite HMR support — clear cache when module is hot-replaced in dev
+if ((import.meta as any).hot) {
+  (import.meta as any).hot.dispose(() => {
+    cache.clear();
+    collegeIdMap = null;
+  });
+}

--- a/tests/player-map.test.ts
+++ b/tests/player-map.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+// Mock fs.readFileSync before importing the module
+vi.mock('node:fs', () => ({
+  readFileSync: vi.fn(),
+}));
+
+const mockReadFileSync = vi.mocked(readFileSync);
+
+// Sample MFL feed data
+const mockFeedData = {
+  version: '1.0',
+  players: {
+    player: [
+      {
+        id: '13116',
+        name: 'Mahomes, Patrick',
+        position: 'QB',
+        team: 'KCC',
+        espn_id: '3139477',
+        draft_year: '2017',
+      },
+      {
+        id: '14836',
+        name: 'Chase, Ja\'Marr',
+        position: 'WR',
+        team: 'CIN',
+        espn_id: '4362628',
+      },
+      {
+        id: '0521',
+        name: 'Chiefs, Kansas City',
+        position: 'Def',
+        team: 'KCC',
+      },
+      {
+        id: '99999',
+        name: 'Smith, John',
+        position: 'QB',
+        team: 'NEP',
+        // No espn_id — should fallback to college IDs
+      },
+      {
+        id: '14000',
+        name: 'Lawrence, Trevor',
+        position: 'QB',
+        team: 'JAC',
+        espn_id: '4360310',
+      },
+      // Non-fantasy positions — should be filtered out
+      {
+        id: '50000',
+        name: 'Linebacker, Joe',
+        position: 'LB',
+        team: 'DAL',
+      },
+      {
+        id: '50001',
+        name: 'Corner, Bob',
+        position: 'CB',
+        team: 'SF',
+      },
+      // Free agent
+      {
+        id: '11111',
+        name: 'Nobody, Joe',
+        position: 'RB',
+        team: 'FA',
+      },
+      // PK position
+      {
+        id: '12345',
+        name: 'Tucker, Justin',
+        position: 'PK',
+        team: 'BLT',
+        espn_id: '15683',
+      },
+    ],
+  },
+};
+
+const mockCollegeIds = {
+  meta: { generatedAt: '2026-01-01' },
+  players: {
+    '99999': { espnCollegeId: '9876543', name: 'John Smith', college: 'Test U' },
+  },
+  unmatched: [],
+};
+
+describe('player-map', () => {
+  let getPlayerMap: typeof import('../src/utils/player-map').getPlayerMap;
+  let getPlayer: typeof import('../src/utils/player-map').getPlayer;
+  let clearPlayerMapCache: typeof import('../src/utils/player-map').clearPlayerMapCache;
+
+  beforeEach(async () => {
+    vi.resetModules();
+
+    mockReadFileSync.mockImplementation((filePath: any) => {
+      const path = String(filePath);
+      if (path.includes('players.json')) {
+        return JSON.stringify(mockFeedData);
+      }
+      if (path.includes('espn-college-ids.json')) {
+        return JSON.stringify(mockCollegeIds);
+      }
+      throw new Error(`File not found: ${path}`);
+    });
+
+    const mod = await import('../src/utils/player-map');
+    getPlayerMap = mod.getPlayerMap;
+    getPlayer = mod.getPlayer;
+    clearPlayerMapCache = mod.clearPlayerMapCache;
+    clearPlayerMapCache();
+  });
+
+  describe('getPlayerMap', () => {
+    it('returns a Map with fantasy-relevant players only', () => {
+      const map = getPlayerMap(2026);
+      // Should include QB, WR, Def, RB, PK
+      expect(map.has('13116')).toBe(true); // QB
+      expect(map.has('14836')).toBe(true); // WR
+      expect(map.has('0521')).toBe(true);  // Def
+      expect(map.has('11111')).toBe(true); // RB
+      expect(map.has('12345')).toBe(true); // PK
+      // Should exclude LB, CB
+      expect(map.has('50000')).toBe(false);
+      expect(map.has('50001')).toBe(false);
+    });
+
+    it('converts "Last, First" to "First Last" for regular players', () => {
+      const map = getPlayerMap(2026);
+      expect(map.get('13116')!.name).toBe('Patrick Mahomes');
+      expect(map.get('14836')!.name).toBe("Ja'Marr Chase");
+    });
+
+    it('formats DEF names as "City Team"', () => {
+      const map = getPlayerMap(2026);
+      expect(map.get('0521')!.name).toBe('Kansas City Chiefs');
+    });
+
+    it('normalizes MFL team codes to ESPN format', () => {
+      const map = getPlayerMap(2026);
+      expect(map.get('13116')!.nflTeam).toBe('KC');   // KCC → KC
+      expect(map.get('99999')!.nflTeam).toBe('NE');   // NEP → NE
+      expect(map.get('14000')!.nflTeam).toBe('JAX');  // JAC → JAX
+      expect(map.get('12345')!.nflTeam).toBe('BAL');  // BLT → BAL
+    });
+
+    it('normalizes free agent team code', () => {
+      const map = getPlayerMap(2026);
+      expect(map.get('11111')!.nflTeam).toBe('NFL');  // FA → NFL
+    });
+
+    it('normalizes "Def" position to "DEF"', () => {
+      const map = getPlayerMap(2026);
+      expect(map.get('0521')!.position).toBe('DEF');
+    });
+
+    it('resolves ESPN ID from feed first', () => {
+      const map = getPlayerMap(2026);
+      expect(map.get('13116')!.espnId).toBe('3139477');
+    });
+
+    it('falls back to college ESPN ID when feed has none', () => {
+      const map = getPlayerMap(2026);
+      expect(map.get('99999')!.espnId).toBe('9876543');
+    });
+
+    it('returns null espnId when neither source has it', () => {
+      const map = getPlayerMap(2026);
+      expect(map.get('0521')!.espnId).toBeNull(); // DEF has no ESPN ID
+    });
+
+    it('generates headshot URL with ESPN ID when available', () => {
+      const map = getPlayerMap(2026);
+      expect(map.get('13116')!.headshot).toContain('espncdn.com');
+      expect(map.get('13116')!.headshot).toContain('3139477');
+    });
+
+    it('generates MFL headshot URL when no ESPN ID', () => {
+      const map = getPlayerMap(2026);
+      // DEF with college ID fallback should use that college ID for headshot
+      // Player 0521 has no ESPN ID at all
+      expect(map.get('0521')!.headshot).toContain('myfantasyleague.com');
+    });
+
+    it('caches results — same Map instance on repeated calls', () => {
+      const map1 = getPlayerMap(2026);
+      const map2 = getPlayerMap(2026);
+      expect(map1).toBe(map2);
+    });
+
+    it('returns empty Map for missing year', () => {
+      mockReadFileSync.mockImplementation(() => {
+        throw new Error('ENOENT');
+      });
+      clearPlayerMapCache();
+      const map = getPlayerMap(2099);
+      expect(map.size).toBe(0);
+    });
+  });
+
+  describe('getPlayer', () => {
+    it('returns PlayerIdentity for known player', () => {
+      const player = getPlayer(2026, '13116');
+      expect(player).toEqual({
+        mflId: '13116',
+        name: 'Patrick Mahomes',
+        position: 'QB',
+        nflTeam: 'KC',
+        headshot: expect.stringContaining('3139477'),
+        espnId: '3139477',
+      });
+    });
+
+    it('returns undefined for unknown player', () => {
+      expect(getPlayer(2026, 'nonexistent')).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
… data

Adds `getPlayerMap(year)` utility backed by the MFL feed (synced every 5 min) as the authoritative source for player name, NFL team, position, and headshot. Migrates all 17 pages/utilities from scattered data loading to this single map, fixing stale NFL team assignments on the roster page and elsewhere.