### PR TITLE
fix(schefter-scan): persist feed before GroupMe on pending-trade posts

### DIFF
--- a/scripts/schefter-scan.mjs
+++ b/scripts/schefter-scan.mjs
@@ -817,80 +817,107 @@ async function scanPendingTrades(league) {
   const recentPostsBlock = buildRecentPostsPromptBlock(history.posts);
   console.log(`  [memory] last ${Math.min(history.posts.length, 5)} posts passed to LLM`);
 
+  // Feed-first, GroupMe-second per trade. Previously the whole loop built up a
+  // `newPosts[]` array and only flushed to disk AFTER the loop. If any call in
+  // the loop (AI, network, history append, next-iteration) threw between a
+  // GroupMe send and the post-loop feed write, the GroupMe message was already
+  // out but the feed never persisted — resulting in "Schefter posted to the
+  // group chat but the rumor is missing from the site". Swap the order per
+  // iteration: persist the feed first, THEN fire GroupMe. Each iteration is
+  // wrapped in its own try/catch so a single bad trade can't drop the batch.
   for (const trade of newPending) {
     const offerId = String(trade.id || trade.trade_id || '');
     if (!offerId) continue;
 
-    const templateBody = generatePendingTradeTemplate(trade, players, teams);
-    const aiBody = await generatePendingTradeAiBody(templateBody, trade, players, teams, {
-      lore,
-      recentPostsBlock,
-    });
-    const body = aiBody || templateBody;
+    try {
+      const templateBody = generatePendingTradeTemplate(trade, players, teams);
+      const aiBody = await generatePendingTradeAiBody(templateBody, trade, players, teams, {
+        lore,
+        recentPostsBlock,
+      });
+      const body = aiBody || templateBody;
 
-    const t1 = teams.get(trade.franchise);
-    const t2 = teams.get(trade.franchise2);
-    const team1 = pickTeamDisplayName(t1) ?? `Team ${trade.franchise}`;
-    const team2 = pickTeamDisplayName(t2) ?? `Team ${trade.franchise2}`;
+      const t1 = teams.get(trade.franchise);
+      const t2 = teams.get(trade.franchise2);
+      const team1 = pickTeamDisplayName(t1) ?? `Team ${trade.franchise}`;
+      const team2 = pickTeamDisplayName(t2) ?? `Team ${trade.franchise2}`;
 
-    const tradeTs = parseInt(trade.timestamp || `${Math.floor(Date.now() / 1000)}`, 10);
-    const post = {
-      id: `sf_pending_${offerId}`,
-      timestamp: new Date().toISOString(),
-      type: 'transaction',
-      transactionSubType: TRADE_PENDING_SUB_TYPE,
-      tier: 'breaking',
-      headline: `Trade on the commish's desk: ${team1} and ${team2}`,
-      body,
-      authorId: 'claude',
-      franchiseIds: [trade.franchise, trade.franchise2].filter(Boolean),
-      sourceTimestamp: String(tradeTs),
-      offerId,
-      tradeSignature: buildTradeSignature(trade.franchise, trade.franchise2, trade.franchise1_gave_up, trade.franchise2_gave_up),
-      league: leagueSlug,
-    };
+      const tradeTs = parseInt(trade.timestamp || `${Math.floor(Date.now() / 1000)}`, 10);
+      const post = {
+        id: `sf_pending_${offerId}`,
+        timestamp: new Date().toISOString(),
+        type: 'transaction',
+        transactionSubType: TRADE_PENDING_SUB_TYPE,
+        tier: 'breaking',
+        headline: `Trade on the commish's desk: ${team1} and ${team2}`,
+        body,
+        authorId: 'claude',
+        franchiseIds: [trade.franchise, trade.franchise2].filter(Boolean),
+        sourceTimestamp: String(tradeTs),
+        offerId,
+        tradeSignature: buildTradeSignature(trade.franchise, trade.franchise2, trade.franchise1_gave_up, trade.franchise2_gave_up),
+        league: leagueSlug,
+      };
 
-    // Dedup guard in case watermark got out of sync with feed
-    if (feed.posts.some(p => p.id === post.id)) {
-      console.log(`  [rumor-mill] Skip ${offerId} — already in feed`);
-      continue;
-    }
+      // Dedup guard in case watermark got out of sync with feed
+      if (feed.posts.some(p => p.id === post.id)) {
+        console.log(`  [rumor-mill] Skip ${offerId} — already in feed`);
+        continue;
+      }
 
-    // One post per topic: don't post a pending rumor if the completed TRADE
-    // already landed on the feed (e.g., approved between scan cycles).
-    if (post.tradeSignature && feed.posts.some(p =>
-      p.transactionSubType === 'TRADE' && p.tradeSignature === post.tradeSignature
-    )) {
-      console.log(`  [rumor-mill] Skip ${offerId} — completed TRADE already in feed`);
-      continue;
-    }
+      // One post per topic: don't post a pending rumor if the completed TRADE
+      // already landed on the feed (e.g., approved between scan cycles).
+      if (post.tradeSignature && feed.posts.some(p =>
+        p.transactionSubType === 'TRADE' && p.tradeSignature === post.tradeSignature
+      )) {
+        console.log(`  [rumor-mill] Skip ${offerId} — completed TRADE already in feed`);
+        continue;
+      }
 
-    newPosts.push(post);
-    console.log(`  [breaking] ${post.headline}`);
+      newPosts.push(post);
+      console.log(`  [breaking] ${post.headline}`);
 
-    // GroupMe: Schefter is the voice of the league — require his bot, never fall back to Roger
-    const schefterBotId = process.env.GROUPME_SCHEFTER_BOT_ID;
-    if (!schefterBotId) {
-      console.warn('  [GroupMe] GROUPME_SCHEFTER_BOT_ID not set — skipping GroupMe post (Roger bot is reserved for deadlines)');
-    } else if (DRY_RUN) {
-      console.log(`  [dry-run] Would post to GroupMe:\n${post.headline}\n\n${post.body}\n\n@Brandon the league awaits.`);
-    } else {
-      const groupMeText = `${post.headline}\n\n${post.body}\n\n@Brandon the league awaits.`;
-      await postToGroupMe(groupMeText, { botIdOverride: schefterBotId });
-    }
+      // Persist the feed BEFORE GroupMe so a GroupMe-without-feed divergence is
+      // impossible. If the write fails, we skip GroupMe too — better to miss
+      // a group-chat notification than to have the feed lie about what posted.
+      if (!DRY_RUN) {
+        const feedWithPost = {
+          ...feed,
+          posts: [post, ...feed.posts],
+        };
+        await fs.writeFile(league.feedPath, JSON.stringify(feedWithPost, null, 2) + '\n');
+        // Mirror the write into our in-memory feed so subsequent iterations
+        // and the post-loop watermark update see it.
+        feed.posts = feedWithPost.posts;
+      }
 
-    // Append to rolling post history (skipped in dry-run). Best-effort.
-    if (!DRY_RUN) {
-      await appendPostHistory(
-        buildHistoryEntry({
-          id: post.id,
-          timestamp: post.timestamp,
-          body: post.body,
-          subject: `trade-pending (${team1} ↔ ${team2})`,
-          tipSources: ['trade_pending'],
-        }),
-        { log: console.log, warn: console.warn },
-      );
+      // GroupMe: Schefter is the voice of the league — require his bot, never fall back to Roger
+      const schefterBotId = process.env.GROUPME_SCHEFTER_BOT_ID;
+      if (!schefterBotId) {
+        console.warn('  [GroupMe] GROUPME_SCHEFTER_BOT_ID not set — skipping GroupMe post (Roger bot is reserved for deadlines)');
+      } else if (DRY_RUN) {
+        console.log(`  [dry-run] Would post to GroupMe:\n${post.headline}\n\n${post.body}\n\n@Brandon the league awaits.`);
+      } else {
+        const groupMeText = `${post.headline}\n\n${post.body}\n\n@Brandon the league awaits.`;
+        await postToGroupMe(groupMeText, { botIdOverride: schefterBotId });
+      }
+
+      // Append to rolling post history (skipped in dry-run). Best-effort.
+      if (!DRY_RUN) {
+        await appendPostHistory(
+          buildHistoryEntry({
+            id: post.id,
+            timestamp: post.timestamp,
+            body: post.body,
+            subject: `trade-pending (${team1} ↔ ${team2})`,
+            tipSources: ['trade_pending'],
+          }),
+          { log: console.log, warn: console.warn },
+        );
+      }
+    } catch (err) {
+      // One trade's failure shouldn't block the rest of the batch.
+      console.error(`  [rumor-mill] Skipping trade ${offerId} due to error: ${err.message}`);
     }
   }
 
@@ -899,10 +926,8 @@ async function scanPendingTrades(league) {
   // (Trades that disappeared from pending drop off automatically.)
   feed.pendingTradeWatermark = Array.from(newWatermarkSet);
 
-  if (newPosts.length > 0) {
-    feed.posts = [...newPosts.reverse(), ...feed.posts];
-  }
-
+  // Feed body is already persisted per-iteration above; here we just flush the
+  // updated watermark (and any non-post-array metadata) back to disk.
   if (DRY_RUN) {
     console.log(`  [dry-run] Would write ${newPosts.length} pending-trade post(s) to feed`);
   } else {

--- a/tests/schefter-scanner-ordering.test.ts
+++ b/tests/schefter-scanner-ordering.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Source-level invariant tests for the Schefter scanners.
+ *
+ * Both scanners send messages to GroupMe. The feed file is the authoritative
+ * record of what Schefter has said. If GroupMe is ever posted to without the
+ * feed being written first, the site drifts out of sync with GroupMe —
+ * exactly the incident we hit on 2026-04-18 when a pending-trade rumor
+ * reached the group chat but was missing from /theleague/news.
+ *
+ * These tests pin the invariant at the source level so regressions in either
+ * scanner script are caught in CI without needing a live GroupMe dry-run.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+function read(rel: string): string {
+  return readFileSync(path.join(process.cwd(), rel), 'utf8');
+}
+
+describe('schefter-scan.mjs — scanPendingTrades feed-vs-GroupMe ordering', () => {
+  const src = read('scripts/schefter-scan.mjs');
+
+  // Isolate the scanPendingTrades function body so we don't accidentally
+  // match code from other scan functions in the same file.
+  const match = src.match(/async function scanPendingTrades[\s\S]+?\n\}\n/);
+  if (!match) throw new Error('scanPendingTrades not found in scanner');
+  const body = match[0];
+
+  it('writes the feed to disk BEFORE posting to GroupMe', () => {
+    // The previous implementation buffered new posts in memory and flushed
+    // AFTER the loop, so a mid-loop throw could leave GroupMe ahead of the
+    // feed. The fix moves fs.writeFile into the iteration, before postToGroupMe.
+    const writeIdx = body.indexOf('await fs.writeFile(league.feedPath');
+    const groupMeIdx = body.indexOf('postToGroupMe(groupMeText');
+    expect(writeIdx).toBeGreaterThan(-1);
+    expect(groupMeIdx).toBeGreaterThan(-1);
+    expect(writeIdx).toBeLessThan(groupMeIdx);
+  });
+
+  it('wraps each trade iteration in its own try/catch', () => {
+    // One bad trade (e.g. a malformed AI response) shouldn't block the rest
+    // of the batch from persisting.
+    expect(body).toMatch(/for \(const trade of newPending\)\s*\{\s*[\s\S]*?try\s*\{/);
+    expect(body).toMatch(/\[rumor-mill\] Skipping trade \$\{offerId\} due to error/);
+  });
+
+  it('does not delete the post-loop feed write (watermark flush still runs)', () => {
+    // After the loop we still need to persist the updated pendingTradeWatermark
+    // and any non-post-array metadata. That final write must remain.
+    const tail = body.slice(body.lastIndexOf('for (const trade of newPending)'));
+    expect(tail).toMatch(/pendingTradeWatermark\s*=\s*Array\.from/);
+    expect(tail).toMatch(/fs\.writeFile\(league\.feedPath/);
+  });
+});
+
+describe('schefter-rumor-scan.mjs — main rumor-mill ordering', () => {
+  const src = read('scripts/schefter-rumor-scan.mjs');
+
+  it('writes the feed to disk BEFORE posting to GroupMe', () => {
+    // Feed-first is the invariant. The main rumor-mill post pipeline already
+    // honored this; pinning it ensures future refactors don't swap the order.
+    const writeIdx = src.indexOf('await fs.writeFile(FEED_PATH');
+    const groupMeIdx = src.indexOf('await postToGroupMe(post.body)');
+    expect(writeIdx).toBeGreaterThan(-1);
+    expect(groupMeIdx).toBeGreaterThan(-1);
+    expect(writeIdx).toBeLessThan(groupMeIdx);
+  });
+});


### PR DESCRIPTION
Incident (2026-04-18): a trade-pending rumor was posted to GroupMe at 7:09 AM PT but never appeared on /theleague/news. Root cause was in scanPendingTrades() — the loop over newPending pushed posts into an in-memory `newPosts[]` array, posted each one to GroupMe inside the loop at line 879, but only flushed the feed to disk via fs.writeFile AFTER the loop at line 909. If any call between the GroupMe send and the post-loop write threw (next-iteration AI request, a network blip, an appendPostHistory regression), the GroupMe message was already public but the feed never received the post. The outer try/catch at line 1857 swallowed the error, the workflow committed the unchanged feed + a lastScanTimestamp bump, and CI stayed green.

Fix:
  - Move the feed write INSIDE the per-trade iteration so every fs.writeFile happens BEFORE postToGroupMe. A GroupMe-without-feed divergence is now impossible at the scanner boundary.
  - Wrap each iteration in its own try/catch. One malformed trade no longer blocks the rest of the batch from shipping.
  - Preserve the post-loop watermark flush — pendingTradeWatermark + any non-post metadata still get persisted at the end.

tests/schefter-scanner-ordering.test.ts — source-level guard tests pinning the feed-before-GroupMe invariant for both scripts (schefter-scan.mjs + schefter-rumor-scan.mjs) so regressions surface in CI without needing a live GroupMe dry-run.

https://claude.ai/code/session_01W8Znp1GEWEt9pyLNdaKj6y