### PR TITLE
fix: Schefter rumor-scan syntax error and CI rebase block

### DIFF
--- a/.github/workflows/schefter-rumor-scan.yml
+++ b/.github/workflows/schefter-rumor-scan.yml
@@ -67,7 +67,7 @@ jobs:
 
           git config user.name "Schefter Bot"
           git config user.email "actions@users.noreply.github.com"
-          git add src/data/theleague/schefter-feed.json
+          git add src/data/theleague/schefter-feed.json data/schefter/post-history.json
           git commit -m "chore: schefter rumor-mill — new anonymous-tip post"
           git pull --rebase origin main
           git push

--- a/.github/workflows/schefter-scan.yml
+++ b/.github/workflows/schefter-scan.yml
@@ -53,7 +53,7 @@ jobs:
 
           git config user.name "Schefter Bot"
           git config user.email "actions@users.noreply.github.com"
-          git add src/data/theleague/schefter-feed.json data/afl-fantasy/schefter-feed.json src/data/theleague/resolved-events.json
+          git add src/data/theleague/schefter-feed.json data/afl-fantasy/schefter-feed.json src/data/theleague/resolved-events.json data/schefter/post-history.json
           git commit -m "chore: schefter scan — new transaction posts"
           git pull --rebase origin main
           git push

--- a/scripts/schefter-rumor-scan.mjs
+++ b/scripts/schefter-rumor-scan.mjs
@@ -488,7 +488,7 @@ HARD RULES (self-enforce, never violate):
 8. Length: 2–4 sentences total (even in mixed batches). Breaking-news tease voice. End with "Developing." or similar when appropriate.
 9. Do NOT include hashtags, emoji, or @-mentions. Plain prose only.
 10. Do NOT reveal how many tips fed this post. No meta commentary about the rumor mill itself.
-11. Thread continuity: if ANY tip in this batch has a `threadFollowup` field (Phase 7 whisper-back), open with continuity language — "Following up on yesterday's…", "More on the…", "Circling back to…", "As a reminder…". Use the parentHeadlineSnippet as a cue, but do not quote it. Still respect every fuzz/anonymity rule above. If no tip has threadFollowup, do not use continuity phrasing.
+11. Thread continuity: if ANY tip in this batch has a \`threadFollowup\` field (Phase 7 whisper-back), open with continuity language — "Following up on yesterday's…", "More on the…", "Circling back to…", "As a reminder…". Use the parentHeadlineSnippet as a cue, but do not quote it. Still respect every fuzz/anonymity rule above. If no tip has threadFollowup, do not use continuity phrasing.
 
 Voice: "League sources tell me…", "I'm told…", "Hearing…", "A division rival whispers…". Salt, not sugar.`;
 


### PR DESCRIPTION
## Summary
- Escape backticks around `` `threadFollowup` `` in the rumor-scan system prompt (line 491). Unescaped, they closed the enclosing template literal and produced `SyntaxError: Unexpected identifier 'threadFollowup'` at script load.
- Stage `data/schefter/post-history.json` in both `schefter-rumor-scan.yml` and `schefter-scan.yml` commits. `appendPostHistory` writes that file on every run, so leaving it out of `git add` left the tree dirty and broke the subsequent `git pull --rebase origin main` with "unstaged changes".

## Test plan
- [x] `node --check scripts/schefter-rumor-scan.mjs` passes
- [ ] Next scheduled Schefter Rumor Mill Scan run completes the commit + rebase + push step without error
- [ ] Next scheduled Schefter Scan run (when it posts) completes the commit + rebase + push step without error

https://claude.ai/code/session_01YCJJjm2bXHUZuVbrLY8uhJ