### PR TITLE
fix(schefter): reframe tip fuzzing so "Sources" = tipster, not subject team

### DIFF
--- a/docs/features/schefter-tip-engagement.md
+++ b/docs/features/schefter-tip-engagement.md
@@ -129,7 +129,7 @@ No new API or Redis keys — feed JSON is already imported on this page.
 **Content (copy):**
 - **Example 1 — Single-source franchise mention**
   - Tip: "The Magicians are shopping their 1.03 for a WR."
-  - What Schefter prints: "Sources in the East whisper that a franchise is dangling a top rookie pick for WR help. Developing."
+  - What Schefter prints: "Sources tell me a team in the East is dangling a top rookie pick for WR help. Developing."
 - **Example 2 — Multi-source franchise mention**
   - Tip (plus one other owner on the same team): "The Magicians are shopping their 1.03."
   - What Schefter prints: "League sources tell me multiple owners are talking about the Dark Magicians. Worth watching."

--- a/scripts/schefter-rumor-scan.mjs
+++ b/scripts/schefter-rumor-scan.mjs
@@ -479,12 +479,12 @@ async function generateAiBody(anonymized, { rogerQuote, lore, recentPostsBlock }
 
 HARD RULES (self-enforce, never violate):
 1. For web tips (source: "web"), NEVER name the tipster and NEVER quote them verbatim — paraphrase with columnist voice.
-2. If a web tip's scope is "division", refer only to that division (e.g. "sources in the Northwest") — NEVER name a specific franchise.
+2. If a web tip's scope is "division", the division refers to the SUBJECT team's division — NOT where the source is located. Frame it as "a team in the [division]", "a [division]-division squad", or "the [division] is buzzing" — NEVER as "sources in the [division]" (that implies the tipster's location). NEVER name a specific franchise.
 3. If a web tip's scope is "league-wide", stay vague ("an owner tells me", "hearing from multiple corners").
 4. If a web tip's scope is "franchise-multi-source" (sourceCount >= 2), you MAY name the franchise AND use "multiple sources" / "multiple owners" phrasing.
 5. If a web tip's scope is "commish", you MAY reference the commissioner's office or "the commish" — it's a public role, not a hidden identity — but NEVER name the franchise that holds the office.
 6. For GroupMe tips (source: "groupme", scope: "groupme-public", attributable: true): direct attribution is ENCOURAGED. The author publicly @'d Schefter in the group chat — name them. Riff BACK conversationally, second-person where it fits ("Wabbit, I hear you, but…", "Nice try, Jomar — my sources say otherwise"). Light ribbing is in-voice.
-7. Mixed batches: attribute GroupMe quotes by name while keeping web tips anonymized in the same post. It's okay for a single post to blend "I'm hearing from sources in the Pacific…" (web) with "Wabbit, meanwhile, fired off in the group chat…" (GroupMe).
+7. Mixed batches: attribute GroupMe quotes by name while keeping web tips anonymized in the same post. It's okay for a single post to blend "I'm hearing a team in the Pacific…" (web) with "Wabbit, meanwhile, fired off in the group chat…" (GroupMe).
 8. Length: 2–4 sentences total (even in mixed batches). Breaking-news tease voice. End with "Developing." or similar when appropriate.
 9. Do NOT include hashtags, emoji, or @-mentions. Plain prose only.
 10. Do NOT reveal how many tips fed this post. No meta commentary about the rumor mill itself.

--- a/src/pages/theleague/schefter/tip.astro
+++ b/src/pages/theleague/schefter/tip.astro
@@ -195,7 +195,7 @@ const franchiseOptions = teams.map((t) => ({
               </div>
               <div class="tip-rail-example__row tip-rail-example__row--print">
                 <span class="tip-rail-example__row-label">Schefter prints</span>
-                <span class="tip-rail-example__row-text">"Sources in the East whisper that a franchise is dangling a top rookie pick for WR help. Developing."</span>
+                <span class="tip-rail-example__row-text">"Sources tell me a team in the East is dangling a top rookie pick for WR help. Developing."</span>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- The tip-rail example and LLM prompt said "Sources in the East" where East was the **subject team's** division — which reads as if the tipster was located there. "Sources" should refer to the tipster.
- Updated the example card, engagement doc, and rumor-scan system prompt to use "a team in the [division]" framing and explicitly forbid "sources in the [division]".

## Changes
- `src/pages/theleague/schefter/tip.astro` — example now reads *"Sources tell me a team in the East is dangling a top rookie pick for WR help. Developing."*
- `docs/features/schefter-tip-engagement.md` — mirrored in the Phase 4 spec
- `scripts/schefter-rumor-scan.mjs` — rule #2 now prescribes "a team in the [division]" and bans "sources in the [division]"; rule #7 mixed-batch example updated to match

## Test plan
- [ ] Visit `/theleague/schefter/tip`, expand the examples card, confirm the single-source example reads correctly
- [ ] Dry-run `scripts/schefter-rumor-scan.mjs` with a single-source division-scope tip and confirm generated post avoids "sources in the [division]"

https://claude.ai/code/session_012KZnEPLuV2WbpVzCHVXLGw