### PR TITLE
Fix markdown formatting in rumor-scan prompt documentation

### DIFF
--- a/scripts/schefter-rumor-scan.mjs
+++ b/scripts/schefter-rumor-scan.mjs
@@ -488,7 +488,7 @@ HARD RULES (self-enforce, never violate):
 8. Length: 2–4 sentences total (even in mixed batches). Breaking-news tease voice. End with "Developing." or similar when appropriate.
 9. Do NOT include hashtags, emoji, or @-mentions. Plain prose only.
 10. Do NOT reveal how many tips fed this post. No meta commentary about the rumor mill itself.
-11. Thread continuity: if ANY tip in this batch has a `threadFollowup` field (Phase 7 whisper-back), open with continuity language — "Following up on yesterday's…", "More on the…", "Circling back to…", "As a reminder…". Use the parentHeadlineSnippet as a cue, but do not quote it. Still respect every fuzz/anonymity rule above. If no tip has threadFollowup, do not use continuity phrasing.
+11. Thread continuity: if ANY tip in this batch has a \`threadFollowup\` field (Phase 7 whisper-back), open with continuity language — "Following up on yesterday's…", "More on the…", "Circling back to…", "As a reminder…". Use the parentHeadlineSnippet as a cue, but do not quote it. Still respect every fuzz/anonymity rule above. If no tip has threadFollowup, do not use continuity phrasing.
 
 Voice: "League sources tell me…", "I'm told…", "Hearing…", "A division rival whispers…". Salt, not sugar.`;
 


### PR DESCRIPTION
## Summary
Fixed markdown formatting in the hard rules documentation within the schefter-rumor-scan script to properly escape backticks in inline code references.

## Changes
- Escaped backticks around `threadFollowup` field reference in rule 11 to ensure proper markdown rendering
- Changed from single backticks to escaped backticks (`\`threadFollowup\``) for correct display in markdown contexts

## Details
This is a documentation/formatting fix that ensures the prompt instructions render correctly when displayed in markdown-aware environments. The change maintains the semantic meaning of the rule while improving readability of the generated documentation.

https://claude.ai/code/session_01YCJJjm2bXHUZuVbrLY8uhJ