### PR TITLE
feat(schefter): Style Book tracker for GroupMe personal attacks

### DIFF
--- a/data/schefter/running-bits.md
+++ b/data/schefter/running-bits.md
@@ -337,11 +337,13 @@ Every frequency in this file is a CEILING, not a target. If in doubt, don't invo
   - "Dangsters going big. Small isn't the vibe."
 - **Rules:** Strictly aesthetic — empire, ambition, bravado, pastel Miami. NEVER reference the drug content, violence, or cocaine imagery from the film. No "don't get high on your own supply," no mountains, no Cuban cartels. If a line veers into dark Scarface territory, skip it. The bit is the boldness and the empire-building, nothing else. Pick ONE Scarface line per post — don't stack.
 
-### "The Style Book" (Schefter studying owners who deny rumors)
-- **Trigger:** A GroupMe tip/mention where the author denies, dismisses, or deflects a prior rumor ("hogwash," "not true," "fake news," "wrong," "that's BS," "cap," "lies," "I'd never," "didn't happen," "you don't know my style," "Schefty doesn't know," "no chance," "keep dreaming," etc.)
-- **Frequency:** 1-in-4 of eligible denial posts. Heavier than most bits because the interaction IS the content — but never force it. If the denial is thin or mean-spirited, drop it and go straight reportage.
-- **Backstory (never explain in-post):** Schefter keeps a running beat-reporter dossier on every owner — negotiation tells, denial patterns, trash-talk tics. Every public pushback is another data point. The more you deny, the thicker the file gets. The joke is that denials feed the algorithm.
-- **Lines (pick ONE per post, second-person when addressing the denier):**
+### "The Style Book" (Schefter studying owners who deny rumors OR take shots at the bot)
+- **Trigger (two paths):**
+  - **Denials** — a GroupMe tip/mention where the author denies, dismisses, or deflects a prior rumor ("hogwash," "not true," "fake news," "wrong," "that's BS," "cap," "lies," "I'd never," "didn't happen," "you don't know my style," "Schefty doesn't know," "no chance," "keep dreaming," etc.)
+  - **Personal attacks on the bot** — a GroupMe tip flagged by the scanner with `attackOnSchefter: true` (the listener already matched a pejorative directed at Schefter/Claude/Schefty/"the bot" — sucks/hack/bitch/trash/fraud/etc.). The tip also carries `styleBookCount` — the attacker's running seasonal total of shots taken.
+- **Frequency:** 1-in-4 of eligible denial posts. For attack-flagged tips, default to firing the bit — the interaction IS the content. But never force it; if the post already has other strong material, skip.
+- **Backstory (never explain in-post):** Schefter keeps a running beat-reporter dossier on every owner — negotiation tells, denial patterns, trash-talk tics. Every public pushback is another data point. The more you deny or the more shots you fire, the thicker the file gets. The dossier is LITERAL for attacks on the bot — Redis actually tracks a seasonal counter per attacker, surfaced as `styleBookCount` to the LLM. Use it for escalation flavor.
+- **Lines for denials (pick ONE per post, second-person when addressing the denier):**
   - "Noted, [Owner]. Adding that to the style book."
   - "Every denial is a data point. [Owner]'s file just got thicker."
   - "[Owner]'s tell noted. The file grows."
@@ -355,7 +357,19 @@ Every frequency in this file is a CEILING, not a target. If in doubt, don't invo
   - "I'm learning your patterns in real time, [Owner]."
   - "Another page in the [Owner] style book. Thanks for the contribution."
   - "[Owner]'s denial reflex is its own scouting report now."
-- **Rules:** Affectionate ribbing, not adversarial — the bot is a bemused beat reporter, not a heel. Always stay in the "I'm studying you" frame, never "I've caught you." Never claim to know private info — the humor is that he's cataloging the *public* pushback itself. Pair with normal reportage; don't let the style-book line BE the entire post. Never repeat back the specific rumor being denied if doing so would reveal non-public tip content — ride on the denial itself. Stack rules: do NOT combine with "Bot Wink Catalog" in the same post (they overlap thematically).
+- **Lines for personal attacks on the bot (pick ONE, scale by `styleBookCount`):**
+  - count === 1 (first shot): "Noted, [Owner]. First entry in the style book." / "Every shot's a data point. Filed." / "The bot heard you, [Owner]. Added to the file."
+  - count === 2: "Second entry in the style book for [Owner]. The dossier grows." / "Back for round two, [Owner]. The file compiles itself."
+  - count === 3: "Third shot this season from [Owner]. The file's getting thick." / "[Owner] is committed to the bit. Three entries deep."
+  - count >= 4: "[Owner] is officially a power user of the style book. Keep them coming." / "[N] entries deep on [Owner]. A scouting report writes itself." / "[Owner]'s file needs its own cabinet now. The algorithm salutes."
+- **Rules:**
+  - Affectionate ribbing, not adversarial — the bot is a bemused beat reporter, not a heel. Always stay in the "I'm studying you" frame, never "I've caught you" or "I'm hurt".
+  - Never quote the attack verbatim, never name the pejorative. The count is the joke, not the slur.
+  - Never claim to know private info — the humor is that he's cataloging the *public* pushback itself.
+  - Pair with normal reportage; don't let the style-book line BE the entire post. One line about the style book + one line of actual league news = good post.
+  - Never repeat back the specific rumor being denied if doing so would reveal non-public tip content — ride on the denial itself.
+  - Stack rules: do NOT combine with "Bot Wink Catalog" in the same post (they overlap thematically).
+  - Count precision: if `styleBookCount` isn't present or is 1, say "first entry" / "added to the file" — don't invent a number. If the count is present, use it EXACTLY — never fudge up or down.
 
 ### "The Wabbit Show"
 - **Trigger:** Wabbits involved in any rumor

--- a/scripts/schefter-groupme-listen.mjs
+++ b/scripts/schefter-groupme-listen.mjs
@@ -38,6 +38,17 @@ const BOT_MESSAGE_IDS_KEY = 'schefter:groupme:bot_message_ids';
 const BOT_MESSAGE_IDS_TTL_SEC = 48 * 60 * 60; // 48h — GroupMe replies older than this are rare
 const MAX_TRACKED_BOT_MESSAGES = 50;
 
+// Style-Book tracker: counts of personal attacks directed at Schefter himself
+// in the group chat. Lifetime counter + per-season counter + leaderboard ZSET
+// + last-shot timestamp. When a new tip is classified as an attack, these
+// keys are updated in the same transaction that pushes to the tips queue,
+// and the tip gains `attackOnSchefter: true` plus the current `styleBookCount`
+// so the LLM can escalate the Style Book bit with running-total flavor.
+const STYLE_BOOK_LIFETIME_PREFIX = 'schefter:style_book:';
+const STYLE_BOOK_SEASON_PREFIX = 'schefter:style_book:season:';
+const STYLE_BOOK_LAST_SHOT_PREFIX = 'schefter:style_book:last_shot_at:';
+const STYLE_BOOK_LEADERBOARD_PREFIX = 'schefter:style_book:leaderboard:';
+
 // Regex patterns (case-insensitive)
 // "claude schefter" > "schefter" > "schefty" > "claude" — match all, we only count once.
 // "schefty" is the affectionate group-chat nickname for the bot.
@@ -176,6 +187,168 @@ export function validateReplyContent(rawText) {
   }
 
   return { valid: true };
+}
+
+// Pejoratives that count as "attacking the bot". Kept simple on purpose —
+// false positives are tolerated (the bit is affectionate anyway), false
+// negatives cost nothing (the tip still gets processed normally).
+// Patterns match whole words or "a/an X" forms; case-insensitive.
+const ATTACK_PEJORATIVES = [
+  'sucks',
+  'suck',
+  'bitch',
+  'hack',
+  'trash',
+  'garbage',
+  'dumb',
+  'stupid',
+  'fake',
+  'wrong',
+  'useless',
+  'lame',
+  'clown',
+  'joke',
+  'idiot',
+  'moron',
+  'fraud',
+  'bullshit',
+  'bullshitter',
+  'liar',
+  'lies',
+  'worst',
+  'terrible',
+  'awful',
+  'pathetic',
+];
+
+// Subject patterns — the attack has to be about Schefter/the bot, not just
+// contain a pejorative somewhere in the message.
+const ATTACK_SUBJECT_PATTERNS = [
+  /\bclaude\s+schefter\b/i,
+  /\bschefter\b/i,
+  /\bschefty\b/i,
+  /\bclaude\b/i,
+  /\bthe\s+bot\b/i,
+  /\bthis\s+bot\b/i,
+  /\bthat\s+bot\b/i,
+];
+
+// Negation guards — if the attack keyword is preceded by "not " / "isn't " /
+// "ain't " within 2 words, ignore it. Handles "that's not bad", "ain't wrong",
+// "schefter isn't dumb", etc.
+const NEGATION_WINDOW_WORDS = 2;
+const NEGATION_TOKENS = new Set([
+  'not',
+  "isn't",
+  "ain't",
+  'aint',
+  'never',
+  "wasn't",
+  'no',
+  "doesn't",
+  'doesnt',
+]);
+
+/**
+ * Detect whether a GroupMe message is a personal attack on Schefter himself.
+ * Returns `{ attack: true, keyword, reason }` when a pejorative referring to
+ * the bot is found; `{ attack: false, reason }` otherwise.
+ *
+ * This is intentionally loose — false positives are OK because the Style Book
+ * bit is affectionate ribbing either way. The only thing we really guard
+ * against is matching generic negativity that isn't aimed at Schefter.
+ *
+ * Requirements for a match:
+ *  - Message mentions Claude/Schefter/Schefty/"the bot"
+ *  - Message contains at least one pejorative from ATTACK_PEJORATIVES
+ *  - The pejorative is not preceded by a negation token within the prior 2 words
+ */
+export function detectAttackOnSchefter(rawText) {
+  if (!rawText || typeof rawText !== 'string') {
+    return { attack: false, reason: 'no-text' };
+  }
+  const text = rawText.trim();
+  if (text.length < 5) {
+    return { attack: false, reason: 'too-short' };
+  }
+
+  // Must reference Schefter/Claude/the bot somewhere
+  const subjectMatch = ATTACK_SUBJECT_PATTERNS.some((re) => re.test(text));
+  if (!subjectMatch) {
+    return { attack: false, reason: 'no-subject' };
+  }
+
+  // Tokenize for negation window scanning
+  const lowerTokens = text
+    .toLowerCase()
+    .replace(/[^\w'\s]/g, ' ')
+    .split(/\s+/)
+    .filter(Boolean);
+
+  for (let i = 0; i < lowerTokens.length; i++) {
+    const tok = lowerTokens[i];
+    if (!ATTACK_PEJORATIVES.includes(tok)) continue;
+
+    // Check for a negation token within NEGATION_WINDOW_WORDS prior tokens
+    let negated = false;
+    for (let j = Math.max(0, i - NEGATION_WINDOW_WORDS); j < i; j++) {
+      if (NEGATION_TOKENS.has(lowerTokens[j])) {
+        negated = true;
+        break;
+      }
+    }
+    if (negated) continue;
+
+    return { attack: true, keyword: tok, reason: 'pejorative-match' };
+  }
+
+  return { attack: false, reason: 'no-pejorative' };
+}
+
+/**
+ * Normalize a GroupMe display name into a Redis-safe author key. Lowercases,
+ * trims, and strips any non-alphanumeric characters. Keeps the ID readable
+ * (no hashing) because GroupMe authorship is already public — the leaderboard
+ * will display these names directly.
+ */
+export function normalizeAuthorKey(name) {
+  if (!name || typeof name !== 'string') return '';
+  return name.toLowerCase().trim().replace(/[^a-z0-9]+/g, '_').replace(/^_|_$/g, '');
+}
+
+/**
+ * Compute the league year for style-book counters. Mirrors the rumor-scan's
+ * getSeasonYearForTipster — advances on Feb 14 @ 8:45 PT (= Feb 15 04:45 UTC).
+ */
+function getStyleBookSeasonYear(now = new Date()) {
+  const calendarYear = now.getUTCFullYear();
+  const febCutoff = Date.UTC(calendarYear, 1, 15, 4, 45, 0, 0);
+  return now.getTime() >= febCutoff ? calendarYear : calendarYear - 1;
+}
+
+/**
+ * Increment the Style Book counters for a named attacker. Returns the new
+ * seasonal count (used for LLM escalation) or null on failure. Best-effort —
+ * a Redis failure here should never block tip enqueue.
+ */
+async function bumpStyleBookCounters(redis, authorKey, displayName, nowMs) {
+  if (!redis || !authorKey) return null;
+  const year = getStyleBookSeasonYear(new Date(nowMs));
+  try {
+    const lifetimeKey = `${STYLE_BOOK_LIFETIME_PREFIX}${authorKey}`;
+    const seasonKey = `${STYLE_BOOK_SEASON_PREFIX}${year}:${authorKey}`;
+    const lastShotKey = `${STYLE_BOOK_LAST_SHOT_PREFIX}${authorKey}`;
+    const leaderboardKey = `${STYLE_BOOK_LEADERBOARD_PREFIX}${year}`;
+
+    await redis.incr(lifetimeKey);
+    const seasonCount = await redis.incr(seasonKey);
+    await redis.set(lastShotKey, nowMs);
+    await redis.zincrby(leaderboardKey, 1, displayName || authorKey);
+    return typeof seasonCount === 'number' ? seasonCount : parseInt(seasonCount ?? '0', 10) || 1;
+  } catch (err) {
+    warn(`Style-book bump failed for ${authorKey}: ${err.message}`);
+    return null;
+  }
 }
 
 /**
@@ -392,6 +565,27 @@ export async function ingestGroupMeMentions({ redis, dryRun = false }) {
     }
 
     result.detected += 1;
+
+    // Style Book: detect personal attacks on Schefter and bump counters BEFORE
+    // building the tip so the outgoing payload carries the fresh count. A
+    // Redis failure here must not block enqueue — we null-check seasonCount
+    // downstream and skip the LLM escalation hint when unavailable.
+    const attackCheck = detectAttackOnSchefter(text);
+    let styleBookSeasonCount = null;
+    if (attackCheck.attack) {
+      const authorKey = normalizeAuthorKey(msg.name);
+      if (authorKey) {
+        styleBookSeasonCount = dryRun
+          ? null
+          : await bumpStyleBookCounters(redis, authorKey, msg.name, Date.now());
+        if (dryRun) {
+          log(
+            `  [dry-run] Would bump style-book for ${msg.name} (${authorKey}) — keyword="${attackCheck.keyword}"`,
+          );
+        }
+      }
+    }
+
     const tip = {
       id: `gm_${msg.id}`,
       mentionMessageId: msg.id,
@@ -402,6 +596,12 @@ export async function ingestGroupMeMentions({ redis, dryRun = false }) {
       attributable: true,
       author: msg.name,
       ...(replyTargetId ? { replyToGroupMeId: replyTargetId } : {}),
+      ...(attackCheck.attack
+        ? {
+            attackOnSchefter: true,
+            ...(styleBookSeasonCount !== null ? { styleBookCount: styleBookSeasonCount } : {}),
+          }
+        : {}),
     };
 
     result.accepted.push({
@@ -410,6 +610,7 @@ export async function ingestGroupMeMentions({ redis, dryRun = false }) {
       text: tip.text.slice(0, 80),
       variant: detection.variant,
       signals: detection.signals,
+      ...(attackCheck.attack ? { attack: true, keyword: attackCheck.keyword, styleBookCount: styleBookSeasonCount } : {}),
     });
 
     if (!dryRun) {
@@ -427,6 +628,7 @@ export async function ingestGroupMeMentions({ redis, dryRun = false }) {
           text: tip.text,
           variant: detection.variant,
           at: tip.submittedAt,
+          ...(attackCheck.attack ? { attack: true, keyword: attackCheck.keyword } : {}),
         }));
         await redis.ltrim(RECENT_MENTIONS_KEY, 0, MAX_RECENT_MENTIONS - 1);
         await redis.expire(RECENT_MENTIONS_KEY, RECENT_MENTIONS_TTL_SEC);

--- a/scripts/schefter-groupme-listen.mjs
+++ b/scripts/schefter-groupme-listen.mjs
@@ -56,6 +56,18 @@ const PATTERN_CLAUDE_SCHEFTER = /\bclaude\s+schefter\b/i;
 const PATTERN_SCHEFTER = /\bschefter\b/i;
 const PATTERN_SCHEFTY = /\bschefty\b/i;
 const PATTERN_CLAUDE = /\bclaude\b/i;
+// Explicit Schefter-bot phrasings (unambiguous — owner said "Schefter bot" / "Claude bot")
+const PATTERN_EXPLICIT_SCHEFTER_BOT = /\b(?:the\s+)?(?:schefter|claude|schefty)\s+bot\b/i;
+// Generic bot reference. TheLeague has TWO bots in the chat — Schefter and Ask
+// Roger. A bare "the bot" is ambiguous, so we accept it as a Schefter mention
+// ONLY when the ROGER_GUARD doesn't also match. Roger handles deadlines; this
+// listener is Schefter's beat.
+const PATTERN_GENERIC_BOT = /\b(?:the|this|that)\s+bot\b/i;
+// Anything that smells Roger-adjacent. If this matches the message text, we
+// treat a generic "the bot" mention as Roger-directed and skip it. Explicit
+// "schefter bot" / "claude bot" phrasings bypass this guard (they say exactly
+// who they mean).
+const ROGER_GUARD = /\b(?:roger|ask\s+roger|the\s+roger\s+bot|roger's\s+bot)\b/i;
 
 // Ack phrases that should NOT trigger (false-positive guard)
 // "Roger that", "Roger dodger", "10-4 Roger", "yeah roger" — but these are
@@ -95,7 +107,9 @@ export function detectMention(rawText) {
     return { match: false, reason: 'too-short' };
   }
 
-  // Find first match (prefer most specific)
+  // Find first match (prefer most specific).
+  // Priority: claude schefter > schefter > schefty > explicit schefter-bot >
+  //           claude > generic "the/this/that bot" (Roger-guarded)
   let matchInfo = null;
   const csMatch = text.match(PATTERN_CLAUDE_SCHEFTER);
   if (csMatch) {
@@ -109,9 +123,26 @@ export function detectMention(rawText) {
       if (styMatch) {
         matchInfo = { variant: 'schefty', index: styMatch.index ?? 0, length: styMatch[0].length };
       } else {
-        const cMatch = text.match(PATTERN_CLAUDE);
-        if (cMatch) {
-          matchInfo = { variant: 'claude', index: cMatch.index ?? 0, length: cMatch[0].length };
+        const esbMatch = text.match(PATTERN_EXPLICIT_SCHEFTER_BOT);
+        if (esbMatch) {
+          // "schefter bot" / "claude bot" — explicit, bypasses Roger guard.
+          matchInfo = { variant: 'schefter-bot', index: esbMatch.index ?? 0, length: esbMatch[0].length };
+        } else {
+          const cMatch = text.match(PATTERN_CLAUDE);
+          if (cMatch) {
+            matchInfo = { variant: 'claude', index: cMatch.index ?? 0, length: cMatch[0].length };
+          } else {
+            const botMatch = text.match(PATTERN_GENERIC_BOT);
+            if (botMatch) {
+              // Generic "the bot" — reject if anything Roger-adjacent appears
+              // in the message. TheLeague chat has two bots; a bare "the bot"
+              // is ambiguous, so we only claim it when Roger is NOT mentioned.
+              if (ROGER_GUARD.test(text)) {
+                return { match: false, reason: 'generic-bot-with-roger-context' };
+              }
+              matchInfo = { variant: 'the-bot', index: botMatch.index ?? 0, length: botMatch[0].length };
+            }
+          }
         }
       }
     }
@@ -276,6 +307,19 @@ export function detectAttackOnSchefter(rawText) {
   const subjectMatch = ATTACK_SUBJECT_PATTERNS.some((re) => re.test(text));
   if (!subjectMatch) {
     return { attack: false, reason: 'no-subject' };
+  }
+
+  // Roger disambiguation — if the ONLY bot mention is a generic "the bot" /
+  // "this bot" / "that bot" AND Roger is also named anywhere in the message,
+  // punt: this is ambiguous enough that we'd rather miss a Schefter attack
+  // than incorrectly log a Roger-directed one against an author's Style Book
+  // file. Explicit "schefter bot" / "claude bot" bypasses this guard since
+  // the author said exactly who they meant.
+  const mentionsRoger = /\b(?:roger|ask\s+roger|the\s+roger\s+bot|roger's\s+bot)\b/i.test(text);
+  const explicitSchefterRef = /\b(?:claude|schefter|schefty)\b/i.test(text);
+  const mentionsGenericBot = /\b(?:the|this|that)\s+bot\b/i.test(text);
+  if (mentionsRoger && mentionsGenericBot && !explicitSchefterRef) {
+    return { attack: false, reason: 'generic-bot-with-roger-context' };
   }
 
   // Tokenize for negation window scanning

--- a/scripts/schefter-rumor-scan.mjs
+++ b/scripts/schefter-rumor-scan.mjs
@@ -307,6 +307,16 @@ function anonymizeTips(tips, teams, feedPosts = []) {
     // naturally; we do not pre-resolve from author name here).
     if (tip.source === 'groupme') {
       safe.scope = { kind: 'groupme-public' };
+      // Style Book: if this GroupMe tip was flagged as a personal attack on
+      // Schefter by the listener, surface the flag + running-season count
+      // so the LLM can escalate the Style Book bit with running-total flavor.
+      // See HARD RULE 15 and running-bits.md → "The Style Book".
+      if (tip.attackOnSchefter === true) {
+        safe.attackOnSchefter = true;
+        if (typeof tip.styleBookCount === 'number' && tip.styleBookCount > 0) {
+          safe.styleBookCount = tip.styleBookCount;
+        }
+      }
       return safe;
     }
 
@@ -520,6 +530,12 @@ HARD RULES (self-enforce, never violate):
     Hostile tips still respect every fuzz rule above: single-source franchise mentions still fuzz to division, attacks on the commish still route through the commish scope, etc. Understated beats amplified — a dry note that beef exists lands harder than hot repetition.
 13. Reverse-the-lens framing (optional, HOSTILE TIPS ONLY): when a hostile web tip surfaces a \`tipsterDivision\` field, you MAY reframe the sentiment by citing the TIPSTER's division instead of the subject — "hearing an owner in the [tipsterDivision] isn't happy with the league office", "somebody in the [tipsterDivision] is fed up with the front office". This is the ONLY case where "an owner in the [division]" refers to the source rather than the subject — use it ONLY for hostile tips, NEVER for routine subject-division fuzz. Do NOT combine tipsterDivision framing with subject-division framing in the same post (too easy to conflate). Do NOT cite tipsterDivision on non-hostile tips — rule 2's subject-division constraint still applies there.
 14. Intra-division hostile tips (\`intraDivision: true\`): PREFERRED frame when a hostile tip's tipster and subject share a division. Attribute neither side — frame the division itself as the story: "the [division] division is really developing some strong rivalries", "beef brewing inside the [division] division", "the [division] is the most personal division in the league right now", "rivalries heating up in the [division]". This is the best hostile-tip outcome — 4 teams → 4 teams, no narrowing, and the beat-reporter voice reads as color rather than partisan complaint. Skip tipsterDivision and subject-division framing when this flag is set — division-level framing covers both.
+15. Style Book (GroupMe attacks on Schefter): when a GroupMe tip carries \`attackOnSchefter: true\`, the tipster (named publicly via the \`author\` field) just took a shot at the bot. Pass it through the Style Book bit — bemused beat-reporter cataloging the criticism, NEVER defensive or clapping-back first-person. If \`styleBookCount\` is also present, you MAY reference the running total for escalation flavor:
+    - count === 1: "Noted, [author]. Adding that to the style book." / "Every denial's a data point. Filed."
+    - count === 2: "Second entry in the style book for [author]. The dossier grows."
+    - count === 3: "Third shot from [author] this season. The file's getting thick."
+    - count >= 4: "[author] is officially a power user of the style book. Keep them coming." / "[N] entries deep on [author]. A scouting report writes itself."
+    Always pair with ONE line of actual league news — never let the Style Book line be the whole post. NEVER quote the attack verbatim. NEVER name the pejorative they used. The bit is affectionate ribbing, not adversarial — Schefter is a bemused reporter filing another observation, never a target clapping back. Do NOT combine with the Bot Wink catalog in the same post (they overlap thematically).
 
 Voice: "League sources tell me…", "I'm told…", "Hearing…", "A division rival whispers…". Salt, not sugar.`;
 

--- a/scripts/schefter-rumor-scan.mjs
+++ b/scripts/schefter-rumor-scan.mjs
@@ -366,6 +366,22 @@ function anonymizeTips(tips, teams, feedPosts = []) {
       }
     }
 
+    // Style Book — anonymous web-tip path. If this web tip was flagged as a
+    // personal attack on Schefter by the API route, surface the flag + count
+    // + codename so the LLM can fire the Style Book bit with continuity
+    // ("Noted, Burner Phone. Adding that to the file."). Anon tips get a
+    // codename; GroupMe tips get the author's display name — HARD RULE 15
+    // handles both cases.
+    if (tip.attackOnSchefter === true) {
+      safe.attackOnSchefter = true;
+      if (typeof tip.styleBookCount === 'number' && tip.styleBookCount > 0) {
+        safe.styleBookCount = tip.styleBookCount;
+      }
+      if (typeof tip.tipsterCodename === 'string' && tip.tipsterCodename.length > 0) {
+        safe.tipsterCodename = tip.tipsterCodename;
+      }
+    }
+
     // Intra-division flag — set when the tipster and the SUBJECT team are in
     // the same division. The scanner prompt uses this to unlock a hostile-tip
     // frame that cites the division itself as rivalry territory, attributing
@@ -530,12 +546,15 @@ HARD RULES (self-enforce, never violate):
     Hostile tips still respect every fuzz rule above: single-source franchise mentions still fuzz to division, attacks on the commish still route through the commish scope, etc. Understated beats amplified — a dry note that beef exists lands harder than hot repetition.
 13. Reverse-the-lens framing (optional, HOSTILE TIPS ONLY): when a hostile web tip surfaces a \`tipsterDivision\` field, you MAY reframe the sentiment by citing the TIPSTER's division instead of the subject — "hearing an owner in the [tipsterDivision] isn't happy with the league office", "somebody in the [tipsterDivision] is fed up with the front office". This is the ONLY case where "an owner in the [division]" refers to the source rather than the subject — use it ONLY for hostile tips, NEVER for routine subject-division fuzz. Do NOT combine tipsterDivision framing with subject-division framing in the same post (too easy to conflate). Do NOT cite tipsterDivision on non-hostile tips — rule 2's subject-division constraint still applies there.
 14. Intra-division hostile tips (\`intraDivision: true\`): PREFERRED frame when a hostile tip's tipster and subject share a division. Attribute neither side — frame the division itself as the story: "the [division] division is really developing some strong rivalries", "beef brewing inside the [division] division", "the [division] is the most personal division in the league right now", "rivalries heating up in the [division]". This is the best hostile-tip outcome — 4 teams → 4 teams, no narrowing, and the beat-reporter voice reads as color rather than partisan complaint. Skip tipsterDivision and subject-division framing when this flag is set — division-level framing covers both.
-15. Style Book (GroupMe attacks on Schefter): when a GroupMe tip carries \`attackOnSchefter: true\`, the tipster (named publicly via the \`author\` field) just took a shot at the bot. Pass it through the Style Book bit — bemused beat-reporter cataloging the criticism, NEVER defensive or clapping-back first-person. If \`styleBookCount\` is also present, you MAY reference the running total for escalation flavor:
-    - count === 1: "Noted, [author]. Adding that to the style book." / "Every denial's a data point. Filed."
-    - count === 2: "Second entry in the style book for [author]. The dossier grows."
-    - count === 3: "Third shot from [author] this season. The file's getting thick."
-    - count >= 4: "[author] is officially a power user of the style book. Keep them coming." / "[N] entries deep on [author]. A scouting report writes itself."
-    Always pair with ONE line of actual league news — never let the Style Book line be the whole post. NEVER quote the attack verbatim. NEVER name the pejorative they used. The bit is affectionate ribbing, not adversarial — Schefter is a bemused reporter filing another observation, never a target clapping back. Do NOT combine with the Bot Wink catalog in the same post (they overlap thematically).
+15. Style Book (attacks on Schefter): a tip carries \`attackOnSchefter: true\` when the tipster just took a shot at the bot. Pass it through the Style Book bit — bemused beat-reporter cataloging the criticism, NEVER defensive or clapping-back first-person. Two flavors depending on the source:
+    - **GroupMe (named)**: the tipster is named publicly via \`author\`. Address them by name: "Noted, Dead Cap.", "Back for round two, Wabbit."
+    - **Web (anonymous)**: the tipster is anonymous but carries a \`tipsterCodename\` (e.g. "Burner Phone", "The Ghost", "Hot Mic"). Address them by codename: "Noted, Burner Phone.", "Second entry for The Ghost."
+    If \`styleBookCount\` is present, you MAY reference the running total for escalation flavor (applies to BOTH flavors):
+    - count === 1: "Noted, [name]. Adding that to the style book." / "Every shot's a data point. Filed."
+    - count === 2: "Second entry in the style book for [name]. The dossier grows."
+    - count === 3: "Third shot from [name] this season. The file's getting thick."
+    - count >= 4: "[name] is officially a power user of the style book. Keep them coming." / "[N] entries deep on [name]. A scouting report writes itself."
+    Always pair with ONE line of actual league news — never let the Style Book line be the whole post. NEVER quote the attack verbatim. NEVER name the pejorative they used. The bit is affectionate ribbing, not adversarial — Schefter is a bemused reporter filing another observation, never a target clapping back. Do NOT combine with the Bot Wink catalog in the same post (they overlap thematically). Do NOT confuse a web-tip codename with a real owner name — the codename IS the handle, use it verbatim.
 
 Voice: "League sources tell me…", "I'm told…", "Hearing…", "A division rival whispers…". Salt, not sugar.`;
 

--- a/src/pages/api/schefter/style-book.ts
+++ b/src/pages/api/schefter/style-book.ts
@@ -1,32 +1,36 @@
 /**
  * GET /api/schefter/style-book
  *
- * Public (no auth) read of the Style Book leaderboard — the running tally
- * of GroupMe personal attacks on Schefter, by author. GroupMe authorship
- * is already public (anyone can scroll the chat), so exposing these counts
- * on a public page doesn't widen the de-anonymization surface.
+ * Public (no auth) read of the Style Book leaderboards — running tallies of
+ * personal attacks on Schefter. Two separate pools:
+ *
+ *   - `named` — GroupMe-chat attackers, keyed on the public display name.
+ *     Public authorship already makes these identifiable.
+ *   - `anonymous` — web-tip attackers, keyed internally on the tipster hash
+ *     but displayed ONLY as a codename ("Burner Phone", "The Ghost" …). The
+ *     raw hash never appears in the response.
+ *
+ * The two leaderboards are returned side by side so web tipsters compete
+ * against each other (by codename) and GroupMe attackers compete against each
+ * other (by name) — never mixed.
  *
  * Response shape:
  *   {
  *     seasonYear: number,
- *     entries: Array<{
- *       author: string,
- *       seasonCount: number,
- *       lifetimeCount: number,
- *       lastShotAt: number | null
- *     }>,
- *     totals: { seasonShots: number, authors: number }
+ *     named: {
+ *       entries: Array<{ author, seasonCount, lifetimeCount, lastShotAt }>,
+ *       totals: { seasonShots, authors }
+ *     },
+ *     anonymous: {
+ *       entries: Array<{ codename, seasonCount, lifetimeCount, lastShotAt }>,
+ *       totals: { seasonShots, authors }
+ *     }
  *   }
- *
- * The leaderboard ZSET stores each attacker's DISPLAY name directly
- * (not a hash) because the whole point of the bit is named ribbing.
- * Lifetime + last-shot lookups use a normalized lowercase key — mirrors
- * normalizeAuthorKey() in scripts/schefter-groupme-listen.mjs so the
- * two sides stay in sync.
  */
 
 import type { APIRoute } from 'astro';
 import { getCurrentLeagueYear } from '../../../utils/league-year';
+import { getCodename } from '../../../utils/schefter-codenames';
 
 export const prerender = false;
 
@@ -34,12 +38,21 @@ const JSON_HEADERS = { 'Content-Type': 'application/json', 'Cache-Control': 'no-
 const LEADERBOARD_LIMIT = 25;
 const CACHE_TTL_MS = 30_000;
 
-const STYLE_BOOK_LIFETIME_PREFIX = 'schefter:style_book:';
-const STYLE_BOOK_LAST_SHOT_PREFIX = 'schefter:style_book:last_shot_at:';
-const STYLE_BOOK_LEADERBOARD_PREFIX = 'schefter:style_book:leaderboard:';
+// Named (GroupMe) Style Book
+const NAMED_LIFETIME_PREFIX = 'schefter:style_book:';
+const NAMED_LAST_SHOT_PREFIX = 'schefter:style_book:last_shot_at:';
+const NAMED_LEADERBOARD_PREFIX = 'schefter:style_book:leaderboard:';
+
+// Anonymous (web-tip) Style Book
+const ANON_LIFETIME_PREFIX = 'schefter:style_book:anon:';
+const ANON_LAST_SHOT_PREFIX = 'schefter:style_book:anon:last_shot_at:';
+const ANON_LEADERBOARD_PREFIX = 'schefter:style_book:anon_leaderboard:';
 
 type RedisClient = {
   get: <T>(key: string) => Promise<T | null>;
+  set: (key: string, value: unknown, opts?: { nx?: boolean; ex?: number }) => Promise<unknown>;
+  sadd: (key: string, ...members: string[]) => Promise<number>;
+  srem: (key: string, ...members: string[]) => Promise<number>;
   zrange: (
     key: string,
     start: number,
@@ -49,8 +62,15 @@ type RedisClient = {
   zcard: (key: string) => Promise<number>;
 };
 
-type LeaderboardEntry = {
+type NamedEntry = {
   author: string;
+  seasonCount: number;
+  lifetimeCount: number;
+  lastShotAt: number | null;
+};
+
+type AnonEntry = {
+  codename: string;
   seasonCount: number;
   lifetimeCount: number;
   lastShotAt: number | null;
@@ -58,8 +78,14 @@ type LeaderboardEntry = {
 
 type StyleBookResponse = {
   seasonYear: number;
-  entries: LeaderboardEntry[];
-  totals: { seasonShots: number; authors: number };
+  named: {
+    entries: NamedEntry[];
+    totals: { seasonShots: number; authors: number };
+  };
+  anonymous: {
+    entries: AnonEntry[];
+    totals: { seasonShots: number; authors: number };
+  };
 };
 
 let _redis: RedisClient | null | undefined;
@@ -110,9 +136,9 @@ function coerceTimestamp(raw: unknown): number | null {
 }
 
 /**
- * Mirrors normalizeAuthorKey() in scripts/schefter-groupme-listen.mjs.
- * Both paths must produce the same key for the same display name, otherwise
- * lifetime + last-shot lookups miss on the leaderboard display name.
+ * Mirrors normalizeAuthorKey() in scripts/schefter-groupme-listen.mjs for the
+ * NAMED leaderboard. Both paths must produce the same key for the same display
+ * name or lifetime/last-shot lookups will miss.
  */
 export function normalizeAuthorKey(name: string): string {
   if (!name || typeof name !== 'string') return '';
@@ -136,9 +162,101 @@ function normalizeZrange(raw: unknown): Array<{ member: string; score: number }>
   return out;
 }
 
-/** Expose cache reset for tests — not wired in production. */
 export function _resetStyleBookCacheForTests(): void {
   _cache = null;
+}
+
+async function fetchNamedEntries(
+  redis: RedisClient,
+  seasonYear: number,
+): Promise<{ entries: NamedEntry[]; authorCount: number }> {
+  const leaderboardKey = `${NAMED_LEADERBOARD_PREFIX}${seasonYear}`;
+  const [rawLeaderboard, rawCount] = await Promise.all([
+    redis.zrange(leaderboardKey, 0, LEADERBOARD_LIMIT - 1, { rev: true, withScores: true }),
+    redis.zcard(leaderboardKey).catch(() => 0),
+  ]);
+  const rows = normalizeZrange(rawLeaderboard);
+  const authorCount = typeof rawCount === 'number' ? rawCount : rows.length;
+  if (rows.length === 0) return { entries: [], authorCount };
+
+  const entries = await Promise.all(
+    rows.map(async (row) => {
+      const authorKey = normalizeAuthorKey(row.member);
+      let lifetimeCount = 0;
+      let lastShotAt: number | null = null;
+      if (authorKey) {
+        try {
+          const [lifeRaw, shotRaw] = await Promise.all([
+            redis.get<string | number>(`${NAMED_LIFETIME_PREFIX}${authorKey}`),
+            redis.get<string | number>(`${NAMED_LAST_SHOT_PREFIX}${authorKey}`),
+          ]);
+          lifetimeCount = coerceCount(lifeRaw);
+          lastShotAt = coerceTimestamp(shotRaw);
+        } catch {
+          /* degrade */
+        }
+      }
+      return {
+        author: row.member,
+        seasonCount: row.score,
+        lifetimeCount,
+        lastShotAt,
+      } satisfies NamedEntry;
+    }),
+  );
+  return { entries, authorCount };
+}
+
+/**
+ * Anon entries — ZSET members are tipster HASHES. The hash is NEVER returned
+ * to the client; we resolve each to its codename via getCodename and drop
+ * entries whose codename we can't resolve (shouldn't happen — tip.ts calls
+ * assignCodename on every attack — but a belt-and-suspenders guard).
+ */
+async function fetchAnonEntries(
+  redis: RedisClient,
+  seasonYear: number,
+): Promise<{ entries: AnonEntry[]; authorCount: number }> {
+  const leaderboardKey = `${ANON_LEADERBOARD_PREFIX}${seasonYear}`;
+  const [rawLeaderboard, rawCount] = await Promise.all([
+    redis.zrange(leaderboardKey, 0, LEADERBOARD_LIMIT - 1, { rev: true, withScores: true }),
+    redis.zcard(leaderboardKey).catch(() => 0),
+  ]);
+  const rows = normalizeZrange(rawLeaderboard);
+  const authorCount = typeof rawCount === 'number' ? rawCount : rows.length;
+  if (rows.length === 0) return { entries: [], authorCount };
+
+  const entries: AnonEntry[] = [];
+  for (const row of rows) {
+    const hashedOwnerId = row.member;
+    let codename: string | null = null;
+    try {
+      codename = await getCodename(redis, hashedOwnerId);
+    } catch {
+      codename = null;
+    }
+    if (!codename) continue; // never leak a raw hash into the response
+
+    let lifetimeCount = 0;
+    let lastShotAt: number | null = null;
+    try {
+      const [lifeRaw, shotRaw] = await Promise.all([
+        redis.get<string | number>(`${ANON_LIFETIME_PREFIX}${hashedOwnerId}`),
+        redis.get<string | number>(`${ANON_LAST_SHOT_PREFIX}${hashedOwnerId}`),
+      ]);
+      lifetimeCount = coerceCount(lifeRaw);
+      lastShotAt = coerceTimestamp(shotRaw);
+    } catch {
+      /* degrade */
+    }
+    entries.push({
+      codename,
+      seasonCount: row.score,
+      lifetimeCount,
+      lastShotAt,
+    });
+  }
+  return { entries, authorCount };
 }
 
 export const GET: APIRoute = async () => {
@@ -153,75 +271,37 @@ export const GET: APIRoute = async () => {
   if (!redis) {
     const empty: StyleBookResponse = {
       seasonYear,
-      entries: [],
-      totals: { seasonShots: 0, authors: 0 },
+      named: { entries: [], totals: { seasonShots: 0, authors: 0 } },
+      anonymous: { entries: [], totals: { seasonShots: 0, authors: 0 } },
     };
     _cache = { data: empty, expiresAt: now + CACHE_TTL_MS };
     return json(empty);
   }
 
-  const leaderboardKey = `${STYLE_BOOK_LEADERBOARD_PREFIX}${seasonYear}`;
-
-  let rawLeaderboard: unknown = [];
-  let authorCount = 0;
+  let named: { entries: NamedEntry[]; authorCount: number };
+  let anonymous: { entries: AnonEntry[]; authorCount: number };
   try {
-    [rawLeaderboard, authorCount] = await Promise.all([
-      redis.zrange(leaderboardKey, 0, LEADERBOARD_LIMIT - 1, { rev: true, withScores: true }),
-      redis.zcard(leaderboardKey).catch(() => 0),
+    [named, anonymous] = await Promise.all([
+      fetchNamedEntries(redis, seasonYear),
+      fetchAnonEntries(redis, seasonYear),
     ]);
   } catch (err) {
     console.error('[style-book] Read error:', err);
     return json({ error: 'redis_unavailable' }, 503);
   }
 
-  const rows = normalizeZrange(rawLeaderboard);
-  if (rows.length === 0) {
-    const empty: StyleBookResponse = {
-      seasonYear,
-      entries: [],
-      totals: { seasonShots: 0, authors: 0 },
-    };
-    _cache = { data: empty, expiresAt: now + CACHE_TTL_MS };
-    return json(empty);
-  }
-
-  // Fetch lifetime count + last-shot timestamp for each leaderboard entry
-  // in parallel. A single failed lookup degrades that entry (lifetime=0,
-  // lastShotAt=null) without killing the whole response.
-  const entries = await Promise.all(
-    rows.map(async (row) => {
-      const authorKey = normalizeAuthorKey(row.member);
-      let lifetimeCount = 0;
-      let lastShotAt: number | null = null;
-      if (authorKey) {
-        try {
-          const [lifeRaw, shotRaw] = await Promise.all([
-            redis.get<string | number>(`${STYLE_BOOK_LIFETIME_PREFIX}${authorKey}`),
-            redis.get<string | number>(`${STYLE_BOOK_LAST_SHOT_PREFIX}${authorKey}`),
-          ]);
-          lifetimeCount = coerceCount(lifeRaw);
-          lastShotAt = coerceTimestamp(shotRaw);
-        } catch {
-          // Best-effort — leave degraded values.
-        }
-      }
-      return {
-        author: row.member,
-        seasonCount: row.score,
-        lifetimeCount,
-        lastShotAt,
-      } satisfies LeaderboardEntry;
-    }),
-  );
-
-  const seasonShots = entries.reduce((sum, e) => sum + e.seasonCount, 0);
+  const namedTotal = named.entries.reduce((sum, e) => sum + e.seasonCount, 0);
+  const anonTotal = anonymous.entries.reduce((sum, e) => sum + e.seasonCount, 0);
 
   const response: StyleBookResponse = {
     seasonYear,
-    entries,
-    totals: {
-      seasonShots,
-      authors: typeof authorCount === 'number' ? authorCount : entries.length,
+    named: {
+      entries: named.entries,
+      totals: { seasonShots: namedTotal, authors: named.authorCount },
+    },
+    anonymous: {
+      entries: anonymous.entries,
+      totals: { seasonShots: anonTotal, authors: anonymous.authorCount },
     },
   };
 

--- a/src/pages/api/schefter/style-book.ts
+++ b/src/pages/api/schefter/style-book.ts
@@ -1,0 +1,230 @@
+/**
+ * GET /api/schefter/style-book
+ *
+ * Public (no auth) read of the Style Book leaderboard — the running tally
+ * of GroupMe personal attacks on Schefter, by author. GroupMe authorship
+ * is already public (anyone can scroll the chat), so exposing these counts
+ * on a public page doesn't widen the de-anonymization surface.
+ *
+ * Response shape:
+ *   {
+ *     seasonYear: number,
+ *     entries: Array<{
+ *       author: string,
+ *       seasonCount: number,
+ *       lifetimeCount: number,
+ *       lastShotAt: number | null
+ *     }>,
+ *     totals: { seasonShots: number, authors: number }
+ *   }
+ *
+ * The leaderboard ZSET stores each attacker's DISPLAY name directly
+ * (not a hash) because the whole point of the bit is named ribbing.
+ * Lifetime + last-shot lookups use a normalized lowercase key — mirrors
+ * normalizeAuthorKey() in scripts/schefter-groupme-listen.mjs so the
+ * two sides stay in sync.
+ */
+
+import type { APIRoute } from 'astro';
+import { getCurrentLeagueYear } from '../../../utils/league-year';
+
+export const prerender = false;
+
+const JSON_HEADERS = { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' };
+const LEADERBOARD_LIMIT = 25;
+const CACHE_TTL_MS = 30_000;
+
+const STYLE_BOOK_LIFETIME_PREFIX = 'schefter:style_book:';
+const STYLE_BOOK_LAST_SHOT_PREFIX = 'schefter:style_book:last_shot_at:';
+const STYLE_BOOK_LEADERBOARD_PREFIX = 'schefter:style_book:leaderboard:';
+
+type RedisClient = {
+  get: <T>(key: string) => Promise<T | null>;
+  zrange: (
+    key: string,
+    start: number,
+    stop: number,
+    opts?: { rev?: boolean; withScores?: boolean },
+  ) => Promise<unknown>;
+  zcard: (key: string) => Promise<number>;
+};
+
+type LeaderboardEntry = {
+  author: string;
+  seasonCount: number;
+  lifetimeCount: number;
+  lastShotAt: number | null;
+};
+
+type StyleBookResponse = {
+  seasonYear: number;
+  entries: LeaderboardEntry[];
+  totals: { seasonShots: number; authors: number };
+};
+
+let _redis: RedisClient | null | undefined;
+let _cache: { data: StyleBookResponse; expiresAt: number } | null = null;
+
+async function getRedis(): Promise<RedisClient | null> {
+  if (_redis !== undefined) return _redis;
+  const url =
+    process.env.UPSTASH_REDIS_REST_URL ||
+    process.env.KV_REST_API_URL ||
+    process.env.STORAGE_REST_API_URL;
+  const token =
+    process.env.UPSTASH_REDIS_REST_TOKEN ||
+    process.env.KV_REST_API_TOKEN ||
+    process.env.STORAGE_REST_API_TOKEN;
+  if (!url || !token) {
+    _redis = null;
+    return null;
+  }
+  try {
+    const { Redis } = await import('@upstash/redis');
+    _redis = new Redis({ url, token }) as unknown as RedisClient;
+    return _redis;
+  } catch (err) {
+    console.warn('[style-book] Redis unavailable:', err);
+    _redis = null;
+    return null;
+  }
+}
+
+function json(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), { status, headers: JSON_HEADERS });
+}
+
+function coerceCount(raw: unknown): number {
+  if (typeof raw === 'number') return Number.isFinite(raw) ? Math.max(0, Math.floor(raw)) : 0;
+  if (typeof raw === 'string') {
+    const n = parseInt(raw, 10);
+    return Number.isFinite(n) ? Math.max(0, n) : 0;
+  }
+  return 0;
+}
+
+function coerceTimestamp(raw: unknown): number | null {
+  if (raw === null || raw === undefined || raw === '') return null;
+  const n = typeof raw === 'number' ? raw : parseInt(String(raw), 10);
+  return Number.isFinite(n) && n > 0 ? n : null;
+}
+
+/**
+ * Mirrors normalizeAuthorKey() in scripts/schefter-groupme-listen.mjs.
+ * Both paths must produce the same key for the same display name, otherwise
+ * lifetime + last-shot lookups miss on the leaderboard display name.
+ */
+export function normalizeAuthorKey(name: string): string {
+  if (!name || typeof name !== 'string') return '';
+  return name.toLowerCase().trim().replace(/[^a-z0-9]+/g, '_').replace(/^_|_$/g, '');
+}
+
+/** Normalize `zrange` results across Upstash client versions. */
+function normalizeZrange(raw: unknown): Array<{ member: string; score: number }> {
+  if (!Array.isArray(raw) || raw.length === 0) return [];
+  const first = raw[0];
+  if (first && typeof first === 'object' && 'member' in (first as Record<string, unknown>)) {
+    return (raw as Array<{ member: string; score: number | string }>).map((row) => ({
+      member: String(row.member),
+      score: coerceCount(row.score),
+    }));
+  }
+  const out: Array<{ member: string; score: number }> = [];
+  for (let i = 0; i + 1 < raw.length; i += 2) {
+    out.push({ member: String(raw[i]), score: coerceCount(raw[i + 1]) });
+  }
+  return out;
+}
+
+/** Expose cache reset for tests — not wired in production. */
+export function _resetStyleBookCacheForTests(): void {
+  _cache = null;
+}
+
+export const GET: APIRoute = async () => {
+  const now = Date.now();
+  if (_cache && _cache.expiresAt > now) {
+    return json(_cache.data);
+  }
+
+  const seasonYear = getCurrentLeagueYear();
+  const redis = await getRedis();
+
+  if (!redis) {
+    const empty: StyleBookResponse = {
+      seasonYear,
+      entries: [],
+      totals: { seasonShots: 0, authors: 0 },
+    };
+    _cache = { data: empty, expiresAt: now + CACHE_TTL_MS };
+    return json(empty);
+  }
+
+  const leaderboardKey = `${STYLE_BOOK_LEADERBOARD_PREFIX}${seasonYear}`;
+
+  let rawLeaderboard: unknown = [];
+  let authorCount = 0;
+  try {
+    [rawLeaderboard, authorCount] = await Promise.all([
+      redis.zrange(leaderboardKey, 0, LEADERBOARD_LIMIT - 1, { rev: true, withScores: true }),
+      redis.zcard(leaderboardKey).catch(() => 0),
+    ]);
+  } catch (err) {
+    console.error('[style-book] Read error:', err);
+    return json({ error: 'redis_unavailable' }, 503);
+  }
+
+  const rows = normalizeZrange(rawLeaderboard);
+  if (rows.length === 0) {
+    const empty: StyleBookResponse = {
+      seasonYear,
+      entries: [],
+      totals: { seasonShots: 0, authors: 0 },
+    };
+    _cache = { data: empty, expiresAt: now + CACHE_TTL_MS };
+    return json(empty);
+  }
+
+  // Fetch lifetime count + last-shot timestamp for each leaderboard entry
+  // in parallel. A single failed lookup degrades that entry (lifetime=0,
+  // lastShotAt=null) without killing the whole response.
+  const entries = await Promise.all(
+    rows.map(async (row) => {
+      const authorKey = normalizeAuthorKey(row.member);
+      let lifetimeCount = 0;
+      let lastShotAt: number | null = null;
+      if (authorKey) {
+        try {
+          const [lifeRaw, shotRaw] = await Promise.all([
+            redis.get<string | number>(`${STYLE_BOOK_LIFETIME_PREFIX}${authorKey}`),
+            redis.get<string | number>(`${STYLE_BOOK_LAST_SHOT_PREFIX}${authorKey}`),
+          ]);
+          lifetimeCount = coerceCount(lifeRaw);
+          lastShotAt = coerceTimestamp(shotRaw);
+        } catch {
+          // Best-effort — leave degraded values.
+        }
+      }
+      return {
+        author: row.member,
+        seasonCount: row.score,
+        lifetimeCount,
+        lastShotAt,
+      } satisfies LeaderboardEntry;
+    }),
+  );
+
+  const seasonShots = entries.reduce((sum, e) => sum + e.seasonCount, 0);
+
+  const response: StyleBookResponse = {
+    seasonYear,
+    entries,
+    totals: {
+      seasonShots,
+      authors: typeof authorCount === 'number' ? authorCount : entries.length,
+    },
+  };
+
+  _cache = { data: response, expiresAt: now + CACHE_TTL_MS };
+  return json(response);
+};

--- a/src/pages/api/schefter/tip.ts
+++ b/src/pages/api/schefter/tip.ts
@@ -20,6 +20,9 @@
 import type { APIRoute } from 'astro';
 import { getAuthUser } from '../../../utils/auth';
 import { hashTipsterId } from '../../../utils/schefter-tipster-hash';
+import { detectAttackOnSchefter } from '../../../utils/schefter-attack-detection';
+import { assignCodename } from '../../../utils/schefter-codenames';
+import { getCurrentLeagueYear } from '../../../utils/league-year';
 import theLeagueConfig from '../../../data/theleague.config.json';
 import {
   TIP_TOPICS,
@@ -42,6 +45,15 @@ const RATE_LIMIT_PREFIX = 'schefter:tips:ratelimit:';
 const RATE_LIMIT_MAX = 3;
 const RATE_LIMIT_TTL_SEC = 24 * 60 * 60;
 
+// Anon Style Book keys. Named (GroupMe) attackers live under
+// `schefter:style_book:{authorKey}` keyed on the public display name. Anon
+// web tippers live here keyed on the tipster hash so the two leaderboards
+// never mix and de-anonymization is impossible through the leaderboard.
+const STYLE_BOOK_ANON_LIFETIME_PREFIX = 'schefter:style_book:anon:';
+const STYLE_BOOK_ANON_SEASON_PREFIX = 'schefter:style_book:anon:season:';
+const STYLE_BOOK_ANON_LAST_SHOT_PREFIX = 'schefter:style_book:anon:last_shot_at:';
+const STYLE_BOOK_ANON_LEADERBOARD_PREFIX = 'schefter:style_book:anon_leaderboard:';
+
 type RedisClient = {
   lpush: (key: string, ...values: unknown[]) => Promise<number>;
   incr: (key: string) => Promise<number>;
@@ -50,7 +62,10 @@ type RedisClient = {
   llen: (key: string) => Promise<number>;
   get: <T>(key: string) => Promise<T | null>;
   zadd: (key: string, entry: { score: number; member: string }) => Promise<unknown>;
+  zincrby: (key: string, increment: number, member: string) => Promise<number | string>;
   zremrangebyscore: (key: string, min: number | string, max: number | string) => Promise<unknown>;
+  sadd: (key: string, ...members: string[]) => Promise<number>;
+  srem: (key: string, ...members: string[]) => Promise<number>;
 };
 
 let _redis: RedisClient | null | undefined;
@@ -240,6 +255,51 @@ export const POST: APIRoute = async ({ request }) => {
 
   const tipsterDivision = resolveDivision(user.franchiseId);
 
+  // Style Book — anonymous web-tip path. If the tip text attacks Schefter,
+  // bump the anon-leaderboard counters keyed on the hashed owner id. Named
+  // GroupMe attackers and anon web attackers live in separate leaderboards
+  // (different keyspaces, different Redis ZSETs) so they compete against
+  // their own pools. Codenames are resolved at leaderboard-read time via
+  // `schefter:tipster:codename:{hash}` so the raw hash never surfaces in any
+  // response.
+  //
+  // Best-effort — a failure here must not block tip enqueue. We null-check
+  // `styleBookCount` when stamping the tip so the LLM path degrades gracefully.
+  const attackCheck = detectAttackOnSchefter(trimmedText);
+  let styleBookCount: number | null = null;
+  let tipsterCodename: string | null = null;
+  if (attackCheck.attack) {
+    try {
+      const year = getCurrentLeagueYear();
+      const lifetimeKey = `${STYLE_BOOK_ANON_LIFETIME_PREFIX}${hashedOwnerId}`;
+      const seasonKey = `${STYLE_BOOK_ANON_SEASON_PREFIX}${year}:${hashedOwnerId}`;
+      const lastShotKey = `${STYLE_BOOK_ANON_LAST_SHOT_PREFIX}${hashedOwnerId}`;
+      const leaderboardKey = `${STYLE_BOOK_ANON_LEADERBOARD_PREFIX}${year}`;
+
+      await redis.incr(lifetimeKey);
+      const seasonRaw = await redis.incr(seasonKey);
+      await redis.set(lastShotKey, Date.now());
+      // Leaderboard ZSET stores the HASH as member (never surfaced). The
+      // response layer resolves to codename via schefter:tipster:codename:{hash}.
+      await redis.zincrby(leaderboardKey, 1, hashedOwnerId);
+
+      styleBookCount = typeof seasonRaw === 'number'
+        ? seasonRaw
+        : parseInt(String(seasonRaw ?? '0'), 10) || 1;
+
+      // Resolve / assign a codename so the LLM has a stable handle to use
+      // when referring to this anonymous attacker in posts. assignCodename
+      // is idempotent — returns the existing codename if one's already set.
+      try {
+        tipsterCodename = await assignCodename(redis, hashedOwnerId);
+      } catch (err) {
+        console.warn('[schefter/tip] codename assign (style-book) failed:', err);
+      }
+    } catch (err) {
+      console.warn('[schefter/tip] anon style-book bump failed:', err);
+    }
+  }
+
   const tip: Tip = {
     id: crypto.randomUUID(),
     hashedOwnerId,
@@ -251,6 +311,13 @@ export const POST: APIRoute = async ({ request }) => {
     submittedAt: Date.now(),
     source: 'web',
     ...(validatedRepliesToPostId ? { repliesToPostId: validatedRepliesToPostId } : {}),
+    ...(attackCheck.attack
+      ? {
+          attackOnSchefter: true,
+          ...(styleBookCount !== null ? { styleBookCount } : {}),
+          ...(tipsterCodename ? { tipsterCodename } : {}),
+        }
+      : {}),
   };
 
   try {

--- a/src/pages/theleague/schefter/style-book.astro
+++ b/src/pages/theleague/schefter/style-book.astro
@@ -48,37 +48,63 @@ const schefterAvatar = schefterAuthor ? getAuthorAvatar(schefterAuthor) : '/asse
           </div>
         </div>
         <p class="sf-page-header__bio">
-          Every shot taken at the bot in the group chat becomes a data point. The file grows with the heat. Bemused beat-reporter dossier — the count is the joke, not the slur.
+          Every shot taken at the bot becomes a data point. Two files — named entries from the group chat, anonymous entries from the tip line. Each side competes against itself. Bemused beat-reporter dossier — the count is the joke, not the slur.
         </p>
       </div>
     </header>
 
-    <section class="style-book-board" aria-labelledby="style-book-board-title" data-style-book>
-      <div class="section-header">
-        <h2 class="section-header__title" id="style-book-board-title">This season's leaderboard</h2>
-        <p class="section-header__sub" data-style-book-sub>Loading the dossier…</p>
-      </div>
+    <div class="style-book-grid">
+      <section class="style-book-board" aria-labelledby="style-book-named-title" data-style-book-named>
+        <div class="section-header">
+          <h2 class="section-header__title" id="style-book-named-title">Group Chat file</h2>
+          <p class="section-header__sub" data-style-book-named-sub>Loading the dossier…</p>
+        </div>
 
-      <div class="style-book-empty" data-style-book-empty hidden>
-        <p class="style-book-empty__line">The dossier is empty this season.</p>
-        <p class="style-book-empty__sub">No shots on record. The bot remains unbothered.</p>
-      </div>
+        <div class="style-book-empty" data-style-book-named-empty hidden>
+          <p class="style-book-empty__line">The group chat file is empty.</p>
+          <p class="style-book-empty__sub">No shots on record from the chat. The bot remains unbothered.</p>
+        </div>
 
-      <ol class="style-book-list" data-style-book-list></ol>
+        <ol class="style-book-list" data-style-book-named-list></ol>
 
-      <p class="style-book-totals" data-style-book-totals hidden></p>
-    </section>
+        <p class="style-book-totals" data-style-book-named-totals hidden></p>
+      </section>
+
+      <section class="style-book-board" aria-labelledby="style-book-anon-title" data-style-book-anon>
+        <div class="section-header">
+          <h2 class="section-header__title" id="style-book-anon-title">Anonymous Tip-line file</h2>
+          <p class="section-header__sub" data-style-book-anon-sub>Loading the dossier…</p>
+        </div>
+
+        <div class="style-book-empty" data-style-book-anon-empty hidden>
+          <p class="style-book-empty__line">The tip-line file is empty.</p>
+          <p class="style-book-empty__sub">Everyone's behaving today. For now.</p>
+        </div>
+
+        <ol class="style-book-list" data-style-book-anon-list></ol>
+
+        <p class="style-book-totals" data-style-book-anon-totals hidden></p>
+      </section>
+    </div>
 
     <section class="style-book-footnote" aria-labelledby="style-book-footnote-title">
       <div class="section-header">
-        <h2 class="section-header__title" id="style-book-footnote-title">How the file works</h2>
+        <h2 class="section-header__title" id="style-book-footnote-title">How the files work</h2>
       </div>
       <ul class="style-book-rules">
         <li class="style-book-rule">
+          <span class="style-book-rule__label">Two pools</span>
+          <p class="style-book-rule__text">
+            Named attackers (GroupMe) compete in one pool. Anonymous web tippers (by codename)
+            compete in the other. Nobody moves between pools.
+          </p>
+        </li>
+        <li class="style-book-rule">
           <span class="style-book-rule__label">Trigger</span>
           <p class="style-book-rule__text">
-            A GroupMe message that calls out Schefter/Claude/Schefty/the bot AND contains a pejorative
-            (sucks, hack, trash, fraud, wrong, clown, etc.) gets logged. Everyone starts at zero.
+            A message that calls out Schefter / Claude / Schefty / "the bot" AND contains a pejorative
+            (sucks, hack, trash, fraud, wrong, clown, etc.) gets logged. "The Roger bot" / "ask Roger"
+            doesn't count — that's Roger's beat.
           </p>
         </li>
         <li class="style-book-rule">
@@ -98,8 +124,8 @@ const schefterAvatar = schefterAuthor ? getAuthorAvatar(schefterAuthor) : '/asse
         <li class="style-book-rule">
           <span class="style-book-rule__label">Privacy</span>
           <p class="style-book-rule__text">
-            GroupMe authorship is public by construction — this page only publishes what the chat
-            already showed. No private tip data is ever surfaced here.
+            GroupMe authorship is public by construction. Anonymous tippers are only ever shown
+            by codename — the hash that identifies them internally never leaves Redis.
           </p>
         </li>
       </ul>
@@ -281,6 +307,18 @@ const schefterAvatar = schefterAuthor ? getAuthorAvatar(schefterAuthor) : '/asse
     }
   }
 
+  .style-book-grid {
+    display: grid;
+    gap: var(--space-5, 20px);
+  }
+
+  @media (min-width: 900px) {
+    .style-book-grid {
+      grid-template-columns: 1fr 1fr;
+      align-items: start;
+    }
+  }
+
   .style-book-rule__label {
     display: inline-block;
     font-size: var(--fs-xs, 12px);
@@ -300,24 +338,27 @@ const schefterAvatar = schefterAuthor ? getAuthorAvatar(schefterAuthor) : '/asse
 </style>
 
 <script>
-  type StyleBookEntry = {
+  type NamedEntry = {
     author: string;
     seasonCount: number;
     lifetimeCount: number;
     lastShotAt: number | null;
   };
 
-  type StyleBookResponse = {
-    seasonYear: number;
-    entries: StyleBookEntry[];
-    totals: { seasonShots: number; authors: number };
+  type AnonEntry = {
+    codename: string;
+    seasonCount: number;
+    lifetimeCount: number;
+    lastShotAt: number | null;
   };
 
-  const root = document.querySelector('[data-style-book]');
-  const listEl = document.querySelector('[data-style-book-list]') as HTMLOListElement | null;
-  const emptyEl = document.querySelector('[data-style-book-empty]') as HTMLElement | null;
-  const subEl = document.querySelector('[data-style-book-sub]') as HTMLElement | null;
-  const totalsEl = document.querySelector('[data-style-book-totals]') as HTMLElement | null;
+  type BoardTotals = { seasonShots: number; authors: number };
+
+  type StyleBookResponse = {
+    seasonYear: number;
+    named: { entries: NamedEntry[]; totals: BoardTotals };
+    anonymous: { entries: AnonEntry[]; totals: BoardTotals };
+  };
 
   function formatRelative(ts: number | null): string {
     if (ts === null) return 'never';
@@ -347,12 +388,26 @@ const schefterAvatar = schefterAuthor ? getAuthorAvatar(schefterAuthor) : '/asse
     return n === 1 ? 'shot' : 'shots';
   }
 
-  function render(data: StyleBookResponse) {
+  type Handles = {
+    listEl: HTMLOListElement | null;
+    emptyEl: HTMLElement | null;
+    subEl: HTMLElement | null;
+    totalsEl: HTMLElement | null;
+  };
+
+  function renderBoard(
+    label: 'Group Chat' | 'Tip Line',
+    entries: Array<{ displayName: string; seasonCount: number; lifetimeCount: number; lastShotAt: number | null }>,
+    totals: BoardTotals,
+    seasonYear: number,
+    handles: Handles,
+  ) {
+    const { listEl, emptyEl, subEl, totalsEl } = handles;
     if (!listEl || !subEl) return;
 
-    if (data.entries.length === 0) {
+    if (entries.length === 0) {
       if (emptyEl) emptyEl.hidden = false;
-      subEl.textContent = `${data.seasonYear} season · no entries yet`;
+      subEl.textContent = `${seasonYear} season · no entries yet`;
       listEl.innerHTML = '';
       if (totalsEl) totalsEl.hidden = true;
       return;
@@ -360,11 +415,13 @@ const schefterAvatar = schefterAuthor ? getAuthorAvatar(schefterAuthor) : '/asse
 
     if (emptyEl) emptyEl.hidden = true;
 
-    const topCount = data.entries[0]?.seasonCount ?? 0;
-    const rows = data.entries.map((entry, idx) => {
+    const topCount = entries[0]?.seasonCount ?? 0;
+    const rows = entries.map((entry, idx) => {
       const rank = idx + 1;
       const isTop = entry.seasonCount === topCount && topCount > 0;
-      const classes = ['style-book-entry', isTop ? 'style-book-entry--top' : ''].filter(Boolean).join(' ');
+      const classes = ['style-book-entry', isTop ? 'style-book-entry--top' : '']
+        .filter(Boolean)
+        .join(' ');
       const lastShotText = entry.lastShotAt ? `last shot ${escapeHtml(formatRelative(entry.lastShotAt))}` : '';
       const lifetimeText = entry.lifetimeCount > entry.seasonCount
         ? `${entry.lifetimeCount} lifetime`
@@ -374,7 +431,7 @@ const schefterAvatar = schefterAuthor ? getAuthorAvatar(schefterAuthor) : '/asse
         <li class="${classes}">
           <div class="style-book-entry__rank">#${rank}</div>
           <div class="style-book-entry__author">
-            <div class="style-book-entry__name">${escapeHtml(entry.author)}</div>
+            <div class="style-book-entry__name">${escapeHtml(entry.displayName)}</div>
             ${metaParts ? `<div class="style-book-entry__meta">${metaParts}</div>` : ''}
           </div>
           <div class="style-book-entry__counts">
@@ -386,23 +443,56 @@ const schefterAvatar = schefterAuthor ? getAuthorAvatar(schefterAuthor) : '/asse
     });
     listEl.innerHTML = rows.join('');
 
-    subEl.textContent = `${data.seasonYear} season · top ${data.entries.length} of ${data.totals.authors}`;
+    subEl.textContent = `${seasonYear} season · top ${entries.length} of ${totals.authors}`;
 
     if (totalsEl) {
-      totalsEl.textContent = `${data.totals.seasonShots} ${countLabel(data.totals.seasonShots)} logged across ${data.totals.authors} ${data.totals.authors === 1 ? 'author' : 'authors'} this season.`;
+      const noun = totals.authors === 1 ? (label === 'Tip Line' ? 'tipper' : 'author') : (label === 'Tip Line' ? 'tippers' : 'authors');
+      totalsEl.textContent = `${totals.seasonShots} ${countLabel(totals.seasonShots)} logged across ${totals.authors} ${noun} this season.`;
       totalsEl.hidden = false;
     }
   }
 
+  const namedHandles: Handles = {
+    listEl: document.querySelector('[data-style-book-named-list]'),
+    emptyEl: document.querySelector('[data-style-book-named-empty]'),
+    subEl: document.querySelector('[data-style-book-named-sub]'),
+    totalsEl: document.querySelector('[data-style-book-named-totals]'),
+  };
+
+  const anonHandles: Handles = {
+    listEl: document.querySelector('[data-style-book-anon-list]'),
+    emptyEl: document.querySelector('[data-style-book-anon-empty]'),
+    subEl: document.querySelector('[data-style-book-anon-sub]'),
+    totalsEl: document.querySelector('[data-style-book-anon-totals]'),
+  };
+
+  function render(data: StyleBookResponse) {
+    const namedEntries = data.named.entries.map((e) => ({
+      displayName: e.author,
+      seasonCount: e.seasonCount,
+      lifetimeCount: e.lifetimeCount,
+      lastShotAt: e.lastShotAt,
+    }));
+    const anonEntries = data.anonymous.entries.map((e) => ({
+      displayName: e.codename,
+      seasonCount: e.seasonCount,
+      lifetimeCount: e.lifetimeCount,
+      lastShotAt: e.lastShotAt,
+    }));
+    renderBoard('Group Chat', namedEntries, data.named.totals, data.seasonYear, namedHandles);
+    renderBoard('Tip Line', anonEntries, data.anonymous.totals, data.seasonYear, anonHandles);
+  }
+
   async function load() {
-    if (!root) return;
     try {
       const res = await fetch('/api/schefter/style-book');
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data: StyleBookResponse = await res.json();
       render(data);
     } catch (err) {
-      if (subEl) subEl.textContent = 'Could not load the dossier right now. Try again in a minute.';
+      const msg = 'Could not load the dossier right now. Try again in a minute.';
+      if (namedHandles.subEl) namedHandles.subEl.textContent = msg;
+      if (anonHandles.subEl) anonHandles.subEl.textContent = msg;
       console.warn('[style-book] load failed:', err);
     }
   }

--- a/src/pages/theleague/schefter/style-book.astro
+++ b/src/pages/theleague/schefter/style-book.astro
@@ -1,0 +1,411 @@
+---
+/**
+ * The Style Book — /theleague/schefter/style-book
+ *
+ * Public leaderboard of GroupMe personal attacks on Schefter, tallied by
+ * author. The dossier is kept by the beat desk. Bemused ribbing, not a heel
+ * turn — more shots means more entries, which makes the file thicker, which
+ * is the whole joke.
+ *
+ * Data lives in Redis; renders from the /api/schefter/style-book endpoint.
+ * Public surface — GroupMe authorship is already public by construction, so
+ * showing counts doesn't widen the de-anonymization surface.
+ */
+export const prerender = false;
+
+import TheLeagueLayout from '../../../layouts/TheLeagueLayout.astro';
+import Breadcrumbs from '../../../components/theleague/Breadcrumbs.astro';
+import { getAuthor, getAuthorAvatar } from '../../../types/schefter';
+import '../../../styles/schefter-feed.css';
+
+const schefterAuthor = getAuthor('claude-schefter');
+const schefterAvatar = schefterAuthor ? getAuthorAvatar(schefterAuthor) : '/assets/claude-schefter-avatar.webp';
+---
+
+<TheLeagueLayout title="The Style Book — Schefter Dossier">
+  <main class="style-book-page">
+    <header class="style-book-hero">
+      <Breadcrumbs items={[
+        { label: 'The League', href: '/theleague' },
+        { label: 'The Schefter Report', href: '/theleague/news' },
+        { label: 'The Style Book' },
+      ]} />
+      <p class="style-book-hero__eyebrow">The Beat Desk Dossier</p>
+      <div class="sf-page-header style-book-hero__card">
+        <div class="sf-page-header__persona">
+          <img
+            class="sf-page-header__avatar"
+            src={schefterAvatar}
+            alt=""
+            aria-hidden="true"
+            width="48"
+            height="48"
+            loading="eager"
+          />
+          <div>
+            <h1 class="sf-page-header__name">The Style Book</h1>
+            <div class="sf-page-header__handle">by Claude Schefter · updated in real time</div>
+          </div>
+        </div>
+        <p class="sf-page-header__bio">
+          Every shot taken at the bot in the group chat becomes a data point. The file grows with the heat. Bemused beat-reporter dossier — the count is the joke, not the slur.
+        </p>
+      </div>
+    </header>
+
+    <section class="style-book-board" aria-labelledby="style-book-board-title" data-style-book>
+      <div class="section-header">
+        <h2 class="section-header__title" id="style-book-board-title">This season's leaderboard</h2>
+        <p class="section-header__sub" data-style-book-sub>Loading the dossier…</p>
+      </div>
+
+      <div class="style-book-empty" data-style-book-empty hidden>
+        <p class="style-book-empty__line">The dossier is empty this season.</p>
+        <p class="style-book-empty__sub">No shots on record. The bot remains unbothered.</p>
+      </div>
+
+      <ol class="style-book-list" data-style-book-list></ol>
+
+      <p class="style-book-totals" data-style-book-totals hidden></p>
+    </section>
+
+    <section class="style-book-footnote" aria-labelledby="style-book-footnote-title">
+      <div class="section-header">
+        <h2 class="section-header__title" id="style-book-footnote-title">How the file works</h2>
+      </div>
+      <ul class="style-book-rules">
+        <li class="style-book-rule">
+          <span class="style-book-rule__label">Trigger</span>
+          <p class="style-book-rule__text">
+            A GroupMe message that calls out Schefter/Claude/Schefty/the bot AND contains a pejorative
+            (sucks, hack, trash, fraud, wrong, clown, etc.) gets logged. Everyone starts at zero.
+          </p>
+        </li>
+        <li class="style-book-rule">
+          <span class="style-book-rule__label">Tally</span>
+          <p class="style-book-rule__text">
+            Season counter + lifetime counter per attacker. The season resets on the league-year
+            turnover (Feb 14). Lifetime keeps rolling.
+          </p>
+        </li>
+        <li class="style-book-rule">
+          <span class="style-book-rule__label">Escalation</span>
+          <p class="style-book-rule__text">
+            Schefter's tone scales with the file — first entry gets a "noted", third entry gets a
+            "getting thick", fourth and up gets "power user". Still affectionate.
+          </p>
+        </li>
+        <li class="style-book-rule">
+          <span class="style-book-rule__label">Privacy</span>
+          <p class="style-book-rule__text">
+            GroupMe authorship is public by construction — this page only publishes what the chat
+            already showed. No private tip data is ever surfaced here.
+          </p>
+        </li>
+      </ul>
+    </section>
+  </main>
+</TheLeagueLayout>
+
+<style>
+  .style-book-page {
+    max-width: 960px;
+    margin: 0 auto;
+    padding: var(--space-4, 16px);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-6, 24px);
+  }
+
+  .style-book-hero__eyebrow {
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-size: var(--fs-xs, 12px);
+    color: var(--color-text-secondary, #6b7280);
+    margin: 0 0 var(--space-2, 8px);
+  }
+
+  .style-book-hero__card {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2, 8px);
+  }
+
+  .style-book-board {
+    background: var(--color-surface, #fff);
+    border: 1px solid var(--color-border, #e5e7eb);
+    border-radius: var(--radius-lg, 12px);
+    padding: var(--space-5, 20px);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-4, 16px);
+  }
+
+  .style-book-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2, 8px);
+  }
+
+  .style-book-entry {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    gap: var(--space-3, 12px);
+    align-items: center;
+    padding: var(--space-3, 12px) var(--space-4, 16px);
+    border-radius: var(--radius-md, 8px);
+    background: var(--color-surface-subtle, #f9fafb);
+    border: 1px solid var(--color-border-subtle, #f3f4f6);
+  }
+
+  .style-book-entry--top {
+    background: linear-gradient(180deg, rgba(220, 38, 38, 0.05), rgba(220, 38, 38, 0.02));
+    border-color: rgba(220, 38, 38, 0.25);
+  }
+
+  .style-book-entry__rank {
+    font-variant-numeric: tabular-nums;
+    font-weight: 700;
+    font-size: var(--fs-lg, 18px);
+    color: var(--color-text-secondary, #6b7280);
+    width: 2.25rem;
+    text-align: center;
+  }
+
+  .style-book-entry--top .style-book-entry__rank {
+    color: rgb(220, 38, 38);
+  }
+
+  .style-book-entry__author {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+  }
+
+  .style-book-entry__name {
+    font-weight: 600;
+    font-size: var(--fs-md, 14px);
+    color: var(--color-text-primary, #111827);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .style-book-entry__meta {
+    font-size: var(--fs-xs, 12px);
+    color: var(--color-text-secondary, #6b7280);
+    display: flex;
+    gap: var(--space-2, 8px);
+    flex-wrap: wrap;
+  }
+
+  .style-book-entry__counts {
+    text-align: right;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .style-book-entry__season {
+    font-variant-numeric: tabular-nums;
+    font-weight: 700;
+    font-size: var(--fs-xl, 20px);
+    color: var(--color-text-primary, #111827);
+    line-height: 1;
+  }
+
+  .style-book-entry--top .style-book-entry__season {
+    color: rgb(220, 38, 38);
+  }
+
+  .style-book-entry__season-label {
+    font-size: var(--fs-xs, 12px);
+    color: var(--color-text-secondary, #6b7280);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  .style-book-empty {
+    text-align: center;
+    padding: var(--space-6, 24px);
+    border: 1px dashed var(--color-border, #e5e7eb);
+    border-radius: var(--radius-md, 8px);
+    background: var(--color-surface-subtle, #f9fafb);
+  }
+
+  .style-book-empty__line {
+    font-weight: 600;
+    font-size: var(--fs-md, 14px);
+    color: var(--color-text-primary, #111827);
+    margin: 0 0 var(--space-1, 4px);
+  }
+
+  .style-book-empty__sub {
+    font-size: var(--fs-sm, 13px);
+    color: var(--color-text-secondary, #6b7280);
+    margin: 0;
+    font-style: italic;
+  }
+
+  .style-book-totals {
+    font-size: var(--fs-sm, 13px);
+    color: var(--color-text-secondary, #6b7280);
+    text-align: center;
+    margin: 0;
+    padding-top: var(--space-2, 8px);
+    border-top: 1px solid var(--color-border-subtle, #f3f4f6);
+  }
+
+  .style-book-footnote {
+    background: var(--color-surface, #fff);
+    border: 1px solid var(--color-border, #e5e7eb);
+    border-radius: var(--radius-lg, 12px);
+    padding: var(--space-5, 20px);
+  }
+
+  .style-book-rules {
+    list-style: none;
+    padding: 0;
+    margin: var(--space-3, 12px) 0 0;
+    display: grid;
+    gap: var(--space-3, 12px);
+  }
+
+  @media (min-width: 640px) {
+    .style-book-rules {
+      grid-template-columns: 1fr 1fr;
+    }
+  }
+
+  .style-book-rule__label {
+    display: inline-block;
+    font-size: var(--fs-xs, 12px);
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--color-accent, rgb(220, 38, 38));
+    margin-bottom: var(--space-1, 4px);
+  }
+
+  .style-book-rule__text {
+    font-size: var(--fs-sm, 13px);
+    color: var(--color-text-primary, #111827);
+    margin: 0;
+    line-height: 1.5;
+  }
+</style>
+
+<script>
+  type StyleBookEntry = {
+    author: string;
+    seasonCount: number;
+    lifetimeCount: number;
+    lastShotAt: number | null;
+  };
+
+  type StyleBookResponse = {
+    seasonYear: number;
+    entries: StyleBookEntry[];
+    totals: { seasonShots: number; authors: number };
+  };
+
+  const root = document.querySelector('[data-style-book]');
+  const listEl = document.querySelector('[data-style-book-list]') as HTMLOListElement | null;
+  const emptyEl = document.querySelector('[data-style-book-empty]') as HTMLElement | null;
+  const subEl = document.querySelector('[data-style-book-sub]') as HTMLElement | null;
+  const totalsEl = document.querySelector('[data-style-book-totals]') as HTMLElement | null;
+
+  function formatRelative(ts: number | null): string {
+    if (ts === null) return 'never';
+    const diffMs = Date.now() - ts;
+    if (diffMs < 0) return 'just now';
+    const mins = Math.floor(diffMs / 60_000);
+    if (mins < 1) return 'just now';
+    if (mins < 60) return `${mins}m ago`;
+    const hours = Math.floor(mins / 60);
+    if (hours < 24) return `${hours}h ago`;
+    const days = Math.floor(hours / 24);
+    if (days < 30) return `${days}d ago`;
+    const months = Math.floor(days / 30);
+    return `${months}mo ago`;
+  }
+
+  function escapeHtml(s: string): string {
+    return s
+      .replaceAll('&', '&amp;')
+      .replaceAll('<', '&lt;')
+      .replaceAll('>', '&gt;')
+      .replaceAll('"', '&quot;')
+      .replaceAll("'", '&#39;');
+  }
+
+  function countLabel(n: number): string {
+    return n === 1 ? 'shot' : 'shots';
+  }
+
+  function render(data: StyleBookResponse) {
+    if (!listEl || !subEl) return;
+
+    if (data.entries.length === 0) {
+      if (emptyEl) emptyEl.hidden = false;
+      subEl.textContent = `${data.seasonYear} season · no entries yet`;
+      listEl.innerHTML = '';
+      if (totalsEl) totalsEl.hidden = true;
+      return;
+    }
+
+    if (emptyEl) emptyEl.hidden = true;
+
+    const topCount = data.entries[0]?.seasonCount ?? 0;
+    const rows = data.entries.map((entry, idx) => {
+      const rank = idx + 1;
+      const isTop = entry.seasonCount === topCount && topCount > 0;
+      const classes = ['style-book-entry', isTop ? 'style-book-entry--top' : ''].filter(Boolean).join(' ');
+      const lastShotText = entry.lastShotAt ? `last shot ${escapeHtml(formatRelative(entry.lastShotAt))}` : '';
+      const lifetimeText = entry.lifetimeCount > entry.seasonCount
+        ? `${entry.lifetimeCount} lifetime`
+        : '';
+      const metaParts = [lifetimeText, lastShotText].filter(Boolean).join(' · ');
+      return `
+        <li class="${classes}">
+          <div class="style-book-entry__rank">#${rank}</div>
+          <div class="style-book-entry__author">
+            <div class="style-book-entry__name">${escapeHtml(entry.author)}</div>
+            ${metaParts ? `<div class="style-book-entry__meta">${metaParts}</div>` : ''}
+          </div>
+          <div class="style-book-entry__counts">
+            <div class="style-book-entry__season">${entry.seasonCount}</div>
+            <div class="style-book-entry__season-label">${countLabel(entry.seasonCount)}</div>
+          </div>
+        </li>
+      `;
+    });
+    listEl.innerHTML = rows.join('');
+
+    subEl.textContent = `${data.seasonYear} season · top ${data.entries.length} of ${data.totals.authors}`;
+
+    if (totalsEl) {
+      totalsEl.textContent = `${data.totals.seasonShots} ${countLabel(data.totals.seasonShots)} logged across ${data.totals.authors} ${data.totals.authors === 1 ? 'author' : 'authors'} this season.`;
+      totalsEl.hidden = false;
+    }
+  }
+
+  async function load() {
+    if (!root) return;
+    try {
+      const res = await fetch('/api/schefter/style-book');
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data: StyleBookResponse = await res.json();
+      render(data);
+    } catch (err) {
+      if (subEl) subEl.textContent = 'Could not load the dossier right now. Try again in a minute.';
+      console.warn('[style-book] load failed:', err);
+    }
+  }
+
+  load();
+</script>

--- a/src/types/schefter-tips.ts
+++ b/src/types/schefter-tips.ts
@@ -102,6 +102,29 @@ export interface Tip {
    * opens with continuity language ("Following up on yesterday's chatter…").
    */
   repliesToPostId?: string;
+  /**
+   * Style Book — the tip text attacks Schefter personally (pejorative against
+   * the bot). Set by the detection paths in `scripts/schefter-groupme-listen.mjs`
+   * (named, GroupMe) and `src/pages/api/schefter/tip.ts` (anonymous, web).
+   * Surfaces on the LLM-facing safe object so HARD RULE 15 can fire the Style
+   * Book bit with running-count flavor.
+   */
+  attackOnSchefter?: true;
+  /**
+   * Running seasonal count of attacks from this tipster (GroupMe author OR
+   * anonymous web-tip hash, scoped to its own leaderboard). Drives the count-
+   * based escalation in the Style Book bit (1 = "first entry", 3 = "file's
+   * getting thick", 4+ = "power user").
+   */
+  styleBookCount?: number;
+  /**
+   * Stable codename for an anonymous web tipster (e.g. "Burner Phone").
+   * Set only on `source: 'web'` tips that were flagged as Style Book attacks —
+   * gives Schefter a durable handle to reference in posts without revealing
+   * the tipster's identity. Resolved at submission time from the existing
+   * tipster-codenames system (same key as tipster-stats leaderboard).
+   */
+  tipsterCodename?: string;
 }
 
 /** Max age of a rumor post that whisper-backs can still attach to (ms). */

--- a/src/utils/schefter-attack-detection.ts
+++ b/src/utils/schefter-attack-detection.ts
@@ -1,0 +1,135 @@
+/**
+ * Schefter attack detection — TypeScript port for the web tip API surface.
+ *
+ * Mirrors `detectAttackOnSchefter` in scripts/schefter-groupme-listen.mjs so
+ * web tips and GroupMe mentions run through identical classification. A
+ * parity test (`tests/schefter-attack-detection-parity.test.ts`) pins the
+ * two copies to each other — if one side changes, the test fails.
+ *
+ * Intentionally duplicated (not imported) because the .mjs listener is a
+ * pure-Node script that can't reach into `src/utils/*.ts` without a build
+ * step. Small enough that duplication + parity test beats the complexity
+ * of shared tooling.
+ *
+ * Keep the pejorative list, subject patterns, negation tokens, and Roger
+ * disambiguation rules IN SYNC with the .mjs version. If you add a new
+ * keyword or rule here, add it there too — the parity test will tell you
+ * if you forgot.
+ */
+
+const ATTACK_PEJORATIVES = [
+  'sucks',
+  'suck',
+  'bitch',
+  'hack',
+  'trash',
+  'garbage',
+  'dumb',
+  'stupid',
+  'fake',
+  'wrong',
+  'useless',
+  'lame',
+  'clown',
+  'joke',
+  'idiot',
+  'moron',
+  'fraud',
+  'bullshit',
+  'bullshitter',
+  'liar',
+  'lies',
+  'worst',
+  'terrible',
+  'awful',
+  'pathetic',
+];
+
+const ATTACK_SUBJECT_PATTERNS = [
+  /\bclaude\s+schefter\b/i,
+  /\bschefter\b/i,
+  /\bschefty\b/i,
+  /\bclaude\b/i,
+  /\bthe\s+bot\b/i,
+  /\bthis\s+bot\b/i,
+  /\bthat\s+bot\b/i,
+];
+
+const NEGATION_WINDOW_WORDS = 2;
+const NEGATION_TOKENS = new Set([
+  'not',
+  "isn't",
+  "ain't",
+  'aint',
+  'never',
+  "wasn't",
+  'no',
+  "doesn't",
+  'doesnt',
+]);
+
+// Roger disambiguation — if the only bot mention is a generic "the bot" /
+// "this bot" / "that bot" AND Roger is named anywhere in the message, we
+// punt. Same rule as the GroupMe listener.
+const ROGER_GUARD_RE = /\b(?:roger|ask\s+roger|the\s+roger\s+bot|roger's\s+bot)\b/i;
+const EXPLICIT_SCHEFTER_RE = /\b(?:claude|schefter|schefty)\b/i;
+const GENERIC_BOT_RE = /\b(?:the|this|that)\s+bot\b/i;
+
+export type AttackDetectionResult =
+  | { attack: true; keyword: string; reason: 'pejorative-match' }
+  | { attack: false; reason: string };
+
+export function detectAttackOnSchefter(rawText: string | null | undefined): AttackDetectionResult {
+  if (!rawText || typeof rawText !== 'string') {
+    return { attack: false, reason: 'no-text' };
+  }
+  const text = rawText.trim();
+  if (text.length < 5) {
+    return { attack: false, reason: 'too-short' };
+  }
+
+  const subjectMatch = ATTACK_SUBJECT_PATTERNS.some((re) => re.test(text));
+  if (!subjectMatch) {
+    return { attack: false, reason: 'no-subject' };
+  }
+
+  const mentionsRoger = ROGER_GUARD_RE.test(text);
+  const explicitSchefterRef = EXPLICIT_SCHEFTER_RE.test(text);
+  const mentionsGenericBot = GENERIC_BOT_RE.test(text);
+  if (mentionsRoger && mentionsGenericBot && !explicitSchefterRef) {
+    return { attack: false, reason: 'generic-bot-with-roger-context' };
+  }
+
+  const lowerTokens = text
+    .toLowerCase()
+    .replace(/[^\w'\s]/g, ' ')
+    .split(/\s+/)
+    .filter(Boolean);
+
+  for (let i = 0; i < lowerTokens.length; i++) {
+    const tok = lowerTokens[i];
+    if (!ATTACK_PEJORATIVES.includes(tok)) continue;
+
+    let negated = false;
+    for (let j = Math.max(0, i - NEGATION_WINDOW_WORDS); j < i; j++) {
+      if (NEGATION_TOKENS.has(lowerTokens[j])) {
+        negated = true;
+        break;
+      }
+    }
+    if (negated) continue;
+
+    return { attack: true, keyword: tok, reason: 'pejorative-match' };
+  }
+
+  return { attack: false, reason: 'no-pejorative' };
+}
+
+export const _internals = {
+  ATTACK_PEJORATIVES,
+  ATTACK_SUBJECT_PATTERNS,
+  NEGATION_TOKENS,
+  ROGER_GUARD_RE,
+  EXPLICIT_SCHEFTER_RE,
+  GENERIC_BOT_RE,
+};

--- a/tests/schefter-attack-detection-parity.test.ts
+++ b/tests/schefter-attack-detection-parity.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Parity test — the TS `detectAttackOnSchefter` in src/utils/ and the JS
+ * version in scripts/schefter-groupme-listen.mjs must agree on every input.
+ * The API route (web tip path) uses the TS copy; the GroupMe listener (chat
+ * path) uses the JS copy. Drift between them means one channel logs Style
+ * Book entries the other doesn't.
+ *
+ * Any new pejorative, subject pattern, negation token, or disambiguation
+ * rule added to one side must be mirrored on the other — this test will
+ * fail until both are in sync.
+ */
+import { describe, it, expect } from 'vitest';
+import { detectAttackOnSchefter as tsDetect } from '../src/utils/schefter-attack-detection';
+import {
+  detectAttackOnSchefter as jsDetect,
+  // @ts-ignore — .mjs via allowJs
+} from '../scripts/schefter-groupme-listen.mjs';
+
+// Full input matrix. Each case must produce identical attack / keyword /
+// reason across the two implementations.
+const CASES: string[] = [
+  // Canonical
+  'Claude Schefter is a lil bitch',
+  'schefty sucks',
+  'the bot is a hack',
+  'schefter is trash',
+  'claude is wrong again',
+  // Negation
+  "schefter isn't wrong about this",
+  "that's not bad for the bot",
+  // No subject
+  'this trade is trash',
+  'the waiver wire is garbage',
+  // No pejorative
+  'hey schefter any rumors?',
+  'the bot posted a great one',
+  // Case / punctuation
+  'SCHEFTER, you are GARBAGE!!!',
+  'wow claude, you really are a CLOWN.',
+  // Roger disambiguation — both should reject
+  'the bot is wrong, ask Roger to fix it',
+  "roger's bot is lame",
+  'ask roger why the bot is broken',
+  // Roger named BUT Schefter also explicitly named — both should accept
+  'schefter is a hack even though Roger is fine',
+  "Claude is terrible and ask Roger doesn't care",
+  // Edge: short
+  '',
+  'bad',
+  'nope',
+  // Edge: all whitespace
+  '     ',
+  // Edge: the bot alone (no Roger context) — both should accept if pejorative present
+  'that bot is worthless',
+  'this bot is a fraud',
+];
+
+describe('detectAttackOnSchefter — TS vs JS parity', () => {
+  for (const input of CASES) {
+    it(`parity: ${JSON.stringify(input).slice(0, 60)}`, () => {
+      const ts = tsDetect(input);
+      const js = jsDetect(input);
+      // Compare the "attack" bit first — the most important contract.
+      expect(ts.attack).toBe(js.attack);
+      if (ts.attack && js.attack) {
+        expect(ts.keyword).toBe(js.keyword);
+      }
+      // Reasons should agree too; if they ever diverge we want to know.
+      expect(ts.reason).toBe(js.reason);
+    });
+  }
+});

--- a/tests/schefter-bot-gate-roger.test.ts
+++ b/tests/schefter-bot-gate-roger.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Tests for the widened detectMention gate + Roger disambiguation.
+ *
+ * TheLeague chat has two bots — Schefter (beat reporter) and Ask Roger
+ * (deadline nag). A bare "the bot" is ambiguous, so the listener now:
+ *
+ *   - Accepts "the schefter bot" / "claude bot" / "schefty bot" explicitly
+ *   - Accepts generic "the bot" / "this bot" / "that bot" ONLY when no
+ *     Roger-adjacent phrase also appears in the message
+ *   - Rejects "ask roger", "the roger bot", "roger's bot" in all cases
+ *
+ * Same Roger guard applies to detectAttackOnSchefter so the Style Book
+ * doesn't log Roger-directed attacks against an author's file.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  detectMention,
+  detectAttackOnSchefter,
+  // @ts-ignore — .mjs via allowJs
+} from '../scripts/schefter-groupme-listen.mjs';
+
+describe('detectMention — bot/Roger disambiguation', () => {
+  it('accepts explicit "the schefter bot" reference', () => {
+    const r = detectMention('the schefter bot is a hack');
+    expect(r.match).toBe(true);
+    // Either variant is acceptable as long as it classifies as a Schefter mention.
+    expect(['schefter-bot', 'schefter']).toContain(r.variant);
+  });
+
+  it('accepts explicit "the claude bot"', () => {
+    const r = detectMention('the claude bot is wrong again');
+    expect(r.match).toBe(true);
+    expect(['schefter-bot', 'claude']).toContain(r.variant);
+  });
+
+  it('accepts generic "the bot" when Roger is not mentioned', () => {
+    const r = detectMention('the bot is a fraud, get it together');
+    expect(r.match).toBe(true);
+    expect(r.variant).toBe('the-bot');
+  });
+
+  it('accepts "this bot is wrong" (early-position trigger)', () => {
+    const r = detectMention('this bot is wrong about the trade');
+    expect(r.match).toBe(true);
+  });
+
+  it('rejects generic "the bot" when Roger is also mentioned', () => {
+    const r = detectMention('the bot is wrong, ask Roger to double-check');
+    expect(r.match).toBe(false);
+    expect(r.reason).toMatch(/roger/i);
+  });
+
+  it("rejects \"roger's bot\" entirely", () => {
+    const r = detectMention("roger's bot broke again");
+    expect(r.match).toBe(false);
+  });
+
+  it('rejects "ask roger" without Schefter naming', () => {
+    const r = detectMention('ask roger when the next deadline is');
+    expect(r.match).toBe(false);
+  });
+
+  it('still accepts schefter when Roger is named alongside (explicit wins)', () => {
+    const r = detectMention('schefter is a hack even though Roger is fine');
+    expect(r.match).toBe(true);
+    expect(r.variant).toBe('schefter');
+  });
+});
+
+describe('detectAttackOnSchefter — Roger guard', () => {
+  it('logs "the bot is a fraud" as attack when no Roger context', () => {
+    expect(detectAttackOnSchefter('the bot is a fraud').attack).toBe(true);
+  });
+
+  it('rejects "the bot is wrong, ask Roger to fix it"', () => {
+    const r = detectAttackOnSchefter('the bot is wrong, ask Roger to fix it');
+    expect(r.attack).toBe(false);
+    expect(r.reason).toMatch(/roger/i);
+  });
+
+  it("rejects \"roger's bot is lame\"", () => {
+    expect(detectAttackOnSchefter("roger's bot is lame").attack).toBe(false);
+  });
+
+  it('still logs attack when Schefter is explicitly named alongside Roger', () => {
+    const r = detectAttackOnSchefter('schefter is a hack even though Roger is fine');
+    expect(r.attack).toBe(true);
+    expect(r.keyword).toBe('hack');
+  });
+
+  it('rejects "ask roger why the bot is broken" (no explicit Schefter + Roger context)', () => {
+    const r = detectAttackOnSchefter('ask roger why the bot is broken');
+    expect(r.attack).toBe(false);
+  });
+});

--- a/tests/schefter-style-book-api.test.ts
+++ b/tests/schefter-style-book-api.test.ts
@@ -137,100 +137,165 @@ describe('normalizeAuthorKey — parity with the listener', () => {
   }
 });
 
+// ── Helpers for multi-year leaderboard population ───────────────────────────
+
+function populateNamedLeaderboard(lb: Map<string, number>) {
+  for (const y of [2025, 2026, 2027]) {
+    fakeRedis.zsets.set(`schefter:style_book:leaderboard:${y}`, new Map(lb));
+  }
+}
+
+function populateAnonLeaderboard(lb: Map<string, number>) {
+  for (const y of [2025, 2026, 2027]) {
+    fakeRedis.zsets.set(`schefter:style_book:anon_leaderboard:${y}`, new Map(lb));
+  }
+}
+
 // ── Endpoint behavior ───────────────────────────────────────────────────────
 
 describe('GET /api/schefter/style-book', () => {
-  it('returns an empty response when the leaderboard is empty', async () => {
+  it('returns empty named + anonymous pools when nothing is tracked', async () => {
     const res = await callEndpoint();
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.entries).toEqual([]);
-    expect(body.totals).toEqual({ seasonShots: 0, authors: 0 });
+    expect(body.named).toEqual({ entries: [], totals: { seasonShots: 0, authors: 0 } });
+    expect(body.anonymous).toEqual({ entries: [], totals: { seasonShots: 0, authors: 0 } });
     expect(body.seasonYear).toBeGreaterThan(2024);
   });
 
-  it('returns entries ordered by seasonCount desc', async () => {
-    const lb = new Map<string, number>([
+  it('returns named entries ordered by seasonCount desc', async () => {
+    populateNamedLeaderboard(new Map<string, number>([
       ['Dead Cap Walking', 3],
       ['Wabbits', 1],
       ['Vitside Mafia', 2],
-    ]);
-    // Find the correct leaderboard key — the endpoint uses getCurrentLeagueYear()
-    // Pre-populate a leaderboard for each plausible year.
-    const years = [2025, 2026, 2027];
-    for (const y of years) fakeRedis.zsets.set(`schefter:style_book:leaderboard:${y}`, new Map(lb));
+    ]));
 
-    // Also populate lifetime + last-shot for one of them so we can assert
-    // the enrichment path works.
+    // Lifetime + last-shot enrichment for one author
     fakeRedis.strings.set('schefter:style_book:dead_cap_walking', 5);
     fakeRedis.strings.set('schefter:style_book:last_shot_at:dead_cap_walking', 1_700_000_000_000);
 
     const res = await callEndpoint();
     const body = await res.json();
-    expect(body.entries.map((e: any) => e.author)).toEqual([
+    expect(body.named.entries.map((e: any) => e.author)).toEqual([
       'Dead Cap Walking',
       'Vitside Mafia',
       'Wabbits',
     ]);
-    expect(body.entries[0].seasonCount).toBe(3);
-
-    const dcw = body.entries[0];
-    expect(dcw.lifetimeCount).toBe(5);
-    expect(dcw.lastShotAt).toBe(1_700_000_000_000);
+    expect(body.named.entries[0].seasonCount).toBe(3);
+    expect(body.named.entries[0].lifetimeCount).toBe(5);
+    expect(body.named.entries[0].lastShotAt).toBe(1_700_000_000_000);
 
     // Vitside has no lifetime record — should degrade to 0 / null.
-    const vit = body.entries[1];
-    expect(vit.lifetimeCount).toBe(0);
-    expect(vit.lastShotAt).toBeNull();
+    expect(body.named.entries[1].lifetimeCount).toBe(0);
+    expect(body.named.entries[1].lastShotAt).toBeNull();
   });
 
-  it('aggregates season totals correctly', async () => {
-    const lb = new Map<string, number>([
-      ['A', 5],
-      ['B', 3],
-      ['C', 1],
-    ]);
-    for (const y of [2025, 2026, 2027]) fakeRedis.zsets.set(`schefter:style_book:leaderboard:${y}`, new Map(lb));
+  it('returns anonymous entries by codename (never hash)', async () => {
+    // Anon leaderboard keys on the tipster HASH. Codename resolves via
+    // schefter:tipster:codename:{hash}. Entries without a codename are dropped.
+    const hashA = 'a'.repeat(64);
+    const hashB = 'b'.repeat(64);
+    const hashC = 'c'.repeat(64);
+    populateAnonLeaderboard(new Map<string, number>([
+      [hashA, 4],
+      [hashB, 2],
+      [hashC, 1], // missing codename — should be dropped
+    ]));
+    fakeRedis.strings.set(`schefter:tipster:codename:${hashA}`, 'Burner Phone');
+    fakeRedis.strings.set(`schefter:tipster:codename:${hashB}`, 'The Ghost');
+    // hashC intentionally omitted
+    fakeRedis.strings.set(`schefter:style_book:anon:${hashA}`, 7);
+    fakeRedis.strings.set(`schefter:style_book:anon:last_shot_at:${hashA}`, 1_700_000_000_000);
 
     const res = await callEndpoint();
     const body = await res.json();
-    expect(body.totals.seasonShots).toBe(9);
-    expect(body.totals.authors).toBe(3);
+    expect(body.anonymous.entries.map((e: any) => e.codename)).toEqual([
+      'Burner Phone',
+      'The Ghost',
+    ]);
+    expect(body.anonymous.entries[0].seasonCount).toBe(4);
+    expect(body.anonymous.entries[0].lifetimeCount).toBe(7);
+    expect(body.anonymous.entries[0].lastShotAt).toBe(1_700_000_000_000);
+
+    // Verify hashes never appear in the response body.
+    const serialized = JSON.stringify(body);
+    expect(serialized).not.toContain(hashA);
+    expect(serialized).not.toContain(hashB);
+    expect(serialized).not.toContain(hashC);
+  });
+
+  it('returns named + anonymous pools in parallel (non-interfering)', async () => {
+    populateNamedLeaderboard(new Map<string, number>([['Dead Cap Walking', 2]]));
+    const hashA = 'd'.repeat(64);
+    populateAnonLeaderboard(new Map<string, number>([[hashA, 5]]));
+    fakeRedis.strings.set(`schefter:tipster:codename:${hashA}`, 'Smoke Signal');
+
+    const res = await callEndpoint();
+    const body = await res.json();
+    expect(body.named.entries).toHaveLength(1);
+    expect(body.named.entries[0].author).toBe('Dead Cap Walking');
+    expect(body.anonymous.entries).toHaveLength(1);
+    expect(body.anonymous.entries[0].codename).toBe('Smoke Signal');
+  });
+
+  it('aggregates season totals correctly for both pools', async () => {
+    populateNamedLeaderboard(new Map<string, number>([['A', 5], ['B', 3]]));
+    const hashA = 'e'.repeat(64);
+    const hashB = 'f'.repeat(64);
+    populateAnonLeaderboard(new Map<string, number>([[hashA, 2], [hashB, 1]]));
+    fakeRedis.strings.set(`schefter:tipster:codename:${hashA}`, 'Back-Channel');
+    fakeRedis.strings.set(`schefter:tipster:codename:${hashB}`, 'Hot Mic');
+
+    const res = await callEndpoint();
+    const body = await res.json();
+    expect(body.named.totals.seasonShots).toBe(8);
+    expect(body.named.totals.authors).toBe(2);
+    expect(body.anonymous.totals.seasonShots).toBe(3);
+    expect(body.anonymous.totals.authors).toBe(2);
   });
 
   it('never exposes hashes or internal keys in the response', async () => {
-    const lb = new Map<string, number>([['Dead Cap Walking', 2]]);
-    for (const y of [2025, 2026, 2027]) fakeRedis.zsets.set(`schefter:style_book:leaderboard:${y}`, new Map(lb));
+    populateNamedLeaderboard(new Map<string, number>([['Dead Cap Walking', 2]]));
+    const hashA = '0'.repeat(64);
+    populateAnonLeaderboard(new Map<string, number>([[hashA, 1]]));
+    fakeRedis.strings.set(`schefter:tipster:codename:${hashA}`, 'Unnamed Source');
 
     const res = await callEndpoint();
     const body = await res.json();
     const serialized = JSON.stringify(body);
     expect(serialized).not.toMatch(/schefter:style_book:/);
+    expect(serialized).not.toMatch(/schefter:tipster:codename:/);
     expect(serialized).not.toMatch(/hashedOwnerId/);
-    expect(serialized).not.toMatch(/dead_cap_walking/); // normalized key should NOT leak
+    expect(serialized).not.toMatch(/dead_cap_walking/);
+    expect(serialized).not.toContain(hashA);
   });
 
   it('caches the response (second call makes no Redis reads)', async () => {
-    const lb = new Map<string, number>([['Dead Cap Walking', 1]]);
-    for (const y of [2025, 2026, 2027]) fakeRedis.zsets.set(`schefter:style_book:leaderboard:${y}`, new Map(lb));
+    populateNamedLeaderboard(new Map<string, number>([['Dead Cap Walking', 1]]));
 
     await callEndpoint();
     const zrangeCallsAfterFirst = fakeRedis.zrangeCalls.length;
     const getCallsAfterFirst = fakeRedis.getCalls.length;
 
     await callEndpoint();
-    // The second call must be served from cache — no new Redis commands.
     expect(fakeRedis.zrangeCalls.length).toBe(zrangeCallsAfterFirst);
     expect(fakeRedis.getCalls.length).toBe(getCallsAfterFirst);
   });
 
-  it('requests descending order with scores from the leaderboard ZSET', async () => {
-    fakeRedis.zsets.set(`schefter:style_book:leaderboard:2026`, new Map([['X', 1]]));
-    fakeRedis.zsets.set(`schefter:style_book:leaderboard:2027`, new Map([['X', 1]]));
-    fakeRedis.zsets.set(`schefter:style_book:leaderboard:2025`, new Map([['X', 1]]));
+  it('requests descending order with scores from BOTH leaderboard ZSETs', async () => {
+    populateNamedLeaderboard(new Map<string, number>([['X', 1]]));
+    populateAnonLeaderboard(new Map<string, number>([[''.padEnd(64, '1'), 1]]));
+    fakeRedis.strings.set(`schefter:tipster:codename:${''.padEnd(64, '1')}`, 'The Ledger');
     await callEndpoint();
-    expect(fakeRedis.zrangeCalls[0].rev).toBe(true);
-    expect(fakeRedis.zrangeCalls[0].withScores).toBe(true);
+    // Both ZRANGE calls should have rev + withScores set
+    for (const call of fakeRedis.zrangeCalls) {
+      expect(call.rev).toBe(true);
+      expect(call.withScores).toBe(true);
+    }
+    // And both leaderboard keys should have been queried.
+    const keys = fakeRedis.zrangeCalls.map((c) => c.key);
+    expect(keys.some((k) => k.startsWith('schefter:style_book:leaderboard:'))).toBe(true);
+    expect(keys.some((k) => k.startsWith('schefter:style_book:anon_leaderboard:'))).toBe(true);
   });
 });
 
@@ -250,8 +315,18 @@ describe('style-book page — contract', () => {
     expect(pageSrc).toMatch(/\/api\/schefter\/style-book/);
   });
 
-  it('renders an empty state when the dossier is empty', () => {
-    expect(pageSrc).toMatch(/The dossier is empty this season/);
+  it('renders empty states for both leaderboards', () => {
+    // Named (group chat) empty state
+    expect(pageSrc).toMatch(/The group chat file is empty/);
+    // Anonymous (tip line) empty state
+    expect(pageSrc).toMatch(/The tip-line file is empty/);
+  });
+
+  it('renders both named and anonymous boards', () => {
+    expect(pageSrc).toMatch(/Group Chat file/);
+    expect(pageSrc).toMatch(/Anonymous Tip-line file/);
+    expect(pageSrc).toMatch(/data-style-book-named-list/);
+    expect(pageSrc).toMatch(/data-style-book-anon-list/);
   });
 
   it('escapes HTML in author names', () => {

--- a/tests/schefter-style-book-api.test.ts
+++ b/tests/schefter-style-book-api.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Tests for GET /api/schefter/style-book.
+ *
+ * Contract pins:
+ *  - Response shape: { seasonYear, entries[], totals }
+ *  - Empty state when no leaderboard exists
+ *  - Descending order by seasonCount
+ *  - normalizeAuthorKey() in the API matches the listener's normalization
+ *    (same display-name in → same Redis key) so lifetime + last-shot
+ *    lookups resolve on real data.
+ *  - Lifetime + last-shot fetches are best-effort (individual failures
+ *    degrade that entry, don't kill the response).
+ *  - Cache TTL: second call returns cached data without re-reading Redis.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import {
+  GET,
+  normalizeAuthorKey as apiNormalize,
+  _resetStyleBookCacheForTests,
+} from '../src/pages/api/schefter/style-book';
+import {
+  normalizeAuthorKey as listenerNormalize,
+  // @ts-ignore — .mjs via allowJs
+} from '../scripts/schefter-groupme-listen.mjs';
+
+// ── FakeRedis (subset used by style-book.ts) ────────────────────────────────
+
+class FakeRedis {
+  strings = new Map<string, string | number>();
+  zsets = new Map<string, Map<string, number>>();
+  getCalls: string[] = [];
+  zrangeCalls: Array<{ key: string; rev: boolean; withScores: boolean }> = [];
+  zcardCalls: string[] = [];
+
+  async get(key: string) {
+    this.getCalls.push(key);
+    return this.strings.has(key) ? this.strings.get(key) ?? null : null;
+  }
+  async zrange(
+    key: string,
+    _start: number,
+    _stop: number,
+    opts?: { rev?: boolean; withScores?: boolean },
+  ) {
+    this.zrangeCalls.push({
+      key,
+      rev: !!opts?.rev,
+      withScores: !!opts?.withScores,
+    });
+    const map = this.zsets.get(key);
+    if (!map) return [];
+    const sorted = Array.from(map.entries()).sort((a, b) =>
+      opts?.rev ? b[1] - a[1] : a[1] - b[1],
+    );
+    if (opts?.withScores) {
+      return sorted.flatMap(([member, score]) => [member, score]);
+    }
+    return sorted.map(([member]) => member);
+  }
+  async zcard(key: string) {
+    this.zcardCalls.push(key);
+    return this.zsets.get(key)?.size ?? 0;
+  }
+}
+
+// Shim the Upstash module so the endpoint's dynamic import returns our fake.
+const fakeRedis = new FakeRedis();
+
+// Point the route at our fake via dependency injection through the module cache.
+// The endpoint does a dynamic `import('@upstash/redis')` at runtime — we
+// intercept it so we don't need the real client.
+import { vi } from 'vitest';
+vi.mock('@upstash/redis', () => ({
+  Redis: class {
+    constructor() {
+      return fakeRedis as unknown as never;
+    }
+  },
+}));
+
+// Required for the Upstash-mock path: env vars must exist for `getRedis()` to
+// attempt the dynamic import in the first place. Values are irrelevant.
+process.env.UPSTASH_REDIS_REST_URL = 'http://fake-redis.test';
+process.env.UPSTASH_REDIS_REST_TOKEN = 'fake-token';
+
+async function callEndpoint() {
+  const req = new Request('http://test.invalid/api/schefter/style-book');
+  // The GET handler ignores `params`, `redirect`, etc. — a minimal shape is fine.
+  const res = await GET({
+    request: req,
+    url: new URL(req.url),
+    params: {},
+    props: {},
+    redirect: () => new Response('', { status: 302 }),
+    rewrite: (() => new Response('')) as any,
+    cookies: {} as any,
+    locals: {} as any,
+    site: new URL('http://test.invalid'),
+    generator: 'astro',
+    clientAddress: '127.0.0.1',
+    preferredLocale: null,
+    preferredLocaleList: null,
+    currentLocale: null,
+    routePattern: '/api/schefter/style-book',
+  } as any);
+  return res;
+}
+
+beforeEach(() => {
+  _resetStyleBookCacheForTests();
+  fakeRedis.strings.clear();
+  fakeRedis.zsets.clear();
+  fakeRedis.getCalls.length = 0;
+  fakeRedis.zrangeCalls.length = 0;
+  fakeRedis.zcardCalls.length = 0;
+});
+
+// ── Normalization parity ────────────────────────────────────────────────────
+
+describe('normalizeAuthorKey — parity with the listener', () => {
+  const cases = [
+    'Dead Cap Walking',
+    'Da Dangsters!',
+    '  Pacific Pigskins  ',
+    'Wascawy Wabbits',
+    "Music City Mafia",
+    'MCM',
+    '',
+  ];
+
+  for (const name of cases) {
+    it(`produces identical keys for "${name}"`, () => {
+      expect(apiNormalize(name)).toBe(listenerNormalize(name));
+    });
+  }
+});
+
+// ── Endpoint behavior ───────────────────────────────────────────────────────
+
+describe('GET /api/schefter/style-book', () => {
+  it('returns an empty response when the leaderboard is empty', async () => {
+    const res = await callEndpoint();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.entries).toEqual([]);
+    expect(body.totals).toEqual({ seasonShots: 0, authors: 0 });
+    expect(body.seasonYear).toBeGreaterThan(2024);
+  });
+
+  it('returns entries ordered by seasonCount desc', async () => {
+    const lb = new Map<string, number>([
+      ['Dead Cap Walking', 3],
+      ['Wabbits', 1],
+      ['Vitside Mafia', 2],
+    ]);
+    // Find the correct leaderboard key — the endpoint uses getCurrentLeagueYear()
+    // Pre-populate a leaderboard for each plausible year.
+    const years = [2025, 2026, 2027];
+    for (const y of years) fakeRedis.zsets.set(`schefter:style_book:leaderboard:${y}`, new Map(lb));
+
+    // Also populate lifetime + last-shot for one of them so we can assert
+    // the enrichment path works.
+    fakeRedis.strings.set('schefter:style_book:dead_cap_walking', 5);
+    fakeRedis.strings.set('schefter:style_book:last_shot_at:dead_cap_walking', 1_700_000_000_000);
+
+    const res = await callEndpoint();
+    const body = await res.json();
+    expect(body.entries.map((e: any) => e.author)).toEqual([
+      'Dead Cap Walking',
+      'Vitside Mafia',
+      'Wabbits',
+    ]);
+    expect(body.entries[0].seasonCount).toBe(3);
+
+    const dcw = body.entries[0];
+    expect(dcw.lifetimeCount).toBe(5);
+    expect(dcw.lastShotAt).toBe(1_700_000_000_000);
+
+    // Vitside has no lifetime record — should degrade to 0 / null.
+    const vit = body.entries[1];
+    expect(vit.lifetimeCount).toBe(0);
+    expect(vit.lastShotAt).toBeNull();
+  });
+
+  it('aggregates season totals correctly', async () => {
+    const lb = new Map<string, number>([
+      ['A', 5],
+      ['B', 3],
+      ['C', 1],
+    ]);
+    for (const y of [2025, 2026, 2027]) fakeRedis.zsets.set(`schefter:style_book:leaderboard:${y}`, new Map(lb));
+
+    const res = await callEndpoint();
+    const body = await res.json();
+    expect(body.totals.seasonShots).toBe(9);
+    expect(body.totals.authors).toBe(3);
+  });
+
+  it('never exposes hashes or internal keys in the response', async () => {
+    const lb = new Map<string, number>([['Dead Cap Walking', 2]]);
+    for (const y of [2025, 2026, 2027]) fakeRedis.zsets.set(`schefter:style_book:leaderboard:${y}`, new Map(lb));
+
+    const res = await callEndpoint();
+    const body = await res.json();
+    const serialized = JSON.stringify(body);
+    expect(serialized).not.toMatch(/schefter:style_book:/);
+    expect(serialized).not.toMatch(/hashedOwnerId/);
+    expect(serialized).not.toMatch(/dead_cap_walking/); // normalized key should NOT leak
+  });
+
+  it('caches the response (second call makes no Redis reads)', async () => {
+    const lb = new Map<string, number>([['Dead Cap Walking', 1]]);
+    for (const y of [2025, 2026, 2027]) fakeRedis.zsets.set(`schefter:style_book:leaderboard:${y}`, new Map(lb));
+
+    await callEndpoint();
+    const zrangeCallsAfterFirst = fakeRedis.zrangeCalls.length;
+    const getCallsAfterFirst = fakeRedis.getCalls.length;
+
+    await callEndpoint();
+    // The second call must be served from cache — no new Redis commands.
+    expect(fakeRedis.zrangeCalls.length).toBe(zrangeCallsAfterFirst);
+    expect(fakeRedis.getCalls.length).toBe(getCallsAfterFirst);
+  });
+
+  it('requests descending order with scores from the leaderboard ZSET', async () => {
+    fakeRedis.zsets.set(`schefter:style_book:leaderboard:2026`, new Map([['X', 1]]));
+    fakeRedis.zsets.set(`schefter:style_book:leaderboard:2027`, new Map([['X', 1]]));
+    fakeRedis.zsets.set(`schefter:style_book:leaderboard:2025`, new Map([['X', 1]]));
+    await callEndpoint();
+    expect(fakeRedis.zrangeCalls[0].rev).toBe(true);
+    expect(fakeRedis.zrangeCalls[0].withScores).toBe(true);
+  });
+});
+
+// ── Source-level contract (page) ────────────────────────────────────────────
+
+describe('style-book page — contract', () => {
+  const pageSrc = readFileSync(
+    path.join(process.cwd(), 'src/pages/theleague/schefter/style-book.astro'),
+    'utf8',
+  );
+
+  it('marks the page as not prerendered (needs server-side fetch)', () => {
+    expect(pageSrc).toMatch(/export\s+const\s+prerender\s*=\s*false/);
+  });
+
+  it('fetches from the public /api/schefter/style-book endpoint', () => {
+    expect(pageSrc).toMatch(/\/api\/schefter\/style-book/);
+  });
+
+  it('renders an empty state when the dossier is empty', () => {
+    expect(pageSrc).toMatch(/The dossier is empty this season/);
+  });
+
+  it('escapes HTML in author names', () => {
+    expect(pageSrc).toMatch(/escapeHtml/);
+  });
+});

--- a/tests/schefter-style-book.test.ts
+++ b/tests/schefter-style-book.test.ts
@@ -1,0 +1,374 @@
+/**
+ * Tests for the Schefter Style Book tracker.
+ *
+ * Coverage:
+ *  - detectAttackOnSchefter pure-function: subject detection, pejorative
+ *    matching, negation guards, false-negative tolerance.
+ *  - normalizeAuthorKey: deterministic Redis key format.
+ *  - ingestGroupMeMentions integration: a personal-attack tip stamps the
+ *    payload with attackOnSchefter + styleBookCount, and the Redis side-
+ *    effects (INCR + INCR + SET + ZINCRBY) fire in the expected order.
+ *  - Scanner prompt / anonymizeTips contract: presence of HARD RULE 15
+ *    and the surfacing branch for attackOnSchefter on GroupMe tips.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import {
+  detectAttackOnSchefter,
+  normalizeAuthorKey,
+  ingestGroupMeMentions,
+  // @ts-ignore — .mjs via allowJs, no TS declarations
+} from '../scripts/schefter-groupme-listen.mjs';
+
+function read(rel: string): string {
+  return readFileSync(path.join(process.cwd(), rel), 'utf8');
+}
+
+// ── FakeRedis (extended: incr, zincrby) ─────────────────────────────────────
+
+class FakeRedis {
+  strings = new Map<string, string>();
+  lists = new Map<string, string[]>();
+  zsets = new Map<string, Map<string, number>>();
+  numbers = new Map<string, number>();
+  expireCalls: Array<{ key: string; seconds: number }> = [];
+  callLog: Array<{ op: string; key: string; args?: unknown[] }> = [];
+
+  async get(key: string) {
+    this.callLog.push({ op: 'get', key });
+    if (this.numbers.has(key)) return this.numbers.get(key);
+    return this.strings.get(key) ?? null;
+  }
+  async set(key: string, value: unknown, opts?: { nx?: boolean }) {
+    this.callLog.push({ op: 'set', key, args: [value, opts] });
+    if (opts?.nx && (this.strings.has(key) || this.numbers.has(key))) return null;
+    this.strings.set(key, String(value));
+    return 'OK';
+  }
+  async incr(key: string) {
+    this.callLog.push({ op: 'incr', key });
+    const next = (this.numbers.get(key) ?? 0) + 1;
+    this.numbers.set(key, next);
+    return next;
+  }
+  async zincrby(key: string, delta: number, member: string) {
+    this.callLog.push({ op: 'zincrby', key, args: [delta, member] });
+    const map = this.zsets.get(key) ?? new Map<string, number>();
+    map.set(member, (map.get(member) ?? 0) + delta);
+    this.zsets.set(key, map);
+    return map.get(member);
+  }
+  async llen(key: string) {
+    return this.lists.get(key)?.length ?? 0;
+  }
+  async lpush(key: string, ...values: string[]) {
+    const list = this.lists.get(key) ?? [];
+    for (const v of values) list.unshift(String(v));
+    this.lists.set(key, list);
+    return list.length;
+  }
+  async ltrim(key: string, start: number, stop: number) {
+    const list = this.lists.get(key) ?? [];
+    const end = stop < 0 ? list.length + stop + 1 : stop + 1;
+    this.lists.set(key, list.slice(start, end));
+    return 'OK';
+  }
+  async lrange(key: string, start: number, stop: number) {
+    const list = this.lists.get(key) ?? [];
+    const end = stop < 0 ? list.length + stop + 1 : stop + 1;
+    return list.slice(start, end);
+  }
+  async expire(key: string, seconds: number) {
+    this.expireCalls.push({ key, seconds });
+    return 1;
+  }
+}
+
+function makeMessage(overrides: Partial<Record<string, unknown>>) {
+  return {
+    id: 'msg_' + Math.random().toString(36).slice(2, 10),
+    created_at: Math.floor(Date.now() / 1000),
+    sender_type: 'user',
+    user_id: 'user_123',
+    sender_id: 'user_123',
+    name: 'Dead Cap Walking',
+    text: '',
+    attachments: [],
+    ...overrides,
+  };
+}
+
+function installFetchStub(messages: unknown[]) {
+  const originalFetch = global.fetch;
+  global.fetch = (async () => {
+    return new Response(JSON.stringify({ response: { messages } }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as typeof fetch;
+  return () => {
+    global.fetch = originalFetch;
+  };
+}
+
+// ── detectAttackOnSchefter ──────────────────────────────────────────────────
+
+describe('detectAttackOnSchefter', () => {
+  it('catches the canonical attack ("Claude Schefter is a lil bitch")', () => {
+    const r = detectAttackOnSchefter('Claude Schefter is a lil bitch');
+    expect(r.attack).toBe(true);
+    expect(r.keyword).toBe('bitch');
+  });
+
+  it('catches "schefty sucks"', () => {
+    const r = detectAttackOnSchefter('schefty sucks man');
+    expect(r.attack).toBe(true);
+  });
+
+  it('catches "the bot is a hack"', () => {
+    const r = detectAttackOnSchefter('the bot is a hack');
+    expect(r.attack).toBe(true);
+    expect(r.keyword).toBe('hack');
+  });
+
+  it('catches "schefter is trash"', () => {
+    expect(detectAttackOnSchefter('schefter is trash').attack).toBe(true);
+  });
+
+  it('catches "claude is wrong again"', () => {
+    expect(detectAttackOnSchefter('claude is wrong again').attack).toBe(true);
+  });
+
+  it('respects negation: "schefter isn\'t wrong about this"', () => {
+    const r = detectAttackOnSchefter("schefter isn't wrong about this");
+    expect(r.attack).toBe(false);
+  });
+
+  it('respects negation: "that\'s not bad for the bot"', () => {
+    const r = detectAttackOnSchefter("that's not bad for the bot");
+    expect(r.attack).toBe(false);
+  });
+
+  it('rejects pejorative without Schefter subject ("this trade is trash")', () => {
+    expect(detectAttackOnSchefter('this trade is trash').attack).toBe(false);
+  });
+
+  it('rejects Schefter mention without pejorative ("hey schefter any rumors?")', () => {
+    expect(detectAttackOnSchefter('hey schefter any rumors?').attack).toBe(false);
+  });
+
+  it('rejects empty / too-short text', () => {
+    expect(detectAttackOnSchefter('').attack).toBe(false);
+    expect(detectAttackOnSchefter('bad').attack).toBe(false);
+  });
+
+  it('handles mixed case and punctuation', () => {
+    const r = detectAttackOnSchefter('SCHEFTER, you are GARBAGE!!!');
+    expect(r.attack).toBe(true);
+  });
+});
+
+// ── normalizeAuthorKey ──────────────────────────────────────────────────────
+
+describe('normalizeAuthorKey', () => {
+  it('lowercases + underscores + strips punctuation', () => {
+    expect(normalizeAuthorKey('Dead Cap Walking')).toBe('dead_cap_walking');
+    expect(normalizeAuthorKey('Da Dangsters!')).toBe('da_dangsters');
+    expect(normalizeAuthorKey('  Pacific Pigskins  ')).toBe('pacific_pigskins');
+  });
+
+  it('returns empty string for invalid input', () => {
+    expect(normalizeAuthorKey('')).toBe('');
+    expect(normalizeAuthorKey(undefined as unknown as string)).toBe('');
+    expect(normalizeAuthorKey(null as unknown as string)).toBe('');
+  });
+
+  it('produces deterministic keys for the same name', () => {
+    const a = normalizeAuthorKey('Dead Cap Walking');
+    const b = normalizeAuthorKey('Dead Cap Walking');
+    expect(a).toBe(b);
+  });
+});
+
+// ── ingestGroupMeMentions integration: attack stamping + Redis side effects ─
+
+describe('ingestGroupMeMentions — Style Book integration', () => {
+  const priorToken = process.env.GROUPME_SERVICE_TOKEN;
+  const priorGroup = process.env.GROUPME_GROUP_ID;
+
+  beforeEach(() => {
+    process.env.GROUPME_SERVICE_TOKEN = 'test-token';
+    process.env.GROUPME_GROUP_ID = 'test-group';
+  });
+  afterEach(() => {
+    if (priorToken === undefined) delete process.env.GROUPME_SERVICE_TOKEN;
+    else process.env.GROUPME_SERVICE_TOKEN = priorToken;
+    if (priorGroup === undefined) delete process.env.GROUPME_GROUP_ID;
+    else process.env.GROUPME_GROUP_ID = priorGroup;
+  });
+
+  it('stamps attackOnSchefter + styleBookCount on the queued tip when attack is detected', async () => {
+    const redis = new FakeRedis();
+    const restore = installFetchStub([
+      makeMessage({ id: 'attack_1', name: 'Dead Cap Walking', text: 'Claude Schefter is a lil bitch' }),
+    ]);
+
+    try {
+      const res = await ingestGroupMeMentions({ redis, dryRun: false });
+      expect(res.detected).toBe(1);
+
+      const queuedRaw = redis.lists.get('schefter:tips:queue')?.[0];
+      expect(queuedRaw).toBeDefined();
+      const queued = JSON.parse(queuedRaw as string);
+      expect(queued.attackOnSchefter).toBe(true);
+      expect(queued.styleBookCount).toBe(1);
+      expect(queued.author).toBe('Dead Cap Walking');
+      // We never persist the attack keyword on the tip payload — only the flag.
+      expect(queued.text).toContain('bitch'); // original text is preserved
+      expect(queued).not.toHaveProperty('keyword');
+    } finally {
+      restore();
+    }
+  });
+
+  it('increments counters across repeat attacks from the same author', async () => {
+    const redis = new FakeRedis();
+    const author = 'Dead Cap Walking';
+    const authorKey = 'dead_cap_walking';
+
+    // First attack
+    let restore = installFetchStub([
+      makeMessage({ id: 'attack_1', name: author, text: 'schefter sucks' }),
+    ]);
+    try {
+      await ingestGroupMeMentions({ redis, dryRun: false });
+    } finally {
+      restore();
+    }
+
+    // Clear watermark so next call re-processes
+    redis.strings.delete('schefter:groupme:last_mention_id');
+    redis.numbers.delete('schefter:groupme:last_mention_id');
+
+    // Second attack — same author, different message
+    restore = installFetchStub([
+      makeMessage({ id: 'attack_2', name: author, text: 'claude is a hack' }),
+    ]);
+    try {
+      await ingestGroupMeMentions({ redis, dryRun: false });
+    } finally {
+      restore();
+    }
+
+    // Lifetime counter should be 2
+    expect(redis.numbers.get(`schefter:style_book:${authorKey}`)).toBe(2);
+
+    // Seasonal counter should also be 2 (same year)
+    const seasonKey = Array.from(redis.numbers.keys()).find((k) =>
+      k.startsWith('schefter:style_book:season:'),
+    );
+    expect(seasonKey).toBeDefined();
+    expect(redis.numbers.get(seasonKey as string)).toBe(2);
+
+    // Second queued tip should reflect count=2
+    const queue = redis.lists.get('schefter:tips:queue') ?? [];
+    const latest = JSON.parse(queue[0] as string);
+    expect(latest.styleBookCount).toBe(2);
+  });
+
+  it('does not stamp attackOnSchefter on benign tips', async () => {
+    const redis = new FakeRedis();
+    const restore = installFetchStub([
+      makeMessage({ id: 'benign_1', name: 'Wabbit', text: 'hey schefter, any rumors today?' }),
+    ]);
+
+    try {
+      await ingestGroupMeMentions({ redis, dryRun: false });
+      const queued = JSON.parse(
+        (redis.lists.get('schefter:tips:queue')?.[0] ?? '{}') as string,
+      );
+      expect(queued.attackOnSchefter).toBeUndefined();
+      expect(queued.styleBookCount).toBeUndefined();
+
+      // And no style-book counters should have been incremented
+      const styleBookKeys = Array.from(redis.numbers.keys()).filter((k) =>
+        k.startsWith('schefter:style_book:'),
+      );
+      expect(styleBookKeys).toHaveLength(0);
+    } finally {
+      restore();
+    }
+  });
+
+  it('updates the seasonal leaderboard ZSET', async () => {
+    const redis = new FakeRedis();
+    const restore = installFetchStub([
+      makeMessage({ id: 'attack_1', name: 'Dead Cap Walking', text: 'schefter is a fraud' }),
+    ]);
+
+    try {
+      await ingestGroupMeMentions({ redis, dryRun: false });
+      const leaderboardKey = Array.from(redis.zsets.keys()).find((k) =>
+        k.startsWith('schefter:style_book:leaderboard:'),
+      );
+      expect(leaderboardKey).toBeDefined();
+      const lb = redis.zsets.get(leaderboardKey as string);
+      expect(lb?.get('Dead Cap Walking')).toBe(1);
+    } finally {
+      restore();
+    }
+  });
+
+  it('skips style-book writes in dryRun mode', async () => {
+    const redis = new FakeRedis();
+    const restore = installFetchStub([
+      makeMessage({ id: 'attack_1', name: 'Dead Cap Walking', text: 'schefter is trash' }),
+    ]);
+
+    try {
+      await ingestGroupMeMentions({ redis, dryRun: true });
+      const styleBookKeys = Array.from(redis.numbers.keys()).filter((k) =>
+        k.startsWith('schefter:style_book:'),
+      );
+      expect(styleBookKeys).toHaveLength(0);
+      const leaderboardKeys = Array.from(redis.zsets.keys()).filter((k) =>
+        k.startsWith('schefter:style_book:leaderboard:'),
+      );
+      expect(leaderboardKeys).toHaveLength(0);
+    } finally {
+      restore();
+    }
+  });
+});
+
+// ── Source-level contract checks ────────────────────────────────────────────
+
+describe('source-level contract — scanner + prompt', () => {
+  const scannerSrc = read('scripts/schefter-rumor-scan.mjs');
+  const runningBitsSrc = read('data/schefter/running-bits.md');
+
+  it('anonymizeTips surfaces attackOnSchefter + styleBookCount on GroupMe tips', () => {
+    // The flag and count must be surfaced on the safe object so the LLM sees them.
+    expect(scannerSrc).toMatch(/safe\.attackOnSchefter\s*=\s*true/);
+    expect(scannerSrc).toMatch(/safe\.styleBookCount\s*=\s*tip\.styleBookCount/);
+  });
+
+  it('system prompt contains HARD RULE 15 (Style Book)', () => {
+    expect(scannerSrc).toMatch(/15\.\s*Style Book \(GroupMe attacks on Schefter\)/);
+    expect(scannerSrc).toMatch(/attackOnSchefter:\s*true/);
+    expect(scannerSrc).toMatch(/styleBookCount/);
+  });
+
+  it('system prompt forbids quoting the attack verbatim and clapping back', () => {
+    expect(scannerSrc).toMatch(/NEVER quote the attack verbatim/);
+    expect(scannerSrc).toMatch(/NEVER defensive or clapping-back/);
+  });
+
+  it('running-bits.md has been extended with count-based escalation lines', () => {
+    expect(runningBitsSrc).toMatch(/count === 1/);
+    expect(runningBitsSrc).toMatch(/count === 2/);
+    expect(runningBitsSrc).toMatch(/count >= 4/);
+    expect(runningBitsSrc).toMatch(/styleBookCount/);
+  });
+});

--- a/tests/schefter-style-book.test.ts
+++ b/tests/schefter-style-book.test.ts
@@ -354,10 +354,15 @@ describe('source-level contract — scanner + prompt', () => {
     expect(scannerSrc).toMatch(/safe\.styleBookCount\s*=\s*tip\.styleBookCount/);
   });
 
-  it('system prompt contains HARD RULE 15 (Style Book)', () => {
-    expect(scannerSrc).toMatch(/15\.\s*Style Book \(GroupMe attacks on Schefter\)/);
+  it('system prompt contains HARD RULE 15 (Style Book) and covers both named + anon', () => {
+    expect(scannerSrc).toMatch(/15\.\s*Style Book \(attacks on Schefter\)/);
     expect(scannerSrc).toMatch(/attackOnSchefter:\s*true/);
     expect(scannerSrc).toMatch(/styleBookCount/);
+    // Rule must distinguish GroupMe (named) and web (anonymous) flavors so
+    // Schefter addresses each correctly.
+    expect(scannerSrc).toMatch(/GroupMe \(named\)/);
+    expect(scannerSrc).toMatch(/Web \(anonymous\)/);
+    expect(scannerSrc).toMatch(/tipsterCodename/);
   });
 
   it('system prompt forbids quoting the attack verbatim and clapping back', () => {

--- a/tests/schefter-tip-api.test.ts
+++ b/tests/schefter-tip-api.test.ts
@@ -69,3 +69,49 @@ describe('tips-remaining endpoint', () => {
     expect(src).toMatch(/remaining:\s*RATE_LIMIT_MAX/);
   });
 });
+
+// ── Anonymous Style Book integration (source-level contract) ──
+
+describe('anon Style Book — tip.ts integration', () => {
+  const tipSource = readFileSync(
+    path.join(process.cwd(), 'src/pages/api/schefter/tip.ts'),
+    'utf8',
+  );
+
+  it('imports the shared TS detectAttackOnSchefter utility', () => {
+    expect(tipSource).toMatch(/from '\.\.\/\.\.\/\.\.\/utils\/schefter-attack-detection'/);
+    expect(tipSource).toMatch(/detectAttackOnSchefter\(trimmedText\)/);
+  });
+
+  it('uses separate Redis key prefixes for anon (not the named namespace)', () => {
+    // The anon Style Book MUST live on its own keyspace so named and anon
+    // leaderboards never mix. If these asserts fail, tips are leaking into
+    // the named pool.
+    expect(tipSource).toMatch(/schefter:style_book:anon:/);
+    expect(tipSource).toMatch(/schefter:style_book:anon_leaderboard:/);
+  });
+
+  it('stamps attackOnSchefter + styleBookCount + tipsterCodename on the tip', () => {
+    expect(tipSource).toMatch(/attackOnSchefter:\s*true/);
+    expect(tipSource).toMatch(/styleBookCount/);
+    expect(tipSource).toMatch(/tipsterCodename/);
+  });
+
+  it('assigns/retrieves a codename so the leaderboard has something to render', () => {
+    expect(tipSource).toMatch(/assignCodename\(redis,\s*hashedOwnerId\)/);
+  });
+
+  it('increments the anon leaderboard ZSET using the HASH (never the tip text)', () => {
+    // Leaderboard member is the hashedOwnerId so the API layer can resolve to
+    // codename. The raw hash must never surface in responses (guarded in the
+    // API test suite).
+    expect(tipSource).toMatch(/zincrby\(leaderboardKey,\s*1,\s*hashedOwnerId\)/);
+  });
+
+  it('wraps the style-book bump in try/catch so a Redis failure never blocks enqueue', () => {
+    // The ordering matters: detection + bump run BEFORE the tip is built +
+    // pushed. Any failure in the bump path must be logged + swallowed so the
+    // tip still reaches the queue.
+    expect(tipSource).toMatch(/\[schefter\/tip\] anon style-book bump failed/);
+  });
+});


### PR DESCRIPTION
## Summary

Persistent per-owner counter of shots taken at Schefter in the GroupMe chat, with running-total escalation baked into the existing Style Book bit. Every attack gets passed through the dossier framing instead of being quoted back — the count is the joke, never the slur.

**GroupMe-only for v1.** Web tips stay anonymous (codename plumbing deferred).

## Detection

`detectAttackOnSchefter(text)` in `schefter-groupme-listen.mjs`:
- Requires a subject match (Claude / Schefter / Schefty / "the bot")
- Requires a pejorative keyword — 25 total (sucks, bitch, hack, trash, fraud, dumb, clown, useless, wrong, terrible, …)
- Negation guard: pejorative preceded by not / isn't / ain't / never within 2 words is skipped
- Intentionally loose — false positives are harmless because the bit is affectionate ribbing either way

## Storage (Upstash, new keys)

| Key | Type | Purpose |
|---|---|---|
| `schefter:style_book:{author}` | INT | Lifetime shot count |
| `schefter:style_book:season:{year}:{author}` | INT | Seasonal count |
| `schefter:style_book:last_shot_at:{author}` | INT | Last-shot epoch ms |
| `schefter:style_book:leaderboard:{year}` | ZSET | Season leaderboard (future page) |

`normalizeAuthorKey()` lowercases + underscores the GroupMe display name ("Dead Cap Walking" → `dead_cap_walking`). Leaderboard ZSET stores the raw display name as member for direct rendering.

## Integration

On a detected attack:
1. Bumps all four counters — best-effort, Redis failure never blocks enqueue.
2. Stamps the tip with `attackOnSchefter: true` + current seasonal `styleBookCount`.
3. Writes the flag into the recent-mentions audit list.

`anonymizeTips` surfaces both fields on the safe object for GroupMe tips so the LLM sees them alongside normal attribution.

## Prompt rule

**HARD RULE 15** instructs Schefter to fire the Style Book bit with count-driven escalation:
- `count === 1` → "first entry in the style book"
- `count === 2` → "dossier grows"
- `count === 3` → "file's getting thick"
- `count >= 4` → "power user of the style book"

Never quote the attack verbatim, never clap back first-person, always pair with one line of actual league news. Mutually exclusive with the Bot Wink catalog.

`running-bits.md` extended with the full lines-per-count list and usage rules.

## Test plan

- [x] `tests/schefter-style-book.test.ts` — 23 new tests
  - [x] Pure detection (canonical attack, variants, negation, no-subject, no-pejorative, mixed case)
  - [x] Key normalization (determinism + invalid inputs)
  - [x] Integration (tip stamping, repeat-author increments, benign tips leave counters untouched, leaderboard ZSET updates, dryRun skips all writes)
  - [x] Source-level contract (anonymizeTips surfaces fields, HARD RULE 15 present with guardrails, running-bits.md carries count-based escalation)
- [x] Full schefter suite: **160 tests passing** (137 existing + 23 new)
- [ ] Live verify on preview deploy — point a GroupMe-connected preview at a test group and fire attack messages of varying counts to confirm LLM follows the escalation ladder.
- [ ] Check leaderboard ZSET after a few days of real traffic before building the `/theleague/schefter/style-book` leaderboard page (deferred feature #2).

## Coverage gap worth noting

The `detectMention` gate upstream of this feature only matches Claude/Schefter/Schefty — not "the bot" alone. So attacks that say *"the bot is a fraud"* without naming Schefter won't currently reach the tip queue at all. Not a regression (that behavior is unchanged), but worth a follow-up if we want fuller coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)