### PR TITLE
feat(standings): link team banners to roster pages

### DIFF
--- a/src/components/theleague/ConferenceLeagueStandingsTable.astro
+++ b/src/components/theleague/ConferenceLeagueStandingsTable.astro
@@ -6,9 +6,10 @@ export interface Props {
   teams: TeamStanding[];
   year?: number;
   preferredTeamId?: string;
+  rosterBaseUrl?: string;
 }
 
-const { conferenceName, teams, year = new Date().getFullYear(), preferredTeamId } = Astro.props;
+const { conferenceName, teams, year = new Date().getFullYear(), preferredTeamId, rosterBaseUrl } = Astro.props;
 
 function parseWLT(wlt: string | undefined) {
   if (!wlt) return { w: 0, l: 0, t: 0 };
@@ -88,12 +89,27 @@ function getRowColor(seed: number | undefined): string {
               <td class="col-team">
                 <div class="team-info">
                   {team.teamBanner && (
-                    <img
-                      src={team.teamBanner}
-                      alt={team.teamName}
-                      class="team-banner"
-                      title={team.teamName}
-                    />
+                    rosterBaseUrl ? (
+                      <a
+                        href={`${rosterBaseUrl}?franchise=${team.id}`}
+                        class="team-banner-link"
+                        aria-label={`View ${team.teamName} roster`}
+                      >
+                        <img
+                          src={team.teamBanner}
+                          alt={team.teamName}
+                          class="team-banner"
+                          title={team.teamName}
+                        />
+                      </a>
+                    ) : (
+                      <img
+                        src={team.teamBanner}
+                        alt={team.teamName}
+                        class="team-banner"
+                        title={team.teamName}
+                      />
+                    )
                   )}
                 </div>
               </td>
@@ -283,6 +299,24 @@ function getRowColor(seed: number | undefined): string {
     max-width: 400px;
     height: auto;
     object-fit: contain;
+  }
+
+  .team-banner-link {
+    display: inline-block;
+    line-height: 0;
+    border-radius: 4px;
+    transition: opacity 0.15s ease, transform 0.15s ease;
+  }
+
+  .team-banner-link:hover,
+  .team-banner-link:focus-visible {
+    opacity: 0.85;
+    transform: translateY(-1px);
+  }
+
+  .team-banner-link:focus-visible {
+    outline: 2px solid var(--color-focus, #2563eb);
+    outline-offset: 2px;
   }
 
   .seed-number {

--- a/src/components/theleague/LeagueStandingsTable.astro
+++ b/src/components/theleague/LeagueStandingsTable.astro
@@ -5,9 +5,10 @@ export interface Props {
   teams: TeamStanding[];
   year?: number;
   preferredTeamId?: string;
+  rosterBaseUrl?: string;
 }
 
-const { teams, year = new Date().getFullYear(), preferredTeamId } = Astro.props;
+const { teams, year = new Date().getFullYear(), preferredTeamId, rosterBaseUrl } = Astro.props;
 
 function parseWLT(wlt: string | undefined) {
   if (!wlt) return { w: 0, l: 0, t: 0 };
@@ -93,12 +94,27 @@ function getRowColor(seed: number | undefined): string {
               <td class="col-team">
                 <div class="team-info">
                   {team.teamBanner && (
-                    <img
-                      src={team.teamBanner}
-                      alt={team.teamName}
-                      class="team-banner"
-                      title={team.teamName}
-                    />
+                    rosterBaseUrl ? (
+                      <a
+                        href={`${rosterBaseUrl}?franchise=${team.id}`}
+                        class="team-banner-link"
+                        aria-label={`View ${team.teamName} roster`}
+                      >
+                        <img
+                          src={team.teamBanner}
+                          alt={team.teamName}
+                          class="team-banner"
+                          title={team.teamName}
+                        />
+                      </a>
+                    ) : (
+                      <img
+                        src={team.teamBanner}
+                        alt={team.teamName}
+                        class="team-banner"
+                        title={team.teamName}
+                      />
+                    )
                   )}
                 </div>
               </td>
@@ -296,6 +312,24 @@ function getRowColor(seed: number | undefined): string {
     max-width: 400px;
     height: auto;
     object-fit: contain;
+  }
+
+  .team-banner-link {
+    display: inline-block;
+    line-height: 0;
+    border-radius: 4px;
+    transition: opacity 0.15s ease, transform 0.15s ease;
+  }
+
+  .team-banner-link:hover,
+  .team-banner-link:focus-visible {
+    opacity: 0.85;
+    transform: translateY(-1px);
+  }
+
+  .team-banner-link:focus-visible {
+    outline: 2px solid var(--color-focus, #2563eb);
+    outline-offset: 2px;
   }
 
   .seed-number {

--- a/src/components/theleague/StandingsTable.astro
+++ b/src/components/theleague/StandingsTable.astro
@@ -11,9 +11,10 @@ export interface Props {
   defendingChampionYear?: number;
   year?: number;
   preferredTeamId?: string;
+  rosterBaseUrl?: string;
 }
 
-const { teams, view, showDivisionHeader = false, divisionName = '', defendingChampion = '', defendingChampionYear, year = new Date().getFullYear(), preferredTeamId } = Astro.props;
+const { teams, view, showDivisionHeader = false, divisionName = '', defendingChampion = '', defendingChampionYear, year = new Date().getFullYear(), preferredTeamId, rosterBaseUrl } = Astro.props;
 
 function parseWLT(wlt: string | undefined) {
   if (!wlt) return { w: 0, l: 0, t: 0 };
@@ -141,12 +142,27 @@ function calculateGamesBack(team: TeamStanding, allTeamsInDivision: TeamStanding
               <td class="col-team">
                 <div class="team-info">
                   {team.teamBanner && (
-                    <img
-                      src={team.teamBanner}
-                      alt={team.teamName}
-                      class="team-banner"
-                      title={team.teamName}
-                    />
+                    rosterBaseUrl ? (
+                      <a
+                        href={`${rosterBaseUrl}?franchise=${team.id}`}
+                        class="team-banner-link"
+                        aria-label={`View ${team.teamName} roster`}
+                      >
+                        <img
+                          src={team.teamBanner}
+                          alt={team.teamName}
+                          class="team-banner"
+                          title={team.teamName}
+                        />
+                      </a>
+                    ) : (
+                      <img
+                        src={team.teamBanner}
+                        alt={team.teamName}
+                        class="team-banner"
+                        title={team.teamName}
+                      />
+                    )
                   )}
                   <span class="team-name">{team.teamName}</span>
                 </div>
@@ -389,6 +405,24 @@ function calculateGamesBack(team: TeamStanding, allTeamsInDivision: TeamStanding
     max-width: 400px;
     height: auto;
     object-fit: contain;
+  }
+
+  .team-banner-link {
+    display: inline-block;
+    line-height: 0;
+    border-radius: 4px;
+    transition: opacity 0.15s ease, transform 0.15s ease;
+  }
+
+  .team-banner-link:hover,
+  .team-banner-link:focus-visible {
+    opacity: 0.85;
+    transform: translateY(-1px);
+  }
+
+  .team-banner-link:focus-visible {
+    outline: 2px solid var(--color-focus, #2563eb);
+    outline-offset: 2px;
   }
 
   .team-name {

--- a/src/components/theleague/TierAllPlayStandingsTable.astro
+++ b/src/components/theleague/TierAllPlayStandingsTable.astro
@@ -5,9 +5,10 @@ export interface Props {
   tierName: string;
   teams: TeamStanding[];
   year?: number;
+  rosterBaseUrl?: string;
 }
 
-const { tierName, teams, year = new Date().getFullYear() } = Astro.props;
+const { tierName, teams, year = new Date().getFullYear(), rosterBaseUrl } = Astro.props;
 
 // Determine logo based on tier
 const tierLogo = tierName === 'Premier League'
@@ -95,17 +96,35 @@ const prizes: Record<string, string[]> = {
                 <span class="rank-number">{rank}</span>
               </td>
               <td class="col-team">
-                <div class="team-info">
-                  {team.teamIcon && (
-                    <img
-                      src={team.teamIcon}
-                      alt={team.teamName}
-                      class="team-icon"
-                      loading="lazy"
-                    />
-                  )}
-                  <span class="team-name">{team.teamName}</span>
-                </div>
+                {rosterBaseUrl ? (
+                  <a
+                    href={`${rosterBaseUrl}?franchise=${team.id}`}
+                    class="team-info team-info-link"
+                    aria-label={`View ${team.teamName} roster`}
+                  >
+                    {team.teamIcon && (
+                      <img
+                        src={team.teamIcon}
+                        alt={team.teamName}
+                        class="team-icon"
+                        loading="lazy"
+                      />
+                    )}
+                    <span class="team-name">{team.teamName}</span>
+                  </a>
+                ) : (
+                  <div class="team-info">
+                    {team.teamIcon && (
+                      <img
+                        src={team.teamIcon}
+                        alt={team.teamName}
+                        class="team-icon"
+                        loading="lazy"
+                      />
+                    )}
+                    <span class="team-name">{team.teamName}</span>
+                  </div>
+                )}
               </td>
               <td class="col-record">
                 {record ? `${record.w}-${record.l}${record.t > 0 ? `-${record.t}` : ''}` : 'N/A'}
@@ -278,6 +297,24 @@ const prizes: Record<string, string[]> = {
     display: flex;
     align-items: center;
     gap: 0.75rem;
+  }
+
+  a.team-info-link {
+    color: inherit;
+    text-decoration: none;
+    border-radius: 4px;
+    transition: opacity 0.15s ease, transform 0.15s ease;
+  }
+
+  a.team-info-link:hover,
+  a.team-info-link:focus-visible {
+    opacity: 0.85;
+    transform: translateY(-1px);
+  }
+
+  a.team-info-link:focus-visible {
+    outline: 2px solid var(--color-focus, #2563eb);
+    outline-offset: 2px;
   }
 
   .team-icon {

--- a/src/pages/afl-fantasy/standings.astro
+++ b/src/pages/afl-fantasy/standings.astro
@@ -202,6 +202,7 @@ const promoRegTeams = [
               defendingChampionYear={previousYear}
               year={selectedYear}
               preferredTeamId={preferredTeamId}
+              rosterBaseUrl={`${baseUrl}/rosters`}
             />
           ))}
         </div>
@@ -214,12 +215,14 @@ const promoRegTeams = [
             teams={conferenceAStandings.allTeams}
             year={selectedYear}
             preferredTeamId={preferredTeamId}
+            rosterBaseUrl={`${baseUrl}/rosters`}
           />
           <ConferenceLeagueStandingsTable
             conferenceName={conferenceBStandings.conference.name}
             teams={conferenceBStandings.allTeams}
             year={selectedYear}
             preferredTeamId={preferredTeamId}
+            rosterBaseUrl={`${baseUrl}/rosters`}
           />
 
           {nitTeams.length > 0 && (
@@ -254,7 +257,11 @@ const promoRegTeams = [
                             <span class="rank-badge">{team.nitRank}</span>
                           </td>
                           <td class="col-team">
-                            <div class="team-info">
+                            <a
+                              href={`${baseUrl}/rosters?franchise=${team.id}`}
+                              class="team-info team-info-link"
+                              aria-label={`View ${team.teamName} roster`}
+                            >
                               {team.teamIcon && (
                                 <img
                                   src={team.teamIcon}
@@ -267,7 +274,7 @@ const promoRegTeams = [
                                 <span class="team-name">{team.teamName}</span>
                                 <span class="team-division">Seed {team.seed || '—'} • Div {team.division}</span>
                               </div>
-                            </div>
+                            </a>
                           </td>
                           <td class="col-seed">{team.seed ?? '—'}</td>
                           <td class="col-record">{wins}-{losses}</td>
@@ -290,6 +297,7 @@ const promoRegTeams = [
               tierName={tierGroup.tier}
               teams={tierGroup.teams}
               year={selectedYear}
+              rosterBaseUrl={`${baseUrl}/rosters`}
             />
           ))}
         </div>
@@ -323,7 +331,11 @@ const promoRegTeams = [
                       <span class="rank-badge">{index + 1}</span>
                     </td>
                     <td class="col-team">
-                      <div class="team-info">
+                      <a
+                        href={`${baseUrl}/rosters?franchise=${team.id}`}
+                        class="team-info team-info-link"
+                        aria-label={`View ${team.teamName} roster`}
+                      >
                         {team.teamIcon && (
                           <img
                             src={team.teamIcon}
@@ -333,7 +345,7 @@ const promoRegTeams = [
                           />
                         )}
                         <span class="team-name">{team.teamName}</span>
-                      </div>
+                      </a>
                     </td>
                     <td class="col-record">{team.all_play_wlt?.split('-')[0] || '0'}</td>
                     <td class="col-record">{team.all_play_wlt?.split('-')[1] || '0'}</td>
@@ -693,6 +705,24 @@ const promoRegTeams = [
     display: flex;
     align-items: center;
     gap: 0.75rem;
+  }
+
+  a.team-info-link {
+    color: inherit;
+    text-decoration: none;
+    border-radius: 4px;
+    transition: opacity 0.15s ease, transform 0.15s ease;
+  }
+
+  a.team-info-link:hover,
+  a.team-info-link:focus-visible {
+    opacity: 0.85;
+    transform: translateY(-1px);
+  }
+
+  a.team-info-link:focus-visible {
+    outline: 2px solid var(--color-focus, #2563eb);
+    outline-offset: 2px;
   }
 
   .promo-reg-table .team-icon {

--- a/src/pages/theleague/standings.astro
+++ b/src/pages/theleague/standings.astro
@@ -154,6 +154,7 @@ const defendingChampions = getDivisionChampions(franchises, yearResolvedConfig);
               defendingChampionYear={selectedYear}
               year={selectedYear}
               preferredTeamId={yearPreferredTeamId}
+              rosterBaseUrl="/theleague/rosters"
             />
           ))}
         </div>
@@ -161,13 +162,13 @@ const defendingChampions = getDivisionChampions(franchises, yearResolvedConfig);
 
       {view === 'league' && (
         <div class="league-view">
-          <LeagueStandingsTable teams={leagueStandings} year={selectedYear} preferredTeamId={yearPreferredTeamId} />
+          <LeagueStandingsTable teams={leagueStandings} year={selectedYear} preferredTeamId={yearPreferredTeamId} rosterBaseUrl="/theleague/rosters" />
         </div>
       )}
 
       {view === 'all_play' && (
         <div class="all-play-view">
-          <StandingsTable teams={allPlayStandings} view="all_play" year={selectedYear} preferredTeamId={yearPreferredTeamId} />
+          <StandingsTable teams={allPlayStandings} view="all_play" year={selectedYear} preferredTeamId={yearPreferredTeamId} rosterBaseUrl="/theleague/rosters" />
         </div>
       )}
 


### PR DESCRIPTION
Clicking a team's banner/icon on any standings view now navigates to
that team's roster page, making it easier to jump from rankings into
the team details.

https://claude.ai/code/session_012Fw3rupst2du9o8E9eNgmZ