### PR TITLE
feat(schefter): reframe-usage telemetry in tagPost

### DIFF
--- a/data/schefter/post-history.json
+++ b/data/schefter/post-history.json
@@ -11,6 +11,7 @@
       "closerUsed": "the closer phrase used",
       "hadBotWink": "boolean",
       "hadLoreCallback": "boolean",
+      "reframeMode": "telemetry — which hostile-tip frame the post used: '' | style-book | intra-division | reverse-lens | rivalry | league-office",
       "tipSources": ["web|groupme|trade_offer|trade_pending"]
     }
   },

--- a/scripts/lib/schefter-lore.mjs
+++ b/scripts/lib/schefter-lore.mjs
@@ -144,6 +144,104 @@ const LORE_CALLBACK_PHRASES = [
   'algorithm\'s taking notes',
 ];
 
+// Hostile-tip reframe detection — telemetry only. Records WHICH frame the
+// LLM picked when working a hostile tip into the post, so we can spot
+// overuse of any one mode after a few cycles of live output and tune the
+// HARD RULES / running bits accordingly.
+//
+// Detection is by substring match on the post body. Priority order matters:
+// style-book is the most structurally specific, then intra-division, then
+// reverse-lens (the redirect-to-tipster framing), then rivalry (named beef),
+// and finally league-office (the institutional softener). First match wins.
+//
+// Any line not matching any pattern returns reframeMode === '' — the typical
+// case for a routine, non-hostile post. False positives are tolerated; the
+// signal we care about is direction-of-trend across many posts, not perfect
+// per-post classification.
+const REFRAME_PATTERNS = [
+  {
+    mode: 'style-book',
+    phrases: [
+      'style book',
+      'dossier',
+      'the file grows',
+      "file's getting thick",
+      "scouting report on",
+      'denial is a data point',
+      "every shot's a data point",
+      'adding that to the file',
+      'algorithm noticed',
+      "algorithm's taking notes",
+      'every denial',
+      'power user of the style book',
+      'entries deep on',
+      'first entry in the style book',
+      'second entry in the style book',
+      'third shot',
+      'first shot',
+      'noted, ',
+      'filed.',
+      'the file',
+    ],
+  },
+  {
+    mode: 'intra-division',
+    phrases: [
+      'developing some strong rivalries',
+      'beef brewing inside',
+      'rivalries heating up in',
+      'most personal division',
+      'most personal corner',
+      'is the most personal',
+    ],
+  },
+  {
+    mode: 'reverse-lens',
+    phrases: [
+      "an owner in the northwest isn't",
+      "an owner in the southwest isn't",
+      "an owner in the central isn't",
+      "an owner in the east isn't",
+      'an owner in the northwest is fed up',
+      'an owner in the southwest is fed up',
+      'an owner in the central is fed up',
+      'an owner in the east is fed up',
+      'an owner in the northwest has opinions',
+      'an owner in the southwest has opinions',
+      'an owner in the central has opinions',
+      'an owner in the east has opinions',
+      'somebody in the northwest is fed up',
+      'somebody in the southwest is fed up',
+      'somebody in the central is fed up',
+      'somebody in the east is fed up',
+    ],
+  },
+  {
+    mode: 'rivalry',
+    phrases: [
+      'bad blood between',
+      'feud heats up',
+      'feud escalates',
+      'feud just got',
+      'rivalry just got real',
+      'rivalry escalates',
+      'long memories',
+      'the rivalry heats',
+    ],
+  },
+  {
+    mode: 'league-office',
+    phrases: [
+      'league office',
+      'front office',
+      "commissioner's office",
+      "commissioner's patience",
+      "the office is catching",
+      "office has heat",
+    ],
+  },
+];
+
 // ── File loading (cached) ──
 
 let _cache = null;
@@ -289,6 +387,25 @@ function anySubstringMatch(haystack, needles) {
 }
 
 /**
+ * Detect which hostile-tip reframe (if any) the LLM used in the body. Returns
+ * the highest-priority match or '' if no frame phrase was found. See
+ * REFRAME_PATTERNS for the priority order and the per-mode phrase list.
+ *
+ * Telemetry only — used by tagPost() to write `reframeMode` into post-history
+ * so we can spot overuse and tune frequencies after enough live output.
+ */
+export function detectReframeMode(body) {
+  if (!body || typeof body !== 'string') return '';
+  const lower = body.toLowerCase();
+  for (const { mode, phrases } of REFRAME_PATTERNS) {
+    for (const p of phrases) {
+      if (lower.includes(p.toLowerCase())) return mode;
+    }
+  }
+  return '';
+}
+
+/**
  * Tag a generated post against the personality catalogs. Returns detection
  * fields ready to merge into a post-history entry. All detections are best-
  * effort; an empty string / false means "we didn't recognize this" — that's
@@ -301,6 +418,7 @@ export function tagPost(body) {
       closerUsed: '',
       hadBotWink: false,
       hadLoreCallback: false,
+      reframeMode: '',
     };
   }
 
@@ -318,6 +436,7 @@ export function tagPost(body) {
     closerUsed,
     hadBotWink: anySubstringMatch(body, BOT_WINKS),
     hadLoreCallback: anySubstringMatch(body, LORE_CALLBACK_PHRASES),
+    reframeMode: detectReframeMode(body),
   };
 }
 
@@ -370,6 +489,7 @@ export function buildHistoryEntry({ id, timestamp, body, subject, tipSources }) 
     closerUsed: tags.closerUsed,
     hadBotWink: tags.hadBotWink,
     hadLoreCallback: tags.hadLoreCallback,
+    reframeMode: tags.reframeMode,
     tipSources: Array.isArray(tipSources) ? tipSources : [],
   };
 }
@@ -379,6 +499,7 @@ export const _internals = {
   CLOSERS,
   BOT_WINKS,
   LORE_CALLBACK_PHRASES,
+  REFRAME_PATTERNS,
   MAX_HISTORY_ENTRIES,
   RECENT_POSTS_FOR_PROMPT,
   SALT_NOT_SUGAR_DIRECTIVE,

--- a/tests/schefter-reframe-telemetry.test.ts
+++ b/tests/schefter-reframe-telemetry.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Tests for hostile-tip reframe-mode telemetry in scripts/lib/schefter-lore.mjs.
+ *
+ * Pins:
+ *  - detectReframeMode() recognizes each frame's signature phrasing.
+ *  - Priority: style-book > intra-division > reverse-lens > rivalry >
+ *    league-office (most-specific-wins). Posts that mix multiple frames
+ *    get tagged with the highest-priority match.
+ *  - tagPost() includes reframeMode in the returned object.
+ *  - buildHistoryEntry() persists reframeMode into the post-history record.
+ *  - Empty / non-string body returns ''.
+ *  - Routine reportage with no hostile frame returns ''.
+ *  - The schema doc in data/schefter/post-history.json mentions reframeMode.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import {
+  tagPost,
+  detectReframeMode,
+  buildHistoryEntry,
+  // @ts-ignore — .mjs via allowJs
+} from '../scripts/lib/schefter-lore.mjs';
+
+// ── detectReframeMode — per-mode happy paths ────────────────────────────────
+
+describe('detectReframeMode — per-mode signatures', () => {
+  it('detects league-office', () => {
+    expect(
+      detectReframeMode(
+        "The league office is catching flak this week. Not everyone's thrilled. Developing.",
+      ),
+    ).toBe('league-office');
+    expect(detectReframeMode("The front office has heat right now. We'll see.")).toBe(
+      'league-office',
+    );
+    expect(detectReframeMode("The commissioner's office is drawing some static.")).toBe(
+      'league-office',
+    );
+  });
+
+  it('detects rivalry', () => {
+    expect(detectReframeMode('Bad blood between Pigskins and Dangsters is back.')).toBe('rivalry');
+    expect(detectReframeMode("The Vit-DCW feud heats up again. Developing.")).toBe('rivalry');
+    expect(detectReframeMode("Long memories on the East division desks.")).toBe('rivalry');
+  });
+
+  it('detects reverse-lens', () => {
+    expect(
+      detectReframeMode(
+        "Hearing an owner in the Northwest isn't happy with the auction process.",
+      ),
+    ).toBe('reverse-lens');
+    expect(
+      detectReframeMode("An owner in the Southwest has opinions about roster standards."),
+    ).toBe('reverse-lens');
+    expect(
+      detectReframeMode("Somebody in the Central is fed up with the league office. Developing."),
+    ).toBe('reverse-lens');
+  });
+
+  it('detects intra-division', () => {
+    expect(
+      detectReframeMode(
+        "The Southwest is really developing some strong rivalries this spring.",
+      ),
+    ).toBe('intra-division');
+    expect(detectReframeMode("Beef brewing inside the East division. Developing.")).toBe(
+      'intra-division',
+    );
+    expect(detectReframeMode("Rivalries heating up in the Central.")).toBe('intra-division');
+    expect(detectReframeMode("The Northwest is the most personal division right now.")).toBe(
+      'intra-division',
+    );
+  });
+
+  it('detects style-book', () => {
+    expect(
+      detectReframeMode("Noted, Dead Cap. Adding that to the file. Developing."),
+    ).toBe('style-book');
+    expect(
+      detectReframeMode("Third shot from Wabbit this season. The dossier grows."),
+    ).toBe('style-book');
+    expect(
+      detectReframeMode("Wabbit is officially a power user of the style book."),
+    ).toBe('style-book');
+  });
+});
+
+// ── Priority resolution: most-specific-wins ─────────────────────────────────
+
+describe('detectReframeMode — priority order', () => {
+  it('style-book beats league-office when both phrases appear', () => {
+    const body =
+      "Noted, Dead Cap. Adding that to the style book. The league office will live. Developing.";
+    expect(detectReframeMode(body)).toBe('style-book');
+  });
+
+  it('intra-division beats reverse-lens when both phrases appear', () => {
+    // Both phrases present — intra-division is more specific so it wins.
+    const body =
+      "The Southwest is really developing some strong rivalries. An owner in the Southwest is fed up too.";
+    expect(detectReframeMode(body)).toBe('intra-division');
+  });
+
+  it('reverse-lens beats rivalry when both phrases appear', () => {
+    const body =
+      "Hearing an owner in the East isn't happy with how things are going. Bad blood between two desks. More to come.";
+    expect(detectReframeMode(body)).toBe('reverse-lens');
+  });
+
+  it('rivalry beats league-office when both phrases appear', () => {
+    const body =
+      "Bad blood between Vit and Pigskins. The league office is staying out of it. Developing.";
+    expect(detectReframeMode(body)).toBe('rivalry');
+  });
+});
+
+// ── Negative paths ──────────────────────────────────────────────────────────
+
+describe('detectReframeMode — negative paths', () => {
+  it('returns empty string for routine non-hostile reportage', () => {
+    expect(
+      detectReframeMode(
+        "I'm told the Magicians are dangling a 2027 first for WR help. Still just smoke. Developing.",
+      ),
+    ).toBe('');
+  });
+
+  it('returns empty string for trade-offer voice without hostility', () => {
+    expect(
+      detectReframeMode(
+        "Quietly, somebody's working the phones. Nothing imminent. One to watch.",
+      ),
+    ).toBe('');
+  });
+
+  it('returns empty string for null / non-string / empty body', () => {
+    expect(detectReframeMode('')).toBe('');
+    expect(detectReframeMode(null as unknown as string)).toBe('');
+    expect(detectReframeMode(undefined as unknown as string)).toBe('');
+    expect(detectReframeMode(42 as unknown as string)).toBe('');
+  });
+
+  it('does not false-positive on the literal word "office" without "league/front"', () => {
+    // "The office crew" is a distinct lore bit (Dead Cap / Vit / Midwest).
+    // It should NOT trip the league-office reframe — that bit is unrelated.
+    // Our patterns require "league office" / "front office" / "commissioner's
+    // office" specifically, so this should pass.
+    expect(detectReframeMode("Office crew at it again. Monday meetings will be tense.")).toBe('');
+  });
+});
+
+// ── Integration with tagPost / buildHistoryEntry ────────────────────────────
+
+describe('tagPost — reframeMode is included in the returned tags', () => {
+  it('returns reframeMode in the tags object', () => {
+    const tags = tagPost("The league office is catching flak this week. Developing.");
+    expect(tags.reframeMode).toBe('league-office');
+    expect(tags).toHaveProperty('openerUsed');
+    expect(tags).toHaveProperty('closerUsed');
+    expect(tags).toHaveProperty('hadBotWink');
+    expect(tags).toHaveProperty('hadLoreCallback');
+  });
+
+  it('returns empty reframeMode for non-string body (default branch)', () => {
+    const tags = tagPost(null);
+    expect(tags.reframeMode).toBe('');
+  });
+
+  it('returns empty reframeMode for routine reportage', () => {
+    const tags = tagPost(
+      "I'm told the Magicians are dangling a 2027 first. Still just smoke. Developing.",
+    );
+    expect(tags.reframeMode).toBe('');
+  });
+});
+
+describe('buildHistoryEntry — reframeMode is persisted', () => {
+  it('writes reframeMode into the history entry', () => {
+    const entry = buildHistoryEntry({
+      id: 'sf_test_1',
+      timestamp: '2026-04-19T15:00:00Z',
+      body: "Noted, Dead Cap. Adding that to the style book. Developing.",
+      subject: 'groupme (Dead Cap)',
+      tipSources: ['groupme'],
+    });
+    expect(entry.reframeMode).toBe('style-book');
+  });
+
+  it('writes empty reframeMode for routine entries', () => {
+    const entry = buildHistoryEntry({
+      id: 'sf_test_2',
+      body: 'Quietly, somebody is working the phones. Developing.',
+      subject: 'trade-offer',
+      tipSources: ['trade_offer'],
+    });
+    expect(entry.reframeMode).toBe('');
+  });
+});
+
+// ── Schema doc ──────────────────────────────────────────────────────────────
+
+describe('post-history.json schema doc mentions reframeMode', () => {
+  const raw = readFileSync(
+    path.join(process.cwd(), 'data/schefter/post-history.json'),
+    'utf8',
+  );
+
+  it('references reframeMode in the _schema entry block', () => {
+    const parsed = JSON.parse(raw);
+    expect(parsed._schema?.entry?.reframeMode).toBeDefined();
+    expect(String(parsed._schema.entry.reframeMode)).toMatch(/style-book|intra-division|reverse-lens|rivalry|league-office/);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a `reframeMode` tag to every post-history record so we can spot overuse of any one hostile-tip frame after a few cycles of live output and tune the HARD RULES / running bits accordingly.

**Observation only — no prompt changes.** The LLM is not told about telemetry. We're watching, not steering.

## Detection

`detectReframeMode(body)` runs a substring-priority scan over the post body. First match wins, in this order (most specific → least specific):

| Priority | Mode | Signature phrases (sample) |
|---|---|---|
| 1 | `style-book` | "style book", "dossier", "the file grows", "every shot's a data point", "noted, " |
| 2 | `intra-division` | "developing some strong rivalries", "beef brewing inside", "rivalries heating up in" |
| 3 | `reverse-lens` | "an owner in the [Northwest/Southwest/Central/East] isn't / has opinions / is fed up" |
| 4 | `rivalry` | "bad blood between", "feud heats up", "rivalry just got real", "long memories" |
| 5 | `league-office` | "league office", "front office", "commissioner's office" |

A post that mixes frames gets tagged with the highest-priority match. A routine non-hostile post returns `''` and is the typical case. False positives are tolerated — the signal we care about is direction-of-trend across many posts, not per-post precision.

## Plumbing

- `tagPost()` returns `reframeMode` alongside the existing tags.
- `buildHistoryEntry()` writes it into the post-history record.
- Schema doc in `data/schefter/post-history.json` updated.
- `_internals` exports `REFRAME_PATTERNS` for testing.

## Test plan

- [x] `tests/schefter-reframe-telemetry.test.ts` — 19 new tests
  - [x] Per-mode happy paths
  - [x] Priority resolution (style-book > intra-division > reverse-lens > rivalry > league-office)
  - [x] Empty / non-string body returns `''`
  - [x] Routine reportage returns `''`
  - [x] "Office crew" lore bit doesn't false-positive into league-office
  - [x] `tagPost` / `buildHistoryEntry` pass the field through
  - [x] Schema doc references `reframeMode`
- [x] Full schefter suite: **156 tests passing** (137 existing + 19 new)
- [ ] After ~30 posts in live output, eyeball the distribution: any mode hitting >40% of hostile posts is a candidate for tightening; any mode at 0% across 30 posts is a candidate for the LLM not finding the right cue.

## Follow-ups (deferred)

- Aggregator script that tallies `reframeMode` counts across the rolling 30-post window and prints a frequency table. Trivial — wait until we have data to look at.
- Decision: should `reframeMode` get exposed on a debug page (similar to the Style Book leaderboard)? Probably not — it's noisier than user-facing data, and surfacing it could nudge the LLM if Brandon tweaks based on what he sees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)