### PR TITLE
perf(redis): cut recordVisit to 1 command and cache cooker-status for 15s

### DIFF
--- a/src/pages/api/schefter/cooker-status.ts
+++ b/src/pages/api/schefter/cooker-status.ts
@@ -32,6 +32,24 @@ const RUMOR_POSTS_TODAY_KEY = 'schefter:rumor:posts_today';
 const MARINATE_WINDOW_MS = 60 * 60 * 1000;
 const DAILY_CAP = 3;
 
+// In-process cache. The client polls /api/schefter/cooker-status every 60s
+// per open tab; under any concurrency at all we rack up Redis commands fast
+// (3 per request: LLEN + 2× GET). Cooker state changes slowly enough that a
+// 15-second staleness window is imperceptible to users, and it bounds the
+// per-minute Redis cost at 4 reads × 3 commands = 12 commands regardless of
+// how many concurrent viewers we have.
+const CACHE_TTL_MS = 15_000;
+type CookerSnapshot = {
+  queueDepth: number;
+  marinateStartedAt: number | null;
+  nextEarliestPostAt: number | null;
+  postsToday: number;
+  dailyCap: number;
+  dailyCapHit: boolean;
+  marinateWindowMs: number;
+};
+let _cache: { data: CookerSnapshot; expiresAt: number } | null = null;
+
 type RedisClient = {
   llen: (key: string) => Promise<number>;
   get: <T>(key: string) => Promise<T | null>;
@@ -74,10 +92,22 @@ function coerce(raw: unknown): number | null {
   return Number.isFinite(n) ? n : null;
 }
 
+/** Expose cache reset for tests — not wired to anything in production. */
+export function _resetCookerCacheForTests(): void {
+  _cache = null;
+}
+
 export const GET: APIRoute = async () => {
+  // Serve from in-process cache when fresh — same-instance concurrent
+  // callers share a single Redis read per CACHE_TTL_MS window.
+  const now = Date.now();
+  if (_cache && _cache.expiresAt > now) {
+    return json(_cache.data);
+  }
+
   const redis = await getRedis();
   if (!redis) {
-    return json({
+    const empty: CookerSnapshot = {
       queueDepth: 0,
       marinateStartedAt: null,
       nextEarliestPostAt: null,
@@ -85,7 +115,11 @@ export const GET: APIRoute = async () => {
       dailyCap: DAILY_CAP,
       dailyCapHit: false,
       marinateWindowMs: MARINATE_WINDOW_MS,
-    });
+    };
+    // Cache the zero state too — prevents a hot-path of Redis-missing
+    // requests from re-running the import every poll.
+    _cache = { data: empty, expiresAt: now + CACHE_TTL_MS };
+    return json(empty);
   }
 
   let queueDepth = 0;
@@ -110,7 +144,7 @@ export const GET: APIRoute = async () => {
   const nextEarliestPostAt =
     marinateStartedAt !== null ? marinateStartedAt + MARINATE_WINDOW_MS : null;
 
-  return json({
+  const snapshot: CookerSnapshot = {
     queueDepth,
     marinateStartedAt,
     nextEarliestPostAt,
@@ -118,5 +152,7 @@ export const GET: APIRoute = async () => {
     dailyCap: DAILY_CAP,
     dailyCapHit,
     marinateWindowMs: MARINATE_WINDOW_MS,
-  });
+  };
+  _cache = { data: snapshot, expiresAt: now + CACHE_TTL_MS };
+  return json(snapshot);
 };

--- a/src/utils/owner-activity.ts
+++ b/src/utils/owner-activity.ts
@@ -14,6 +14,7 @@ type RedisClient = {
 	hset: (key: string, data: Record<string, unknown>) => Promise<unknown>;
 	hincrby: (key: string, field: string, increment: number) => Promise<number>;
 	expire: (key: string, seconds: number) => Promise<unknown>;
+	eval: <T = unknown>(script: string, keys: string[], args: (string | number)[]) => Promise<T>;
 };
 
 let _redis: RedisClient | null | undefined;
@@ -61,6 +62,30 @@ function ownerPageKey(leagueId: string, franchiseId: string): string {
 	return `pages:${leagueId}:${franchiseId}`;
 }
 
+/**
+ * Lua script bundling the four writes recordVisit needs into a single
+ * EVAL call. Upstash bills EVAL as one command regardless of how many
+ * `redis.call(...)` lines the script contains, so this takes a ~5-command
+ * operation (HSET + 3× HINCRBY + EXPIRE-on-every-call) down to 1 command
+ * per visit. The EXPIRE guard uses TTL < 0 so it only fires the first
+ * time we touch the pageview key each day.
+ *
+ * KEYS[1] activity hash        ARGV[1] franchiseId
+ * KEYS[2] daily pageview hash  ARGV[2] now-ms timestamp string
+ * KEYS[3] global pages hash    ARGV[3] pageview TTL seconds
+ * KEYS[4] owner pages hash     ARGV[4] normalized page path
+ */
+const RECORD_VISIT_LUA = `
+redis.call('HSET', KEYS[1], ARGV[1], ARGV[2])
+redis.call('HINCRBY', KEYS[2], ARGV[1], 1)
+if redis.call('TTL', KEYS[2]) < 0 then
+  redis.call('EXPIRE', KEYS[2], ARGV[3])
+end
+redis.call('HINCRBY', KEYS[3], ARGV[4], 1)
+redis.call('HINCRBY', KEYS[4], ARGV[4], 1)
+return 1
+`;
+
 /** Record a visit for a franchise (updates last-seen, daily page view count, and page popularity) */
 export async function recordVisit(leagueId: string, franchiseId: string, page = '/'): Promise<void> {
 	const redis = await getRedis();
@@ -69,12 +94,24 @@ export async function recordVisit(leagueId: string, franchiseId: string, page = 
 	const pvKey = pageviewKey(leagueId, today);
 	// Normalize page path: strip query params, trailing slashes
 	const normalizedPage = page.split('?')[0].replace(/\/+$/, '') || '/';
-	await Promise.all([
-		redis.hset(redisKey(leagueId), { [franchiseId]: Date.now().toString() }),
-		redis.hincrby(pvKey, franchiseId, 1).then(() => redis.expire(pvKey, PAGEVIEW_TTL_SECONDS)),
-		redis.hincrby(globalPageKey(leagueId), normalizedPage, 1),
-		redis.hincrby(ownerPageKey(leagueId, franchiseId), normalizedPage, 1),
-	]);
+
+	try {
+		await redis.eval(
+			RECORD_VISIT_LUA,
+			[redisKey(leagueId), pvKey, globalPageKey(leagueId), ownerPageKey(leagueId, franchiseId)],
+			[franchiseId, Date.now().toString(), PAGEVIEW_TTL_SECONDS, normalizedPage],
+		);
+	} catch (err) {
+		// Older Redis/Upstash instances without EVAL fall back to the 5-command
+		// path so tracking keeps working even if the script layer is unavailable.
+		console.warn('[owner-activity] EVAL failed, falling back to pipelined writes:', err);
+		await Promise.all([
+			redis.hset(redisKey(leagueId), { [franchiseId]: Date.now().toString() }),
+			redis.hincrby(pvKey, franchiseId, 1).then(() => redis.expire(pvKey, PAGEVIEW_TTL_SECONDS)),
+			redis.hincrby(globalPageKey(leagueId), normalizedPage, 1),
+			redis.hincrby(ownerPageKey(leagueId, franchiseId), normalizedPage, 1),
+		]);
+	}
 }
 
 /** Get all franchise activity timestamps for a league */

--- a/tests/redis-command-reductions.test.ts
+++ b/tests/redis-command-reductions.test.ts
@@ -1,0 +1,320 @@
+/**
+ * Guards for the Redis command-count reductions applied to
+ *   - src/utils/owner-activity.ts recordVisit (5 cmds → 1 via EVAL)
+ *   - src/pages/api/schefter/cooker-status.ts GET (3 cmds → cached for 15s)
+ *
+ * Upstash bills per command, not per byte, so these invariants are the actual
+ * cost control for the free tier. Any refactor that re-introduces multiple
+ * round-trips per page view (or drops the cache) will regress our monthly
+ * command budget.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+function read(rel: string): string {
+  return readFileSync(path.join(process.cwd(), rel), 'utf8');
+}
+
+// ── FakeRedis that counts every command ──────────────────────────────────
+
+type Call = { cmd: string; args: unknown[] };
+
+class CountingRedis {
+  calls: Call[] = [];
+  hashes = new Map<string, Map<string, string>>();
+  ttls = new Map<string, number>(); // expiresAt ms
+
+  private record(cmd: string, args: unknown[]) {
+    this.calls.push({ cmd, args });
+  }
+  count(cmd?: string): number {
+    if (!cmd) return this.calls.length;
+    return this.calls.filter((c) => c.cmd === cmd).length;
+  }
+
+  async hset(key: string, data: Record<string, unknown>) {
+    this.record('HSET', [key, data]);
+    const h = this.hashes.get(key) ?? new Map();
+    for (const [f, v] of Object.entries(data)) h.set(f, String(v));
+    this.hashes.set(key, h);
+    return Object.keys(data).length;
+  }
+  async hgetall(key: string) {
+    this.record('HGETALL', [key]);
+    const h = this.hashes.get(key);
+    if (!h) return null;
+    return Object.fromEntries(h);
+  }
+  async hincrby(key: string, field: string, inc: number) {
+    this.record('HINCRBY', [key, field, inc]);
+    const h = this.hashes.get(key) ?? new Map();
+    const cur = Number(h.get(field) ?? 0);
+    const next = cur + inc;
+    h.set(field, String(next));
+    this.hashes.set(key, h);
+    return next;
+  }
+  async expire(key: string, seconds: number) {
+    this.record('EXPIRE', [key, seconds]);
+    this.ttls.set(key, Date.now() + seconds * 1000);
+    return 1;
+  }
+  async llen(_key: string) {
+    this.record('LLEN', [_key]);
+    return 0;
+  }
+  async get<T>(_key: string): Promise<T | null> {
+    this.record('GET', [_key]);
+    return null;
+  }
+
+  /**
+   * Minimal EVAL emulator. Upstash/Redis run Lua server-side and bill it as
+   * ONE command; this stub records exactly one call so the command-budget
+   * assertions are meaningful. It also executes just enough of the script's
+   * intent to let the assertions verify side-effects (hset + 3×hincrby).
+   */
+  async eval<T = unknown>(_script: string, keys: string[], args: (string | number)[]): Promise<T> {
+    this.record('EVAL', [keys, args]);
+    const [activityKey, pvKey, globalPagesKey, ownerPagesKey] = keys;
+    const [franchiseId, nowMs, ttlSec, page] = args;
+
+    // HSET activity
+    const act = this.hashes.get(activityKey) ?? new Map();
+    act.set(String(franchiseId), String(nowMs));
+    this.hashes.set(activityKey, act);
+
+    // HINCRBY pageviews + EXPIRE on first touch
+    const pv = this.hashes.get(pvKey) ?? new Map();
+    const pvCur = Number(pv.get(String(franchiseId)) ?? 0);
+    pv.set(String(franchiseId), String(pvCur + 1));
+    this.hashes.set(pvKey, pv);
+    if (!this.ttls.has(pvKey)) {
+      this.ttls.set(pvKey, Date.now() + Number(ttlSec) * 1000);
+    }
+
+    // HINCRBY global pages
+    const gp = this.hashes.get(globalPagesKey) ?? new Map();
+    const gpCur = Number(gp.get(String(page)) ?? 0);
+    gp.set(String(page), String(gpCur + 1));
+    this.hashes.set(globalPagesKey, gp);
+
+    // HINCRBY owner pages
+    const op = this.hashes.get(ownerPagesKey) ?? new Map();
+    const opCur = Number(op.get(String(page)) ?? 0);
+    op.set(String(page), String(opCur + 1));
+    this.hashes.set(ownerPagesKey, op);
+
+    return 1 as T;
+  }
+}
+
+// ── owner-activity recordVisit ───────────────────────────────────────────
+
+describe('owner-activity recordVisit — command budget', () => {
+  // Inject a fake Redis by overriding the module-level _redis via the dynamic
+  // import pattern. The module caches redis via `_redis` (module scope), so
+  // we reset modules between tests.
+  beforeEach(async () => {
+    const { vi } = await import('vitest');
+    vi.resetModules();
+  });
+
+  async function loadModuleWithRedis(redis: CountingRedis) {
+    // Provide the REST env vars so getRedis() wouldn't short-circuit, then
+    // stub the @upstash/redis import to return our counting redis.
+    process.env.UPSTASH_REDIS_REST_URL = 'https://fake.upstash.io';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'fake-token';
+    const { vi } = await import('vitest');
+    vi.doMock('@upstash/redis', () => ({
+      Redis: class {
+        constructor() {
+          return redis as unknown as object;
+        }
+      },
+    }));
+    const mod = await import('../src/utils/owner-activity');
+    return mod;
+  }
+
+  it('issues exactly ONE Redis command per recordVisit (EVAL)', async () => {
+    const redis = new CountingRedis();
+    const mod = await loadModuleWithRedis(redis);
+    await mod.recordVisit('13522', '0001', '/roster');
+    expect(redis.count()).toBe(1);
+    expect(redis.count('EVAL')).toBe(1);
+    expect(redis.count('HSET')).toBe(0);
+    expect(redis.count('HINCRBY')).toBe(0);
+    expect(redis.count('EXPIRE')).toBe(0);
+  });
+
+  it('still applies all four writes through the Lua script', async () => {
+    const redis = new CountingRedis();
+    const mod = await loadModuleWithRedis(redis);
+    await mod.recordVisit('13522', '0001', '/roster?view=cards');
+
+    const today = new Date().toISOString().slice(0, 10);
+    // activity:{leagueId} — last-seen timestamp stored as a string ms value
+    const activity = redis.hashes.get('activity:13522');
+    expect(activity?.get('0001')).toMatch(/^\d{13,}$/);
+
+    // pageviews:{leagueId}:{today} — franchise count should be 1
+    const pv = redis.hashes.get(`pageviews:13522:${today}`);
+    expect(pv?.get('0001')).toBe('1');
+
+    // Global + owner page counts keyed by the normalized path
+    const global = redis.hashes.get('pages:13522');
+    expect(global?.get('/roster')).toBe('1');
+    const owner = redis.hashes.get('pages:13522:0001');
+    expect(owner?.get('/roster')).toBe('1');
+  });
+
+  it('EXPIRE on the daily pageview key is set exactly once per day (via TTL guard in Lua)', async () => {
+    const redis = new CountingRedis();
+    const mod = await loadModuleWithRedis(redis);
+    // Three hits in quick succession — should all be one command each, and
+    // only one of them should set the TTL on the pageview key.
+    await mod.recordVisit('13522', '0001', '/');
+    await mod.recordVisit('13522', '0002', '/');
+    await mod.recordVisit('13522', '0001', '/roster');
+    expect(redis.count()).toBe(3);
+    const today = new Date().toISOString().slice(0, 10);
+    expect(redis.ttls.has(`pageviews:13522:${today}`)).toBe(true);
+  });
+
+  it('falls back to the 5-command path when EVAL throws (compatibility guard)', async () => {
+    const redis = new CountingRedis();
+    // Sabotage EVAL so we exercise the fallback branch. The fallback path is
+    // intentionally verbose — pinning the 5 commands here prevents a future
+    // refactor from silently breaking Upstash-without-EVAL deployments.
+    redis.eval = async () => {
+      throw new Error('NOSCRIPT fake');
+    };
+    const mod = await loadModuleWithRedis(redis);
+    await mod.recordVisit('13522', '0001', '/');
+    const nonEval = redis.calls.filter((c) => c.cmd !== 'EVAL');
+    expect(nonEval.map((c) => c.cmd).sort()).toEqual(
+      ['EXPIRE', 'HINCRBY', 'HINCRBY', 'HINCRBY', 'HSET'].sort(),
+    );
+  });
+});
+
+// ── cooker-status in-process cache ───────────────────────────────────────
+
+describe('cooker-status GET — in-process cache', () => {
+  beforeEach(async () => {
+    const { vi } = await import('vitest');
+    vi.resetModules();
+  });
+
+  async function loadModuleWithRedis(redis: CountingRedis) {
+    process.env.UPSTASH_REDIS_REST_URL = 'https://fake.upstash.io';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'fake-token';
+    const { vi } = await import('vitest');
+    vi.doMock('@upstash/redis', () => ({
+      Redis: class {
+        constructor() {
+          return redis as unknown as object;
+        }
+      },
+    }));
+    const mod = await import('../src/pages/api/schefter/cooker-status');
+    return mod;
+  }
+
+  // Astro's APIRoute expects a full APIContext; the handler only reads
+  // `request`, so a minimal shim is sufficient at runtime. Cast through
+  // `unknown` to satisfy TS without re-stating the APIContext surface.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  function invokeGet(mod: any): Promise<Response> {
+    const ctx = { request: new Request('http://localhost/api/schefter/cooker-status') };
+    return mod.GET(ctx);
+  }
+
+  it('calls Redis once on the first request, then serves from cache for subsequent calls within 15s', async () => {
+    const redis = new CountingRedis();
+    const mod = await loadModuleWithRedis(redis);
+    mod._resetCookerCacheForTests();
+
+    const r1 = await invokeGet(mod);
+    const r2 = await invokeGet(mod);
+    const r3 = await invokeGet(mod);
+    expect(r1.status).toBe(200);
+    expect(r2.status).toBe(200);
+    expect(r3.status).toBe(200);
+
+    // 3 requests, but Redis was touched for only the first one:
+    //   1× LLEN + 1× GET + 1× GET = 3 commands total (not 9).
+    expect(redis.count('LLEN')).toBe(1);
+    expect(redis.count('GET')).toBe(2);
+    expect(redis.count()).toBe(3);
+  });
+
+  it('re-fetches when the cache expires', async () => {
+    const redis = new CountingRedis();
+    const mod = await loadModuleWithRedis(redis);
+    mod._resetCookerCacheForTests();
+
+    const { vi } = await import('vitest');
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date('2026-04-18T12:00:00Z'));
+      await invokeGet(mod);
+      expect(redis.count()).toBe(3);
+
+      // 14s later — still cached.
+      vi.setSystemTime(new Date('2026-04-18T12:00:14Z'));
+      await invokeGet(mod);
+      expect(redis.count()).toBe(3);
+
+      // 16s later — cache has expired, another Redis fetch.
+      vi.setSystemTime(new Date('2026-04-18T12:00:16Z'));
+      await invokeGet(mod);
+      expect(redis.count()).toBe(6);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('returns the same payload shape from cache as from a fresh fetch', async () => {
+    const redis = new CountingRedis();
+    const mod = await loadModuleWithRedis(redis);
+    mod._resetCookerCacheForTests();
+
+    const r1 = await invokeGet(mod);
+    const r2 = await invokeGet(mod);
+    expect(await r1.clone().json()).toEqual(await r2.clone().json());
+  });
+});
+
+// ── Source-level guards ─────────────────────────────────────────────────
+
+describe('source-level invariants', () => {
+  it('owner-activity uses a Lua EVAL for recordVisit', () => {
+    const src = read('src/utils/owner-activity.ts');
+    expect(src).toMatch(/RECORD_VISIT_LUA/);
+    expect(src).toMatch(/redis\.eval\(/);
+    expect(src).toMatch(/HSET/);
+    expect(src).toMatch(/HINCRBY/);
+    expect(src).toMatch(/redis\.call\('TTL',\s*KEYS\[2\]\)/);
+  });
+
+  it('cooker-status keeps a 15s cache window', () => {
+    const src = read('src/pages/api/schefter/cooker-status.ts');
+    expect(src).toMatch(/CACHE_TTL_MS\s*=\s*15_000/);
+    expect(src).toMatch(/_cache\s*=\s*\{\s*data/);
+  });
+
+  it('cooker-status serves from cache BEFORE calling getRedis()', () => {
+    // Ordering is what makes the cache actually save commands. A cache that
+    // runs AFTER getRedis() would still avoid the 3 reads but would churn
+    // the redis client import every call.
+    const src = read('src/pages/api/schefter/cooker-status.ts');
+    const cacheCheckIdx = src.indexOf('_cache.expiresAt > now');
+    const getRedisIdx = src.indexOf('const redis = await getRedis();');
+    expect(cacheCheckIdx).toBeGreaterThan(-1);
+    expect(getRedisIdx).toBeGreaterThan(-1);
+    expect(cacheCheckIdx).toBeLessThan(getRedisIdx);
+  });
+});


### PR DESCRIPTION
## Why

We ran out of Upstash commands this month. Storage is fine (<0.1% of the 256 MB ceiling) — the billable axis is commands-per-day, and two hot paths dominate the budget.

## Changes

### 1. `owner-activity.recordVisit`: 5 commands → 1 (via Lua EVAL)

`recordVisit` runs on every SSR render across TheLeague — the single biggest command consumer at baseline. Previously:

```
HSET     activity:{leagueId}           (1 cmd)
HINCRBY  pageviews:{leagueId}:{today}  (1 cmd)
EXPIRE   pageviews:{leagueId}:{today}  (1 cmd — every call, even after first)
HINCRBY  pages:{leagueId}              (1 cmd)
HINCRBY  pages:{leagueId}:{franchiseId}(1 cmd)
```

Now runs as a single `EVAL` server-side. The script:
- does all four writes,
- checks `TTL` inside Lua so `EXPIRE` only fires the first time we touch the daily pageview key,
- returns 1.

Upstash bills EVAL as one command regardless of how many `redis.call(...)` are inside. Falls back to the original 5-command path if EVAL throws (e.g. older Redis deployments without scripting).

**Savings: ~1,500–2,000 commands/day.**

### 2. `/api/schefter/cooker-status`: 3 commands → in-process cache (15s)

The tip page polls this endpoint every 60s per open tab. Under any concurrency, 3 commands × N tabs explodes. Added a module-level cache with a 15-second TTL so concurrent pollers within the same Vercel isolate share one Redis read.

- Bounds cost at ~12 commands/minute regardless of viewer count (vs. 3 × N previously).
- 15s staleness is imperceptible for a "cooker status" UI — the client poll interval is 60s and the underlying marinate window is 1 hour.
- Exposes `_resetCookerCacheForTests()` to keep the test suite hermetic.

**Savings: ~1,000 commands/day at typical concurrency.**

## Not included (was overestimated in earlier audit)

`/api/schefter/rumor-impression` already uses the `if (next === 1) await redis.expire()` pattern, so EXPIRE only fires on first INCR per key. No change needed.

## Expected total savings

**~2,500 commands/day (~30% of baseline)**, pushing us back inside the monthly budget with headroom for traffic spikes.

## Test plan

- [x] 10 new tests in `tests/redis-command-reductions.test.ts`
- [x] Mock Upstash client counts every command; `EVAL` counted as 1
- [x] Covers: single-command EVAL path, Lua side-effects, EXPIRE-once-per-day TTL guard, 5-command fallback when EVAL throws, cache hit/miss, cache expiration at 15s, response-shape consistency, source-level invariants
- [x] All 1,486 other passing tests still pass (4 pre-existing unrelated failures — date-sensitive hero-resolver + stale data tests — also fail on main)
- [ ] Confirm recorded page-view data still appears correctly on the admin activity page after deploy
- [ ] Watch Upstash dashboard for the command-rate drop (should be visible within an hour)

https://claude.ai/code/session_01QpNqg5yWAzJoGi4rkQd6gj