### PR TITLE
fix: trade alert modal JS stops working after View Transition navigation

### DIFF
--- a/src/components/theleague/TradeAlertModal.astro
+++ b/src/components/theleague/TradeAlertModal.astro
@@ -13,7 +13,7 @@
 ---
 
 <div class="trade-alert-modal" id="trade-alert-modal" role="dialog" aria-modal="true" aria-label="Trade offers">
-  <div class="tam-overlay"></div>
+  <div class="tam-overlay" id="tam-overlay"></div>
   <div class="tam-content">
     <button class="tam-close" id="tam-close" aria-label="Close" title="Close (ESC)">
       <svg width="18" height="18" viewBox="0 0 18 18" fill="none">

--- a/src/scripts/trade-alert.ts
+++ b/src/scripts/trade-alert.ts
@@ -580,15 +580,15 @@ function tamOpenFromBell() {
   tamOpen();
 }
 
-// ---- Event handlers (attached once) ----
+// ---- Event handlers ----
+// Element-level handlers must be re-attached after every View Transition because
+// Astro's ClientRouter swaps DOM nodes, destroying old event listeners.
+// The document-level keydown handler survives swaps and is only attached once.
 
-let tamHandlersAttached = false;
+let tamDocKeydownBound = false;
 
 function tamAttachHandlers() {
-  if (tamHandlersAttached) return;
-  tamHandlersAttached = true;
-
-  // Close
+  // Element handlers — re-bind to fresh DOM after each View Transition
   tamEl('tam-overlay')?.addEventListener('click', tamClose);
   tamEl('tam-close')?.addEventListener('click', tamClose);
 
@@ -617,32 +617,35 @@ function tamAttachHandlers() {
   });
   tamEl('tam-confirm-no')?.addEventListener('click', () => tamResetFooter());
 
-  // ESC + focus trap
-  document.addEventListener('keydown', (e) => {
-    const modal = tamEl('trade-alert-modal');
-    if (!modal?.classList.contains('active')) return;
+  // ESC + focus trap — document-level, survives View Transitions, attach once
+  if (!tamDocKeydownBound) {
+    tamDocKeydownBound = true;
+    document.addEventListener('keydown', (e) => {
+      const modal = tamEl('trade-alert-modal');
+      if (!modal?.classList.contains('active')) return;
 
-    if (e.key === 'Escape') {
-      e.stopPropagation();
-      tamClose();
-      return;
-    }
-
-    // Focus trap
-    if (e.key === 'Tab') {
-      const focusable = modal.querySelectorAll<HTMLElement>(
-        'button:not([disabled]):not([style*="display: none"]), a[href]:not([style*="display: none"]), [tabindex="0"]'
-      );
-      if (!focusable.length) return;
-      const first = focusable[0];
-      const last = focusable[focusable.length - 1];
-      if (e.shiftKey && document.activeElement === first) {
-        e.preventDefault(); last.focus();
-      } else if (!e.shiftKey && document.activeElement === last) {
-        e.preventDefault(); first.focus();
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        tamClose();
+        return;
       }
-    }
-  });
+
+      // Focus trap
+      if (e.key === 'Tab') {
+        const focusable = modal.querySelectorAll<HTMLElement>(
+          'button:not([disabled]):not([style*="display: none"]), a[href]:not([style*="display: none"]), [tabindex="0"]'
+        );
+        if (!focusable.length) return;
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (e.shiftKey && document.activeElement === first) {
+          e.preventDefault(); last.focus();
+        } else if (!e.shiftKey && document.activeElement === last) {
+          e.preventDefault(); first.focus();
+        }
+      }
+    });
+  }
 }
 
 // ---- Mock data for preview (?mockTrades=1 for single, ?mockTrades=3 for multi) ----


### PR DESCRIPTION
Two bugs caused the trade alert modal to be unresponsive, especially on
mobile after navigating between pages:

1. The tamHandlersAttached flag was set once and never reset. After Astro's
   ClientRouter swaps the DOM during navigation, all element-level event
   listeners are lost — but the flag prevented re-attachment. Now element
   handlers (close, bell, accept/reject, overlay click) are always re-bound
   to fresh DOM on each page load, while the document-level keydown handler
   (ESC/focus trap) is correctly attached only once.

2. The modal overlay div was missing its id attribute, so the
   click-to-dismiss backdrop handler was never attached at all.

https://claude.ai/code/session_01GCoVJmrcM9abzZ6F5YuDx1