### PR TITLE
fix: use DP_ format for current-year draft picks in trade submissions

### DIFF
--- a/data/theleague/live-starting-lineups-week-22.json
+++ b/data/theleague/live-starting-lineups-week-22.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-10T03:45:35.213Z",
+  "generatedAt": "2026-04-11T21:53:41.681Z",
   "week": 22,
   "year": 2025,
   "leagueId": "13522",

--- a/src/components/theleague/trade-builder/TradeBuilder.tsx
+++ b/src/components/theleague/trade-builder/TradeBuilder.tsx
@@ -15,7 +15,7 @@ import {
   serializeTradeToParams,
   deserializeTradeFromParams,
 } from '../../../utils/trade-calculations';
-import { buildMflAssetString, parseFpCode } from '../../../utils/trade-asset-parsing';
+import { buildMflAssetString, parseFpCode, parseDpCode } from '../../../utils/trade-asset-parsing';
 import TeamPanel from './TeamPanel';
 import TradeBaitMarketplace from './TradeBaitMarketplace';
 import MultiYearCapTable from './MultiYearCapTable';
@@ -428,8 +428,8 @@ export default function TradeBuilder({ pageData, defaultTeamId, authUser: authUs
     const otherTeamSide = currentUserSide === 'A' ? state.teamB : state.teamA;
     const otherTeam = currentUserSide === 'A' ? teamB : teamA;
 
-    const willGiveUp = buildMflAssetString(userTeamSide.playerIds, userTeamSide.draftPicks);
-    const willReceive = buildMflAssetString(otherTeamSide.playerIds, otherTeamSide.draftPicks);
+    const willGiveUp = buildMflAssetString(userTeamSide.playerIds, userTeamSide.draftPicks, data.currentYearDpMap);
+    const willReceive = buildMflAssetString(otherTeamSide.playerIds, otherTeamSide.draftPicks, data.currentYearDpMap);
 
     try {
       const res = await fetch('/api/trades/submit', {
@@ -552,9 +552,14 @@ export default function TradeBuilder({ pageData, defaultTeamId, authUser: authUs
       const parts = assetStr.split(',').filter(Boolean);
       for (const part of parts) {
         const trimmed = part.trim();
-        const pick = parseFpCode(trimmed);
-        if (pick) {
-          dispatch({ type: 'ADD_DRAFT_PICK', side, pick });
+        const fpPick = parseFpCode(trimmed);
+        if (fpPick) {
+          dispatch({ type: 'ADD_DRAFT_PICK', side, pick: fpPick });
+        } else if (trimmed.startsWith('DP_')) {
+          const dpPick = parseDpCode(trimmed, data.dpReverseMap);
+          if (dpPick) {
+            dispatch({ type: 'ADD_DRAFT_PICK', side, pick: dpPick });
+          }
         } else if (/^\d+$/.test(trimmed)) {
           dispatch({ type: 'ADD_PLAYER', side, playerId: trimmed });
         }

--- a/src/pages/theleague/trade-builder.astro
+++ b/src/pages/theleague/trade-builder.astro
@@ -184,6 +184,12 @@ const rawDraftResultPicks: any[] = (() => {
 })();
 
 const currentYearPicksByFranchise = new Map<string, any[]>();
+// Build DP_ code lookup maps for current-year draft picks.
+// MFL uses DP_{round-1}_{pick-1} format for current-year picks (zero-indexed),
+// while future picks use FP_{franchiseId}_{year}_{round}.
+const currentYearDpMap: Record<string, string> = {};
+const dpReverseMap: Record<string, { year: string; round: string; originalPickFor: string }> = {};
+
 for (const pick of rawDraftResultPicks) {
   if (pick.player) continue; // Skip already-drafted picks
 
@@ -212,6 +218,14 @@ for (const pick of rawDraftResultPicks) {
         abbrev: origTeamConfig.abbrev,
       }, 'short')
     : `Team ${originalPickFor}`;
+
+  // Build DP_ code: DP_{0-based-round}_{0-based-pick-in-round}
+  const dpRound = parseInt(pick.round, 10) - 1;
+  const dpPick = parseInt(pick.pick, 10) - 1;
+  const dpCode = `DP_${dpRound}_${String(dpPick).padStart(2, '0')}`;
+  const dpKey = `${leagueYearStr}-${round}-${originalPickFor}`;
+  currentYearDpMap[dpKey] = dpCode;
+  dpReverseMap[dpCode] = { year: leagueYearStr, round, originalPickFor };
 
   const draftPick = {
     year: leagueYearStr,
@@ -456,6 +470,8 @@ const pageData = {
   positionAverages,
   ...(Object.keys(surplusMap).length > 0 ? { surplusMap } : {}),
   ...(Object.keys(pickValueMap).length > 0 ? { pickValueMap } : {}),
+  ...(Object.keys(currentYearDpMap).length > 0 ? { currentYearDpMap } : {}),
+  ...(Object.keys(dpReverseMap).length > 0 ? { dpReverseMap } : {}),
 };
 ---
 

--- a/src/types/trade-builder.ts
+++ b/src/types/trade-builder.ts
@@ -88,6 +88,10 @@ export interface TradeBuilderPageData {
   positionAverages: PositionSalaryAverages;
   surplusMap?: Record<string, PlayerSurplusData>;
   pickValueMap?: Record<string, DraftPickValueData>;
+  /** Map from "{year}-{round}-{originalPickFor}" to DP_ code for current-year draft picks */
+  currentYearDpMap?: Record<string, string>;
+  /** Reverse map from DP_ code to DraftPickKey for loading pending trades with DP_ codes */
+  dpReverseMap?: Record<string, { year: string; round: string; originalPickFor: string }>;
 }
 
 /** Key to uniquely identify a draft pick */

--- a/src/utils/trade-asset-parsing.ts
+++ b/src/utils/trade-asset-parsing.ts
@@ -45,9 +45,11 @@ export function formatPickCode(code: string, allTeams: TradeBuilderTeam[]): stri
     return `${year} Rd ${round}${via}`;
   }
   if (code.startsWith('DP_')) {
+    // DP_ format: DP_{round-1}_{pick-1} (both zero-indexed)
     const parts = code.split('_');
     const round = parseInt(parts[1], 10) + 1;
-    return `Current Rd ${round}`;
+    const pickInRound = parts[2] != null ? parseInt(parts[2], 10) + 1 : null;
+    return pickInRound ? `Current Rd ${round}, Pick ${pickInRound}` : `Current Rd ${round}`;
   }
   return code;
 }
@@ -65,16 +67,44 @@ export function parseFpCode(code: string): DraftPickKey | null {
 }
 
 /**
+ * Parse DP_ code into a DraftPickKey using a reverse lookup map.
+ * DP_ codes identify current-year draft picks by slot (DP_{round-1}_{pick-1}).
+ * The reverse map is built from draftResults data at page load time.
+ */
+export function parseDpCode(
+  code: string,
+  reverseMap?: Record<string, { year: string; round: string; originalPickFor: string }>
+): DraftPickKey | null {
+  if (!code.startsWith('DP_')) return null;
+  if (!reverseMap) return null;
+  const entry = reverseMap[code];
+  if (!entry) return null;
+  return { year: entry.year, round: entry.round, originalPickFor: entry.originalPickFor };
+}
+
+/**
  * Build the MFL asset string from player IDs and draft picks.
- * Players are numeric IDs, future picks are FP_{franchise}_{year}_{round}.
+ * Players are numeric IDs, future picks are FP_{franchise}_{year}_{round},
+ * current-year picks are DP_{round-1}_{pick-1} (zero-indexed).
+ *
+ * @param dpMap - Optional map from "{year}-{round}-{originalPickFor}" to DP_ code.
+ *   When a pick is found in this map, the DP_ code is used instead of FP_ format.
+ *   This is required for current-year picks that MFL no longer tracks as "future".
  */
 export function buildMflAssetString(
   playerIds: string[],
-  draftPicks: DraftPickKey[]
+  draftPicks: DraftPickKey[],
+  dpMap?: Record<string, string>
 ): string {
   const parts: string[] = [...playerIds];
   for (const pick of draftPicks) {
-    parts.push(`FP_${pick.originalPickFor}_${pick.year}_${pick.round}`);
+    const dpKey = `${pick.year}-${pick.round}-${pick.originalPickFor}`;
+    const dpCode = dpMap?.[dpKey];
+    if (dpCode) {
+      parts.push(dpCode);
+    } else {
+      parts.push(`FP_${pick.originalPickFor}_${pick.year}_${pick.round}`);
+    }
   }
   return parts.join(',');
 }


### PR DESCRIPTION
Current-year (2026) draft picks are in MFL's draftResults system, not
futureDraftPicks. Sending them as FP_ tokens caused MFL to reject trades
with "Does Not Have This Future Draft Pick To Trade" for both franchises.

- Build DP_{round-1}_{pick-1} lookup maps from draftResults at page load
- Use DP_ format for current-year picks, FP_ format for future picks
- Add parseDpCode() for loading pending trades that contain DP_ codes
- Fix formatPickCode() to handle two-part DP_X_Y format

https://claude.ai/code/session_01KTJdFgzeg5FkjVCpCwAqUC