### PR TITLE
fix(schefter): recover missing 2026-04-18 7:09 AM PT rumor-mill post

### DIFF
--- a/src/data/theleague/schefter-feed.json
+++ b/src/data/theleague/schefter-feed.json
@@ -3,6 +3,19 @@
   "lastProcessedMflTimestamp": "1774696063",
   "posts": [
     {
+      "id": "sf_rumor_1776521340000_a7b4c9d2",
+      "timestamp": "2026-04-18T14:09:00.000Z",
+      "type": "transaction",
+      "transactionSubType": "rumor_mill",
+      "tier": "rumor",
+      "headline": "Schefter hearing\u2026",
+      "body": "Hearing from sources in the East that Wabbits is quietly shopping for QB help. Weak at the position, one injury away from real trouble. Meanwhile, division intel from the Southwest suggests Midwest is loaded with 2nd and 3rd round picks and looking to move them cheap. File under developing, but the phones are moving.",
+      "authorId": "claude",
+      "franchiseIds": [],
+      "tipIds": [],
+      "league": "theleague"
+    },
+    {
       "id": "wire_48513002",
       "timestamp": "2026-04-18T10:34:16Z",
       "type": "external",
@@ -10,7 +23,7 @@
       "headline": "2026 NFL draft: Louis Riddick's favorite prospects, sleepers",
       "body": "Louis Riddick picks his guys in the 2026 class, including some offensive playmakers and ball-hawking defensive backs. See who's on his 10-player list.",
       "link": "https://www.espn.com/nfl/draft2026/story/_/id/48513002/2026-nfl-draft-riddick-favorite-prospects-class-sleepers-love-styles-cooper",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -23,7 +36,7 @@
       "headline": "Titans feel draft ready with a 'cluster' of choices at No. 4",
       "body": "GM Mike Borgonzi knows that Tennessee will have many options when the Titans are on the clock at No. 4.",
       "link": "https://www.espn.com/nfl/story/_/id/48506406/tennessee-titans-ready-nfl-draft-no-4-pick-cluster-prospects",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -36,7 +49,7 @@
       "headline": "Texans looking to bolster roster, not fill holes, in draft",
       "body": "Houston has built its perennial playoff roster with same draft philosophy since coach DeMeco Ryans arrived in 2023.",
       "link": "https://www.espn.com/nfl/story/_/id/48507431/houston-texans-draft-best-player-available-regardless-position",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -49,7 +62,7 @@
       "headline": "Should the Giants take a RB in the top 5?",
       "body": "New York, with needs all over the roster, selects fifth Thursday when the NFL draft begins.",
       "link": "https://www.espn.com/nfl/story/_/id/48505427/should-new-york-giants-take-rb-top-5-2026-nfl-draft-jeremiyah-love",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -62,7 +75,7 @@
       "headline": "Who won the Jaguars-Browns draft-day trade for Travis Hunter?",
       "body": "The Browns and Jags swapped picks in 2025 so Jacksonville could draft Hunter. Now, Cleveland has an extra first-rounder in 2026.",
       "link": "https://www.espn.com/nfl/story/_/id/48504635/nfl-draft-trade-jacksonville-jaguars-travis-hunter-cleveland-browns-mason-graham",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -73,7 +86,7 @@
       "type": "transaction",
       "transactionSubType": "rumor_mill",
       "tier": "rumor",
-      "headline": "Schefter hearing…",
+      "headline": "Schefter hearing\u2026",
       "body": "Hearing some chatter in the Northwest about running back interest. Nothing imminent, but the phones are moving. Developing.",
       "authorId": "claude",
       "franchiseIds": [],
@@ -88,7 +101,7 @@
       "headline": "Rams drop 'Thursday' 2026 NFL draft teaser featuring sons of 'Friday' stars",
       "body": "The short film inspired by the 1995 comedy \"Friday\" stars the sons of Ice Cube and Chris Tucker, joined by Rams players and celebrity cameos.",
       "link": "https://www.espn.com/nfl/story/_/id/48515102/los-angeles-rams-2026-nfl-draft-friday-thursday-ice-cube",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -101,7 +114,7 @@
       "headline": "Logan Jones' NFL draft profile",
       "body": "Check out some of the top highlights from Iowa's Logan Jones.",
       "link": "https://www.espn.com/video/clip?id=48514562",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -114,7 +127,7 @@
       "headline": "Sources: the Falcons are trading DT Ruke Orhorhoro to the Jaguars in exchange for DT Maason Smith.",
       "body": "Sources: the Falcons are trading DT Ruke Orhorhoro to the Jaguars in exchange for DT Maason Smith.",
       "link": "https://www.espn.com/contributor/adam-schefter/45a0bdc90d753",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "adam-schefter",
       "franchiseIds": [],
       "league": "theleague"
@@ -127,7 +140,7 @@
       "headline": "Sources: Cardinals' Jacoby Brissett not at offseason program",
       "body": "Cardinals incumbent starter Jacoby Brissett has not been in attendance for the start of the team's offseason program as he waits for a new deal, sources told NFL Network.",
       "link": "https://www.espn.com/nfl/story/_/id/48514446/cardinals-jacoby-brissett-not-offseason-program",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "nfl-wire",
       "franchiseIds": [],
       "league": "theleague"
@@ -140,7 +153,7 @@
       "headline": "Source: Will Anderson is signing a three-year $150 million extension that makes him the highest paid non-quarterback in NFL history. The deal includes $134 million guaranteed.",
       "body": "Source: Will Anderson is signing a three-year $150 million extension that makes him the highest paid non-quarterback in NFL history. The deal includes $134 million guaranteed.",
       "link": "https://www.espn.com/contributor/adam-schefter/655faafb38f7f",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "adam-schefter",
       "franchiseIds": [],
       "league": "theleague"
@@ -153,7 +166,7 @@
       "headline": "Jeff Darlington: Chiefs' 9th pick is 'pivot point' in NFL draft",
       "body": "Jeff Darlington and Domonique Foxworth discuss the importance of the Chiefs' draft pick at No. 9.",
       "link": "https://www.espn.com/video/clip?id=48512781",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -166,7 +179,7 @@
       "headline": "Darlington: Eagles to operate in draft as if A.J. Brown will be traded",
       "body": "Jeff Darlington, Domonique Foxworth and Mike Tannenbaum discuss the Eagles' potential draft plans and what it could mean for A.J. Brown.",
       "link": "https://www.espn.com/video/clip?id=48512098",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -179,7 +192,7 @@
       "headline": "10 NFL draft prospects to put on your fantasy radar -- and three others to monitor",
       "body": "With the NFL draft nearly upon us, it's time to think about how the top prospects will fare in fantasy.",
       "link": "https://www.espn.com/fantasy/football/story/_/id/48476312/2026-nfl-draft-prospects-fantasy-football-rookies",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -192,7 +205,7 @@
       "headline": "The true measure of NFL draft prospect Carnell Tate",
       "body": "Wide receiver Carnell Tate is confident, intelligent and ready to star in the NFL. His mother made sure of it.",
       "link": "https://www.espn.com/nfl/draft2026/story/_/id/48483888/2026-nfl-draft-wide-receiver-carnell-tate-ohio-state-first-round-pick",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -205,7 +218,7 @@
       "headline": "2026 NFL draft latest buzz: Caleb Downs, Day 2 steals, more",
       "body": "When could Caleb Downs and Jordyn Tyson get drafted? What are the Eagles, Giants and Steelers thinking for their picks? Our experts share new intel.",
       "link": "https://www.espn.com/nfl/draft2026/story/_/id/48495253/2026-nfl-draft-latest-buzz-steals-news-downs-tyson-sadiq-eagles-giants-steelers",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -218,7 +231,7 @@
       "headline": "2026 NFL mock draft: Scouts, execs predict the top 10 picks",
       "body": "We asked NFL scouts to make draft picks for other teams, assigning one to each top-10 slot. Which prospects could go early?",
       "link": "https://www.espn.com/nfl/draft2026/story/_/id/48488008/2026-nfl-draft-mock-scouts-top-10-predictions-picks",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "matt-miller",
       "franchiseIds": [],
       "league": "theleague"
@@ -231,7 +244,7 @@
       "headline": "Why Ravens' draft is critical to improving Lamar's supporting cast",
       "body": "The 2026 NFL draft is shaping up to be an important one for Ravens quarterback Lamar Jackson.",
       "link": "https://www.espn.com/nfl/story/_/id/48505241/baltimore-ravens-2026-nfl-draft-critical-improving-lamar-jackson-supporting-cast",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -244,7 +257,7 @@
       "headline": "Vikings confident in interim GM Brzezinski leading draft",
       "body": "Here's what we know about how Brzezinski will oversee Minnesota's draft in his unique interim role.",
       "link": "https://www.espn.com/nfl/story/_/id/48507157/nfl-minnesota-vikings-2026-draft-interim-gm-brzezinski-kevin-oconnell",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -270,7 +283,7 @@
       "headline": "Mike Washington Jr's NFL draft profile",
       "body": "Check out some of the top highlights from Arkansas' Mike Washington Jr.",
       "link": "https://www.espn.com/video/clip?id=48507964",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -283,7 +296,7 @@
       "headline": "Gracen Halton's NFL draft profile",
       "body": "Check out some of the top highlights from Oklahoma's Gracen Halton.",
       "link": "https://www.espn.com/video/clip?id=48507878",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -296,7 +309,7 @@
       "headline": "Taylen Green's NFL draft profile",
       "body": "Check out some of the top highlights from Arkansas' Taylen Green.",
       "link": "https://www.espn.com/video/clip?id=48507725",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -309,7 +322,7 @@
       "headline": "2026 NFL draft: How all 32 teams can ace their picks, needs",
       "body": "A week before the NFL draft, Ben Solak hits the top priorities for every single team -- and the prospects who can meet those needs.",
       "link": "https://www.espn.com/nfl/draft2026/story/_/id/48494162/2026-nfl-draft-32-teams-positions-picks-grades-predictions-needs-solak",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "ben-solak",
       "franchiseIds": [],
       "league": "theleague"
@@ -322,7 +335,7 @@
       "headline": "Cam Ward on track in recovery from Week 18 shoulder injury",
       "body": "Quarterback Cam Ward, who injured his throwing shoulder in the Titans' season finale, is trending toward throwing at minicamp in June, general manager Mike Borgonzi says.",
       "link": "https://www.espn.com/nfl/story/_/id/48504522/cam-ward-track-recovery-week-18-shoulder-injury",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "nfl-wire",
       "franchiseIds": [],
       "league": "theleague"
@@ -335,7 +348,7 @@
       "headline": "Chargers GM Joe Hortiz shuts down Quentin Johnston trade rumors",
       "body": "Chargers general manager Joe Hortiz shut down trade rumors surrounding wide receiver Quentin Johnston on Thursday.",
       "link": "https://www.espn.com/nfl/story/_/id/48505918/chargers-gm-joe-hortiz-shuts-quentin-johnston-trade-rumors",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "nfl-wire",
       "franchiseIds": [],
       "league": "theleague"
@@ -348,7 +361,7 @@
       "headline": "Chiefs GM Brett Veach expecting a lot of trades in first round",
       "body": "Chiefs general manager Brett Veach said Thursday that there will \"probably be a lot of trades\" in the first round of this year's NFL draft.",
       "link": "https://www.espn.com/nfl/story/_/id/48504831/chiefs-gm-brett-veach-expecting-lot-trades-first-round",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -361,7 +374,7 @@
       "headline": "How the Chiefs lucked into drafting All-Pro Chris Jones",
       "body": "A look back 10 years later at the selection of Jones, one of the most important picks in franchise history.",
       "link": "https://www.espn.com/nfl/story/_/id/48496049/nfl-2026-draft-chris-jones-kansas-city-chiefs",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -374,7 +387,7 @@
       "headline": "Woody: Jayden Daniels and Jeremiyah Love would be 'terrifying' together",
       "body": "Damien Woody and Dan Graziano talk about how Jeremiyah Love would fit on the Commanders. ",
       "link": "https://www.espn.com/video/clip?id=48503745",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "nfl-wire",
       "franchiseIds": [],
       "league": "theleague"
@@ -387,7 +400,7 @@
       "headline": "Steelers looking to add depth at WR in draft",
       "body": "Pittsburgh has done significant homework on the 2026 wide receiver draft class.",
       "link": "https://www.espn.com/nfl/story/_/id/48494500/pittsburgh-steelers-add-wr-depth-2026-nfl-draft",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -400,7 +413,7 @@
       "headline": "Three positions Saints should consider in 2026 NFL draft",
       "body": "Here's a look at three needs for the Saints and what they could be looking for in the draft.",
       "link": "https://www.espn.com/nfl/story/_/id/48485873/new-orleans-saints-consider-positions-2026-nfl-draft",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -413,7 +426,7 @@
       "headline": "Carnell Tate discusses NFL draft process with Rich Eisen",
       "body": "Ohio State WR Carnell Tate chats with Rich Eisen about the teams he has visited so far leading up to the NFL draft.",
       "link": "https://www.espn.com/video/clip?id=48495241",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -426,7 +439,7 @@
       "headline": "How legitimate is the reported criticism of Jalen Hurts?",
       "body": "Louis Riddick comments on the recent critical reports surrounding Eagles QB Jalen Hurts.",
       "link": "https://www.espn.com/video/clip?id=48493354",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "nfl-wire",
       "franchiseIds": [],
       "league": "theleague"
@@ -439,7 +452,7 @@
       "headline": "College football fan guide to the 2026 NFL draft",
       "body": "Attention college football fans: The NFL draft is coming. Here's everything you need to know.",
       "link": "https://www.espn.com/nfl/draft2026/story/_/id/48475095/nfl-draft-2026-college-football-fan-guide-teams-picks-trends-more",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -452,7 +465,7 @@
       "headline": "Akheem Mesidor's long, long road to the NFL",
       "body": "The Miami defensive end once struggled to make an impact in youth football. Now, he's a potential first-round pick.",
       "link": "https://www.espn.com/nfl/draft2026/story/_/id/48465658/nfl-draft-2026-akheem-mesidor-miami-hurricanes",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -465,7 +478,7 @@
       "headline": "2026 NFL mock draft: Kiper's pick predictions for Rounds 1-2",
       "body": "Mel Kiper Jr. predicts 64 picks across the first two rounds of the NFL draft, including two potential trades, a few QB landing spots and plenty of impact additions.",
       "link": "https://www.espn.com/nfl/draft2026/story/_/id/48478995/2026-nfl-mock-draft-mel-kiper-two-rounds-64-picks-final-predictions",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "mel-kiper",
       "franchiseIds": [],
       "league": "theleague"
@@ -478,7 +491,7 @@
       "headline": "Broncos looking for options at off-ball linebacker for 2026",
       "body": "Elliss could be ready for more playing time at off-ball linebacker, while Denver's second-round pick could be used, too.",
       "link": "https://www.espn.com/nfl/story/_/id/48479658/denver-broncos-ball-linebacker-nfl-draft-jonah-elliss",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -491,7 +504,7 @@
       "headline": "Packers clear the way for Matthew Golden to emerge in Year 2",
       "body": "After trading Dontayvion Wicks and letting Romeo Doubs walk, Green Bay is counting on Golden, the 2025 first-round WR, to step up.",
       "link": "https://www.espn.com/nfl/story/_/id/48482985/nfl-green-bay-packers-matthew-golden-dontayvion-wicks-trade",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "nfl-wire",
       "franchiseIds": [],
       "league": "theleague"
@@ -504,7 +517,7 @@
       "headline": "Raiders' Spytek says teams have inquired about No. 1 draft pick",
       "body": "Raiders GM John Spytek said teams have called to inquire about the possibility of trading for the No. 1 overall pick but added, \"Those teams know where they stand.\"",
       "link": "https://www.espn.com/nfl/story/_/id/48488757/raiders-spytek-says-teams-inquired-no-1-draft-pick",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -530,7 +543,7 @@
       "headline": "Ted Ginn Jr. resumes coaching team following arrest on DWI charge",
       "body": "Ted Ginn Jr. is back with the Columbus Aviators and will coach the UFL team Friday  after missing one game following his weekend arrest on a DWI charge, the league told ESPN on Tuesday.",
       "link": "https://www.espn.com/united-football-league/story/_/id/48485633/ted-ginn-jr-resumes-coaching-aviators-following-dwi-arrest",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "nfl-wire",
       "franchiseIds": [],
       "league": "theleague"
@@ -543,7 +556,7 @@
       "headline": "Eagles' Roseman: A.J. Brown stance unchanged despite Wicks trade",
       "body": "Eagles general manager Howie Roseman on Tuesday kept the same public stance regarding wide receiver A.J. Brown despite the team's recent trade for Dontayvion Wicks.",
       "link": "https://www.espn.com/nfl/story/_/id/48485453/eagles-gm-howie-roseman-says-stance-aj-brown-unchanged-wake-dontayvion-wicks-trade",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "nfl-wire",
       "franchiseIds": [],
       "league": "theleague"
@@ -556,7 +569,7 @@
       "headline": "Cole Payton's NFL draft profile",
       "body": "Check out some of the top highlights from North Dakota State's Cole Payton.",
       "link": "https://www.espn.com/video/clip?id=48483806",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -569,7 +582,7 @@
       "headline": "Why Tannenbaum says Steelers should draft Ty Simpson",
       "body": "Mike Tannenbaum and Jason McCourty discuss why the Steelers should consider drafting Alabama quarterback Ty Simpson even if Aaron Rodgers returns.",
       "link": "https://www.espn.com/video/clip?id=48483685",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -582,7 +595,7 @@
       "headline": "Meet Iowa's Gennings Dunker, the NFL draft's viral star",
       "body": "He was 'one of five' on Iowa's offensive line. That was before the mullet and personality took over the NFL combine.",
       "link": "https://www.espn.com/nfl/draft2026/story/_/id/48455868/nfl-draft-2026-gennings-dunker-iowa-hawkeyes-viral-star",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -595,7 +608,7 @@
       "headline": "2026 NFL draft: Which teams should trade up, down in Round 1?",
       "body": "Would it make sense for the Eagles, Bears and Chiefs to trade up in Round 1? Should the Cowboys and Lions try to move down the board? Here's our advice for 10 teams.",
       "link": "https://www.espn.com/nfl/draft2026/story/_/id/48470863/2026-nfl-draft-round-1-trades-barnwell-teams-moves-picks",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -608,7 +621,7 @@
       "headline": "2026 NFL draft rankings: Jordan Reid's top 500 prospects",
       "body": "Jordan Reid ranked every draftable player in the 2026 class and graded them by round. Here's his final list, plus scouting reports on the top names.",
       "link": "https://www.espn.com/nfl/draft2026/story/_/id/47027232/2026-nfl-draft-rankings-jordan-reid-top-prospects-players-positions",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "jordan-reid",
       "franchiseIds": [],
       "league": "theleague"
@@ -621,7 +634,7 @@
       "headline": "49ers well positioned to add a receiver in the NFL draft",
       "body": "San Francisco added two veteran receivers in free agency and now want to add youth at the NFL draft.",
       "link": "https://www.espn.com/nfl/story/_/id/48476241/san-francisco-49ers-nfl-draft-visit-receivers-27th-overall-pick",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -634,7 +647,7 @@
       "headline": "Zachariah Branch's NFL draft profile",
       "body": "Check out some of the top highlights from Georgia's Zachariah Branch.",
       "link": "https://www.espn.com/video/clip?id=48480503",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -647,7 +660,7 @@
       "headline": "Caleb Banks' NFL draft profile",
       "body": "Check out some of the top highlights from Florida's Caleb Banks.",
       "link": "https://www.espn.com/video/clip?id=48480349",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -660,7 +673,7 @@
       "headline": "KC Concepcion's NFL draft profile",
       "body": "Check out some of the top highlights from Texas A&M's KC Concepcion.",
       "link": "https://www.espn.com/video/clip?id=48480276",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -673,7 +686,7 @@
       "headline": "Arvell Reese's NFL draft profile",
       "body": "Check out some of the top highlights from Ohio State's Arvell Reese.",
       "link": "https://www.espn.com/video/clip?id=48479734",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -686,7 +699,7 @@
       "headline": "Max Iheanachor's NFL draft profile",
       "body": "Check out some of the top highlights from Arizona State's Max Iheanachor.",
       "link": "https://www.espn.com/video/clip?id=48478323",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -699,7 +712,7 @@
       "headline": "2026 NFL Draft: How to watch every round, pick on ESPN",
       "body": "The 2026 NFL draft, the marquee event of the NFL offseason, gets underway April 23 in Pittsburgh.",
       "link": "https://www.espn.com/nfl/story/_/id/48477599/2026-nfl-draft-how-watch-every-round-pick-espn",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -712,7 +725,7 @@
       "headline": "Should the Chargers give up a 1st-round pick for A.J. Brown?",
       "body": "\"The Rich Eisen Show\" debates whether A.J. Brown is worth trading a first-round pick to acquire as Los Angeles looks to bolster its offense.  ",
       "link": "https://www.espn.com/video/clip?id=48476523",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "nfl-wire",
       "franchiseIds": [],
       "league": "theleague"
@@ -725,7 +738,7 @@
       "headline": "Adam Schefter lays out Jaguars' plans for Travis Hunter",
       "body": "Adam Schefter joins \"The Pat McAfee Show\" to discuss how the Jaguars will utilize Travis Hunter on both sides of the ball.",
       "link": "https://www.espn.com/video/clip?id=48476460",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "nfl-wire",
       "franchiseIds": [],
       "league": "theleague"
@@ -738,7 +751,7 @@
       "headline": "College coaches pick 2026 NFL draft sleepers",
       "body": "We know the top talent in the draft, but who could surprise in the pros? We asked their college coaches.",
       "link": "https://www.espn.com/nfl/draft2026/story/_/id/48380198/2026-nfl-draft-college-football-coaches-sleeper-picks",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -751,7 +764,7 @@
       "headline": "2026 NFL draft: Top prospects at 100 different skills, traits",
       "body": "Strongest arm? Fastest offensive and defensive playmakers? Quickest first step? Let's hand out superlatives for this NFL draft class.",
       "link": "https://www.espn.com/nfl/draft2026/story/_/id/48428711/2026-nfl-draft-best-prospects-skills-traits-standouts-positions-superlatives-best",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -764,7 +777,7 @@
       "headline": "Cincinnati Bengals 2026 NFL draft picks, biggest needs",
       "body": "Let's take a closer look at each of the Bengals' 2026 draft picks.",
       "link": "https://www.espn.com/nfl/draft2026/story/_/id/48451433/cincinnati-bengals-nfl-draft-picks-2026-selection-analysis-depth-chart",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -777,7 +790,7 @@
       "headline": "Jacksonville Jaguars 2026 NFL draft picks, biggest needs",
       "body": "Let's take a closer look at each of the Jaguars' 2026 draft picks.",
       "link": "https://www.espn.com/nfl/draft2026/story/_/id/48431947/jacksonville-jaguars-nfl-draft-picks-2026-selection-analysis-depth-chart",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -790,7 +803,7 @@
       "headline": "Baltimore Ravens 2026 NFL draft picks, biggest needs",
       "body": "Let's take a closer look at each of the Ravens' 2026 draft picks.",
       "link": "https://www.espn.com/nfl/draft2026/story/_/id/48431100/baltimore-ravens-nfl-draft-picks-2026-selection-analysis-depth-chart",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -803,7 +816,7 @@
       "headline": "Houston Texans 2026 NFL draft picks, biggest needs",
       "body": "Let's take a closer look at each of the Texans' 2026 draft picks.",
       "link": "https://www.espn.com/nfl/draft2026/story/_/id/48451968/houston-texans-nfl-draft-picks-2026-selection-analysis-depth-chart",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -816,7 +829,7 @@
       "headline": "New Orleans Saints 2026 NFL draft picks, biggest needs",
       "body": "Let's take a closer look at each of the Saints' 2026 draft picks.",
       "link": "https://www.espn.com/nfl/draft2026/story/_/id/48452136/new-orleans-saints-nfl-draft-picks-2026-selection-analysis-depth-chart",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -829,7 +842,7 @@
       "headline": "New York Jets 2026 NFL draft picks, biggest needs",
       "body": "Let's take a closer look at each of the Jets' 2026 draft picks.",
       "link": "https://www.espn.com/nfl/draft2026/story/_/id/48452087/new-york-jets-nfl-draft-picks-2026-selection-analysis-depth-chart",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -842,7 +855,7 @@
       "headline": "Eagles, A.J. Brown intrigue increases as NFL draft nears",
       "body": "The Eagles haven't been highly incentivized to move Brown to this point, in large part due to the financials.",
       "link": "https://www.espn.com/nfl/story/_/id/48447304/philadelphia-eagles-aj-brown-intrigue-increases-2026-nfl-draft-nears",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -855,7 +868,7 @@
       "headline": "Tennessee Titans 2026 NFL draft picks, biggest needs",
       "body": "Let's take a closer look at each of the Titans' 2026 draft picks.",
       "link": "https://www.espn.com/nfl/draft2026/story/_/id/48452986/tennessee-titans-nfl-draft-picks-2026-selection-analysis-depth-chart",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -868,7 +881,7 @@
       "headline": "Los Angeles Rams 2026 NFL draft picks, biggest needs",
       "body": "Let's take a closer look at each of the Rams' 2026 draft picks.",
       "link": "https://www.espn.com/nfl/draft2026/story/_/id/48430601/los-angeles-rams-nfl-draft-picks-2026-selection-analysis-depth-chart",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -881,7 +894,7 @@
       "headline": "Los Angeles Chargers 2026 NFL draft picks, biggest needs",
       "body": "Let's take a closer look at each of the Chargers' 2026 draft picks.",
       "link": "https://www.espn.com/nfl/draft2026/story/_/id/48446331/los-angeles-chargers-nfl-draft-picks-2026-selection-analysis-depth-chart",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -894,7 +907,7 @@
       "headline": "Tampa Bay Buccaneers 2026 NFL draft picks, biggest needs",
       "body": "Let's take a closer look at each of the Buccaneers' 2026 draft picks.",
       "link": "https://www.espn.com/nfl/draft2026/story/_/id/48453077/tampa-bay-buccaneers-nfl-draft-picks-2026-selection-analysis-depth-chart",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -907,7 +920,7 @@
       "headline": "Denver Broncos 2026 NFL draft picks, biggest needs",
       "body": "Let's take a closer look at each of the Broncos' 2026 NFL draft picks.",
       "link": "https://www.espn.com/nfl/draft2026/story/_/id/48441282/denver-broncos-nfl-draft-picks-2026-selection-analysis-depth-chart",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -920,7 +933,7 @@
       "headline": "New York Giants 2026 NFL draft picks, biggest needs",
       "body": "Let's take a closer look at each of the Giants' 2026 draft picks.",
       "link": "https://www.espn.com/nfl/draft2026/story/_/id/48431325/new-york-giants-nfl-draft-picks-2026-selection-analysis-depth-chart",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -933,7 +946,7 @@
       "headline": "Washington Commanders 2026 NFL draft picks, biggest needs",
       "body": "Let's take a closer look at each of the Commanders' 2026 draft picks.",
       "link": "https://www.espn.com/nfl/draft2026/story/_/id/48431713/washington-commanders-nfl-draft-picks-2026-selection-analysis-depth-chart",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -946,7 +959,7 @@
       "headline": "Indianapolis Colts 2026 NFL draft picks, biggest needs",
       "body": "Let's take a closer look at each of the Colts' 2026 draft picks.",
       "link": "https://www.espn.com/nfl/draft2026/story/_/id/48450484/indianapolis-colts-nfl-draft-picks-2026-selection-analysis-depth-chart",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -959,7 +972,7 @@
       "headline": "Chicago Bears 2026 NFL draft picks, biggest needs",
       "body": "Let's take a closer look at each of the Bears' 2026 draft picks.",
       "link": "https://www.espn.com/nfl/draft2026/story/_/id/48451000/chicago-bears-nfl-draft-picks-2026-selection-analysis-depth-chart",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -972,7 +985,7 @@
       "headline": "Arizona Cardinals 2026 NFL draft picks, biggest needs",
       "body": "Let's take a closer look at each of the Cardinals' 2026 draft picks.",
       "link": "https://www.espn.com/nfl/draft2026/story/_/id/48451198/arizona-cardinals-nfl-draft-picks-2026-selection-analysis-depth-chart",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -985,7 +998,7 @@
       "headline": "Colts look to continue draft trend of making hay on Day 2",
       "body": "The Colts don't have a first-round pick, but GM Chris Ballard's draft resume might be better on Day 2 anyway.",
       "link": "https://www.espn.com/nfl/story/_/id/48441351/indianapolis-colts-nfl-draft-recent-day-2-history",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -998,7 +1011,7 @@
       "headline": "Philadelphia Eagles 2026 NFL draft picks, biggest needs",
       "body": "Let's take a closer look at each of the Eagles' 2026 draft picks.",
       "link": "https://www.espn.com/nfl/draft2026/story/_/id/48431211/philadelphia-eagles-nfl-draft-picks-2026-selection-analysis-depth-chart",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -1011,7 +1024,7 @@
       "headline": "Cleveland Browns 2026 NFL draft picks, biggest needs",
       "body": "Let's take a closer look at each of the Browns' 2026 draft picks.",
       "link": "https://www.espn.com/nfl/draft2026/story/_/id/48452321/cleveland-browns-nfl-draft-picks-2026-selection-analysis-depth-chart",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -1024,7 +1037,7 @@
       "headline": "Green Bay Packers 2026 NFL draft picks, biggest needs",
       "body": "Let's take a closer look at each of the Packers' 2026 draft picks.",
       "link": "https://www.espn.com/nfl/draft2026/story/_/id/48453227/green-bay-packers-nfl-draft-picks-2026-selection-analysis-depth-chart",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -1037,7 +1050,7 @@
       "headline": "Minnesota Vikings 2026 NFL draft picks, biggest needs",
       "body": "Let's take a closer look at each of the Vikings' 2026 draft picks.",
       "link": "https://www.espn.com/nfl/draft2026/story/_/id/48453300/minnesota-vikings-nfl-draft-picks-2026-selection-analysis-depth-chart",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -1050,7 +1063,7 @@
       "headline": "Dallas Cowboys 2026 NFL draft picks, biggest needs",
       "body": "Let's take a closer look at each of the Cowboys' 2026 draft picks.",
       "link": "https://www.espn.com/nfl/draft2026/story/_/id/48453382/dallas-cowboys-nfl-draft-picks-2026-selection-analysis-depth-chart",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -1063,7 +1076,7 @@
       "headline": "Ex-NFL WR Ted Ginn Jr. charged with DWI in Texas",
       "body": "Former NFL wide receiver and current Aviators coach Ted Ginn Jr. was charged with driving while intoxicated in Tarrant County, Texas, on Saturday.",
       "link": "https://www.espn.com/united-football-league/story/_/id/48465811/ex-nfl-wr-ted-ginn-jr-charged-dwi-texas",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "nfl-wire",
       "franchiseIds": [],
       "league": "theleague"
@@ -1076,7 +1089,7 @@
       "headline": "Emmanuel McNeil-Warren's NFL draft profile",
       "body": "Check out some of the top highlights from Toledo's Emmanuel McNeil-Warren.",
       "link": "https://www.espn.com/video/clip?id=48465526",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -1089,7 +1102,7 @@
       "headline": "2026 NFL draft risers: Seven prospects climbing boards",
       "body": "Dillon Thieneman and Monroe Freeling have drastically boosted their stock since the start of last season. Who else has climbed the board?",
       "link": "https://www.espn.com/nfl/draft2026/story/_/id/48443025/2026-nfl-draft-risers-prospects-freeling-thieneman-iheanachor",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -1102,7 +1115,7 @@
       "headline": "Will Jets get defensive at No. 2 with edge David Bailey?",
       "body": "The Jets have never taken a defensive player as high as No. 2, but Bailey is not an ordinary edge rusher.",
       "link": "https://www.espn.com/nfl/story/_/id/48457356/will-jets-get-defensive-no-2-edge-david-bailey",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -1115,7 +1128,7 @@
       "headline": "Why Keyshawn Johnson was the last WR to go No. 1, 30 years ago",
       "body": "The 1996 draft didn't produce a first-round QB, but the Jets found a playmaker with star power in Johnson.",
       "link": "https://www.espn.com/nfl/story/_/id/48440687/nfl-draft-keyshawn-johnson-was-last-wr-go-no-1-30-years-ago-new-york-jets",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -1128,7 +1141,7 @@
       "headline": "Former Belichick aide brings insight to Patriots' No. 31 pick",
       "body": "Ernie Adams and the Belichick-led Patriots picked at bottom of Round 1 many times. Adams shares the strategy.",
       "link": "https://www.espn.com/nfl/story/_/id/48451661/new-england-patriots-31-overall-pick-nfl-draft-bill-belichick-ernie-adams-insight-notebook",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -1141,7 +1154,7 @@
       "headline": "Chris Johnson's NFL draft profile",
       "body": "Check out some of the top highlights from San Diego State's Chris Johnson.",
       "link": "https://www.espn.com/video/clip?id=48462025",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -1154,7 +1167,7 @@
       "headline": "Keionte Scott's NFL draft profile",
       "body": "Keionte Scott's NFL draft profile  Check out some of the top highlights from Miami's Keionte Scott.",
       "link": "https://www.espn.com/video/clip?id=48461940",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -1164,10 +1177,10 @@
       "timestamp": "2026-04-12T00:46:23Z",
       "type": "external",
       "tier": "standard",
-      "headline": "Emmanuel Pregnon's NFL draft profile",
+      "headline": "Emmanuel Pregnon's\u00a0NFL draft profile",
       "body": "Check out some of the top highlights from Oregon's Emmanuel Pregnon.",
       "link": "https://www.espn.com/video/clip?id=48461830",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -1180,7 +1193,7 @@
       "headline": "Keldric Faulk NFL draft profile",
       "body": "Check out some of the top highlights from Auburn's Keldric Faulk.",
       "link": "https://www.espn.com/video/clip?id=48459852",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -1193,7 +1206,7 @@
       "headline": "2026 NFL quarterback projections: Stats, rankings",
       "body": "Aaron Schatz uses his QBASE 2.0 model to project NFL career ceilings and floors for the 2026 draft class' top QBs.",
       "link": "https://www.espn.com/nfl/draft2026/story/_/id/48446727/2026-nfl-draft-quarterback-projections-stats-rankings-comps-prospects",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -1206,7 +1219,7 @@
       "headline": "How AI is pushing NFL draft prep to 'a different level'",
       "body": "When a prospect skips NFL combine workouts, teams can use artificial intelligence to project his measurables.",
       "link": "https://www.espn.com/nfl/story/_/id/48446759/nfl-draft-combine-artificial-intelligence-caleb-downs-arvell-reese-david-bailey",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -1219,7 +1232,7 @@
       "headline": "What kind of edge player will Seahawks be looking to draft?",
       "body": "Seahawks have to start planning for replacements as edge rushers age. Who will they target at the NFL draft?",
       "link": "https://www.espn.com/nfl/story/_/id/48441800/what-kind-edge-player-seattle-seahawks-looking-2026-nfl-draft-demarcus-lawrence",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -1232,7 +1245,7 @@
       "headline": "Will Jags draft by positional need or best player available?",
       "body": "GM James Gladstone and coach Liam Coen reveal what they are focusing on heading into 2026 NFL draft.",
       "link": "https://www.espn.com/nfl/story/_/id/48451110/jacksonville-jaguars-gm-james-gladstone-nfl-draft-positional-need-best-player-available",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -1245,7 +1258,7 @@
       "headline": "How Schottenheimer is prepping for Cowboys draft in Year 2",
       "body": "Last year, Schottenheimer was just getting settled in as the new head coach in Dallas.",
       "link": "https://www.espn.com/nfl/story/_/id/48437117/nfl-dallas-cowboys-brian-schottenheimer-draft-arvell-reese",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -1258,7 +1271,7 @@
       "headline": "Jordyn Tyson's NFL draft profile",
       "body": "Check out some of the top highlights from Arizona State's Jordyn Tyson.",
       "link": "https://www.espn.com/video/clip?id=48454235",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -1271,7 +1284,7 @@
       "headline": "2026 NFL draft: Latest New Orleans Saints updates, intel, buzz",
       "body": "The Saints pick early in Round 1 and have eight total selections in the 2026 draft. Here's the latest on what New Orleans might do.",
       "link": "https://www.espn.com/nfl/story/_/id/48451889/2026-nfl-draft-new-orleans-saints-updates-buzz-intel-picks-positions",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -1284,7 +1297,7 @@
       "headline": "Keylan Rutledge NFL draft profile",
       "body": "Check out some of the top highlights from Georgia Tech Kylan Rutledge.",
       "link": "https://www.espn.com/video/clip?id=48451530",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -1297,7 +1310,7 @@
       "headline": "Eagles get WR Dontayvion Wicks from Packers, sources say",
       "body": "The Eagles have acquired wide receiver Dontayvion Wicks from the Packers for two draft picks, sources told ESPN's Adam Schefter.",
       "link": "https://www.espn.com/nfl/story/_/id/48451181/eagles-get-wr-dontayvion-wick-packers-sources-say",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "nfl-wire",
       "franchiseIds": [],
       "league": "theleague"
@@ -1310,7 +1323,7 @@
       "headline": "Jake Golday's NFL draft profile",
       "body": "Check out some of the top highlights from Cincinnati's Jake Golday.",
       "link": "https://www.espn.com/video/clip?id=48451270",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -1323,7 +1336,7 @@
       "headline": "Falcons pick up fifth-year option for RB Bijan Robinson",
       "body": "The Atlanta Falcons picked up running back Bijan Robinson's fifth-year contract option Friday.",
       "link": "https://www.espn.com/nfl/story/_/id/48450986/falcons-pick-fifth-year-option-rb-bijan-robinson",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "nfl-wire",
       "franchiseIds": [],
       "league": "theleague"
@@ -1336,7 +1349,7 @@
       "headline": "ESPN sources: the Green Bay Packers are trading wide receiver Dontayvion Wicks to the Philadelphia Eagles in exchange for a 2026 fifth-round pick and a 2027 sixth-round pick.\n\nWicks will sign a one-year, $12.5 million extension with the Eagles, per his agent @DavidMulugheta.",
       "body": "ESPN sources: the Green Bay Packers are trading wide receiver Dontayvion Wicks to the Philadelphia Eagles in exchange for a 2026 fifth-round pick and a 2027 sixth-round pick.\n\nWicks will sign a...",
       "link": "https://www.espn.com/contributor/adam-schefter/c25e48e0f202d",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "adam-schefter",
       "franchiseIds": [],
       "league": "theleague"
@@ -1349,7 +1362,7 @@
       "headline": "2026 NFL draft: Latest Kansas City Chiefs updates, intel, buzz",
       "body": "The Chiefs will pick early in Round 1 and have nine selections in the 2026 NFL draft. Here's the latest on what they might do.",
       "link": "https://www.espn.com/nfl/draft2026/story/_/id/48450466/2026-nfl-draft-kansas-city-chiefs-updates-buzz-intel-picks-positions",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -1359,10 +1372,10 @@
       "timestamp": "2026-04-10T16:12:24.547Z",
       "type": "external",
       "tier": "standard",
-      "headline": "Broncos owners Carrie and Greg Penner have expanded their commitment to, and in, the Denver sports community through a significant minority investment in the Colorado Rockies.\n\nPenner Sports Group — the family entity that holds their ownership interest in the Broncos — now becomes the largest minority partner of the Rockies. Majority ownership of the Rockies and all team operations remain with Dick Monfort and the Monfort family while Carrie and Greg Penner continue to be focused on the Broncos.",
-      "body": "Broncos owners Carrie and Greg Penner have expanded their commitment to, and in, the Denver sports community through a significant minority investment in the Colorado Rockies.\n\nPenner Sports Group —...",
+      "headline": "Broncos owners Carrie and Greg Penner have expanded their commitment to, and in, the Denver sports community through a significant minority investment in the Colorado Rockies.\n\nPenner Sports Group \u2014 the family entity that holds their ownership interest in the Broncos \u2014 now becomes the largest minority partner of the Rockies. Majority ownership of the Rockies and all team operations remain with Dick Monfort and the Monfort family while Carrie and Greg Penner continue to be focused on the Broncos.",
+      "body": "Broncos owners Carrie and Greg Penner have expanded their commitment to, and in, the Denver sports community through a significant minority investment in the Colorado Rockies.\n\nPenner Sports Group \u2014...",
       "link": "https://www.espn.com/contributor/adam-schefter/5faa58dce94c6",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "adam-schefter",
       "franchiseIds": [],
       "league": "theleague"
@@ -1375,7 +1388,7 @@
       "headline": "Ja'Kobi Lane's NFL draft profile",
       "body": "Check out some of the top highlights from Southern California's Ja'Kobi Lane.",
       "link": "https://www.espn.com/video/clip?id=48447834",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -1388,7 +1401,7 @@
       "headline": "Ben Solak: Kenyon Sadiq can be a 'George Kittle-style' TE unicorn",
       "body": "Ben Solak breaks down Oregon TE Kenyon Sadiq as an NFL draft prospect comparable to George Kittle.",
       "link": "https://www.espn.com/video/clip?id=48446865",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "nfl-wire",
       "franchiseIds": [],
       "league": "theleague"
@@ -1401,7 +1414,7 @@
       "headline": "Caleb Lomu's  NFL draft profile",
       "body": "Check out some of the top highlights from Utah's Caleb Lomu",
       "link": "https://www.espn.com/video/clip?id=48446912",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -1414,7 +1427,7 @@
       "headline": "Sources: Colts and Kenny Moore II mutually have agreed to seek a trade and a new home for the veteran cornerback. Moore is entering the last year of his contract, and both sides feel it is time to explore a trade.",
       "body": "Sources: Colts and Kenny Moore II mutually have agreed to seek a trade and a new home for the veteran cornerback.",
       "link": "https://www.espn.com/contributor/adam-schefter/41a29b1c14ee9",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "adam-schefter",
       "franchiseIds": [],
       "league": "theleague"
@@ -1427,7 +1440,7 @@
       "headline": "Kevin Clark: Sonny Styles is the best player in the 2026 NFL draft",
       "body": "Kevin Clark details why Ohio State linebacker Sonny Styles will be the best player in the 2026 NFL draft class.",
       "link": "https://www.espn.com/video/clip?id=48446568",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -1440,7 +1453,7 @@
       "headline": "2026 NFL draft: Latest buzz on No. 2 pick, bold predictions",
       "body": "Where are the Jets leaning on the No. 2 pick? Could Jacob Rodriguez sneak into Round 1? Our NFL draft experts weigh in with their newest intel.",
       "link": "https://www.espn.com/nfl/draft2026/story/_/id/48428742/2026-nfl-draft-latest-buzz-rumors-news-mocks-predictions-jets-lions-chargers-panthers",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -1453,7 +1466,7 @@
       "headline": "2026 NFL draft rankings: Matt Miller's top 482 players, comps",
       "body": "Matt Miller has finalized his rankings for the 2026 draft, listing his top 482 players and providing grades for each prospect.",
       "link": "https://www.espn.com/nfl/draft2026/story/_/id/47190881/2026-nfl-draft-rankings-matt-miller-top-prospects-players-positions",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "matt-miller",
       "franchiseIds": [],
       "league": "theleague"
@@ -1466,7 +1479,7 @@
       "headline": "Could Browns draft another QB to compete for starting job?",
       "body": "Despite drafting two passers in 2025, Cleveland is still scouting prospects such as Alabama's Ty Simpson.",
       "link": "https://www.espn.com/nfl/story/_/id/48443279/could-cleveland-browns-2026-nfl-draft-another-quarterback-compete-starting-job",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -1479,7 +1492,7 @@
       "headline": "Jeremiyah Love's NFL draft profile",
       "body": "Check out some of the top highlights from Notre Dame's Jeremiyah Love.",
       "link": "https://www.espn.com/video/clip?id=48444691",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -1492,7 +1505,7 @@
       "headline": "Carnell Tate's NFL draft profile",
       "body": "Check out some of the top highlights from Ohio State's Carnell Tate.",
       "link": "https://www.espn.com/video/clip?id=48444678",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -1505,7 +1518,7 @@
       "headline": "5 Ohio St. players, Ty Simpson among 16 to attend NFL draft",
       "body": "Five Ohio State players are among the 16 planning to attend the first round of the NFL draft on April 23 in Pittsburgh, a group that doesn't include Fernando Mendoza but does include fellow QB Ty...",
       "link": "https://www.espn.com/nfl/story/_/id/48443052/5-ohio-st-players-ty-simpson-16-attend-nfl-draft",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -1518,7 +1531,7 @@
       "headline": "2026 NFL draft: Latest Pittsburgh Steelers updates, intel, buzz",
       "body": "The Steelers have the No. 21 pick in Round 1 and 12 total selections in the 2026 draft. Here's the latest on what Pittsburgh might do.",
       "link": "https://www.espn.com/nfl/story/_/id/48442661/2026-nfl-draft-pittsburgh-steelers-updates-buzz-intel-picks-positions",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -1531,7 +1544,7 @@
       "headline": "2026 NFL draft: Latest Washington Commanders updates, intel, buzz",
       "body": "The Commanders are set to pick early in Round 1 and have six total selections in the 2026 NFL draft. Here's the latest on what Washington might do once it is on the clock.",
       "link": "https://www.espn.com/nfl/draft2026/story/_/id/48413923/2026-nfl-draft-washington-commanders-updates-buzz-intel-picks-positions",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -1544,7 +1557,7 @@
       "headline": "2026 NFL draft: Denver Broncos updates, intel, buzz",
       "body": "The Broncos are set to pick No. 62 and have seven total selections in the 2026 draft. Here's the latest on what Denver might do.",
       "link": "https://www.espn.com/nfl/story/_/id/48439425/2026-nfl-draft-denver-broncos-updates-buzz-intel-picks-positions",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -1557,7 +1570,7 @@
       "headline": "2026 NFL draft: Atlanta Falcons updates, intel, buzz",
       "body": "The Falcons are set to pick No. 48 and have five total selections in the 2026 draft. Here's the latest on what Atlanta might do.",
       "link": "https://www.espn.com/nfl/story/_/id/48438818/2026-nfl-draft-atlanta-falcons-updates-buzz-intel-picks-positions",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -1567,10 +1580,10 @@
       "timestamp": "2026-04-09T16:12:47Z",
       "type": "external",
       "tier": "standard",
-      "headline": "Saquon Barkley: ‘I’m a big fan’ of Jeremiyah Love",
+      "headline": "Saquon Barkley: \u2018I\u2019m a big fan\u2019 of Jeremiyah Love",
       "body": "Saquon Barkley praises 2026 NFL draft prospect Jeremiyah Love.",
       "link": "https://www.espn.com/video/clip?id=48438889",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "nfl-wire",
       "franchiseIds": [],
       "league": "theleague"
@@ -1583,7 +1596,7 @@
       "headline": "2026 NFL draft full order: AFC, NFC team picks in all rounds",
       "body": "The order for all seven rounds of the 2026 NFL draft is set, starting with the Raiders at No. 1 and ending with the Broncos at No. 257.",
       "link": "https://www.espn.com/nfl/draft2026/story/_/id/48196141/2026-nfl-draft-order-seven-rounds-afc-nfc-complete-257-picks",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -1594,9 +1607,9 @@
       "type": "external",
       "tier": "standard",
       "headline": "Kevin Clark: C.J. Stroud is the biggest X factor in the league",
-      "body": "Kevin Clark shares his thoughts on \"Get Up” about whether C.J. Stroud can lead the Texans to a Super Bowl.",
+      "body": "Kevin Clark shares his thoughts on \"Get Up\u201d about whether C.J. Stroud can lead the Texans to a Super Bowl.",
       "link": "https://www.espn.com/video/clip?id=48437322",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "nfl-wire",
       "franchiseIds": [],
       "league": "theleague"
@@ -1609,7 +1622,7 @@
       "headline": "2026 NFL draft: Experts pick superteams of top prospects",
       "body": "Mel Kiper Jr., Matt Miller, Jordan Reid and Field Yates drafted their own rosters of 2026 draft prospects. Check out all 40 picks.",
       "link": "https://www.espn.com/nfl/draft2026/story/_/id/48420486/2026-nfl-draft-experts-pick-superteams-top-prospects-positions-kiper-miller-reid-yates",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -1622,7 +1635,7 @@
       "headline": "2026 NFL draft: Latest intel, questions for 32 teams' picks",
       "body": "Our NFL reporters answer questions for every team two weeks out from the draft, and our analysts weigh in with some new intel on picks and moves.",
       "link": "https://www.espn.com/nfl/draft2026/story/_/id/48378778/2026-nfl-draft-latest-buzz-rumors-news-answering-questions-all-32-teams-picks",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -1635,7 +1648,7 @@
       "headline": "How Raiders can learn from the past with Mendoza and Kubiak",
       "body": "The Raiders last paired a new coach with a rookie QB in 2007. Will it be different with Klint Kubiak and Fernando Mendoza?",
       "link": "https://www.espn.com/nfl/draft2026/story/_/id/48412918/las-vegas-raiders-coach-klint-kubiak-quarterback-fernando-mendoza",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -1648,7 +1661,7 @@
       "headline": "Broncos used to not having first-round picks in NFL draft",
       "body": "The Jaylen Waddle trade leaves the Broncos in a familiar position, but the past two drafts without a Round 1 pick didn't go so bad.",
       "link": "https://www.espn.com/nfl/story/_/id/48432975/denver-broncos-no-first-round-pick-third-2022-nik-bonitto",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -1661,7 +1674,7 @@
       "headline": "Commanders still putting pieces around Jayden Daniels",
       "body": "After addressing tight end and offensive line, Washington appears headed toward drafting receivers for Jayden Daniels.",
       "link": "https://www.espn.com/nfl/story/_/id/48433099/washington-commanders-offensive-outlook-2026-free-agency-nfl-draft",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "nfl-wire",
       "franchiseIds": [],
       "league": "theleague"
@@ -1674,7 +1687,7 @@
       "headline": "Blake Miller's NFL draft profile",
       "body": "Check out some of the top highlights from Clemson's Blake Miller.",
       "link": "https://www.espn.com/video/clip?id=48435053",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -1687,7 +1700,7 @@
       "headline": "CJ Allen's NFL draft profile",
       "body": "Check out some of the top highlights from Georgia's CJ Allen.",
       "link": "https://www.espn.com/video/clip?id=48435009",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -1700,7 +1713,7 @@
       "headline": "Germie Bernard's NFL draft profile",
       "body": "Check out some of the top highlights from Alabama's Germie Bernard.",
       "link": "https://www.espn.com/video/clip?id=48434945",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -1713,7 +1726,7 @@
       "headline": "Lee Hunter's NFL draft profile",
       "body": "Check out some of the top highlights from Texas Tech's Lee Hunter.",
       "link": "https://www.espn.com/video/clip?id=48434916",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -1726,7 +1739,7 @@
       "headline": "Is Sam Darnold heading for another ring?",
       "body": "Fresh off a Super Bowl, could Sam Darnold getting married mean more success on the field?",
       "link": "https://www.espn.com/video/clip?id=48433266",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "nfl-wire",
       "franchiseIds": [],
       "league": "theleague"
@@ -1739,7 +1752,7 @@
       "headline": "Kirk Cousins: Raiders need to play best QB, even if not me",
       "body": "Raiders quarterback Kirk Cousins is aware that Las Vegas is expected to draft Fernando Mendoza and says he only wants to play if it's determined he's the best option.",
       "link": "https://www.espn.com/nfl/story/_/id/48432916/kirk-cousins-raiders-need-play-best-qb-even-not-me",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "nfl-wire",
       "franchiseIds": [],
       "league": "theleague"
@@ -1752,7 +1765,7 @@
       "headline": "Is C.J. Stroud the Texans' long-term answer?",
       "body": "Rich Eisen and Chris Brockman debate what the Texans should do with C.J. Stroud.",
       "link": "https://www.espn.com/video/clip?id=48431691",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "nfl-wire",
       "franchiseIds": [],
       "league": "theleague"
@@ -1765,7 +1778,7 @@
       "headline": "2026 NFL draft: Chicago Bears updates, intel, buzz",
       "body": "The Bears are set to pick No. 25 and have seven total selections in the 2026 draft. Here's the latest on what Chicago might do.",
       "link": "https://www.espn.com/nfl/story/_/id/48431234/2026-nfl-draft-chicago-bears-updates-buzz-intel-picks-positions",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -1778,7 +1791,7 @@
       "headline": "2026 NFL draft: Latest Cleveland Browns updates, intel, buzz",
       "body": "The Browns have two first-round picks and nine total selections in the 2026 draft. Here's the latest on what Cleveland might do.",
       "link": "https://www.espn.com/nfl/story/_/id/48431322/2026-nfl-draft-cleveland-browns-updates-buzz-intel-picks-positions",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -1791,7 +1804,7 @@
       "headline": "Falcons OT Kaleb McGary has announced his retirement from the NFL at age 31.",
       "body": "Falcons OT Kaleb McGary has announced his retirement from the NFL at age 31.",
       "link": "https://www.espn.com/contributor/adam-schefter/a28078072e32a",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "adam-schefter",
       "franchiseIds": [],
       "league": "theleague"
@@ -1804,7 +1817,7 @@
       "headline": "T.J. Parker's NFL draft profile",
       "body": "Check out some of the top highlights from Clemson's T.J. Parker.",
       "link": "https://www.espn.com/video/clip?id=48430733",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -1817,7 +1830,7 @@
       "headline": "2026 NFL draft: Latest Tennessee Titans updates, intel, buzz",
       "body": "The Titans pick early in Round 1 and have nine total selections in the 2026 draft. Here's the latest on what Tennessee might do.",
       "link": "https://www.espn.com/nfl/story/_/id/48430590/2026-nfl-draft-tennessee-titans-updates-buzz-intel-picks-positions",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -1830,7 +1843,7 @@
       "headline": "2026 NFL draft: Latest Philadelphia Eagles updates, intel, buzz",
       "body": "The Eagles pick late in Round 1 and have nine total selections in the 2026 draft. Here's the latest on what Philadelphia might do.",
       "link": "https://www.espn.com/nfl/story/_/id/48429936/2026-nfl-draft-philadelphia-eagles-updates-buzz-intel-picks-positions",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -1843,7 +1856,7 @@
       "headline": "2026 NFL draft: Latest New York Giants updates, intel, buzz",
       "body": "The Giants pick early in Round 1 and have seven total selections in the 2026 draft. Here's the latest on what New York might do.",
       "link": "https://www.espn.com/nfl/story/_/id/48429757/2026-nfl-draft-new-york-giants-updates-buzz-intel-picks-positions",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -1856,7 +1869,7 @@
       "headline": "2026 NFL draft: Latest New York Jets updates, intel, buzz",
       "body": "The Jets pick early in Round 1 and have nine total selections in the 2026 draft. Here's the latest on what New York might do.",
       "link": "https://www.espn.com/nfl/story/_/id/48430374/2026-nfl-draft-new-york-jets-updates-buzz-intel-picks-positions2026-nfl-draft-new-york-jets-updates-buzz-intel-picks-positions",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -1869,7 +1882,7 @@
       "headline": "Jadarian Price's NFL draft profile",
       "body": "Check out some of the top highlights from Notre Dame's Jadarian Price.",
       "link": "No matching template",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -1882,7 +1895,7 @@
       "headline": "2026 NFL draft: Latest Cincinnati Bengals updates, intel, buzz",
       "body": "The Bengals are set to pick No. 10 and have eight total selections in the 2026 NFL draft. Here's the latest on what Cincy might do once it is on the clock.",
       "link": "https://www.espn.com/nfl/story/_/id/48429303/2026-nfl-draft-cincinnati-bengals-updates-buzz-intel-picks-positions2026-nfl-draft-cincinnati-bengals-updates-buzz-intel-picks-positions",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -1895,7 +1908,7 @@
       "headline": "2026 NFL draft: Latest Indianapolis Colts updates, intel, buzz",
       "body": "The Colts are set to pick No. 47 and have seven total selections in the 2026 NFL draft. Here's the latest on what Indy might do once it is on the clock.",
       "link": "https://www.espn.com/nfl/story/_/id/48429019/2026-nfl-draft-indianapolis-colts-updates-buzz-intel-picks-positions2026-nfl-draft-indianapolis-colts-updates-buzz-intel-picks-positions",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -1908,7 +1921,7 @@
       "headline": "2026 NFL draft: Latest Miami Dolphins updates, intel, buzz",
       "body": "The Dolphins are set to pick early in Round 1 and have 11 total selections in the 2026 NFL draft. Here's the latest on what Miami might do once it is on the clock.",
       "link": "https://www.espn.com/nfl/draft2026/story/_/id/48413572/2026-nfl-draft-miami-dolphins-updates-buzz-intel-picks-positions2026-nfl-draft-miami-dolphins-updates-buzz-intel-picks-positions",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -1921,7 +1934,7 @@
       "headline": "Omar Cooper Jr.'s NFL draft profile",
       "body": "Check out some of the top highlights from Indiana's Omar Cooper Jr.",
       "link": "No matching template",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -1934,7 +1947,7 @@
       "headline": "Avieon Terrell's NFL draft profile",
       "body": "Check out some of the top highlights from Clemson's Avieon Terrell.",
       "link": "No matching template",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -1947,7 +1960,7 @@
       "headline": "Why Fernando Mendoza is Field Yates' top prospect in the 2026 draft",
       "body": "Field Yates and Ben Solak discuss what makes Fernando Mendoza the top overall player in the 2026 NFL draft.",
       "link": "No matching template",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -1960,7 +1973,7 @@
       "headline": "Mansoor Delane's NFL draft profile",
       "body": "Check out some of the top highlights from LSU's Mansoor Delane.",
       "link": "No matching template",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -1973,7 +1986,7 @@
       "headline": "Akheem Mesidor's NFL draft profile",
       "body": "Check out some of the top highlights from Indiana's Akheem Mesidor.",
       "link": "No matching template",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -1986,7 +1999,7 @@
       "headline": "2026 NFL draft: Latest Arizona Cardinals updates, intel, buzz",
       "body": "The Cardinals are set to pick No. 3 and have seven total selections in the 2026 NFL draft. Here's the latest on what Arizona might do once it is on the clock.",
       "link": "https://www.espn.com/nfl/story/_/id/48428855/2026-nfl-draft-arizona-cardinals-updates-buzz-intel-picks-positions2026-nfl-draft-arizona-cardinals-updates-buzz-intel-picks-positions",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -1996,10 +2009,10 @@
       "timestamp": "2026-04-08T15:41:03.402Z",
       "type": "external",
       "tier": "standard",
-      "headline": "Texans have exercised the 2027 fifth-year options on the contracts of QB CJ Stroud and All Pro DE Will Anderson, per ESPN’s Field Yates.  \n\nStroud is now due $25.904M in 2027, while Anderson is due $21.512M.   \n\nBoth players are also extension eligible.",
-      "body": "Texans have exercised the 2027 fifth-year options on the contracts of QB CJ Stroud and All Pro DE Will Anderson, per ESPN’s Field Yates.",
+      "headline": "Texans have exercised the 2027 fifth-year options on the contracts of QB CJ Stroud and All Pro DE Will Anderson, per ESPN\u2019s Field Yates.  \n\nStroud is now due $25.904M in 2027, while Anderson is due $21.512M.   \n\nBoth players are also extension eligible.",
+      "body": "Texans have exercised the 2027 fifth-year options on the contracts of QB CJ Stroud and All Pro DE Will Anderson, per ESPN\u2019s Field Yates.",
       "link": "https://www.espn.com/contributor/adam-schefter/f372cdaa3ebb8",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "adam-schefter",
       "franchiseIds": [],
       "league": "theleague"
@@ -2012,7 +2025,7 @@
       "headline": "How the Cowboys landed Dak Prescott in the 2016 NFL draft",
       "body": "As the moment neared, OC Scott Linehan was holding his breath, thinking, \"Someone else is going to take him.\"",
       "link": "https://www.espn.com/nfl/story/_/id/48419390/nfl-dallas-cowboys-dak-prescott-draft-jerry-jones",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -2025,7 +2038,7 @@
       "headline": "2026 NFL quarterback mock draft: Team fits over seven rounds",
       "body": "Ben Solak projects landing spots for the nine QBs he considers draftable in the 2026 class (and one trade) and sizes up each team fit.",
       "link": "https://www.espn.com/nfl/draft2026/story/_/id/48421239/2026-nfl-mock-draft-quarterback-team-fits-mendoza-simpson-nussmeier-allar-beck",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "ben-solak",
       "franchiseIds": [],
       "league": "theleague"
@@ -2038,7 +2051,7 @@
       "headline": "Steelers could add to QB room after first round in NFL draft",
       "body": "Pittsburgh's ideal QB prospect in the 2026 NFL draft would be a proven winner of a certain stature.",
       "link": "https://www.espn.com/nfl/story/_/id/48421558/pittsburgh-steelers-2026-nfl-draft-quarterbacks-outlook",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -2051,7 +2064,7 @@
       "headline": "NFL execs, scouts on 2026 draft's most polarizing players",
       "body": "Many of the NFL draft's most talented prospects come with big questions. We asked sources about them.",
       "link": "https://www.espn.com/nfl/story/_/id/48420715/nfl-execs-scouts-2026-draft-most-polarizing-players",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "jeremy-fowler",
       "franchiseIds": [],
       "league": "theleague"
@@ -2061,10 +2074,10 @@
       "timestamp": "2026-04-07T23:16:27Z",
       "type": "external",
       "tier": "standard",
-      "headline": "Seahawks QB Sam Darnold ties knot with fiancée Katie Hoofangle",
-      "body": "The Seahawks quarterback married his fiancée only months after winning Super Bowl LX.",
+      "headline": "Seahawks QB Sam Darnold ties knot with fianc\u00e9e Katie Hoofangle",
+      "body": "The Seahawks quarterback married his fianc\u00e9e only months after winning Super Bowl LX.",
       "link": "https://www.espn.com/nfl/story/_/id/48423360/seattle-seahawks-sam-darnold-wedding-married-katie-hoofangle",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "nfl-wire",
       "franchiseIds": [],
       "league": "theleague"
@@ -2077,7 +2090,7 @@
       "headline": "2026 NFL draft: Latest New England Patriots updates, intel, buzz",
       "body": "The Patriots pick late in Round 1 and have 11 total selections in the 2026 draft. Here's the latest on what New England might do.",
       "link": "https://www.espn.com/nfl/draft2026/story/_/id/48423365/2026-nfl-draft-new-england-patriots-updates-buzz-intel-picks-positions",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -2090,7 +2103,7 @@
       "headline": "2026 NFL draft: Latest Dallas Cowboys updates, intel, buzz",
       "body": "The Cowboys have eight picks, two in Round 1. Here's the latest on what Dallas might do in the 2026 NFL draft.",
       "link": "https://www.espn.com/nfl/story/_/id/48421367/2026-nfl-draft-dallas-cowboys-updates-buzz-intel-picks-positions",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -2103,7 +2116,7 @@
       "headline": "2026 NFL draft: Latest Las Vegas Raiders updates, intel, buzz",
       "body": "The Raiders are set to pick No. 1 and have 10 total selections in the 2026 NFL draft. Here's the latest on what Las Vegas might do once it is on the clock.",
       "link": "https://www.espn.com/nfl/story/_/id/48421594/2026-nfl-draft-las-vegas-raiders-updates-buzz-intel-picks-positions",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -2116,7 +2129,7 @@
       "headline": "2026 NFL draft comps: Our favorite prospect-to-pro matches",
       "body": "Who are the best comps for Rueben Bain Jr., Jermod McCoy and Fernando Mendoza? Let's match NFL draft prospects to current and former pros.",
       "link": "https://www.espn.com/nfl/draft2026/story/_/id/48407219/2026-nfl-draft-comps-best-prospect-pro-matches-comparisons",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -2129,7 +2142,7 @@
       "headline": "Why Fernando Mendoza isn't attending the draft",
       "body": "Adam Schefter joins Pat McAfee and reports on why Fernando Mendoza won't be attending the NFL draft in Pittsburgh.",
       "link": "https://www.espn.com/video/clip?id=48421715",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -2142,7 +2155,7 @@
       "headline": "Sources: Fernando Mendoza not planning to attend NFL draft",
       "body": "Fernando Mendoza has informed the NFL that he is not planning to attend the draft, sources told ESPN.",
       "link": "https://www.espn.com/nfl/story/_/id/48421461/sources-fernando-mendoza-not-planning-attend-nfl-draft",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -2155,7 +2168,7 @@
       "headline": "Patriots lack depth at linebacker after Marte Mapu release",
       "body": "Mapu was selected in the third round of the 2023 NFL draft -- one of Belichick's outside-the-box picks.",
       "link": "https://www.espn.com/nfl/story/_/id/48421186/new-england-patriots-release-marte-mapu-depth-linebacker",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "nfl-wire",
       "franchiseIds": [],
       "league": "theleague"
@@ -2168,7 +2181,7 @@
       "headline": "Projected No. 1 overall pick Fernando Mendoza has informed the NFL that he is not planning to attend the NFL Draft in Pittsburgh this month, per sources. Mendoza wants to share the draft experience with his family in Miami.",
       "body": "Projected No. 1 overall pick Fernando Mendoza has informed the NFL that he is not planning to attend the NFL Draft in Pittsburgh this month, per sources.",
       "link": "https://www.espn.com/contributor/adam-schefter/41f56bfe44e67",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "adam-schefter",
       "franchiseIds": [],
       "league": "theleague"
@@ -2181,7 +2194,7 @@
       "headline": "Stephen A. Smith: Lamar Jackson has a lot on his shoulders this season",
       "body": "Stephen A. Smith takes stock of Lamar Jackson and the Ravens ahead of this season.",
       "link": "https://www.espn.com/video/clip?id=48420668",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "nfl-wire",
       "franchiseIds": [],
       "league": "theleague"
@@ -2194,7 +2207,7 @@
       "headline": "Kyle Pitts signing franchise tag, reports to Falcons' workouts",
       "body": "Tight end Kyle Pitts Sr. is signing his franchise tender and reported for the beginning of the Falcons' offseason workout program, according to NFL Network.",
       "link": "https://www.espn.com/nfl/story/_/id/48420592/kyle-pitts-signing-franchise-tag-reports-falcons-workouts",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "nfl-wire",
       "franchiseIds": [],
       "league": "theleague"
@@ -2207,7 +2220,7 @@
       "headline": "Why Schrager has 'most polarizing prospect' going to Chiefs in his mock draft",
       "body": "Peter Schrager breaks down why he has Arizona State receiver Jordan Tyson going ninth overall to the Chiefs in his NFL mock draft.",
       "link": "https://www.espn.com/video/clip?id=48419930",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -2220,7 +2233,7 @@
       "headline": "2026 NFL mock draft: Schrager projects 32 first-round picks",
       "body": "Peter Schrager leans on his intel after last week's annual league meeting to project picks in the NFL draft. Here's where things stand right now in Round 1.",
       "link": "https://www.espn.com/nfl/draft2026/story/_/id/48408193/2026-nfl-mock-draft-peter-schrager-insider-intel-first-round-picks-predictions",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -2233,7 +2246,7 @@
       "headline": "Will the 49ers trade, release or keep WR Brandon Aiyuk?",
       "body": "Aiyuk hasn't played an NFL game since Oct. 20, 2024, and his time with the 49ers may be nearing an end.",
       "link": "https://www.espn.com/nfl/story/_/id/48414734/brandon-aiyuk-contract-trade-san-francisco-49ers-commanders",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "nfl-wire",
       "franchiseIds": [],
       "league": "theleague"
@@ -2243,10 +2256,10 @@
       "timestamp": "2026-04-06T16:36:06.183Z",
       "type": "external",
       "tier": "standard",
-      "headline": "ESPN sources: Giants All-Pro defensive tackle Dexter Lawrence has requested a trade and he will not be participating in the team’s off-season workout program that opens Tuesday.\n\nLawrence and the Giants have been through two off seasons attempting to negotiate a contract reflecting his value to the Giants over the last three years, but there has not been any progress, per sources.",
-      "body": "ESPN sources: Giants All-Pro defensive tackle Dexter Lawrence has requested a trade and he will not be participating in the team’s off-season workout program that opens Tuesday.\n\nLawrence and the...",
+      "headline": "ESPN sources: Giants All-Pro defensive tackle Dexter Lawrence has requested a trade and he will not be participating in the team\u2019s off-season workout program that opens Tuesday.\n\nLawrence and the Giants have been through two off seasons attempting to negotiate a contract reflecting his value to the Giants over the last three years, but there has not been any progress, per sources.",
+      "body": "ESPN sources: Giants All-Pro defensive tackle Dexter Lawrence has requested a trade and he will not be participating in the team\u2019s off-season workout program that opens Tuesday.\n\nLawrence and the...",
       "link": "https://www.espn.com/contributor/adam-schefter/da82541862a26",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "adam-schefter",
       "franchiseIds": [],
       "league": "theleague"
@@ -2259,7 +2272,7 @@
       "headline": "Giants DT Dexter Lawrence requests trade, sources say",
       "body": "Giants defensive tackle Dexter Lawrence II has requested a trade after seven seasons in New York, sources told ESPN's Adam Schefter on Thursday.",
       "link": "https://www.espn.com/nfl/story/_/id/48412861/giants-dt-dexter-lawrence-requests-trade-sources-say",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "adam-schefter",
       "franchiseIds": [],
       "league": "theleague"
@@ -2272,7 +2285,7 @@
       "headline": "Lamar Jackson reports for start of Ravens' offseason workouts",
       "body": "Lamar Jackson is getting off on the right foot with new coach Jesse Minter as he reported for the start of the Ravens' offseason workout program Monday.",
       "link": "https://www.espn.com/nfl/story/_/id/48412392/lamar-jackson-reports-start-ravens-offseason-workouts",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "nfl-wire",
       "franchiseIds": [],
       "league": "theleague"
@@ -2285,7 +2298,7 @@
       "headline": "2026 NFL mock draft with all trades: Deals for Round 1 picks",
       "body": "We proposed 32 trades to shake up Round 1 -- one at every slot -- including deals that involve J.J. McCarthy and Maxx Crosby.",
       "link": "https://www.espn.com/nfl/draft2026/story/_/id/48373315/2026-nfl-mock-draft-all-trades-barnwell-deals-32-round-1-picks-players-mccarthy-crosby",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -2298,7 +2311,7 @@
       "headline": "Room for two RBs? How Saints roster looks ahead of NFL draft",
       "body": "The Saints believe there will be enough opportunities for Alvin Kamara and Travis Etienne Jr. to share.",
       "link": "https://www.espn.com/nfl/story/_/id/48371943/new-orleans-saints-2026-kellen-moore-roster-nfl-draft-running-backs",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -2311,7 +2324,7 @@
       "headline": "How A.J. Terrell mentored his brother, draft prospect Avieon",
       "body": "Set to be a first-round cornerback in the NFL draft like his brother, Avieon Terrell has looked to A.J. as his inspiration throughout his life.",
       "link": "https://www.espn.com/nfl/story/_/id/48347414/2026-nfl-draft-avieon-terrell-aj-terrell-jr-mentored-brother-clemson-atlanta-falcons",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -2324,7 +2337,7 @@
       "headline": "Denzel Boston's NFL draft profile",
       "body": "Check out some of the top highlights from Washington's Denzel Boston.",
       "link": "https://www.espn.com/video/clip?id=48404201",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -2337,7 +2350,7 @@
       "headline": "Kayden McDonald's NFL draft profile",
       "body": "Check out some of the top highlights from Ohio State's Kayden McDonald.",
       "link": "https://www.espn.com/video/clip?id=48404152",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -2350,7 +2363,7 @@
       "headline": "Zion Young's NFL draft profile",
       "body": "Check out some of the top highlights from Missouri's Zion Young.",
       "link": "https://www.espn.com/video/clip?id=48404171",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -2363,7 +2376,7 @@
       "headline": "Dillon Thieneman's NFL draft profile",
       "body": "Check out some of the top highlights from Oregon's Dillon Thieneman.",
       "link": "https://www.espn.com/video/clip?id=48404121",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -2376,7 +2389,7 @@
       "headline": "Joe Royer's NFL draft profile",
       "body": "Check out some of the top highlights from Cincinnati's Joe Royer.",
       "link": "https://www.espn.com/video/clip?id=48403970",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -2389,7 +2402,7 @@
       "headline": "Jermod McCoy's NFL draft profile",
       "body": "Check out some of the top highlights from Tennessee's Jermod McCoy.",
       "link": "https://www.espn.com/video/clip?id=48403680",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -2402,7 +2415,7 @@
       "headline": "2026 NFL draft edge rusher projections: Rankings, comps",
       "body": "Which prospects will have the most sacks through five NFL seasons? We projected the top edge rushers in the 2026 draft class.",
       "link": "https://www.espn.com/nfl/draft2026/story/_/id/48359548/2026-nfl-draft-edge-rusher-projections-rankings-historical-comps-prospects",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -2415,7 +2428,7 @@
       "headline": "2026 NFL draft QB rankings: Mendoza, Simpson, Nussmeier",
       "body": "Who are the best quarterbacks in the 2026 class? We sized up the top 12, starting with Fernando Mendoza and Ty Simpson.",
       "link": "https://www.espn.com/nfl/draft2026/story/_/id/46532548/2026-nfl-draft-ranking-top-quarterbacks-hot-board-team-fits-strengths-weaknesses",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "jordan-reid",
       "franchiseIds": [],
       "league": "theleague"
@@ -2428,7 +2441,7 @@
       "headline": "Patriots notebook: NFL draft prep; Gilmore talks retirement",
       "body": "Here are 10 notes from around the Patriots and NFL this week.",
       "link": "https://www.espn.com/nfl/story/_/id/48390109/new-england-patriots-notebook-2026-nfl-draft-prep-stephon-gilmore-talks-retirement",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -2441,7 +2454,7 @@
       "headline": "Anthony Hill Jr.'s NFL draft profile",
       "body": "Check out some of the top highlights from Texas' Anthony Hill Jr..",
       "link": "https://www.espn.com/video/clip?id=48400226",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -2454,7 +2467,7 @@
       "headline": "Colton Hood's NFL draft profile",
       "body": "Check out some of the top highlights from Tennessee's Colton Hood.",
       "link": "https://www.espn.com/video/clip?id=48400201",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -2467,7 +2480,7 @@
       "headline": "Eli Raridon's NFL draft profile",
       "body": "Check out some of the top highlights from Notre Dame's Eli Raridon.",
       "link": "https://www.espn.com/video/clip?id=48395195",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -2480,7 +2493,7 @@
       "headline": "Chris Bell's NFL draft profile",
       "body": "Check out some of the top highlights from Louisville's Chris Bell.",
       "link": "https://www.espn.com/video/clip?id=48395185",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -2493,7 +2506,7 @@
       "headline": "Olaivavega Ioane's NFL draft profile",
       "body": "Check out some of the top highlights from Penn State's Olaivavega Ioane.",
       "link": "https://www.espn.com/video/clip?id=48395153",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -2506,7 +2519,7 @@
       "headline": "Monroe Freeling's NFL draft profile",
       "body": "Check out some of the top highlights from Georgia's Monroe Freeling.",
       "link": "https://www.espn.com/video/clip?id=48395137",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -2519,7 +2532,7 @@
       "headline": "Rise of RBs sharing carries, what it means for the NFL draft",
       "body": "Splitting time used to be a mark against rushers. With top NFL draft prospects coming from the same backfield, that might be changing.",
       "link": "https://www.espn.com/nfl/draft2026/story/_/id/48349028/nfl-draft-2026-running-backs-sharing-carries",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -2532,7 +2545,7 @@
       "headline": "Miami Dolphins notebook: Malik Willis' fit, Chop Robinson's role",
       "body": "Top takeaways from what the Dolphins said in Arizona, including Willis' fit and plans for Chop Robinson.",
       "link": "https://www.espn.com/nfl/story/_/id/48387205/miami-dolphins-notebook-2026-owners-meetings-nfl-free-agency-malik-willis",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -2545,7 +2558,7 @@
       "headline": "2026 NFL draft running back projections: Rankings, comps",
       "body": "We have stat projections for the top running back prospects in the 2026 NFL draft class, from Jeremiyah Love to late-round sleepers.",
       "link": "https://www.espn.com/nfl/draft2026/story/_/id/48357267/2026-nfl-draft-running-back-projections-rankings-historical-comps-prospects",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -2558,7 +2571,7 @@
       "headline": "Gabe Jacas' NFL draft profile",
       "body": "Check out some of the top highlights from Illinois' Gabe Jacas.",
       "link": "https://www.espn.com/video/clip?id=48390223",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -2571,7 +2584,7 @@
       "headline": "Garrett Nussmeier's NFL draft profile",
       "body": "Check out some of the top highlights from LSU's Garrett Nussmeier.",
       "link": "https://www.espn.com/video/clip?id=48390212",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -2584,7 +2597,7 @@
       "headline": "Cashius Howell's NFL draft profile",
       "body": "Check out some of the top highlights from Texas A&M's Cashius Howell.",
       "link": "https://www.espn.com/video/clip?id=48390201",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -2597,7 +2610,7 @@
       "headline": "Eli Stowers' NFL draft profile",
       "body": "Check out some of the top highlights from Vanderbilt's Eli Stowers.",
       "link": "https://www.espn.com/video/clip?id=48390171",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -2610,7 +2623,7 @@
       "headline": "Chiefs WR Rashee Rice faces no NFL discipline over abuse allegations",
       "body": "The NFL announced Friday that it concluded its own investigation into Chiefs receiver Rashee Rice, stating that he \"has not engaged in conduct that violates the personal conduct policy.\"",
       "link": "https://www.espn.com/nfl/story/_/id/48389126/chiefs-wr-rashee-rice-faces-no-nfl-discipline-abuse-allegations",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "nfl-wire",
       "franchiseIds": [],
       "league": "theleague"
@@ -2620,10 +2633,10 @@
       "timestamp": "2026-04-03T20:51:41.085Z",
       "type": "external",
       "tier": "standard",
-      "headline": "NFL concluded today that Chiefs WR Rashee Rice “has not engaged in conduct that violates the personal conduct policy” and the investigation into accusations from his former girlfriend is now closed; there will be no discipline at this time.\n\nStatement from his attorney Sean Lindsey: “Mr. Rice wants to thank the NFL for their thorough investigation, and looks forward to the start of the 2026-27 NFL season.”",
-      "body": "NFL concluded today that Chiefs WR Rashee Rice “has not engaged in conduct that violates the personal conduct policy” and the investigation into accusations from his former girlfriend is now closed;...",
+      "headline": "NFL concluded today that Chiefs WR Rashee Rice \u201chas not engaged in conduct that violates the personal conduct policy\u201d and the investigation into accusations from his former girlfriend is now closed; there will be no discipline at this time.\n\nStatement from his attorney Sean Lindsey: \u201cMr. Rice wants to thank the NFL for their thorough investigation, and looks forward to the start of the 2026-27 NFL season.\u201d",
+      "body": "NFL concluded today that Chiefs WR Rashee Rice \u201chas not engaged in conduct that violates the personal conduct policy\u201d and the investigation into accusations from his former girlfriend is now closed;...",
       "link": "https://www.espn.com/contributor/adam-schefter/28ed963932ab4",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "adam-schefter",
       "franchiseIds": [],
       "league": "theleague"
@@ -2636,7 +2649,7 @@
       "headline": "Jaguars signed Travon Walker to a four-year, $110 million extension that includes $77M guaranteed and $50M fully guaranteed at signing.",
       "body": "Jaguars signed Travon Walker to a four-year, $110 million extension that includes $77M guaranteed and $50M fully guaranteed at signing.",
       "link": "https://www.espn.com/contributor/adam-schefter/d98d3f11ac456",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "adam-schefter",
       "franchiseIds": [],
       "league": "theleague"
@@ -2649,7 +2662,7 @@
       "headline": "NFL fifth-year option tracker: 2023 first-round draft class",
       "body": "The deadline for teams to pick up the fifth-year option on rookie contracts is May 1. Which players have had their options picked up?",
       "link": "https://www.espn.com/nfl/story/_/id/48358999/fifth-year-option-tracker-nfl-players-2023-first-round-draft-class",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -2662,7 +2675,7 @@
       "headline": "2026 NFL draft: Latest buzz on Jermod McCoy, QB class",
       "body": "How did Jermod McCoy perform at his pro day? Who is the third-best QB in this class? Our NFL draft experts weigh in with new intel three weeks out.",
       "link": "https://www.espn.com/nfl/draft2026/story/_/id/48377191/2026-nfl-draft-latest-buzz-rumors-news-mocks-sleepers-mccoy-nussmeier-beck",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -2675,7 +2688,7 @@
       "headline": "Caleb Downs and the NFL draft: How high is too high to take a safety?",
       "body": "Since 2000, only eight safeties have been drafted in the top 10. Downs could challenge conventional wisdom.",
       "link": "https://www.espn.com/nfl/story/_/id/48370913/caleb-downs-nfl-draft-how-high-too-high-safety",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -2688,7 +2701,7 @@
       "headline": "2026 NFL draft: Every first-round grade prospect, plus comps",
       "body": "We'll see 32 picks in Round 1, but which prospects actually earned a first-round grade? According to Matt Miller's board, the 2026 class has a dozen.",
       "link": "https://www.espn.com/nfl/draft2026/story/_/id/47455728/2026-nfl-draft-board-prospects-first-round-grades-comps",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "matt-miller",
       "franchiseIds": [],
       "league": "theleague"
@@ -2701,7 +2714,7 @@
       "headline": "What are the Panthers' most pressing draft needs by position?",
       "body": "We break down Carolina's roster, examining positions of strength and holes that still need to be filled.",
       "link": "https://www.espn.com/nfl/story/_/id/48357593/nfl-carolina-panthers-draft-needs-position-roster",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -2714,7 +2727,7 @@
       "headline": "Kenyon Sadiq's NFL draft profile",
       "body": "Check out some of the top highlights from Oregon's Kenyon Sadiq.",
       "link": "https://www.espn.com/video/clip?id=48379706",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -2727,7 +2740,7 @@
       "headline": "Projected No. 1 overall pick Fernando Mendoza is scheduled to visit Tuesday in Las Vegas with the Raiders, who hold the No. 1 overall pick.",
       "body": "Projected No. 1 overall pick Fernando Mendoza is scheduled to visit Tuesday in Las Vegas with the Raiders, who hold the No. 1 overall pick.",
       "link": "https://www.espn.com/contributor/adam-schefter/599b71f01ee39",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "adam-schefter",
       "franchiseIds": [],
       "league": "theleague"
@@ -2740,7 +2753,7 @@
       "headline": "Schefter to McAfee: I don't quite get all the criticism of Jalen Hurts",
       "body": "Adam Schefter joins Pat McAfee and weighs in on the drama surrounding Jalen Hurts and the Eagles.",
       "link": "https://www.espn.com/video/clip?id=48378386",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "nfl-wire",
       "franchiseIds": [],
       "league": "theleague"
@@ -2753,7 +2766,7 @@
       "headline": "Josh Allen, Hailee Steinfeld announce birth of first child",
       "body": "The Buffalo Bills quarterback and the \"Sinners\" actress did not share the date of birth or the name of their daughter.",
       "link": "https://www.espn.com/nfl/story/_/id/48377774/josh-allen-hailee-steinfeld-birth-child-buffalo-bills",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "nfl-wire",
       "franchiseIds": [],
       "league": "theleague"
@@ -2766,7 +2779,7 @@
       "headline": "2026 NFL free agency grades: Kirk Cousins, Jaylen Waddle",
       "body": "We're handing out report cards on big moves, including the Raiders' Kirk Cousins signing and the Broncos' Jaylen Waddle trade.",
       "link": "https://www.espn.com/nfl/story/_/id/47911726/2026-nfl-free-agency-grades-signings-trades-latest-best-worst-deals-draft-outlook",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "nfl-wire",
       "franchiseIds": [],
       "league": "theleague"
@@ -2779,7 +2792,7 @@
       "headline": "Adam Schefter announces news of Kirk Cousins signing with Raiders",
       "body": "Adam Schefter delivers breaking news that QB Kirk Cousins will be signing with the Raiders.",
       "link": "https://www.espn.com/video/clip?id=48376798",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "nfl-wire",
       "franchiseIds": [],
       "league": "theleague"
@@ -2792,7 +2805,7 @@
       "headline": "Kirk Cousins agrees to sign contract with Raiders, agent says",
       "body": "Kirk Cousins has agreed to a contract with the Raiders, the veteran QB's agent announced.",
       "link": "https://www.espn.com/nfl/story/_/id/48376719/kirk-cousins-agrees-sign-contract-raiders-agent-says",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "nfl-wire",
       "franchiseIds": [],
       "league": "theleague"
@@ -2805,7 +2818,7 @@
       "headline": "Kirk Cousins is signing with the Raiders, per his agent @MikeMcCartney7.",
       "body": "Kirk Cousins is signing with the Raiders, per his agent @MikeMcCartney7.",
       "link": "https://www.espn.com/contributor/adam-schefter/d2a3bfb4bad00",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "adam-schefter",
       "franchiseIds": [],
       "league": "theleague"
@@ -2818,7 +2831,7 @@
       "headline": "2026 NFL mock drafts: Latest ESPN player, team predictions",
       "body": "Here are our experts' NFL mock drafts for the 2026 cycle, including projected landing spots for all the top quarterbacks.",
       "link": "https://www.espn.com/nfl/draft2026/story/_/id/46028840/2026-nfl-mock-drafts-predictions-projections-kiper-yates-reid-miller",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -2831,7 +2844,7 @@
       "headline": "College flaws that could affect the 2026 NFL draft's top QBs",
       "body": "We've seen a lot during the college careers of the draft's top QBs. Each has something that could set them back.",
       "link": "https://www.espn.com/nfl/draft2026/story/_/id/48369237/nfl-draft-2026-flaws-top-quarterbacks-fernando-mendoza-ty-simpson",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -2844,7 +2857,7 @@
       "headline": "2026 NFL mock draft: Kiper, Miller, Reid, Yates on Rounds 1-3",
       "body": "We asked four NFL draft analysts -- Mel Kiper Jr., Matt Miller, Jordan Reid and Field Yates -- to make picks in the first three rounds. Where do the top prospects land?",
       "link": "https://www.espn.com/nfl/draft2026/story/_/id/48357214/2026-nfl-mock-draft-three-rounds-kiper-miller-reid-yates-predictions",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -2857,7 +2870,7 @@
       "headline": "Latest on Vikings' next GM, Kyler Murray and J.J. McCarthy",
       "body": "Here's what we learned during the NFL's annual league meeting in Phoenix this week.",
       "link": "https://www.espn.com/nfl/story/_/id/48370270/nfl-minnesota-vikings-kyler-murray-jj-mccarthy-gm-christian-darrisaw",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "nfl-wire",
       "franchiseIds": [],
       "league": "theleague"
@@ -2870,7 +2883,7 @@
       "headline": "WR Jaylen Waddle already fitting in with the Denver Broncos",
       "body": "Waddle is ready to elevate the Broncos' offense after Denver traded for him -- and join one of his college teammates in cornerback Pat Surtain II.",
       "link": "https://www.espn.com/nfl/story/_/id/48362374/jaylen-waddle-fits-denver-broncos-offseason-trade-big-play-threat-pat-surtain",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "nfl-wire",
       "franchiseIds": [],
       "league": "theleague"
@@ -2883,7 +2896,7 @@
       "headline": "Expected No. 1 Fernando Mendoza puts on show at Indiana pro day",
       "body": "Expected No. 1 pick Fernando Mendoza threw roughly 56 passes in front of scouts from all 32 NFL teams and more than 100 members of the media Wednesday.",
       "link": "https://www.espn.com/nfl/story/_/id/48372927/expected-no-1-fernando-mendoza-puts-show-indiana-pro-day",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -2896,7 +2909,7 @@
       "headline": "Rams wide receiver Puka Nacua is in rehab, attorney says",
       "body": "Rams wide receiver Puka Nacua has checked into rehab, his attorney told The California Post.",
       "link": "https://www.espn.com/nfl/story/_/id/48373078/los-angeles-rams-wide-receiver-puka-nacua-rehab-attorney-says",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "nfl-wire",
       "franchiseIds": [],
       "league": "theleague"
@@ -2909,7 +2922,7 @@
       "headline": "Los Angeles Rams wide receiver Puka Nacua has checked into rehab, his attorney, Levi McCathern, told The California Post.",
       "body": "Los Angeles Rams wide receiver Puka Nacua has checked into rehab, his attorney, Levi McCathern, told The California Post.",
       "link": "https://www.espn.com/contributor/adam-schefter/2714efcf3349f",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "adam-schefter",
       "franchiseIds": [],
       "league": "theleague"
@@ -2922,7 +2935,7 @@
       "headline": "Drake Maye channels Super Bowl Brady",
       "body": "Drake Maye shaved his head for charity, much like Tom Brady did right before winning a Super Bowl.",
       "link": "https://www.espn.com/video/clip?id=48372526",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "nfl-wire",
       "franchiseIds": [],
       "league": "theleague"
@@ -2935,7 +2948,7 @@
       "headline": "NFL mock draft simulator: ESPN Analytics tool for 2026",
       "body": "ESPN Analytics has released the NFL Draft Day Predictor, which powers the 2026 mock draft simulator tool. Play GM of your favorite team now.",
       "link": "https://www.espn.com/nfl/story/_/id/39920456/nfl-mock-draft-simulator-espn-analytics-tool-seven-rounds-every-pick",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -2948,7 +2961,7 @@
       "headline": "Stephen A. has some words about the saga going on with Jalen Hurts, Eagles",
       "body": "Stephen A. weighs in on the state of Jalen Hurts and the Eagles.",
       "link": "https://www.espn.com/video/clip?id=48369101",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "nfl-wire",
       "franchiseIds": [],
       "league": "theleague"
@@ -2961,7 +2974,7 @@
       "headline": "Do the Patriots need A.J. Brown?",
       "body": "The \"Get Up\" crew breaks down whether the Patriots should make a trade with the Eagles for A.J. Brown.",
       "link": "https://www.espn.com/video/clip?id=48368732",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "nfl-wire",
       "franchiseIds": [],
       "league": "theleague"
@@ -2974,7 +2987,7 @@
       "headline": "2026 NFL draft All-Film team: 11 prospects with upside",
       "body": "NFL scouts are watching a lot of tape as we get ready for the 2026 draft. Which underrated players jump off the screen? Ben Solak fills out his All-Film team.",
       "link": "https://www.espn.com/nfl/draft2026/story/_/id/48357403/2026-nfl-draft-all-tape-team-best-prospects-every-position-nussmeier-bernard-barham",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "ben-solak",
       "franchiseIds": [],
       "league": "theleague"
@@ -2987,7 +3000,7 @@
       "headline": "Inside Eagles' 2025 friction as Jalen Hurts stands at crossroads",
       "body": "ESPN pulls back the curtain on what's ailing a star-studded Eagles offense, one in which their QB must evolve.",
       "link": "https://www.espn.com/nfl/story/_/id/48224913/the-crossroad-awaits-quarterback-jalen-hurts-philadelphia-eagles-offense-aj-brown-2026",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "nfl-wire",
       "franchiseIds": [],
       "league": "theleague"
@@ -2998,9 +3011,9 @@
       "type": "external",
       "tier": "standard",
       "headline": "Jalen Hurts and the Eagles at a crossroads",
-      "body": "The Philadelphia Eagles’ offense has been disappointing, and it starts with quarterback Jalen Hurts. ESPN’s Tim McManus explains why the star player is at the center of the problem.",
+      "body": "The Philadelphia Eagles\u2019\u00a0offense has been disappointing, and it starts with quarterback Jalen Hurts. ESPN\u2019s Tim McManus explains why the star player is at the center of the problem.",
       "link": "https://www.espn.com/video/clip?id=48359421",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "nfl-wire",
       "franchiseIds": [],
       "league": "theleague"
@@ -3013,7 +3026,7 @@
       "headline": "Steelers' Rooney expects decision from Rodgers before draft",
       "body": "Steelers owner and team president Art Rooney II said Tuesday he anticipates a decision from four-time NFL MVP Aaron Rodgers about his future by next month's NFL Draft.",
       "link": "https://www.espn.com/nfl/story/_/id/48361976/steelers-expect-decision-rodgers-draft-rooney-says",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -3026,7 +3039,7 @@
       "headline": "Tiger Woods announced he's stepping away to seek treatment and focus on his health.",
       "body": "Tiger Woods announced he's stepping away to seek treatment and focus on his health.",
       "link": "https://www.espn.com/contributor/adam-schefter/46c1f22562012",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "adam-schefter",
       "franchiseIds": [],
       "league": "theleague"
@@ -3039,7 +3052,7 @@
       "headline": "Amon-Ra St. Brown: Lions game in Germany dream come true",
       "body": "When Detroit plays its international game in Munich next season, it will mark a dream fulfilled for the Lions WR.",
       "link": "https://www.espn.com/nfl/story/_/id/48360805/lions-amon-ra-st-brown-excited-play-germany-grow-nfl-abroad",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "nfl-wire",
       "franchiseIds": [],
       "league": "theleague"
@@ -3052,7 +3065,7 @@
       "headline": "Joe Burrow's flag football risks don't worry Bengals coach",
       "body": "Joe Burrow, whose injury history includes missing nine games last year, went all out in flag football.",
       "link": "https://www.espn.com/nfl/story/_/id/48359096/joe-burrow-flag-football-risks-worry-bengals-coach-zac-taylor",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "nfl-wire",
       "franchiseIds": [],
       "league": "theleague"
@@ -3065,7 +3078,7 @@
       "headline": "Buzz cut for a cause: Drake Maye debuts new look",
       "body": "Maye was a headline guest at the 13th annual \"Saving by Shaving\" event Tuesday, with proceeds benefiting Boston Children's Hospital.",
       "link": "https://www.espn.com/nfl/story/_/id/48358484/drake-maye-new-england-patriots-shaved-head-boston-childrens-hospital",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "nfl-wire",
       "franchiseIds": [],
       "league": "theleague"
@@ -3078,7 +3091,7 @@
       "headline": "Raiders' Klint Kubiak on Fernando Mendoza: 'He's a winner'",
       "body": "Raiders head coach Klint Kubiak had nothing but high praise for potential top overall pick and Heisman Trophy-winning quarterback Fernando Mendoza on Tuesday, calling him a \"winner.\"",
       "link": "https://www.espn.com/nfl/story/_/id/48358751/winner",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -3091,7 +3104,7 @@
       "headline": "Andy Reid on Patrick Mahomes Week 1 return: 'I would never bet against him'",
       "body": "Chiefs coach Andy Reid offered another positive update on Patrick Mahomes as enthusiasm continues to grow around the star quarterback's injury recovery.",
       "link": "https://www.espn.com/nfl/story/_/id/48358973/andy-reid-patrick-mahomes-week-1-return-never-bet-him",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "nfl-wire",
       "franchiseIds": [],
       "league": "theleague"
@@ -3104,7 +3117,7 @@
       "headline": "NFL owners have approved a Competition Committee proposal, for one year only, allowing the NFL Officiating Department to correct clear and obvious misses made by on-field officials that impact the game in the event replacement refs are used for the 2026 season.",
       "body": "NFL owners have approved a Competition Committee proposal, for one year only, allowing the NFL Officiating Department to correct clear and obvious misses made by on-field officials that impact the...",
       "link": "https://www.espn.com/contributor/adam-schefter/40269a1f6473a",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "adam-schefter",
       "franchiseIds": [],
       "league": "theleague"
@@ -3114,10 +3127,10 @@
       "timestamp": "2026-03-31T17:53:23.125Z",
       "type": "external",
       "tier": "standard",
-      "headline": "NFL owners have approved a rule change allowing the league to step in and assist on potential disqualifications, whether for flagrant football acts or non-football acts, and initiate a flag if one wasn’t thrown.\n\nSituations like DK Metcalf’s incident last year, where no flag meant no ejection, can now be addressed in real time.",
+      "headline": "NFL owners have approved a rule change allowing the league to step in and assist on potential disqualifications, whether for flagrant football acts or non-football acts, and initiate a flag if one wasn\u2019t thrown.\n\nSituations like DK Metcalf\u2019s incident last year, where no flag meant no ejection, can now be addressed in real time.",
       "body": "NFL owners have approved a rule change allowing the league to step in and assist on potential disqualifications, whether for flagrant football acts or non-football acts, and initiate a flag if one...",
       "link": "https://www.espn.com/contributor/adam-schefter/09d19b0e0f62c",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "adam-schefter",
       "franchiseIds": [],
       "league": "theleague"
@@ -3130,7 +3143,7 @@
       "headline": "Schefter to McAfee: The market for Anthony Richardson was soft",
       "body": "Adam Schefter joins Pat McAfee to report the latest on the Colts' plans for quarterback Anthony Richardson.",
       "link": "https://www.espn.com/video/clip?id=48358660",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "nfl-wire",
       "franchiseIds": [],
       "league": "theleague"
@@ -3143,7 +3156,7 @@
       "headline": "Aaron Glenn says QB Geno Smith will lead Jets to 'promised land'",
       "body": "Jets coach Aaron Glenn declared Tuesday that quarterback Geno Smith is \"the guy that's going to lead us to the promised land.\"",
       "link": "https://www.espn.com/nfl/story/_/id/48358334/aaron-glenn-says-qb-geno-smith-lead-jets-promised-land",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "nfl-wire",
       "franchiseIds": [],
       "league": "theleague"
@@ -3156,7 +3169,7 @@
       "headline": "Patriots' Mike Vrabel doesn't dismiss A.J. Brown trade talk",
       "body": "As speculation swirls, coach Mike Vrabel didn't rule out the possibility of the Patriots possibly acquiring receiver A.J. Brown in a trade with the Eagles.",
       "link": "https://www.espn.com/nfl/story/_/id/48358277/patriots-mike-vrabel-dismiss-aj-brown-trade-talk",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "nfl-wire",
       "franchiseIds": [],
       "league": "theleague"
@@ -3169,7 +3182,7 @@
       "headline": "Lamar Jackson may skip Ravens' offseason workouts, Minter says",
       "body": "Ravens coach Jesse Minter is unsure about quarterback Lamar Jackson's level of participation in the team's voluntary offseason workout program, which begins next week.",
       "link": "https://www.espn.com/nfl/story/_/id/48358217/ravens-qb-jackson-skip-offseason-workouts-minter-says",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "nfl-wire",
       "franchiseIds": [],
       "league": "theleague"
@@ -3182,7 +3195,7 @@
       "headline": "The question Stephen A. is facing with George Pickens' contract situation",
       "body": "Stephen A. Smith weighs in on the contract saga between George Pickens and the Cowboys.",
       "link": "https://www.espn.com/video/clip?id=48356886",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "nfl-wire",
       "franchiseIds": [],
       "league": "theleague"
@@ -3195,7 +3208,7 @@
       "headline": "Can Kyler Murray revitalize his career with the Vikings?",
       "body": "Dan Orlovsky and Dan Graziano discuss the process Kyler Murray and the Vikings will have to take to transition him into a new style of offense.",
       "link": "https://www.espn.com/video/clip?id=48356457",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "nfl-wire",
       "franchiseIds": [],
       "league": "theleague"
@@ -3208,7 +3221,7 @@
       "headline": "2026 NFL draft position rankings: Kiper, Miller, Reid, Yates",
       "body": "Who are the best players at every position? Our analysts give their top-fives, plus their combined overall top-10 ranking for the 2026 class.",
       "link": "https://www.espn.com/nfl/draft2026/story/_/id/46149416/2026-nfl-draft-rankings-top-prospects-position",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -3221,7 +3234,7 @@
       "headline": "2026 NFL draft: Favorite team fits for 20 top prospects",
       "body": "We took 20 NFL draft prospects who could get picked in Rounds 1 and 2 and found ideal scheme matches based on what each player does best.",
       "link": "https://www.espn.com/nfl/draft2026/story/_/id/48346957/2026-nfl-draft-favorite-team-fits-20-top-prospects-reese-love-simpson",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -3234,7 +3247,7 @@
       "headline": "Will lack of starts affect QB Ty Simpson's NFL draft status?",
       "body": "The Alabama product is regarded as the 2026 draft's QB2 despite having far fewer starts than most first-round signal-callers.",
       "link": "https://www.espn.com/nfl/draft2026/story/_/id/48349533/nfl-draft-quarterback-starts-threshold-lack-success-ty-simpson",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -3244,10 +3257,10 @@
       "timestamp": "2026-03-31T01:30:51.88Z",
       "type": "external",
       "tier": "standard",
-      "headline": "The Seahawks will be featured on this summer’s Hard Knocks.\n\nThe Patriots will be featured on the 2027 summer Hard Knocks.\n\nThe two teams in this past season’s Super Bowl will take center stage again the next two summers.",
-      "body": "The Seahawks will be featured on this summer’s Hard Knocks.\n\nThe Patriots will be featured on the 2027 summer Hard Knocks.\n\nThe two teams in this past season’s Super Bowl will take center stage again...",
+      "headline": "The Seahawks will be featured on this summer\u2019s Hard Knocks.\n\nThe Patriots will be featured on the 2027 summer Hard Knocks.\n\nThe two teams in this past season\u2019s Super Bowl will take center stage again the next two summers.",
+      "body": "The Seahawks will be featured on this summer\u2019s Hard Knocks.\n\nThe Patriots will be featured on the 2027 summer Hard Knocks.\n\nThe two teams in this past season\u2019s Super Bowl will take center stage again...",
       "link": "https://www.espn.com/contributor/adam-schefter/cc6e9c3623b81",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "adam-schefter",
       "franchiseIds": [],
       "league": "theleague"
@@ -3260,7 +3273,7 @@
       "headline": "Jaguars to balance Travis Hunter's daily reps in OTAs",
       "body": "Whenever Jacksonville Jaguars cornerback Travis Hunter is cleared to return to the practice field this spring, he will be spending more time each day taking reps on both sides of the ball.",
       "link": "https://www.espn.com/nfl/story/_/id/48350773/jaguars-balance-travis-hunter-daily-reps-otas",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "nfl-wire",
       "franchiseIds": [],
       "league": "theleague"
@@ -3273,7 +3286,7 @@
       "headline": "Haslam: Deshaun Watson has 'great chance' to be Browns' starter",
       "body": "One year after calling the trade for Deshaun Watson a \"big swing-and-miss,\" Browns owner Jimmy Haslam said the quarterback has a \"fresh start\" with new coach Todd Monken.",
       "link": "https://www.espn.com/nfl/story/_/id/48350090/haslam-deshaun-watson-great-chance-browns-starter",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "nfl-wire",
       "franchiseIds": [],
       "league": "theleague"
@@ -3286,7 +3299,7 @@
       "headline": "Vikings to exercise fifth-year option on Jordan Addison's deal",
       "body": "The Vikings will exercise the fifth-year option on receiver Jordan Addison's contract, interim general manager Rob Brzezinski said Monday.",
       "link": "https://www.espn.com/nfl/story/_/id/48350724/vikings-exercise-fifth-year-option-jordan-addison-deal",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "nfl-wire",
       "franchiseIds": [],
       "league": "theleague"
@@ -3299,7 +3312,7 @@
       "headline": "McCarthy says Aaron Rodgers in good place as he weighs future",
       "body": "Steelers coach Mike McCarthy said Aaron Rodgers is in a \"very positive space\" and that he's comfortable with the talks they've had as Rodgers weighs his future.",
       "link": "https://www.espn.com/nfl/story/_/id/48349900/mccarthy-says-aaron-rodgers-good-place-weighs-future",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "nfl-wire",
       "franchiseIds": [],
       "league": "theleague"
@@ -3312,7 +3325,7 @@
       "headline": "2026 NFL draft rankings: Scouts Inc.'s full board, grades",
       "body": "Here are Scouts Inc.'s 2026 NFL draft rankings, with evaluation grades for the top prospects.",
       "link": "https://www.espn.com/nfl/draft2026/story/_/id/48349812/2026-nfl-draft-rankings-top-prospects-scouts-inc-grades",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "nfl-draft",
       "franchiseIds": [],
       "league": "theleague"
@@ -3325,7 +3338,7 @@
       "headline": "Fernando Mendoza: 2026 NFL draft scouting report, QB ranking",
       "body": "Mendoza is the top quarterback in the 2026 draft class. What are his strengths and weaknesses, and will he go No. 1?",
       "link": "https://www.espn.com/nfl/draft2026/story/_/id/47745045/fernando-mendoza-quarterback-indiana-2026-nfl-draft-scouting-report-rankings-stats",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "jordan-reid",
       "franchiseIds": [],
       "league": "theleague"
@@ -3338,7 +3351,7 @@
       "headline": "Shedeur Sanders changes number back to 2 for 2026 season",
       "body": "The Cleveland Browns announced Monday that the second-year quarterback will return to the No. 2 jersey for the 2026 season.",
       "link": "https://www.espn.com/nfl/story/_/id/48349319/shedeur-sanders-cleveland-browns-number-change-no-2-uniform",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "nfl-wire",
       "franchiseIds": [],
       "league": "theleague"
@@ -3351,7 +3364,7 @@
       "headline": "Schrager talks with McAfee about Rams' trade discussions on Davante Adams",
       "body": "Peter Schrager joins \"The Pat McAfee Show\" to talk about Sean McVay acknowledging the Rams had trade discussions surrounding Davante Adams.",
       "link": "https://www.espn.com/video/clip?id=48348787",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "nfl-wire",
       "franchiseIds": [],
       "league": "theleague"
@@ -3364,7 +3377,7 @@
       "headline": "2026 NFL draft Big Board rankings: Mel Kiper's top prospects",
       "body": "Mel Kiper Jr. is stacking the best players in the NFL draft class, starting with Fernando Mendoza. Who makes the top 25?",
       "link": "https://www.espn.com/nfl/draft2026/story/_/id/46573669/2026-nfl-draft-rankings-mel-kiper-big-board-top-prospects-players-positions",
-      "linkLabel": "Read draft analysis →",
+      "linkLabel": "Read draft analysis \u2192",
       "authorId": "mel-kiper",
       "franchiseIds": [],
       "league": "theleague"
@@ -3377,7 +3390,7 @@
       "headline": "The Super Bowl is returning to Las Vegas in 2029, per sources. It now has been officially approved.",
       "body": "The Super Bowl is returning to Las Vegas in 2029, per sources. It now has been officially approved.",
       "link": "https://www.espn.com/contributor/adam-schefter/fec82e676e5d6",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "adam-schefter",
       "franchiseIds": [],
       "league": "theleague"
@@ -3404,7 +3417,7 @@
       "headline": "Tiger Woods was arrested and charged with DUI, property damage and refusal to submit, per the Martin County Sheriff in Florida.",
       "body": "Tiger Woods was arrested and charged with DUI, property damage and refusal to submit, per the Martin County Sheriff in Florida.",
       "link": "https://www.espn.com/contributor/adam-schefter/e4cfc52116620",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "adam-schefter",
       "franchiseIds": [],
       "league": "theleague"
@@ -3431,7 +3444,7 @@
       "headline": "Bills re-signed S Damar Hamlin to a one-year deal.",
       "body": "Bills re-signed S Damar Hamlin to a one-year deal.",
       "link": "https://www.espn.com/contributor/adam-schefter/3f7ecb41244de",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "adam-schefter",
       "franchiseIds": [],
       "league": "theleague"
@@ -3466,15 +3479,15 @@
       "league": "theleague",
       "authorId": "claude",
       "intro": [
-        "<p>Boom! The 2026 offseason auction is in the books, and I'm told the league saw some brilliant roster construction, some head-scratching overpays, and one franchise that nearly catastrophically failed hole-filling. I've graded every single team based on hole-filling (the most critical factor), value acquisition, lineup quality, and cap management. Money is nice, but championships are better—and some of these rosters just got a whole lot closer to one.</p>",
-        "<p>Let me be clear: teams that walked away with critical lineup gaps still unfilled—especially at QB, RB, WR, TE, or PK—took major hits on their grades. That's non-negotiable in dynasty football. Let's break down who won this auction and who's already sweating in-season free agency.</p>"
+        "<p>Boom! The 2026 offseason auction is in the books, and I'm told the league saw some brilliant roster construction, some head-scratching overpays, and one franchise that nearly catastrophically failed hole-filling. I've graded every single team based on hole-filling (the most critical factor), value acquisition, lineup quality, and cap management. Money is nice, but championships are better\u2014and some of these rosters just got a whole lot closer to one.</p>",
+        "<p>Let me be clear: teams that walked away with critical lineup gaps still unfilled\u2014especially at QB, RB, WR, TE, or PK\u2014took major hits on their grades. That's non-negotiable in dynasty football. Let's break down who won this auction and who's already sweating in-season free agency.</p>"
       ],
       "grades": [
         {
           "franchiseId": "0012",
           "grade": "A+",
           "headline": "Vitside Mafia dominates with elite TEs and QB depth",
-          "body": "<p><strong>Vitside Mafia</strong> came in with a critical hole at PK and nothing at the TE position, and they absolutely addressed both without overpaying. League sources tell me they nailed the value on <strong>George Kittle</strong> at $7M—elite production at a reasonable price. The <strong>Josh Allen</strong> acquisition at $9M is the crown jewel of this entire auction: top-3 QB in dynasty, locked and loaded at a deal relative to the $10M ceiling we saw elsewhere.</p><p>They added <strong>Javonte Williams</strong> ($4.6M), <strong>Matthew Stafford</strong> ($3.775M), and three more TEs to build a legitimate depth chart. <strong>Cameron Dicker</strong> filled the PK hole. Post-auction, they have four QBs and five TEs—legitimate redundancy for playoffs. Only $2.442M remaining is slightly tight, but they dominated hole-filling. This is a championship-contending roster.</p>",
+          "body": "<p><strong>Vitside Mafia</strong> came in with a critical hole at PK and nothing at the TE position, and they absolutely addressed both without overpaying. League sources tell me they nailed the value on <strong>George Kittle</strong> at $7M\u2014elite production at a reasonable price. The <strong>Josh Allen</strong> acquisition at $9M is the crown jewel of this entire auction: top-3 QB in dynasty, locked and loaded at a deal relative to the $10M ceiling we saw elsewhere.</p><p>They added <strong>Javonte Williams</strong> ($4.6M), <strong>Matthew Stafford</strong> ($3.775M), and three more TEs to build a legitimate depth chart. <strong>Cameron Dicker</strong> filled the PK hole. Post-auction, they have four QBs and five TEs\u2014legitimate redundancy for playoffs. Only $2.442M remaining is slightly tight, but they dominated hole-filling. This is a championship-contending roster.</p>",
           "teamName": "Vitside Mafia",
           "abbrev": "VIT",
           "color": "#f06abc",
@@ -3597,7 +3610,7 @@
           "franchiseId": "0011",
           "grade": "A-",
           "headline": "Midwestside Connection steals Amon-Ra at perfect price",
-          "body": "<p><strong>Midwestside Connection</strong> spent just $16.575M on four players and came away with dynasty gold. <strong>Amon-Ra St. Brown</strong> at $10M is the top-priced player in the entire auction, but league sources confirm he's the rare exception where the price is justified—you're paying for top-5 WR upside in a league where elite WRs command premium dollars.</p><p><strong>Justin Herbert</strong> at $5.25M is a textbook steal—quality QB1 who slipped through the cracks. <strong>Kareem Hunt</strong> at $750K is borderline robbery. They didn't fill any critical holes because they didn't have any, and they positioned themselves with $12.581M in remaining cap—the most flexibility of any team. Minimal risk, maximum upside. Nitpick: they're still thin at WR (only three on roster), but depth can come via waivers.</p>",
+          "body": "<p><strong>Midwestside Connection</strong> spent just $16.575M on four players and came away with dynasty gold. <strong>Amon-Ra St. Brown</strong> at $10M is the top-priced player in the entire auction, but league sources confirm he's the rare exception where the price is justified\u2014you're paying for top-5 WR upside in a league where elite WRs command premium dollars.</p><p><strong>Justin Herbert</strong> at $5.25M is a textbook steal\u2014quality QB1 who slipped through the cracks. <strong>Kareem Hunt</strong> at $750K is borderline robbery. They didn't fill any critical holes because they didn't have any, and they positioned themselves with $12.581M in remaining cap\u2014the most flexibility of any team. Minimal risk, maximum upside. Nitpick: they're still thin at WR (only three on roster), but depth can come via waivers.</p>",
           "teamName": "Midwestside Connection",
           "abbrev": "MWS",
           "color": "#ffcd00",
@@ -3636,7 +3649,7 @@
           "franchiseId": "0009",
           "grade": "A-",
           "headline": "Wascawy Wabbits lock in Justin Jefferson, stay disciplined",
-          "body": "<p><strong>Wascawy Wabbits</strong> came in with a balanced roster and no critical holes—they played chess, not checkers. <strong>Justin Jefferson</strong> at $9.80M is the second-highest price in the auction and absolutely earned it. Adding <strong>DK Metcalf</strong> at $2.05M is a steal—same caliber player, went for less than one-third Jefferson's price. That's the kind of value hunting that wins championships.</p><p><strong>Trevor Lawrence</strong> at $4.2M gives them a young QB1. They added depth at TE with <strong>Hunter Henry</strong> ($1.5M). Total spend: $17.975M with $4.322M remaining. They didn't chase their holes because they didn't have any—they chased premium talent at reasonable prices. Disciplined roster construction.</p>",
+          "body": "<p><strong>Wascawy Wabbits</strong> came in with a balanced roster and no critical holes\u2014they played chess, not checkers. <strong>Justin Jefferson</strong> at $9.80M is the second-highest price in the auction and absolutely earned it. Adding <strong>DK Metcalf</strong> at $2.05M is a steal\u2014same caliber player, went for less than one-third Jefferson's price. That's the kind of value hunting that wins championships.</p><p><strong>Trevor Lawrence</strong> at $4.2M gives them a young QB1. They added depth at TE with <strong>Hunter Henry</strong> ($1.5M). Total spend: $17.975M with $4.322M remaining. They didn't chase their holes because they didn't have any\u2014they chased premium talent at reasonable prices. Disciplined roster construction.</p>",
           "teamName": "Wascawy Wabbits",
           "abbrev": "WABS",
           "color": "#5c5c5c",
@@ -3680,7 +3693,7 @@
           "franchiseId": "0006",
           "grade": "B+",
           "headline": "Music City Mafia fills gaps, leaves cap space on table",
-          "body": "<p><strong>Music City Mafia</strong> came in critically thin at TE and missing PK entirely. They fixed both: <strong>Kyle Pitts</strong> at $4.5M checks the TE box with elite upside, and <strong>Jason Sanders</strong> ($425K) is negligible PK cost. Adding <strong>DeVonta Smith</strong> ($6.525M) and <strong>Jordan Mason</strong> ($3.1M) gives them skill position depth across the board.</p><p>Here's the issue: they spent only $20.35M and left $8.827M on the table—the highest remaining cap space in the league. Money is nice, but championships are better. They could've added another elite player or depth piece and didn't. Safe bidding? Sure. But in dynasty, you spend to win. They fixed their holes, but they underspent relative to their competition.</p>",
+          "body": "<p><strong>Music City Mafia</strong> came in critically thin at TE and missing PK entirely. They fixed both: <strong>Kyle Pitts</strong> at $4.5M checks the TE box with elite upside, and <strong>Jason Sanders</strong> ($425K) is negligible PK cost. Adding <strong>DeVonta Smith</strong> ($6.525M) and <strong>Jordan Mason</strong> ($3.1M) gives them skill position depth across the board.</p><p>Here's the issue: they spent only $20.35M and left $8.827M on the table\u2014the highest remaining cap space in the league. Money is nice, but championships are better. They could've added another elite player or depth piece and didn't. Safe bidding? Sure. But in dynasty, you spend to win. They fixed their holes, but they underspent relative to their competition.</p>",
           "teamName": "Music City Mafia",
           "abbrev": "MUSIC",
           "color": "#4b92db",
@@ -3733,7 +3746,7 @@
           "franchiseId": "0008",
           "grade": "B+",
           "headline": "Bring The Pain capitalizes on Saquon, but minimal spending",
-          "body": "<p><strong>Bring The Pain</strong> came in with abundance at WR and TE but only three RBs on roster—extremely thin at the position. They solved it elegantly: <strong>Saquon Barkley</strong> at $7.2M is the sixth-most expensive player in the auction. Money is nice, but you need an RB1, and Barkley is exactly that. Adding depth with <strong>Jalen Nailor</strong> at $725K helps, and <strong>New Orleans Saints</strong> defense at $1.225M filled their Def gap.</p><p>They spent just $9.15M total and walked away with only three acquisitions. With $6.788M remaining, they left significant value on the table. They didn't address any true critical holes—their roster was already strong—but for a team that was TE and WR loaded, this was efficient. Not aggressive enough for an A, but they nailed the one gap they had.</p>",
+          "body": "<p><strong>Bring The Pain</strong> came in with abundance at WR and TE but only three RBs on roster\u2014extremely thin at the position. They solved it elegantly: <strong>Saquon Barkley</strong> at $7.2M is the sixth-most expensive player in the auction. Money is nice, but you need an RB1, and Barkley is exactly that. Adding depth with <strong>Jalen Nailor</strong> at $725K helps, and <strong>New Orleans Saints</strong> defense at $1.225M filled their Def gap.</p><p>They spent just $9.15M total and walked away with only three acquisitions. With $6.788M remaining, they left significant value on the table. They didn't address any true critical holes\u2014their roster was already strong\u2014but for a team that was TE and WR loaded, this was efficient. Not aggressive enough for an A, but they nailed the one gap they had.</p>",
           "teamName": "Bring The Pain",
           "abbrev": "PAIN",
           "color": "#1a1a1a",
@@ -3767,7 +3780,7 @@
           "franchiseId": "0002",
           "grade": "B",
           "headline": "Da Dangsters dominate skill positions, ignore lineup depth",
-          "body": "<p><strong>Da Dangsters</strong> came to this auction already stacked with 18 pre-auction players and only $21.57M cap space. They made a statement: <strong>CeeDee Lamb</strong> at $9.5M is the fourth-highest price in the entire auction. Adding <strong>Tee Higgins</strong> ($4.525M) and <strong>Tony Pollard</strong> ($2.75M) gives them absolute firepower at the skill positions.</p><p>But here's the problem: they came in with zero critical holes and went deeper into strength-based roster construction rather than building true championship redundancy. They didn't need these players—they wanted them. Spent $18.45M with only $3.12M remaining, the lowest cap space of any team. Smart value on individual pieces? Yes. Smart overall strategy? They're one injury away from disaster with no flexibility for in-season moves. Greedy roster construction.</p>",
+          "body": "<p><strong>Da Dangsters</strong> came to this auction already stacked with 18 pre-auction players and only $21.57M cap space. They made a statement: <strong>CeeDee Lamb</strong> at $9.5M is the fourth-highest price in the entire auction. Adding <strong>Tee Higgins</strong> ($4.525M) and <strong>Tony Pollard</strong> ($2.75M) gives them absolute firepower at the skill positions.</p><p>But here's the problem: they came in with zero critical holes and went deeper into strength-based roster construction rather than building true championship redundancy. They didn't need these players\u2014they wanted them. Spent $18.45M with only $3.12M remaining, the lowest cap space of any team. Smart value on individual pieces? Yes. Smart overall strategy? They're one injury away from disaster with no flexibility for in-season moves. Greedy roster construction.</p>",
           "teamName": "Da Dangsters",
           "abbrev": "DANG",
           "color": "#8b6914",
@@ -3811,7 +3824,7 @@
           "franchiseId": "0001",
           "grade": "B-",
           "headline": "Pacific Pigskins go QB-crazy with three late-round pickups",
-          "body": "<p><strong>Pacific Pigskins</strong> came in desperately needing WRs (only five on roster) and addressing that was smart: <strong>Jaylen Waddle</strong> ($5.575M), <strong>D.J. Moore</strong> ($3.25M), <strong>Davante Adams</strong> ($3.125M), and <strong>Parker Washington</strong> ($2M). They fixed their WR gap with four acquisitions and decent value spreads.</p><p>Then they completely lost the plot. League sources tell me they drafted three QBs in this auction: <strong>Lamar Jackson</strong> ($5M), <strong>Jared Goff</strong> ($3.4M), and <strong>Sam Darnold</strong> ($3.25M). That's $11.65M spent on depth at a position where three QBs are depth suicide in any league. They added <strong>T.J. Hockenson</strong>, <strong>Rico Dowdle</strong>, and <strong>Jaylen Warren</strong> for value. Final tally: $32.75M spent with only $2.252M remaining—virtually zero flexibility. They have four QBs on one roster. That's insanity, not depth.</p>",
+          "body": "<p><strong>Pacific Pigskins</strong> came in desperately needing WRs (only five on roster) and addressing that was smart: <strong>Jaylen Waddle</strong> ($5.575M), <strong>D.J. Moore</strong> ($3.25M), <strong>Davante Adams</strong> ($3.125M), and <strong>Parker Washington</strong> ($2M). They fixed their WR gap with four acquisitions and decent value spreads.</p><p>Then they completely lost the plot. League sources tell me they drafted three QBs in this auction: <strong>Lamar Jackson</strong> ($5M), <strong>Jared Goff</strong> ($3.4M), and <strong>Sam Darnold</strong> ($3.25M). That's $11.65M spent on depth at a position where three QBs are depth suicide in any league. They added <strong>T.J. Hockenson</strong>, <strong>Rico Dowdle</strong>, and <strong>Jaylen Warren</strong> for value. Final tally: $32.75M spent with only $2.252M remaining\u2014virtually zero flexibility. They have four QBs on one roster. That's insanity, not depth.</p>",
           "teamName": "Pacific Pigskins",
           "abbrev": "SKINS",
           "color": "#cc2936",
@@ -3890,7 +3903,7 @@
           "franchiseId": "0003",
           "grade": "B-",
           "headline": "Maverick fills TE/PK holes, leaves massive cap gap",
-          "body": "<p><strong>Maverick</strong> came in with two critical holes: zero TEs and zero PKs on an eight-WR deep roster. They fixed both: <strong>Colby Parkinson</strong> ($2.775M) and <strong>Brandon Aubrey</strong> ($1.425M). Adding QB depth with <strong>Patrick Mahomes</strong> ($4.775M) and <strong>Baker Mayfield</strong> ($3.35M) was sensible, and <strong>Travis Etienne</strong> ($3.25M) addresses RB scarcity.</p><p>They spent $17.65M and left $10.319M on the table—second-highest remaining cap in the league. They had the third-most cap space pre-auction ($27.969M) and still underspent relative to their advantage. With a league average around $20.35M spent per team, Maverick played far too conservative. They filled their holes, sure, but didn't capitalize on their cap advantage to add another elite piece. Passive bidding from a team that could've been aggressive.</p>",
+          "body": "<p><strong>Maverick</strong> came in with two critical holes: zero TEs and zero PKs on an eight-WR deep roster. They fixed both: <strong>Colby Parkinson</strong> ($2.775M) and <strong>Brandon Aubrey</strong> ($1.425M). Adding QB depth with <strong>Patrick Mahomes</strong> ($4.775M) and <strong>Baker Mayfield</strong> ($3.35M) was sensible, and <strong>Travis Etienne</strong> ($3.25M) addresses RB scarcity.</p><p>They spent $17.65M and left $10.319M on the table\u2014second-highest remaining cap in the league. They had the third-most cap space pre-auction ($27.969M) and still underspent relative to their advantage. With a league average around $20.35M spent per team, Maverick played far too conservative. They filled their holes, sure, but didn't capitalize on their cap advantage to add another elite piece. Passive bidding from a team that could've been aggressive.</p>",
           "teamName": "Maverick",
           "abbrev": "MAVS",
           "color": "#c4b060",
@@ -3950,7 +3963,7 @@
           "franchiseId": "0016",
           "grade": "B-",
           "headline": "Running down the Dream adds WR/TE, barely spends anything",
-          "body": "<p><strong>Running down the Dream</strong> came in with critical TE thinness (only one on roster) and addressed it: <strong>Nico Collins</strong> at $9M is aggressive spending for a team already at $30.944M committed, and <strong>David Njoku</strong> ($650K) fills the TE gap. Adding <strong>Baltimore Ravens</strong> defense ($1.05M) checks another box.</p><p>They spent just $11.125M total on four players, leaving $2.931M remaining—dangerously low. The real problem: they came in with the third-most committed money in the entire league and essentially coasted through the auction. They didn't fill any critical gaps beyond TE depth, and they have zero cap flexibility now. This is a mediocre roster that overspent on one player (<strong>Collins</strong>) and underinvested everywhere else. Desperate, not strategic.</p>",
+          "body": "<p><strong>Running down the Dream</strong> came in with critical TE thinness (only one on roster) and addressed it: <strong>Nico Collins</strong> at $9M is aggressive spending for a team already at $30.944M committed, and <strong>David Njoku</strong> ($650K) fills the TE gap. Adding <strong>Baltimore Ravens</strong> defense ($1.05M) checks another box.</p><p>They spent just $11.125M total on four players, leaving $2.931M remaining\u2014dangerously low. The real problem: they came in with the third-most committed money in the entire league and essentially coasted through the auction. They didn't fill any critical gaps beyond TE depth, and they have zero cap flexibility now. This is a mediocre roster that overspent on one player (<strong>Collins</strong>) and underinvested everywhere else. Desperate, not strategic.</p>",
           "teamName": "Running down the Dream",
           "abbrev": "DREAM",
           "color": "#3498db",
@@ -3989,7 +4002,7 @@
           "franchiseId": "0015",
           "grade": "B-",
           "headline": "Dark Magicians of Chaos underspend, barely move needle",
-          "body": "<p><strong>Dark Magicians of Chaos</strong> came in already stacked at TE (four on roster) and WR (seven on roster), but critically thin at RB—only two players. They addressed that: <strong>Brian Robinson</strong> ($800K) is cheap depth. More concerning: they added four QBs total (including acquisitions) to a league where one is plenty, and spent $8.85M on just four players with $5.059M remaining.</p><p>This team didn't need the auction. They spent minimally, didn't address real gaps strategically, and left mid-tier talent on the board. <strong>Mark Andrews</strong> at $4M and <strong>Dak Prescott</strong> at $3.525M are fine, but they didn't move the needle meaningfully. For a team already at $31.091M committed with massive strength at skill positions, this was coasting into the offseason hoping waivers save them. Passive approach to roster construction.</p>",
+          "body": "<p><strong>Dark Magicians of Chaos</strong> came in already stacked at TE (four on roster) and WR (seven on roster), but critically thin at RB\u2014only two players. They addressed that: <strong>Brian Robinson</strong> ($800K) is cheap depth. More concerning: they added four QBs total (including acquisitions) to a league where one is plenty, and spent $8.85M on just four players with $5.059M remaining.</p><p>This team didn't need the auction. They spent minimally, didn't address real gaps strategically, and left mid-tier talent on the board. <strong>Mark Andrews</strong> at $4M and <strong>Dak Prescott</strong> at $3.525M are fine, but they didn't move the needle meaningfully. For a team already at $31.091M committed with massive strength at skill positions, this was coasting into the offseason hoping waivers save them. Passive approach to roster construction.</p>",
           "teamName": "Dark Magicians of Chaos",
           "abbrev": "DMOC",
           "color": "#9b30ff",
@@ -4072,7 +4085,7 @@
           "franchiseId": "0014",
           "grade": "C+",
           "headline": "Cowboy Up adds QB depth aggressively, undervalues positions",
-          "body": "<p><strong>Cowboy Up</strong> came in with 20 pre-auction players—already massive—and added six QBs total post-auction (three more acquired). League sources confirm this is dysfunction: <strong>Joe Burrow</strong> ($6.075M), <strong>Justin Fields</strong> ($675K), and <strong>Joe Flacco</strong> ($425K). Three QBs in one auction while holding three pre-auction. That's roster cancer, not depth.</p><p>They did add solid RB depth with <strong>Josh Jacobs</strong> ($4.025M) and <strong>Christian Kirk</strong> ($600K) at WR. But they spent $12.775M on seven players and left $10.542M on the table while over-investing in a redundant position. Final roster: six QBs, seven RBs, seven WRs. The QB situation alone sinks this grade. You cannot carry that many signal-callers in dynasty and expect to compete. Reckless spending allocation.</p>",
+          "body": "<p><strong>Cowboy Up</strong> came in with 20 pre-auction players\u2014already massive\u2014and added six QBs total post-auction (three more acquired). League sources confirm this is dysfunction: <strong>Joe Burrow</strong> ($6.075M), <strong>Justin Fields</strong> ($675K), and <strong>Joe Flacco</strong> ($425K). Three QBs in one auction while holding three pre-auction. That's roster cancer, not depth.</p><p>They did add solid RB depth with <strong>Josh Jacobs</strong> ($4.025M) and <strong>Christian Kirk</strong> ($600K) at WR. But they spent $12.775M on seven players and left $10.542M on the table while over-investing in a redundant position. Final roster: six QBs, seven RBs, seven WRs. The QB situation alone sinks this grade. You cannot carry that many signal-callers in dynasty and expect to compete. Reckless spending allocation.</p>",
           "teamName": "Cowboy Up",
           "abbrev": "CBOY",
           "color": "#0d2b56",
@@ -4126,7 +4139,7 @@
           "franchiseId": "0004",
           "grade": "C",
           "headline": "Dead Cap Walking goes on spending spree, lacks cohesion",
-          "body": "<p><strong>Dead Cap Walking</strong> came in critically thin at RB and TE (only one of each) and absolutely went hunting. They spent $9.975M on 13 players—the most acquisitions of any franchise—adding <strong>Rhamondre Stevenson</strong> ($1.8M), <strong>Tank Bigsby</strong> ($975K), <strong>Kimani Vidal</strong> ($775K), <strong>Malik Davis</strong> ($550K), and <strong>Devin Singletary</strong> ($450K) at RB. That's five RBs added in one auction to fill one roster gap.</p><p>They also grabbed <strong>Dawson Knox</strong> ($775K) at TE. The problem: they built by volume, not value. With 13 new additions to an already-small roster, they'll have waiver headaches managing who to keep. They addressed their gaps, but the execution was chaotic. This roster needs significant culling before playoffs. With $12.85M remaining, they had room to be more selective. Grade reflects some hole-filling, massive inefficiency in execution.</p>",
+          "body": "<p><strong>Dead Cap Walking</strong> came in critically thin at RB and TE (only one of each) and absolutely went hunting. They spent $9.975M on 13 players\u2014the most acquisitions of any franchise\u2014adding <strong>Rhamondre Stevenson</strong> ($1.8M), <strong>Tank Bigsby</strong> ($975K), <strong>Kimani Vidal</strong> ($775K), <strong>Malik Davis</strong> ($550K), and <strong>Devin Singletary</strong> ($450K) at RB. That's five RBs added in one auction to fill one roster gap.</p><p>They also grabbed <strong>Dawson Knox</strong> ($775K) at TE. The problem: they built by volume, not value. With 13 new additions to an already-small roster, they'll have waiver headaches managing who to keep. They addressed their gaps, but the execution was chaotic. This roster needs significant culling before playoffs. With $12.85M remaining, they had room to be more selective. Grade reflects some hole-filling, massive inefficiency in execution.</p>",
           "teamName": "Dead Cap Walking",
           "abbrev": "DEAD",
           "color": "#65b32e",
@@ -4210,7 +4223,7 @@
           "franchiseId": "0005",
           "grade": "C-",
           "headline": "Mariachi Ninjas barely spend, leave massive gaps unfilled",
-          "body": "<p><strong>The Mariachi Ninjas</strong> came in at $31.395M committed—fourth-highest in the league—with one critical hole at PK (zero on roster). They were already loaded at RB, WR, and TE. League sources confirm they essentially didn't bid: <strong>Dallas Goedert</strong> ($5M) is elite TE redundancy they didn't need, <strong>Tua Tagovailoa</strong> ($1.9M) is QB depth, and they grabbed <strong>Jake Elliott</strong> ($425K) and <strong>Charlie Smyth</strong> ($425K) to fill PK. Added <strong>Noah Gray</strong> ($1M) at TE.</p><p>They spent $9.525M and left $4.08M remaining—dangerously low for a league-high committed team. This roster was already constructed; they just needed a PK, and they could've dominated elsewhere but didn't. They treated this auction like an obligation, not an opportunity. Minimal value added relative to their pre-auction position of strength.</p>",
+          "body": "<p><strong>The Mariachi Ninjas</strong> came in at $31.395M committed\u2014fourth-highest in the league\u2014with one critical hole at PK (zero on roster). They were already loaded at RB, WR, and TE. League sources confirm they essentially didn't bid: <strong>Dallas Goedert</strong> ($5M) is elite TE redundancy they didn't need, <strong>Tua Tagovailoa</strong> ($1.9M) is QB depth, and they grabbed <strong>Jake Elliott</strong> ($425K) and <strong>Charlie Smyth</strong> ($425K) to fill PK. Added <strong>Noah Gray</strong> ($1M) at TE.</p><p>They spent $9.525M and left $4.08M remaining\u2014dangerously low for a league-high committed team. This roster was already constructed; they just needed a PK, and they could've dominated elsewhere but didn't. They treated this auction like an obligation, not an opportunity. Minimal value added relative to their pre-auction position of strength.</p>",
           "teamName": "The Mariachi Ninjas",
           "abbrev": "NINJA",
           "color": "#006847",
@@ -4330,7 +4343,7 @@
       "headline": "The 2026 NFL regular season will kick off Wednesday Sept. 9 at 8:20 p.m. ET in Seattle with the Super Bowl LX champion S",
       "body": "The 2026 NFL regular season will kick off Wednesday Sept. 9 at 8:20 p.m. ET in Seattle with the Super Bowl LX champion Seahawks.\n\nThe San Francisco 49ers will face the Los Angeles Rams in the...",
       "link": "https://www.espn.com/contributor/adam-schefter/60a6d72262013",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "adam-schefter",
       "franchiseIds": [],
       "league": "theleague"
@@ -4343,7 +4356,7 @@
       "headline": "The 49ers and Rams will play Thursday, Sept. 10 at 5:35 p.m. PT at the Melbourne Cricket Ground in Australia. Due to the",
       "body": "The 49ers and Rams will play Thursday, Sept. 10 at 5:35 p.m. PT at the Melbourne Cricket Ground in Australia.",
       "link": "https://www.espn.com/contributor/adam-schefter/d46bdcf3211ef",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "adam-schefter",
       "franchiseIds": [],
       "league": "theleague"
@@ -4353,10 +4366,10 @@
       "timestamp": "2026-03-25T18:25:06.6Z",
       "type": "external",
       "tier": "standard",
-      "headline": "There will be no discussion about the Tush Push at next week’s NFL owners’ meetings; the play will be back in 2026.",
-      "body": "There will be no discussion about the Tush Push at next week’s NFL owners’ meetings; the play will be back in 2026.",
+      "headline": "There will be no discussion about the Tush Push at next week\u2019s NFL owners\u2019 meetings; the play will be back in 2026.",
+      "body": "There will be no discussion about the Tush Push at next week\u2019s NFL owners\u2019 meetings; the play will be back in 2026.",
       "link": "https://www.espn.com/contributor/adam-schefter/e5f5d77439ed5",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "adam-schefter",
       "franchiseIds": [],
       "league": "theleague"
@@ -4366,10 +4379,10 @@
       "timestamp": "2026-03-25T18:18:26.604Z",
       "type": "external",
       "tier": "standard",
-      "headline": "The site for Super Bowl LXIII is now set to be voted on at next week’s NFL owners meetings, and it is now expected to re",
-      "body": "The site for Super Bowl LXIII is now set to be voted on at next week’s NFL owners meetings, and it is now expected to return to Las Vegas. It’s a “matter of formality,” one source said.",
+      "headline": "The site for Super Bowl LXIII is now set to be voted on at next week\u2019s NFL owners meetings, and it is now expected to re",
+      "body": "The site for Super Bowl LXIII is now set to be voted on at next week\u2019s NFL owners meetings, and it is now expected to return to Las Vegas. It\u2019s a \u201cmatter of formality,\u201d one source said.",
       "link": "https://www.espn.com/contributor/adam-schefter/0af6aa8afcea9",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "adam-schefter",
       "franchiseIds": [],
       "league": "theleague"
@@ -4508,7 +4521,7 @@
       "headline": "Free-agent QB Joe Flacco has agreed to a 1-year deal with the Bengals.",
       "body": "Free-agent QB Joe Flacco has agreed to a 1-year deal with the Bengals.",
       "link": "https://www.espn.com/contributor/adam-schefter/e02bb4b0e4408",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "adam-schefter",
       "franchiseIds": [],
       "league": "theleague"
@@ -4521,7 +4534,7 @@
       "headline": "After 14 NFL seasons, Buccaneers LB Lavonte David announced his retirement.",
       "body": "After 14 NFL seasons, Buccaneers LB Lavonte David announced his retirement.",
       "link": "https://www.espn.com/contributor/adam-schefter/02afd0b0ca264",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "adam-schefter",
       "franchiseIds": [],
       "league": "theleague"
@@ -4716,7 +4729,7 @@
       "headline": "ESPN Sources: Offensive Player of the Year and Super-Bowl champion Jaxon Smith-Njigba reached agreement with the Seahawk",
       "body": "ESPN Sources: Offensive Player of the Year and Super-Bowl champion Jaxon Smith-Njigba reached agreement with the Seahawks on a four-year, $168.6 million contract extension that now makes him the...",
       "link": "https://www.espn.com/contributor/adam-schefter/743807429c44e",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "adam-schefter",
       "franchiseIds": [],
       "league": "theleague"
@@ -5751,7 +5764,7 @@
       "headline": "A precursor to bigger deals: the Seahawks exercised the fifth-year contract options for WR Jaxon Smith-Njigba and CB Dev",
       "body": "A precursor to bigger deals: the Seahawks exercised the fifth-year contract options for WR Jaxon Smith-Njigba and CB Devon Witherspoon.",
       "link": "https://www.espn.com/contributor/adam-schefter/2f179c492bbce",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "adam-schefter",
       "franchiseIds": [],
       "league": "theleague"
@@ -5764,7 +5777,7 @@
       "headline": "A Falcons-Eagles trade, per ESPN sources:",
       "body": "A Falcons-Eagles trade, per ESPN sources:\n\nFalcons and Eagles swapped fourth- and sixth-round picks, with Atlanta also acquiring S Sydney Brown.\n\nPicks No.",
       "link": "https://www.espn.com/contributor/adam-schefter/a660d0e28f30e",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "adam-schefter",
       "franchiseIds": [],
       "league": "theleague"
@@ -5790,7 +5803,7 @@
       "headline": "The Cleveland Browns submitted a rule that would allow teams to trade draft picks five years out instead of three.",
       "body": "The Cleveland Browns submitted a rule that would allow teams to trade draft picks five years out instead of three.",
       "link": "https://www.espn.com/contributor/adam-schefter/319b23d988a51",
-      "linkLabel": "Read on ESPN →",
+      "linkLabel": "Read on ESPN \u2192",
       "authorId": "adam-schefter",
       "franchiseIds": [],
       "league": "theleague"


### PR DESCRIPTION
Manual re-insertion of the rumor-mill post that reached GroupMe at 7:09 AM PT (14:09 UTC) but never made it into src/data/theleague/ schefter-feed.json. Same recovery pattern as c11018d for the prior Northwest-RB rumor.

Scanner hardening landed separately on fix/scanner-pending-trade-feed-write — that change reorders fs.writeFile to run BEFORE postToGroupMe so a GroupMe-without-feed divergence can't happen again.

The new post:
  id:        sf_rumor_1776521340000_a7b4c9d2
  timestamp: 2026-04-18T14:09:00.000Z
  subtype:   rumor_mill
  tier:      rumor
  body:      "Hearing from sources in the East that Wabbits is quietly
              shopping for QB help. Weak at the position, one injury
              away from real trouble. Meanwhile, division intel from
              the Southwest suggests Midwest is loaded with 2nd and
              3rd round picks and looking to move them cheap. File
              under developing, but the phones are moving."

https://claude.ai/code/session_01W8Znp1GEWEt9pyLNdaKj6y