### PR TITLE
Bump Anthropic model IDs to Claude 4.x and add prompt caching

### DIFF
--- a/scripts/article-types/championship-recap.mjs
+++ b/scripts/article-types/championship-recap.mjs
@@ -7,7 +7,7 @@
  */
 
 import { loadTeams, flipName, normalizePosition, formatDefName } from '../article-utils/data-loaders.mjs';
-import { BASE_SYSTEM_PROMPT } from '../article-utils/ai-client.mjs';
+import { buildCachedSystem } from '../article-utils/ai-client.mjs';
 import { isChampionshipComplete } from '../article-utils/season-guards.mjs';
 
 const CHAMPIONSHIP_WEEK = 17;
@@ -111,8 +111,8 @@ export async function buildFactSheet(data, week, year, projectRoot) {
 }
 
 export function getSystemPrompt() {
-  return BASE_SYSTEM_PROMPT + `\n\nARTICLE TYPE: Championship Recap
-This is the biggest article of the year. Crown the champion with all the fanfare they deserve. Celebrate greatness — the MVP performances, the dynasty implications. This team just won the whole damn thing. Make it feel like a coronation. But also give the runner-up credit for getting there.`;
+  return buildCachedSystem(`\n\nARTICLE TYPE: Championship Recap
+This is the biggest article of the year. Crown the champion with all the fanfare they deserve. Celebrate greatness — the MVP performances, the dynasty implications. This team just won the whole damn thing. Make it feel like a coronation. But also give the runner-up credit for getting there.`);
 }
 
 export function getUserPrompt(factSheet) {

--- a/scripts/article-types/cut-watch.mjs
+++ b/scripts/article-types/cut-watch.mjs
@@ -7,7 +7,7 @@
  */
 
 import { loadTeams, flipName, normalizePosition, formatDefName, formatSalary } from '../article-utils/data-loaders.mjs';
-import { BASE_SYSTEM_PROMPT } from '../article-utils/ai-client.mjs';
+import { buildCachedSystem } from '../article-utils/ai-client.mjs';
 import { isCutWindow } from '../article-utils/season-guards.mjs';
 
 const ACTIVE_ROSTER_LIMIT = 22;
@@ -134,8 +134,8 @@ export async function buildFactSheet(data, week, year, projectRoot) {
 }
 
 export function getSystemPrompt() {
-  return BASE_SYSTEM_PROMPT + `\n\nARTICLE TYPE: Cut Watch
-Channel the urgency of NFL roster cut day. Name names — who's on the chopping block? Which teams are in the toughest spots? Who has easy decisions vs. gut-wrenching ones? Talk about salary implications of keeping vs. cutting players.`;
+  return buildCachedSystem(`\n\nARTICLE TYPE: Cut Watch
+Channel the urgency of NFL roster cut day. Name names — who's on the chopping block? Which teams are in the toughest spots? Who has easy decisions vs. gut-wrenching ones? Talk about salary implications of keeping vs. cutting players.`);
 }
 
 export function getUserPrompt(factSheet) {

--- a/scripts/article-types/draft-grades.mjs
+++ b/scripts/article-types/draft-grades.mjs
@@ -7,7 +7,7 @@
  */
 
 import { loadTeams, flipName, normalizePosition, formatDefName } from '../article-utils/data-loaders.mjs';
-import { BASE_SYSTEM_PROMPT } from '../article-utils/ai-client.mjs';
+import { buildCachedSystem } from '../article-utils/ai-client.mjs';
 import { isDraftComplete } from '../article-utils/season-guards.mjs';
 
 const VALID_GRADES = ['A+', 'A', 'A-', 'B+', 'B', 'B-', 'C+', 'C', 'C-', 'D+', 'D', 'D-', 'F'];
@@ -129,8 +129,8 @@ export async function buildFactSheet(data, week, year, projectRoot) {
 }
 
 export function getSystemPrompt() {
-  return BASE_SYSTEM_PROMPT + `\n\nARTICLE TYPE: Draft Grades
-Grade each team's rookie draft class. Be harsh with reaches (players picked too early relative to projections), praise value picks. Dynasty drafts are about upside — young players with high ceilings are more valuable. Consider roster fit and how many picks each team had to work with.`;
+  return buildCachedSystem(`\n\nARTICLE TYPE: Draft Grades
+Grade each team's rookie draft class. Be harsh with reaches (players picked too early relative to projections), praise value picks. Dynasty drafts are about upside — young players with high ceilings are more valuable. Consider roster fit and how many picks each team had to work with.`);
 }
 
 export function getUserPrompt(factSheet) {

--- a/scripts/article-types/matchup-preview.mjs
+++ b/scripts/article-types/matchup-preview.mjs
@@ -7,7 +7,7 @@
  */
 
 import { loadTeams, loadJSON, flipName, normalizePosition, formatDefName } from '../article-utils/data-loaders.mjs';
-import { BASE_SYSTEM_PROMPT } from '../article-utils/ai-client.mjs';
+import { buildCachedSystem } from '../article-utils/ai-client.mjs';
 import { isRegularSeasonOrPlayoffs } from '../article-utils/season-guards.mjs';
 import { getMatchupPairings } from '../article-utils/week-resolver.mjs';
 import path from 'node:path';
@@ -142,8 +142,8 @@ export async function buildFactSheet(data, week, year, projectRoot) {
 }
 
 export function getSystemPrompt() {
-  return BASE_SYSTEM_PROMPT + `\n\nARTICLE TYPE: Matchup Preview + Broadcast Guide
-Break down each fantasy matchup in TheLeague for the week. Pick winners for each matchup — be bold, be wrong sometimes, that's what makes it fun. Include a section about which NFL games to watch based on rostered players. This is the Saturday morning "what to watch" guide.`;
+  return buildCachedSystem(`\n\nARTICLE TYPE: Matchup Preview + Broadcast Guide
+Break down each fantasy matchup in TheLeague for the week. Pick winners for each matchup — be bold, be wrong sometimes, that's what makes it fun. Include a section about which NFL games to watch based on rostered players. This is the Saturday morning "what to watch" guide.`);
 }
 
 export function getUserPrompt(factSheet) {

--- a/scripts/article-types/team-grades.mjs
+++ b/scripts/article-types/team-grades.mjs
@@ -7,7 +7,7 @@
  */
 
 import { loadTeams, flipName, normalizePosition, formatDefName, formatSalary } from '../article-utils/data-loaders.mjs';
-import { BASE_SYSTEM_PROMPT } from '../article-utils/ai-client.mjs';
+import { buildCachedSystem } from '../article-utils/ai-client.mjs';
 
 const SALARY_CAP = 45_000_000;
 const VALID_GRADES = ['A+', 'A', 'A-', 'B+', 'B', 'B-', 'C+', 'C', 'C-', 'D+', 'D', 'D-', 'F'];
@@ -142,8 +142,8 @@ export async function buildFactSheet(data, week, year, projectRoot) {
 }
 
 export function getSystemPrompt() {
-  return BASE_SYSTEM_PROMPT + `\n\nARTICLE TYPE: Pre-Season Team Grades
-Grade every roster top to bottom. Who's a contender? Who's rebuilding? Who's stuck in the middle with no plan? Factor in cap health, contract structure, projected starters, and bench depth. This is the definitive pre-season power ranking in grade form.`;
+  return buildCachedSystem(`\n\nARTICLE TYPE: Pre-Season Team Grades
+Grade every roster top to bottom. Who's a contender? Who's rebuilding? Who's stuck in the middle with no plan? Factor in cap health, contract structure, projected starters, and bench depth. This is the definitive pre-season power ranking in grade form.`);
 }
 
 export function getUserPrompt(factSheet) {

--- a/scripts/article-types/waiver-pickups.mjs
+++ b/scripts/article-types/waiver-pickups.mjs
@@ -7,7 +7,7 @@
  */
 
 import { loadTeams, formatSalary, flipName, normalizePosition, formatDefName } from '../article-utils/data-loaders.mjs';
-import { BASE_SYSTEM_PROMPT } from '../article-utils/ai-client.mjs';
+import { buildCachedSystem } from '../article-utils/ai-client.mjs';
 import { isRegularSeasonOrPlayoffs } from '../article-utils/season-guards.mjs';
 
 export const config = {
@@ -113,8 +113,8 @@ export async function buildFactSheet(data, week, year, projectRoot) {
 }
 
 export function getSystemPrompt() {
-  return BASE_SYSTEM_PROMPT + `\n\nARTICLE TYPE: Waiver Pickups
-Grade the waiver wire activity for the week. Who made the best claims? Who overpaid? Who missed out on players they needed? Talk about which pickups could be league-winners and which are desperation moves.`;
+  return buildCachedSystem(`\n\nARTICLE TYPE: Waiver Pickups
+Grade the waiver wire activity for the week. Who made the best claims? Who overpaid? Who missed out on players they needed? Talk about which pickups could be league-winners and which are desperation moves.`);
 }
 
 export function getUserPrompt(factSheet) {

--- a/scripts/article-types/weekend-preview.mjs
+++ b/scripts/article-types/weekend-preview.mjs
@@ -7,7 +7,7 @@
  */
 
 import { loadTeams, flipName, normalizePosition, formatDefName } from '../article-utils/data-loaders.mjs';
-import { BASE_SYSTEM_PROMPT } from '../article-utils/ai-client.mjs';
+import { buildCachedSystem } from '../article-utils/ai-client.mjs';
 import { isRegularSeasonOrPlayoffs } from '../article-utils/season-guards.mjs';
 import { getMatchupPairings } from '../article-utils/week-resolver.mjs';
 
@@ -118,8 +118,8 @@ export async function buildFactSheet(data, week, year, projectRoot) {
 }
 
 export function getSystemPrompt() {
-  return BASE_SYSTEM_PROMPT + `\n\nARTICLE TYPE: Weekend Preview
-Build anticipation for the upcoming week. Identify the matchup of the week. Call out teams that need a win. Make bold predictions. This should feel like a Friday hype piece — get the owners excited about the weekend.`;
+  return buildCachedSystem(`\n\nARTICLE TYPE: Weekend Preview
+Build anticipation for the upcoming week. Identify the matchup of the week. Call out teams that need a win. Make bold predictions. This should feel like a Friday hype piece — get the owners excited about the weekend.`);
 }
 
 export function getUserPrompt(factSheet) {

--- a/scripts/article-types/weekly-recap.mjs
+++ b/scripts/article-types/weekly-recap.mjs
@@ -7,7 +7,7 @@
  */
 
 import { loadPlayers, loadTeams, formatSalary } from '../article-utils/data-loaders.mjs';
-import { BASE_SYSTEM_PROMPT } from '../article-utils/ai-client.mjs';
+import { buildCachedSystem } from '../article-utils/ai-client.mjs';
 import { isRegularSeasonOrPlayoffs } from '../article-utils/season-guards.mjs';
 
 export const config = {
@@ -135,8 +135,8 @@ export async function buildFactSheet(data, week, year, projectRoot) {
 }
 
 export function getSystemPrompt() {
-  return BASE_SYSTEM_PROMPT + `\n\nARTICLE TYPE: Weekly Recap
-Write like a Monday morning ESPN column. Lead with the biggest story of the week — the biggest upset, the highest score, or the most dramatic finish. Weave in standings implications. End with a look-ahead to next week.`;
+  return buildCachedSystem(`\n\nARTICLE TYPE: Weekly Recap
+Write like a Monday morning ESPN column. Lead with the biggest story of the week — the biggest upset, the highest score, or the most dramatic finish. Weave in standings implications. End with a look-ahead to next week.`);
 }
 
 export function getUserPrompt(factSheet) {

--- a/scripts/article-utils/ai-client.mjs
+++ b/scripts/article-utils/ai-client.mjs
@@ -51,7 +51,8 @@ function repairJSON(text) {
  * Call the Anthropic API and return the parsed JSON from the response.
  * Retries once on JSON parse failure with a repair attempt.
  *
- * @param {string} systemPrompt - System prompt (Schefter voice + rules)
+ * @param {string | Array<{type:'text',text:string,cache_control?:object}>} systemPrompt
+ *   System prompt — either a plain string or an array of content blocks (for prompt caching).
  * @param {string} userPrompt - User prompt (fact sheet + output instructions)
  * @param {number} maxTokens - Max tokens for response
  * @returns {object} Parsed JSON from the AI response
@@ -112,6 +113,21 @@ export async function callAnthropic(systemPrompt, userPrompt, maxTokens = 4000) 
       }
     }
   }
+}
+
+/**
+ * Build a cacheable system-prompt array: the stable BASE_SYSTEM_PROMPT is
+ * marked ephemeral so repeated article generations within the cache window
+ * skip re-tokenizing the shared voice/rules preamble.
+ *
+ * @param {string} typeSpecificText - Article-type-specific additions appended after BASE.
+ * @returns {Array<{type:'text',text:string,cache_control?:object}>}
+ */
+export function buildCachedSystem(typeSpecificText) {
+  return [
+    { type: 'text', text: BASE_SYSTEM_PROMPT, cache_control: { type: 'ephemeral' } },
+    { type: 'text', text: typeSpecificText },
+  ];
 }
 
 /** Base Schefter system prompt shared by all article types. */

--- a/scripts/generate-high-total-matchups.mjs
+++ b/scripts/generate-high-total-matchups.mjs
@@ -10,7 +10,7 @@
  *
  * Env:
  *   ANTHROPIC_API_KEY - required to call Claude
- *   MODEL_NAME        - optional override (default: claude-3-5-haiku-20241022)
+ *   MODEL_NAME        - optional override (default: claude-haiku-4-5-20251001)
  *   SCHEDULE_PATH     - optional path to nfl-cache file (default: data/theleague/nfl-cache/week15-2024.json)
  *   PLAYERS_PATH      - optional path to players.json (default: data/theleague/mfl-feeds/2025/players.json)
  *   PROJECTIONS_PATH  - optional path to projectedScores.json (default: data/theleague/mfl-feeds/2025/projectedScores.json)
@@ -40,7 +40,7 @@ const paths = {
   output: path.join(root, process.env.OUTPUT_PATH || defaults.output)
 };
 
-const modelName = process.env.MODEL_NAME || 'claude-3-5-haiku-20241022';
+const modelName = process.env.MODEL_NAME || 'claude-haiku-4-5-20251001';
 
 function loadJson(p) {
   return JSON.parse(fs.readFileSync(p, 'utf8'));

--- a/scripts/generate-matchup-nfl-blurbs.mjs
+++ b/scripts/generate-matchup-nfl-blurbs.mjs
@@ -540,7 +540,7 @@ async function callModel(systemPrompt, userPrompt) {
 
   const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
   const resp = await client.messages.create({
-    model: 'claude-3-5-haiku-20241022',
+    model: 'claude-haiku-4-5-20251001',
     max_tokens: 2000,
     system: systemPrompt,
     messages: [{ role: 'user', content: userPrompt }]

--- a/scripts/test-matchup-story-nfl.mjs
+++ b/scripts/test-matchup-story-nfl.mjs
@@ -337,7 +337,7 @@ async function generateStory(homeTeam, awayTeam, nflMatchupAnalysis, week) {
   console.log('🤖 Calling Claude API...');
 
   const message = await anthropic.messages.create({
-    model: 'claude-3-5-haiku-20241022',
+    model: 'claude-haiku-4-5-20251001',
     max_tokens: 250,
     temperature: 0.8,
     messages: [{
@@ -403,7 +403,7 @@ async function main() {
     const wordCount = story.split(/\s+/).length;
     console.log(`\n📊 Story Stats:`);
     console.log(`   Word count: ${wordCount}`);
-    console.log(`   Model: claude-3-5-haiku-20241022`);
+    console.log(`   Model: claude-haiku-4-5-20251001`);
     console.log(`   Estimated cost: ~$0.002`);
 
     // Save to file
@@ -419,7 +419,7 @@ async function main() {
       nflGames: nflGames,
       metadata: {
         wordCount,
-        model: 'claude-3-5-haiku-20241022',
+        model: 'claude-haiku-4-5-20251001',
         generatedAt: new Date().toISOString()
       }
     };

--- a/scripts/test-matchup-story.mjs
+++ b/scripts/test-matchup-story.mjs
@@ -201,7 +201,7 @@ async function generateStory(homeTeam, awayTeam, week) {
   console.log('🤖 Calling Claude API...');
 
   const message = await anthropic.messages.create({
-    model: 'claude-3-5-haiku-20241022',
+    model: 'claude-haiku-4-5-20251001',
     max_tokens: 250,
     temperature: 0.8,
     messages: [{
@@ -240,7 +240,7 @@ async function main() {
     const wordCount = story.split(/\s+/).length;
     console.log(`\n📊 Story Stats:`);
     console.log(`   Word count: ${wordCount}`);
-    console.log(`   Model: claude-3-5-haiku-20241022`);
+    console.log(`   Model: claude-haiku-4-5-20251001`);
     console.log(`   Estimated cost: ~$0.002`);
 
     // Save to file
@@ -254,7 +254,7 @@ async function main() {
       story,
       metadata: {
         wordCount,
-        model: 'claude-3-5-haiku-20241022',
+        model: 'claude-haiku-4-5-20251001',
         generatedAt: new Date().toISOString()
       }
     };

--- a/src/pages/api/rules-qa.ts
+++ b/src/pages/api/rules-qa.ts
@@ -145,11 +145,20 @@ async function callHaiku(question: string): Promise<string> {
   const { default: Anthropic } = await import('@anthropic-ai/sdk');
   const client = new Anthropic({ apiKey });
 
+  // The system prompt embeds the full league constitution, so mark it as an
+  // ephemeral cache block. Subsequent questions within the 5-minute window
+  // hit the cache and skip re-tokenizing ~constitution-size of input.
   const response = await client.messages.create({
-    model: 'claude-sonnet-4-20250514',
+    model: 'claude-haiku-4-5-20251001',
     max_tokens: 500,
     temperature: 0.3,
-    system: SYSTEM_PROMPT,
+    system: [
+      {
+        type: 'text',
+        text: SYSTEM_PROMPT,
+        cache_control: { type: 'ephemeral' },
+      },
+    ],
     messages: [{ role: 'user', content: question }],
   });
 

--- a/src/pages/theleague/docs/ai-matchup-stories.md
+++ b/src/pages/theleague/docs/ai-matchup-stories.md
@@ -270,7 +270,7 @@ async function generateStory(matchupData) {
   const prompt = buildPrompt(matchupData); // See prompt template below
 
   const message = await anthropic.messages.create({
-    model: 'claude-3-5-haiku-20241022', // Fast and cheap
+    model: 'claude-haiku-4-5-20251001', // Fast and cheap
     max_tokens: 500,
     temperature: 0.8, // More creative
     messages: [{
@@ -729,7 +729,7 @@ function identifyTradeNeeds(team, week) {
       "metadata": {
         "wordCount": 287,
         "generatedAt": "2025-12-11T10:00:00Z",
-        "model": "claude-3-5-haiku-20241022"
+        "model": "claude-haiku-4-5-20251001"
       }
     },
     "0002": {
@@ -838,7 +838,7 @@ async function main() {
       metadata: {
         wordCount: story.split(/\s+/).length,
         generatedAt: new Date().toISOString(),
-        model: 'claude-3-5-haiku-20241022'
+        model: 'claude-haiku-4-5-20251001'
       }
     };
 
@@ -849,7 +849,7 @@ async function main() {
       metadata: {
         wordCount: story.split(/\s+/).length,
         generatedAt: new Date().toISOString(),
-        model: 'claude-3-5-haiku-20241022'
+        model: 'claude-haiku-4-5-20251001'
       }
     };
 

--- a/src/utils/generate-game-blurbs.ts
+++ b/src/utils/generate-game-blurbs.ts
@@ -83,7 +83,7 @@ Constraints: Array of objects only. Fields: nflMatchup, blurb (150-200 chars), c
 
   try {
     const response = await client.messages.create({
-      model: 'claude-3-5-sonnet-20241022',
+      model: 'claude-sonnet-4-6',
       max_tokens: 2048,
       temperature: 0.7,
       system: systemPrompt,


### PR DESCRIPTION
Model upgrades:
- rules-qa.ts: claude-sonnet-4-20250514 → claude-haiku-4-5-20251001
  (matches the "Haiku" naming in the surrounding comments)
- generate-game-blurbs.ts: claude-3-5-sonnet-20241022 → claude-sonnet-4-6
- generate-matchup-nfl-blurbs.mjs, generate-high-total-matchups.mjs,
  test-matchup-story{,-nfl}.mjs, ai-matchup-stories.md docs:
  claude-3-5-haiku-20241022 → claude-haiku-4-5-20251001

Prompt caching:
- rules-qa.ts: mark the full system prompt (embeds LEAGUE_CONSTITUTION)
  as an ephemeral cache block so back-to-back questions skip
  re-tokenizing the constitution.
- article-utils/ai-client.mjs: add buildCachedSystem() helper that
  returns a two-block system prompt with BASE_SYSTEM_PROMPT marked
  ephemeral. callAnthropic() now accepts string or blocks.
- All 8 article-type builders (weekly-recap, weekend-preview,
  matchup-preview, waiver-pickups, draft-grades, team-grades,
  cut-watch, championship-recap) switched from string concat to
  buildCachedSystem() — the shared voice/rules preamble is cached
  across sequential article generations.