### PR TITLE
refactor: migrate manual player-cell HTML to standard components

### DIFF
--- a/src/components/theleague/DeadMoneyTable.astro
+++ b/src/components/theleague/DeadMoneyTable.astro
@@ -146,9 +146,6 @@ const { tableBodyId = 'deadMoneyTableBody', class: className } = Astro.props;
     color: var(--error-color, #dc2626);
   }
 
-  :global(.player-cell__avatar--dm) {
-    opacity: 0.6;
-  }
 
   @media (max-width: 767px) {
     .dead-money-table-header {

--- a/src/components/theleague/PlayerCell.astro
+++ b/src/components/theleague/PlayerCell.astro
@@ -29,7 +29,7 @@
  */
 
 import '../../styles/player-cell.css';
-import { DEFAULT_HEADSHOT_URL, buildHeadshotOnerror } from '../../constants/roster-constants';
+import { DEFAULT_HEADSHOT_URL, buildHeadshotOnerror, getPlayerHeadshot } from '../../constants/roster-constants';
 import { normalizeTeamCode } from '../../utils/nfl-logo';
 import type { PlayerModalData } from '../../utils/player-modal-trigger';
 
@@ -81,8 +81,12 @@ const isDef = position?.toUpperCase() === 'DEF';
 const normalizedTeam = nflTeam ? normalizeTeamCode(nflTeam) : '';
 const teamLogoUrl = normalizedTeam ? `/assets/nfl-logos/${normalizedTeam}.svg` : '';
 
+// ESPN is the primary headshot source when espnId is available
+const resolvedHeadshot = resolvedEspnId
+  ? getPlayerHeadshot(resolvedMflId, resolvedEspnId)
+  : (headshot ?? DEFAULT_HEADSHOT_URL);
 // Avatar: DEF uses team logo, others use headshot
-const avatarSrc = isDef && teamLogoUrl ? teamLogoUrl : (headshot ?? DEFAULT_HEADSHOT_URL);
+const avatarSrc = isDef && teamLogoUrl ? teamLogoUrl : resolvedHeadshot;
 
 // NFL logo in meta row: DEF hides it, others show it
 const nflLogoUrl = isDef ? '' : (explicitNflLogo || teamLogoUrl || '/assets/nfl-logos/NFL.svg');

--- a/src/components/theleague/PlayerCell.tsx
+++ b/src/components/theleague/PlayerCell.tsx
@@ -4,6 +4,7 @@ import { normalizeTeamCode } from '../../utils/nfl-logo';
 import {
   DEFAULT_HEADSHOT_URL,
   getCollegeHeadshot,
+  getPlayerHeadshot,
   getPlayerImageUrl,
 } from '../../constants/roster-constants';
 
@@ -43,7 +44,11 @@ export function PlayerCell({
   const normalizedTeam = nflTeam ? normalizeTeamCode(nflTeam) : '';
   const teamLogoUrl = normalizedTeam ? `/assets/nfl-logos/${normalizedTeam}.svg` : '';
 
-  const avatarSrc = isDef && teamLogoUrl ? teamLogoUrl : (headshot ?? DEFAULT_HEADSHOT_URL);
+  // ESPN is the primary headshot source when espnId is available
+  const resolvedHeadshot = espnId
+    ? getPlayerHeadshot(mflId, espnId)
+    : (headshot ?? DEFAULT_HEADSHOT_URL);
+  const avatarSrc = isDef && teamLogoUrl ? teamLogoUrl : resolvedHeadshot;
   const nflLogoUrl = isDef ? '' : (explicitNflLogo ?? teamLogoUrl);
 
   const handleImgError = (e: React.SyntheticEvent<HTMLImageElement>) => {

--- a/src/components/theleague/custom-rankings/PlayerRow.tsx
+++ b/src/components/theleague/custom-rankings/PlayerRow.tsx
@@ -8,11 +8,8 @@
 
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { normalizeTeamCode } from '../../../utils/nfl-logo';
+import { PlayerCell } from '../PlayerCell';
 import type { RankedPlayer } from '../../../types/custom-rankings';
-
-const DEFAULT_HEADSHOT =
-  'https://www49.myfantasyleague.com/player_photos_2010/no_photo_available.jpg';
 
 interface PlayerRowProps {
   player: RankedPlayer;
@@ -35,11 +32,6 @@ export default function PlayerRow({ player, rank, isEditing = false }: PlayerRow
     transition,
     opacity: isDragging ? 0.5 : 1,
   };
-
-  const isDef = player.position === 'DEF';
-  const normalized = normalizeTeamCode(player.nflTeam);
-  const teamLogo = normalized ? `/assets/nfl-logos/${normalized}.svg` : '';
-  const avatarSrc = isDef && teamLogo ? teamLogo : (player.headshot || DEFAULT_HEADSHOT);
 
   // Rank delta: positive = moved up (green), negative = moved down (red)
   let delta: number | null = null;
@@ -70,36 +62,15 @@ export default function PlayerRow({ player, rank, isEditing = false }: PlayerRow
       {/* Rank number */}
       <div className="cr-row__rank">{rank}</div>
 
-      {/* Player lockup (reuses player-cell CSS) */}
-      <div className="player-cell player-cell--compact">
-        <div className={`player-cell__avatar${isDef ? ' player-cell__avatar--def' : ''}`}>
-          <img
-            src={avatarSrc}
-            alt={isDef ? `${player.nflTeam} logo` : `${player.name} headshot`}
-            loading="lazy"
-            decoding="async"
-            onError={(e) => {
-              (e.target as HTMLImageElement).onerror = null;
-              (e.target as HTMLImageElement).src = DEFAULT_HEADSHOT;
-            }}
-          />
-        </div>
-        <div className="player-cell__info">
-          <strong className="player-cell__name">{player.name}</strong>
-          <div className="player-meta">
-            {!isDef && teamLogo && (
-              <img
-                src={teamLogo}
-                alt={`${normalized} logo`}
-                className="player-meta__logo"
-                loading="lazy"
-                decoding="async"
-              />
-            )}
-            <span className="player-meta__pos">{player.position}</span>
-          </div>
-        </div>
-      </div>
+      {/* Player lockup */}
+      <PlayerCell
+        name={player.name}
+        headshot={player.headshot}
+        position={player.position}
+        nflTeam={player.nflTeam}
+        mflId={player.id}
+        size="compact"
+      />
 
       {/* VORP chip (when enabled) */}
       {player.vorpPoints != null && (

--- a/src/pages/theleague/rosters.astro
+++ b/src/pages/theleague/rosters.astro
@@ -819,15 +819,38 @@ Object.entries(salaryAdjustmentFeeds).forEach(([path, mod]) => {
   const season = extractFeedSeason(path);
   const data = getModuleData(mod);
   if (!season || !data?.salaryAdjustments?.salaryAdjustment) return;
+
+  // Build name→identity lookup for enriching dead money entries with headshots
+  // Index by both "First Last" and "Last, First" since dead money uses MFL's "Last, First" format
+  const identityMap = getPlayerMap(Number(season));
+  const nameToIdentity = new Map<string, { id: string; espnId: string | null; headshot: string }>();
+  for (const [id, identity] of identityMap) {
+    const entry = { id, espnId: identity.espnId, headshot: identity.headshot };
+    nameToIdentity.set(identity.name.toLowerCase(), entry); // "first last"
+    const parts = identity.name.split(' ');
+    if (parts.length >= 2) {
+      const lastFirst = `${parts.slice(-1)[0]}, ${parts.slice(0, -1).join(' ')}`;
+      nameToIdentity.set(lastFirst.toLowerCase(), entry); // "last, first"
+    }
+  }
+
   feedSalaryAdjustmentsBySeason[season] = data.salaryAdjustments.salaryAdjustment
-    .map((adj) => ({
-      franchiseId: adj.franchise_id ?? adj.franchiseId ?? '',
-      amount: parseNumber(adj.amount),
-      description: adj.description ?? '',
-      yearOffset: 0, // default to current season; can enhance if offset parsing desired
-      timestamp: adj.timestamp ?? null,
-      ...parseAdjustmentMeta(adj.description ?? ''),
-    }))
+    .map((adj) => {
+      const meta = parseAdjustmentMeta(adj.description ?? '');
+      const playerIdentity = meta.name ? nameToIdentity.get(meta.name.toLowerCase()) : null;
+      return {
+        franchiseId: adj.franchise_id ?? adj.franchiseId ?? '',
+        amount: parseNumber(adj.amount),
+        description: adj.description ?? '',
+        yearOffset: 0,
+        timestamp: adj.timestamp ?? null,
+        ...meta,
+        // Enrich with player identity for headshot display
+        playerId: playerIdentity?.id ?? null,
+        espnId: playerIdentity?.espnId ?? null,
+        headshot: playerIdentity?.headshot ?? null,
+      };
+    })
     .filter((adj) => Number.isFinite(adj.amount));
 });
 
@@ -6565,15 +6588,19 @@ const defaultLastSeenText = formatLastSeen(defaultLastSeen);
             })
             .join('');
           const name = adj.name || adj.description || 'Adjustment';
-          const playerData = findPlayerData(name);
 
-          // Use player headshot if available, otherwise use franchise team logo, finally fallback to default
+          // Use build-time enriched identity data (covers dropped players too)
+          // Fall back to runtime roster lookup, then franchise icon
+          const enrichedId = adj.playerId;
+          const enrichedEspnId = adj.espnId;
+          const enrichedHeadshot = adj.headshot;
+
           let headshot = DEFAULT_HEADSHOT_URL;
-          if (playerData?.headshot) {
-            headshot = playerData.headshot;
-          } else if (playerData?.id) {
-            headshot = getPlayerImageUrl(playerData.id);
-          } else if (config.teams[franchiseId]?.icon) {
+          if (enrichedHeadshot) {
+            headshot = enrichedHeadshot;
+          } else if (enrichedId) {
+            headshot = getPlayerImageUrl(enrichedId);
+          } else if (!enrichedId && config.teams[franchiseId]?.icon) {
             headshot = config.teams[franchiseId].icon;
           }
           const rowClasses = ['deadmoney-row', adj.rowClass === 'eventablerow' ? 'deadmoney-row--alt' : ''];
@@ -6582,8 +6609,8 @@ const defaultLastSeenText = formatLastSeen(defaultLastSeen);
             headshot,
             position: adj.position || undefined,
             nflTeam: adj.nflTeam || undefined,
-            mflId: playerData?.id || undefined,
-            espnId: playerData?.espnId || undefined,
+            mflId: enrichedId || undefined,
+            espnId: enrichedEspnId || undefined,
           });
           return `<tr class="${rowClasses.join(' ').trim()}">
             <td data-column="player" class="deadmoney-player-cell">

--- a/src/pages/theleague/rosters.astro
+++ b/src/pages/theleague/rosters.astro
@@ -6017,8 +6017,12 @@ const defaultLastSeenText = formatLastSeen(defaultLastSeen);
             ];
             allPlayers.forEach(player => {
               if (player.name && player.id) {
-                // Store by "Last, First" format
-                lookup[player.name.toLowerCase()] = player.id;
+                // Store by "Last, First" format — include espnId and headshot for dead money display
+                lookup[player.name.toLowerCase()] = {
+                  id: player.id,
+                  espnId: player.espnId || null,
+                  headshot: player.headshot || null,
+                };
               }
             });
           });
@@ -6029,7 +6033,7 @@ const defaultLastSeenText = formatLastSeen(defaultLastSeen);
 
     const playerLookup = createPlayerLookup();
 
-    const findPlayerId = (playerName) => {
+    const findPlayerData = (playerName) => {
       if (!playerName) return null;
       return playerLookup[playerName.toLowerCase()] || null;
     };
@@ -6561,12 +6565,14 @@ const defaultLastSeenText = formatLastSeen(defaultLastSeen);
             })
             .join('');
           const name = adj.name || adj.description || 'Adjustment';
-          const playerId = findPlayerId(name);
+          const playerData = findPlayerData(name);
 
           // Use player headshot if available, otherwise use franchise team logo, finally fallback to default
           let headshot = DEFAULT_HEADSHOT_URL;
-          if (playerId) {
-            headshot = getPlayerImageUrl(playerId);
+          if (playerData?.headshot) {
+            headshot = playerData.headshot;
+          } else if (playerData?.id) {
+            headshot = getPlayerImageUrl(playerData.id);
           } else if (config.teams[franchiseId]?.icon) {
             headshot = config.teams[franchiseId].icon;
           }
@@ -6576,7 +6582,8 @@ const defaultLastSeenText = formatLastSeen(defaultLastSeen);
             headshot,
             position: adj.position || undefined,
             nflTeam: adj.nflTeam || undefined,
-            mflId: playerId || undefined,
+            mflId: playerData?.id || undefined,
+            espnId: playerData?.espnId || undefined,
           });
           return `<tr class="${rowClasses.join(' ').trim()}">
             <td data-column="player" class="deadmoney-player-cell">

--- a/src/pages/theleague/rosters.astro
+++ b/src/pages/theleague/rosters.astro
@@ -6561,8 +6561,6 @@ const defaultLastSeenText = formatLastSeen(defaultLastSeen);
             })
             .join('');
           const name = adj.name || adj.description || 'Adjustment';
-          const teamLabel = adj.nflTeam || 'FA';
-          const nflLogo = adj.nflTeam ? getNflLogoUrl(adj.nflTeam) : '';
           const playerId = findPlayerId(name);
 
           // Use player headshot if available, otherwise use franchise team logo, finally fallback to default
@@ -6573,24 +6571,16 @@ const defaultLastSeenText = formatLastSeen(defaultLastSeen);
             headshot = config.teams[franchiseId].icon;
           }
           const rowClasses = ['deadmoney-row', adj.rowClass === 'eventablerow' ? 'deadmoney-row--alt' : ''];
+          const playerCellHtml = buildPlayerCellHTML({
+            name,
+            headshot,
+            position: adj.position || undefined,
+            nflTeam: adj.nflTeam || undefined,
+            mflId: playerId || undefined,
+          });
           return `<tr class="${rowClasses.join(' ').trim()}">
             <td data-column="player" class="deadmoney-player-cell">
-              <div class="player-cell">
-                <div class="player-cell__avatar player-cell__avatar--dm">
-                  <img src="${headshot}" alt="${name} headshot" loading="lazy" decoding="async" onerror="this.onerror=null;this.src='${DEFAULT_HEADSHOT_URL}';" />
-                </div>
-                <div>
-                  <strong>${name}</strong>
-                  <div class="player-meta">
-                    ${
-                      adj.position && adj.position.toUpperCase() !== 'DEF' && nflLogo
-                        ? `<img src="${nflLogo}" alt="${teamLabel} logo" class="player-meta__logo" loading="lazy" decoding="async" />`
-                        : ''
-                    }
-                    ${adj.position ? `<span class="player-meta__pos">${adj.position}</span>` : ''}
-                  </div>
-                </div>
-              </div>
+              ${playerCellHtml}
             </td>
             ${cells}
           </tr>`;

--- a/src/styles/player-cell.css
+++ b/src/styles/player-cell.css
@@ -71,10 +71,6 @@
   object-position: center;
 }
 
-/* Dead-money variant */
-.player-cell__avatar--dm {
-  opacity: 0.6;
-}
 
 /* Eligible demo/mock highlight */
 .player-cell__avatar--eligible {

--- a/src/utils/player-cell-html.ts
+++ b/src/utils/player-cell-html.ts
@@ -19,7 +19,7 @@
  */
 
 import type { PlayerModalData } from './player-modal-trigger';
-import { DEFAULT_HEADSHOT_URL, buildHeadshotOnerror } from '../constants/roster-constants';
+import { DEFAULT_HEADSHOT_URL, buildHeadshotOnerror, getPlayerHeadshot } from '../constants/roster-constants';
 
 /** Map MFL team codes to standard codes (must match nfl-logo.ts) */
 const TEAM_CODE_MAP: Record<string, string> = {
@@ -85,7 +85,11 @@ export function buildPlayerCellHTML(opts: PlayerCellOptions): string {
   const normalized = nflTeam ? normalizeTeam(nflTeam) : '';
   const teamLogo = normalized ? `/assets/nfl-logos/${normalized}.svg` : '';
 
-  const avatarSrc = isDef && teamLogo ? teamLogo : (headshot || DEFAULT_HEADSHOT_URL);
+  // ESPN is the primary headshot source when espnId is available
+  const resolvedHeadshot = resolvedEspnId
+    ? getPlayerHeadshot(resolvedMflId, resolvedEspnId)
+    : (headshot || DEFAULT_HEADSHOT_URL);
+  const avatarSrc = isDef && teamLogo ? teamLogo : resolvedHeadshot;
   const nflLogoUrl = isDef ? '' : (teamLogo || '/assets/nfl-logos/NFL.svg');
 
   const sizeClass = size === 'compact' ? ' player-cell--compact' : '';


### PR DESCRIPTION
- PlayerRow.tsx: replace 30 lines of manual JSX with PlayerCell.tsx component
- rosters.astro DeadMoneyTable: replace manual HTML with buildPlayerCellHTML()
- Remove dead-money dimmed opacity (player-cell__avatar--dm)