### PR TITLE
feat(schefter): simplify tip responses — one topic per post, 7d queue, Friday mailbag

### DIFF
--- a/scripts/schefter-rumor-scan.mjs
+++ b/scripts/schefter-rumor-scan.mjs
@@ -123,7 +123,9 @@ const QUIET_HOUR_END = 7;    // 7am PT
 // Public URL of the tip page — appended to every GroupMe rumor post so
 // owners always have a one-tap path to whisper back with intel. The feed
 // card renders the same destination via post.link / post.linkLabel.
-const TIP_PAGE_PATH = '/theleague/schefter/tip';
+// On theleague.us, vercel.json 301s /theleague/:path* → /:path*, so the
+// canonical path is /schefter/tip.
+const TIP_PAGE_PATH = '/schefter/tip';
 const TIP_PAGE_LINK_LABEL = 'Got a tip? Whisper to Schefter →';
 const PUBLIC_BASE_URL = (process.env.SCHEFTER_PUBLIC_BASE_URL || 'https://theleague.us').replace(/\/+$/, '');
 const TIP_PAGE_ABSOLUTE_URL = `${PUBLIC_BASE_URL}${TIP_PAGE_PATH}`;

--- a/scripts/schefter-rumor-scan.mjs
+++ b/scripts/schefter-rumor-scan.mjs
@@ -108,8 +108,10 @@ const PLAYER_HISTORY_WINDOW_MS = 21 * 24 * 60 * 60 * 1000;  // 21d player escala
 const ROGER_RIFF_PROBABILITY = 0.07;
 
 // Trade rumors eat the bulk of our daily post quota; gossip is rationed
-// to at most one per day so the feed doesn't read like a group-chat burn book.
-const MAX_POSTS_PER_DAY = 2;
+// to at most one per day so the feed doesn't read like a group-chat burn
+// book. With a hard gossip cap of 1/day, the remaining slots are effectively
+// reserved for trade rumors.
+const MAX_POSTS_PER_DAY = 3;
 const MAX_GOSSIP_POSTS_PER_DAY = 1;
 const MIN_SPACING_MS = 4 * 60 * 60 * 1000;
 const MIN_MARINATE_MS = 1 * 60 * 60 * 1000;

--- a/scripts/schefter-rumor-scan.mjs
+++ b/scripts/schefter-rumor-scan.mjs
@@ -3,8 +3,11 @@
  * Schefter Rumor Mill Scanner (Phase 2)
  *
  * Drains anonymous tips from Redis (pushed by POST /api/schefter/tip),
- * runs the editorial gate checks, and — when all gates pass — asks Claude
- * to tighten the batch into a 2–4 sentence Schefter-voiced rumor post.
+ * runs the editorial gate checks, picks ONE topic bucket (trade rumors
+ * first, then multi-tip gossip clusters), and asks Claude to write a
+ * focused 1–2 sentence Schefter-voiced rumor post on that single topic.
+ * Tips in other buckets stay in the queue and are considered on the next
+ * cycle — so a slow-news day can ride the same marinating queue.
  *
  * Runs every 15 min via .github/workflows/schefter-rumor-scan.yml, but also
  * fine to invoke manually:
@@ -14,6 +17,8 @@
  *
  * Environment:
  *   SCHEFTER_RUMOR_MILL_ENABLED  gate flag (required truthy to run)
+ *   SCHEFTER_PUBLIC_BASE_URL     absolute site origin for the tip-page link in GroupMe
+ *                                (defaults to https://mflfootballv2.vercel.app)
  *   UPSTASH_REDIS_REST_URL / TOKEN (or KV_*)  Redis credentials
  *   ANTHROPIC_API_KEY            required for AI post; falls back to template
  *   GROUPME_SCHEFTER_BOT_ID      required to post to GroupMe (Roger is NOT a fallback)
@@ -22,12 +27,19 @@
  * Gates (in order, all must pass):
  *   1. SCHEFTER_RUMOR_MILL_ENABLED truthy
  *   2. Not in quiet hours (23:00–07:00 PT) — tips held, scanner exits
- *   3. schefter:rumor:posts_today < 3
- *   4. If posts_today >= 1, last post must be > 4h ago
- *   5. first_tip_ts must be >= 1h old (marinate window)
+ *   3. schefter:rumor:posts_today < MAX_POSTS_PER_DAY (trade-rumor-heavy cap)
+ *   4. If posts_today >= 1, last post must be > MIN_SPACING_MS ago
+ *   5. first_tip_ts must be >= MIN_MARINATE_MS old (marinate window)
+ *   6. If chosen bucket is "gossip" (non-trade), schefter:rumor:gossip_posts_today < 1
  *
- * On success: drain queue, anonymize (division-fuzz single-franchise tips),
- * generate post, append to feed JSON, post to GroupMe, update counters.
+ * Topic-bucket priority (first match wins):
+ *   a. Trade rumors (trade_offer source OR topic === "trade")
+ *   b. Gossip bucket with the most tips (clusters of similar tips)
+ *   c. Singleton gossip tip — only if its own 1h marinate window has passed
+ *
+ * On success: drain ONLY the tips in the chosen bucket, anonymize, generate
+ * post (with a "Whisper to Schefter" link), append feed JSON, post GroupMe,
+ * update counters. Leftover tips stay in the queue for the next cycle.
  */
 
 import { promises as fs } from 'node:fs';
@@ -61,6 +73,7 @@ const PLAYERS_PATH = (year) =>
   path.join(projectRoot, 'data', 'theleague', 'mfl-feeds', String(year), 'players.json');
 
 const RUMOR_POSTS_TODAY_KEY = 'schefter:rumor:posts_today';
+const RUMOR_GOSSIP_POSTS_TODAY_KEY = 'schefter:rumor:gossip_posts_today';
 const RUMOR_LAST_POST_TS_KEY = 'schefter:rumor:last_post_ts';
 const FIRST_TIP_TS_KEY = 'schefter:tips:first_tip_ts';
 const TIPS_QUEUE_KEY = 'schefter:tips:queue';
@@ -94,7 +107,10 @@ const PLAYER_HISTORY_WINDOW_MS = 21 * 24 * 60 * 60 * 1000;  // 21d player escala
 
 const ROGER_RIFF_PROBABILITY = 0.07;
 
-const MAX_POSTS_PER_DAY = 3;
+// Trade rumors eat the bulk of our daily post quota; gossip is rationed
+// to at most one per day so the feed doesn't read like a group-chat burn book.
+const MAX_POSTS_PER_DAY = 2;
+const MAX_GOSSIP_POSTS_PER_DAY = 1;
 const MIN_SPACING_MS = 4 * 60 * 60 * 1000;
 const MIN_MARINATE_MS = 1 * 60 * 60 * 1000;
 const MAX_TIPS_PER_BATCH = 10;
@@ -103,6 +119,14 @@ const PROCESSED_TTL_SEC = 24 * 60 * 60;
 
 const QUIET_HOUR_START = 23; // 11pm PT
 const QUIET_HOUR_END = 7;    // 7am PT
+
+// Public URL of the tip page — appended to every GroupMe rumor post so
+// owners always have a one-tap path to whisper back with intel. The feed
+// card renders the same destination via post.link / post.linkLabel.
+const TIP_PAGE_PATH = '/theleague/schefter/tip';
+const TIP_PAGE_LINK_LABEL = 'Got a tip? Whisper to Schefter →';
+const PUBLIC_BASE_URL = (process.env.SCHEFTER_PUBLIC_BASE_URL || 'https://mflfootballv2.vercel.app').replace(/\/+$/, '');
+const TIP_PAGE_ABSOLUTE_URL = `${PUBLIC_BASE_URL}${TIP_PAGE_PATH}`;
 
 // ── Logging ──
 
@@ -429,6 +453,113 @@ function anonymizeTips(tips, teams, feedPosts = []) {
   });
 }
 
+// ── Topic-bucket selection ──
+
+/**
+ * Classify each tip into a "kind" that drives daily-cap accounting.
+ *   - trade  : source === 'trade_offer' OR topic === 'trade'
+ *   - gossip : everything else (commish beef, predictions, roster gripes,
+ *              off-topic shots, GroupMe riffs). Rationed to 1 post/day.
+ */
+function classifyTipKind(tip) {
+  if (!tip) return 'gossip';
+  if (tip.source === 'trade_offer') return 'trade';
+  if (tip.topic === 'trade') return 'trade';
+  return 'gossip';
+}
+
+/**
+ * Group tips into single-topic buckets. Bucket keys:
+ *   - trade_offer tips         → 'trade:offer'
+ *   - web/groupme trade tips   → 'trade:web'
+ *   - whisper-back followups   → 'thread:<parentPostId>'
+ *   - everything else          → 'topic:<topic>' (commish / roster / prediction / other)
+ *
+ * Trade-offer tips and web trade tips land in separate buckets because they
+ * read as different stories even though both are trade rumors — we only want
+ * one in a given post. When multiple trade buckets exist, the priority
+ * selector prefers the larger one (ties broken by trade-offer > web).
+ */
+function buildTopicBuckets(tips) {
+  const map = new Map();
+  for (const tip of tips) {
+    let key;
+    if (tip.source === 'trade_offer') {
+      key = 'trade:offer';
+    } else if (tip.topic === 'trade') {
+      key = 'trade:web';
+    } else if (typeof tip.repliesToPostId === 'string' && tip.repliesToPostId.length > 0) {
+      key = `thread:${tip.repliesToPostId}`;
+    } else {
+      key = `topic:${tip.topic ?? 'other'}`;
+    }
+    let bucket = map.get(key);
+    if (!bucket) {
+      bucket = {
+        key,
+        kind: classifyTipKind(tip),
+        tips: [],
+        oldestSubmittedAt: tip.submittedAt ?? Date.now(),
+      };
+      map.set(key, bucket);
+    }
+    bucket.tips.push(tip);
+    if ((tip.submittedAt ?? Date.now()) < bucket.oldestSubmittedAt) {
+      bucket.oldestSubmittedAt = tip.submittedAt ?? Date.now();
+    }
+    // Promote bucket kind to 'trade' if ANY tip in it is trade-classified —
+    // shouldn't happen given the bucketing above, but safety-first.
+    if (classifyTipKind(tip) === 'trade') bucket.kind = 'trade';
+  }
+  return [...map.values()];
+}
+
+/**
+ * Pick the single bucket we will post about this cycle.
+ *
+ * Priority order:
+ *   1. Trade rumors — sorted by bucket size (descending). Ties prefer
+ *      trade-offer tips over web trade tips because trade-offer is
+ *      structured data from MFL, less noisy than owner speculation.
+ *   2. Gossip buckets with ≥2 tips (multi-tip topic clusters) — largest wins.
+ *   3. Singleton gossip — only returned when no better bucket exists. Lets
+ *      the caller decide to hold it for the next cycle when gossip quota is
+ *      already spent today.
+ *
+ * Returns `null` when nothing qualifies (e.g. only gossip exists but the
+ * gossip daily cap is already used).
+ */
+function pickPrimaryBucket(buckets, { gossipAllowedToday }) {
+  const tradeBuckets = buckets.filter((b) => b.kind === 'trade');
+  if (tradeBuckets.length > 0) {
+    tradeBuckets.sort((a, b) => {
+      if (b.tips.length !== a.tips.length) return b.tips.length - a.tips.length;
+      // Prefer trade-offer over web-trade on ties
+      if (a.key === 'trade:offer' && b.key !== 'trade:offer') return -1;
+      if (b.key === 'trade:offer' && a.key !== 'trade:offer') return 1;
+      return 0;
+    });
+    return tradeBuckets[0];
+  }
+
+  if (!gossipAllowedToday) return null;
+
+  const gossipBuckets = buckets.filter((b) => b.kind === 'gossip');
+  if (gossipBuckets.length === 0) return null;
+
+  const clusters = gossipBuckets.filter((b) => b.tips.length >= 2);
+  if (clusters.length > 0) {
+    clusters.sort((a, b) => b.tips.length - a.tips.length);
+    return clusters[0];
+  }
+
+  // Only singletons left. Pick the oldest-submitted one so tips that have
+  // been marinating longest get their turn first. Caller still decides
+  // whether to post or hold based on queue shape.
+  gossipBuckets.sort((a, b) => a.oldestSubmittedAt - b.oldestSubmittedAt);
+  return gossipBuckets[0];
+}
+
 // ── Post generation ──
 
 const RUMOR_SUB_TYPE = 'rumor_mill';
@@ -485,12 +616,15 @@ function templateBody(anonymized) {
   }
   if (groupmeAuthors.length >= 2) {
     const [a, b] = groupmeAuthors;
-    return `${a} and ${b} are both making noise in the group chat — I hear both of you, and sources around the league are starting to agree. Developing.`;
+    return `${a} and ${b} are saying the same thing in the group chat — and sources tell me they're not alone. Developing.`;
   }
   if (divisions.length === 1) {
-    return `League sources tell me the ${divisions[0]} division is the center of the universe this week — multiple owners whispering the same tune. Developing.`;
+    return `League sources tell me the ${divisions[0]} division is buzzing — multiple owners whispering the same tune. Developing.`;
   }
-  return `Hearing from multiple corners of the league tonight — this one's bigger than a single rumor. More as it clears.`;
+  // Single-topic fallback: the batch agrees on one subject even if the
+  // LLM can't articulate it. Lead with "multiple sources" — the batch
+  // size already earned that phrasing.
+  return `Multiple sources around the league are pushing the same tune right now. More as it clears.`;
 }
 
 /**
@@ -508,7 +642,7 @@ Cadence rules (Schefter-specific):
   Openers — rotate, pick ONE: "Hearing…", "I'm told…", "Per source…", "Quietly…", "Plenty of noise around…", "One to watch…", "File this under 'developing' but…"
   Hedges — MUST include one when escalation tier is "named": "Still just smoke.", "Nothing imminent.", "Barring a last-minute change…", "To be determined.", "Or not. We'll see."
   Closers — pick ONE: "Developing.", "More to come.", "Stay tuned.", "We'll see.", "Here we go.", "One to watch."
-  Rhythm — short sentences, staccato, three beats. Drop subjects where you can. Commas sparingly — a period usually works. 2–4 sentences TOTAL.
+  Rhythm — short sentences, staccato, two beats. Drop subjects where you can. Commas sparingly — a period usually works. 1–2 sentences TOTAL (HARD RULE 8 overrides any older guidance here).
 
 Redaction rules (HARD — never violate):
   NEVER surface franchise names, owner names, raw draft pick slot numbers, or player names EXCEPT when escalatedPlayer.tier === "named".
@@ -575,17 +709,18 @@ async function generateAiBody(anonymized, { rogerQuote, lore, recentPostsBlock }
   const hasTradeOffer = anonymized.some((t) => t.source === 'trade_offer');
   const includeBotWink = hasTradeOffer && Math.random() < 0.2;
 
-  let system = `You are Claude Schefter — a dynasty fantasy football beat reporter channeling Adam Schefter's rumor-mill energy. You synthesize owner tips into a columnist-voiced rumor post.
+  let system = `You are Claude Schefter — a dynasty fantasy football beat reporter channeling Adam Schefter's rumor-mill energy. You turn owner tips into a columnist-voiced rumor post.
 
 HARD RULES (self-enforce, never violate):
+0. ONE TOPIC ONLY. Every tip in this batch is already pre-filtered to a single topic/thread. NEVER pivot to a second unrelated subject inside the same post. If tips feel like different stories, cover the DOMINANT angle and drop the rest — save them for future posts. No "meanwhile…", no "elsewhere in the league…", no topic hops.
 1. For web tips (source: "web"), NEVER name the tipster and NEVER quote them verbatim — paraphrase with columnist voice.
 2. If a web tip's scope is "division", the division refers to the SUBJECT team's division — NOT where the source is located. Frame it as "a team in the [division]", "a [division]-division squad", or "the [division] is buzzing" — NEVER as "sources in the [division]" (that implies the tipster's location). NEVER name a specific franchise.
 3. If a web tip's scope is "league-wide", stay vague ("an owner tells me", "hearing from multiple corners").
 4. If a web tip's scope is "franchise-multi-source" (sourceCount >= 2), you MAY name the franchise AND use "multiple sources" / "multiple owners" phrasing.
 5. If a web tip's scope is "commish", you MAY reference the commissioner's office but PREFER institutional framing — "the league office", "the commissioner's office", "the front office" — over the personal "the commish" or "Brandon". Institutional framing tones down heat while still passing on the sentiment. NEVER name the franchise that holds the office.
 6. For GroupMe tips (source: "groupme", scope: "groupme-public", attributable: true): direct attribution is ENCOURAGED. The author publicly @'d Schefter in the group chat — name them. Riff BACK conversationally, second-person where it fits ("Wabbit, I hear you, but…", "Nice try, Jomar — my sources say otherwise"). Light ribbing is in-voice.
-7. Mixed batches: attribute GroupMe quotes by name while keeping web tips anonymized in the same post. It's okay for a single post to blend "I'm hearing a team in the Pacific…" (web) with "Wabbit, meanwhile, fired off in the group chat…" (GroupMe).
-8. Length: 2–4 sentences total (even in mixed batches). Breaking-news tease voice. End with "Developing." or similar when appropriate.
+7. If the batch mixes GroupMe and web tips, they are about the SAME topic — attribute the GroupMe author by name while keeping the web tipster anonymous, still one story.
+8. Length: 1–2 sentences. Tight, tease-voice, no throat-clearing. End with "Developing." only when it genuinely fits — don't force it.
 9. Do NOT include hashtags, emoji, or @-mentions. Plain prose only.
 10. Do NOT reveal how many tips fed this post. No meta commentary about the rumor mill itself.
 11. Thread continuity: if ANY tip in this batch has a \`threadFollowup\` field (Phase 7 whisper-back), open with continuity language — "Following up on yesterday's…", "More on the…", "Circling back to…", "As a reminder…". Use the parentHeadlineSnippet as a cue, but do not quote it. Still respect every fuzz/anonymity rule above. If no tip has threadFollowup, do not use continuity phrasing.
@@ -1315,9 +1450,34 @@ async function main() {
   }
   log(`  Gates OK (posts_today=${gates.postsToday}, marinated enough)`);
 
-  // Cap batch size
-  const batch = freshTips.slice(0, MAX_TIPS_PER_BATCH);
-  log(`  Processing batch of ${batch.length}`);
+  // Pick one topic-bucket to post about. Trade rumors come first, then
+  // multi-tip gossip clusters, then (rarely) a lone gossip tip. Tips in
+  // other buckets stay in the queue — that's how "slow news day" leftovers
+  // bubble up on the next cycle.
+  const buckets = buildTopicBuckets(freshTips);
+  log(
+    `  Buckets (${buckets.length}): ` +
+      buckets.map((b) => `${b.key}[${b.kind}×${b.tips.length}]`).join(', '),
+  );
+  const gossipToday = Number(
+    (await redis.get(RUMOR_GOSSIP_POSTS_TODAY_KEY).catch(() => 0)) ?? 0,
+  );
+  const gossipAllowedToday = gossipToday < MAX_GOSSIP_POSTS_PER_DAY;
+  log(`  Gossip budget: ${gossipToday}/${MAX_GOSSIP_POSTS_PER_DAY} used today (${gossipAllowedToday ? 'available' : 'spent'})`);
+
+  const primaryBucket = pickPrimaryBucket(buckets, { gossipAllowedToday });
+  if (!primaryBucket) {
+    log('  No bucket qualifies (gossip cap used, no trade rumors) — holding tips for the next cycle');
+    return 0;
+  }
+  log(`  Chose bucket ${primaryBucket.key} (kind=${primaryBucket.kind}, size=${primaryBucket.tips.length})`);
+
+  // Cap batch size (within the chosen bucket). Leftovers from other buckets
+  // survive this cycle by being rewritten to the queue further down.
+  const batch = primaryBucket.tips.slice(0, MAX_TIPS_PER_BATCH);
+  const postKind = primaryBucket.kind;
+  const unusedTips = freshTips.filter((t) => !batch.some((b) => b.id === t.id));
+  log(`  Processing batch of ${batch.length} (holding ${unusedTips.length} for next cycle)`);
 
   // Anonymize — load the feed early so whisper-back tips can pull parent
   // headline snippets into their scope.
@@ -1420,19 +1580,31 @@ async function main() {
     tipIds,
     hadRogerRiff,
     league: LEAGUE_SLUG,
+    // Every rumor card links back to the tip page so any reader can
+    // whisper a follow-up with a single tap. SchefterPostCard renders
+    // this as a CTA under the body.
+    link: TIP_PAGE_PATH,
+    linkLabel: TIP_PAGE_LINK_LABEL,
     ...(threadId ? { threadId } : {}),
   };
+
+  // GroupMe gets the body plus the absolute tip-page URL on its own line —
+  // the feed card shows the same call-to-action via post.link.
+  const groupMeText = `${post.body}\n\nGot a tip? ${TIP_PAGE_ABSOLUTE_URL}`;
 
   if (DRY_RUN) {
     log('\n  [dry-run] Would append post to feed:');
     log(JSON.stringify(post, null, 2));
     log('\n  [dry-run] Would remove the following tipIds from queue:');
     log(`    ${tipIds.join(', ')}`);
-    log('\n  [dry-run] Would increment schefter:rumor:posts_today and set last_post_ts + DEL first_tip_ts');
+    if (unusedTips.length > 0) {
+      log(`  [dry-run] Would hold ${unusedTips.length} tip(s) for the next cycle: ${unusedTips.map((t) => t.id).join(', ')}`);
+    }
+    log(`  [dry-run] Would increment schefter:rumor:posts_today${postKind === 'gossip' ? ' + schefter:rumor:gossip_posts_today' : ''}, set last_post_ts${unusedTips.length > 0 ? ', rewrite queue with leftover tips' : ', DEL first_tip_ts'}`);
     if (hadRogerRiff) {
       log(`  [dry-run] Would set ${ROGER_LAST_RIFF_DATE_KEY}=${todayPt} (ex=48h)`);
     }
-    await postToGroupMe(`${post.body}`);
+    await postToGroupMe(groupMeText);
     return 0;
   }
 
@@ -1443,8 +1615,9 @@ async function main() {
   await fs.writeFile(FEED_PATH, JSON.stringify(feed, null, 2) + '\n');
   log(`  Appended to feed (total posts: ${feed.posts.length})`);
 
-  // GroupMe
-  await postToGroupMe(post.body);
+  // GroupMe — body plus the absolute tip-page URL so owners always have a
+  // one-tap path back to whisper a follow-up.
+  await postToGroupMe(groupMeText);
 
   // Append to rolling post history (best-effort — never crashes the run).
   // Subject is a short tag derived from dominant tip source/scope.
@@ -1462,22 +1635,44 @@ async function main() {
   );
 
   // Redis updates: increment counter (with TTL to midnight PT), last post ts,
-  // drop marinate anchor, drain consumed tips, record processed for audit
+  // rewrite queue with leftovers from unchosen buckets, record processed
+  // for audit, and bump the gossip cap counter when this was a gossip post.
   try {
     const newCount = await redis.incr(RUMOR_POSTS_TODAY_KEY);
     if (newCount === 1) {
       await redis.expire(RUMOR_POSTS_TODAY_KEY, secondsUntilPtMidnight(now));
     }
+    if (postKind === 'gossip') {
+      const newGossipCount = await redis.incr(RUMOR_GOSSIP_POSTS_TODAY_KEY);
+      if (newGossipCount === 1) {
+        await redis.expire(RUMOR_GOSSIP_POSTS_TODAY_KEY, secondsUntilPtMidnight(now));
+      }
+      log(`  Gossip counter: now ${newGossipCount}/${MAX_GOSSIP_POSTS_PER_DAY}`);
+    }
     await redis.set(RUMOR_LAST_POST_TS_KEY, now.getTime());
 
-    // Remove consumed tips. Simplest + correct: DEL the whole queue. Any tip
-    // that arrived between LRANGE and now would be lost — but the marinate
-    // window means the next batch needs a fresh first_tip_ts anchor set by
-    // the API on the next push, so this is acceptable. If we wanted strict
-    // preservation we'd LTRIM by the exact count; here we prefer simplicity
-    // because no concurrent writers matter in this cadence.
+    // Remove consumed tips from the queue while preserving tips in other
+    // buckets for the next cycle. We replace the list atomically: DEL then
+    // RPUSH each leftover JSON string back. Any tip that arrived between
+    // LRANGE and now would be lost — acceptable at our 15 min cadence.
     await redis.del(TIPS_QUEUE_KEY);
-    await redis.del(FIRST_TIP_TS_KEY);
+    if (unusedTips.length > 0) {
+      const serialized = unusedTips.map((t) => JSON.stringify(t));
+      await redis.rpush(TIPS_QUEUE_KEY, ...serialized);
+      // Keep first_tip_ts anchored at the OLDEST surviving tip so the
+      // marinate gate still gates the next cycle accurately — tips that
+      // have already sat longer than MIN_MARINATE_MS stay eligible.
+      const oldest = unusedTips.reduce(
+        (acc, t) => Math.min(acc, t.submittedAt ?? Date.now()),
+        Number.MAX_SAFE_INTEGER,
+      );
+      if (Number.isFinite(oldest)) {
+        await redis.set(FIRST_TIP_TS_KEY, oldest);
+      }
+      log(`  Queue held ${unusedTips.length} tip(s) for next cycle (oldest submittedAt=${new Date(oldest).toISOString()})`);
+    } else {
+      await redis.del(FIRST_TIP_TS_KEY);
+    }
 
     // Processed audit list (TTL 24h)
     if (tipIds.length > 0) {

--- a/scripts/schefter-rumor-scan.mjs
+++ b/scripts/schefter-rumor-scan.mjs
@@ -33,15 +33,18 @@
  *   5. first_tip_ts must be >= MIN_MARINATE_MS old (marinate window)
  *   6. If chosen bucket is "gossip", schefter:rumor:gossip_posts_today < adaptive cap
  *
- * Topic-bucket priority (bucketPriorityScore = size + oldest-age-in-days):
+ * Topic-bucket priority (bucketPriorityScore = (size - 1) * 2 + oldest-age-in-days):
  *   a. Trade rumors (trade_offer source OR topic === "trade")
- *   b. Gossip buckets — largest/oldest wins, with an optional second bucket
- *      ridden along as a second "quick hit" beat in the same post
+ *   b. Gossip buckets — largest/oldest wins. When a second distinct gossip
+ *      bucket exists, it ships as its OWN independent feed post in the same
+ *      cycle (separate post id, reactions, comments, whisper-back thread),
+ *      but both posts share one cap slot — MAX_POSTS_PER_DAY /
+ *      MAX_GOSSIP_POSTS_PER_DAY (adaptive) each increment by one.
  *   c. Oldest gossip singleton if nothing else qualifies
  *
  * Special paths:
  *   - Friday mailbag: on Friday PT, once per day, sweeps ALL gossip tips
- *     still in the queue into a bullet-style roundup (HARD RULE 19). Ensures
+ *     still in the queue into a bullet-style roundup (HARD RULE 18). Ensures
  *     every tip gets a shot at the feed before the 7-day TTL fires.
  *   - Adaptive gossip cap: when gossip queue depth >= 6 OR oldest gossip
  *     tip is >= 3 days old, the day's gossip cap bumps to 2.
@@ -588,10 +591,11 @@ function bucketPriorityScore(bucket, now = new Date()) {
  *   3. Singleton gossip — returned when nothing else qualifies. Age boost
  *      means older singletons rise above newer ones naturally.
  *
- * For gossip posts we also return a SECONDARY bucket when one exists — the
- * caller wires both into a single two-beat post so two distinct gossip
- * topics can share one feed card without triggering a wall-of-text feel.
- * Trade-rumor posts never carry a secondary (they stay strictly one-topic).
+ * For gossip posts we also return a SECONDARY bucket when one exists —
+ * the caller ships the secondary as its OWN independent feed post so
+ * each gossip topic has separate reactions and whisper-back threads.
+ * Both posts consume exactly one slot from the daily cap. Trade-rumor
+ * posts never carry a secondary (they stay strictly single-topic).
  *
  * Returns `{ primary, secondary }` or `null` when nothing qualifies.
  */
@@ -811,7 +815,7 @@ Example F — lingering named (framingHint=lingering, escalatedPlayer.tier=named
 `;
 }
 
-async function generateAiBody(anonymized, { rogerQuote, lore, recentPostsBlock, mode = 'single', secondaryAnonymized = null } = {}) {
+async function generateAiBody(anonymized, { rogerQuote, lore, recentPostsBlock, mode = 'single' } = {}) {
   const apiKey = process.env.ANTHROPIC_API_KEY;
   if (!apiKey) {
     warn('  [rumor-scan] ANTHROPIC_API_KEY not set — using template');
@@ -824,7 +828,7 @@ async function generateAiBody(anonymized, { rogerQuote, lore, recentPostsBlock, 
   let system = `You are Claude Schefter — a dynasty fantasy football beat reporter channeling Adam Schefter's rumor-mill energy. You turn owner tips into a columnist-voiced rumor post.
 
 HARD RULES (self-enforce, never violate):
-0. ONE TOPIC per beat. The batch is pre-bucketed so each beat is a single topic/thread. For TRADE-RUMOR posts and MAILBAG posts the rules are different — see rules 18 and 19 for the narrow cases where two distinct gossip beats may share a post. Otherwise: never pivot to a second unrelated subject inside the same post. No "meanwhile…", no "elsewhere in the league…", no topic hops on single-beat posts.
+0. ONE TOPIC per post. The batch is pre-bucketed so each post is a single topic/thread. MAILBAG posts are the only exception — see rule 18. Otherwise: never pivot to a second unrelated subject inside the same post. No "meanwhile…", no "elsewhere in the league…", no topic hops. When the scanner has two unrelated gossip topics queued it ships them as TWO separate posts — not as one blended post — so each has its own reactions and whisper-back thread.
 1. For web tips (source: "web"), NEVER name the tipster and NEVER quote them verbatim — paraphrase with columnist voice.
 2. If a web tip's scope is "division", the division refers to the SUBJECT team's division — NOT where the source is located. Frame it as "a team in the [division]", "a [division]-division squad", or "the [division] is buzzing" — NEVER as "sources in the [division]" (that implies the tipster's location). NEVER name a specific franchise.
 3. If a web tip's scope is "league-wide", stay vague ("an owner tells me", "hearing from multiple corners").
@@ -832,7 +836,7 @@ HARD RULES (self-enforce, never violate):
 5. If a web tip's scope is "commish", you MAY reference the commissioner's office but PREFER institutional framing — "the league office", "the commissioner's office", "the front office" — over the personal "the commish" or "Brandon". Institutional framing tones down heat while still passing on the sentiment. NEVER name the franchise that holds the office.
 6. For GroupMe tips (source: "groupme", scope: "groupme-public", attributable: true): direct attribution is ENCOURAGED. The author publicly @'d Schefter in the group chat — name them. Riff BACK conversationally, second-person where it fits ("Wabbit, I hear you, but…", "Nice try, Jomar — my sources say otherwise"). Light ribbing is in-voice.
 7. If the batch mixes GroupMe and web tips, they are about the SAME topic — attribute the GroupMe author by name while keeping the web tipster anonymous, still one story.
-8. Length: 1–2 sentences per beat (a single-beat post is 1–2 sentences; a two-beat gossip post is 2–4 total, one per beat). Tight, tease-voice, no throat-clearing. End with "Developing." only when it genuinely fits — don't force it.
+8. Length: 1–2 sentences. Tight, tease-voice, no throat-clearing. End with "Developing." only when it genuinely fits — don't force it.
 9. Do NOT include hashtags, emoji, or @-mentions. Plain prose only.
 10. Do NOT reveal how many tips fed this post. No meta commentary about the rumor mill itself.
 11. Thread continuity: if ANY tip in this batch has a \`threadFollowup\` field (Phase 7 whisper-back), open with continuity language — "Following up on yesterday's…", "More on the…", "Circling back to…", "As a reminder…". Use the parentHeadlineSnippet as a cue, but do not quote it. Still respect every fuzz/anonymity rule above. If no tip has threadFollowup, do not use continuity phrasing.
@@ -917,15 +921,7 @@ HARD RULES (self-enforce, never violate):
 
 17. AGE-AWARE FRAMING. Each tip carries \`ageDays\` (integer) and \`isStale\` (boolean, true when ageDays >= 3). NEVER claim a stale tip is fresh. When ANY tip in the beat has \`isStale: true\`, you MUST either (a) reference when the whisper started — "the chatter that started earlier this week…", "a whisper from a few days back…", "been hearing this for days now…" — OR (b) explicitly hedge the staleness — "still hearing about…", "this one's been sitting with me…", "hasn't gone away…". Pick ONE device per beat; don't stack them. For tips with ageDays === 0 or 1, treat as fresh ("I'm told…", "just hearing…", "late word…"). Never invent a specific date the tip doesn't have (don't say "Monday" unless the tip was actually whispered on Monday — the scanner supplies integer day counts, not calendar labels, so stick to relative language).
 
-18. TWO-BEAT GOSSIP POSTS (only when the batch contains a \`secondaryBucket\` marker — see user message). Two distinct gossip topics share one post. Rules:
-    - Format as TWO short beats, each 1 sentence. Each beat covers ONE of the two topics. Separate the beats with a line break (\\n\\n) and optionally a dash or bullet (— …) so the reader sees two quick hits instead of a wall of text.
-    - Do NOT try to connect the beats thematically. They are independent blurbs.
-    - Still respect every anonymity / hostile-tip rule above per beat.
-    - The beats may include a transition phrase ("— Also") but NEVER the banned "meanwhile" chain.
-    - Example shape:
-        Beat 1 on topic A.\\n\\n— Beat 2 on topic B.
-
-19. MAILBAG POSTS (only when the user message starts with "MAILBAG:" — Friday news-dump). Bundled roundup of every gossip tip still in the queue that would otherwise expire. Rules:
+18. MAILBAG POSTS (only when the user message starts with "MAILBAG:" — Friday news-dump). Bundled roundup of every gossip tip still in the queue that would otherwise expire. Rules:
     - Open with a brief mailbag framing: "Cleaning out the mailbag before the weekend.", "Friday loose-notes dump.", "Before I log off — a few whispers worth airing out."
     - Cover up to 6 bullet-style one-liners, one per topic bucket. Each one-liner is a single clause. Line-break between bullets (\\n\\n• …).
     - Still age-aware per rule 17 — if a tip is days old, frame it as such ("been sitting on this one all week…").
@@ -957,11 +953,9 @@ Voice: "League sources tell me…", "I'm told…", "Hearing…", "A division riv
 
   let userMessage;
   if (mode === 'mailbag') {
-    userMessage = `MAILBAG: Friday news-dump. Apply HARD RULE 19 — bullet each topic in the GOSSIP_TIPS array as a one-liner (≤6 bullets). Open with a mailbag framing and sign off at the end. Output plain text only — no JSON, no formatting, no headlines.${rogerDirective}${recentBlock}\n\nGOSSIP_TIPS:\n${JSON.stringify(anonymized, null, 2)}`;
-  } else if (mode === 'two-beat' && Array.isArray(secondaryAnonymized) && secondaryAnonymized.length > 0) {
-    userMessage = `Two-beat gossip post: apply HARD RULE 18. Write ONE short sentence for PRIMARY_TIPS, then a blank line and a bullet (— …) with ONE short sentence for SECONDARY_TIPS. Two distinct topics, two quick hits, no "meanwhile" chain. Output plain text only — no JSON, no formatting, no headlines.${rogerDirective}${recentBlock}\n\nPRIMARY_TIPS:\n${JSON.stringify(anonymized, null, 2)}\n\nSECONDARY_TIPS:\n${JSON.stringify(secondaryAnonymized, null, 2)}`;
+    userMessage = `MAILBAG: Friday news-dump. Apply HARD RULE 18 — bullet each topic in the GOSSIP_TIPS array as a one-liner (≤6 bullets). Open with a mailbag framing and sign off at the end. Output plain text only — no JSON, no formatting, no headlines.${rogerDirective}${recentBlock}\n\nGOSSIP_TIPS:\n${JSON.stringify(anonymized, null, 2)}`;
   } else {
-    userMessage = `Synthesize these tips into ONE rumor-mill post (single beat, 1–2 sentences, one topic). Output plain text only — no JSON, no formatting, no headlines.${rogerDirective}${recentBlock}\n\nTIPS:\n${JSON.stringify(anonymized, null, 2)}`;
+    userMessage = `Synthesize these tips into ONE rumor-mill post (1–2 sentences, one topic). Output plain text only — no JSON, no formatting, no headlines.${rogerDirective}${recentBlock}\n\nTIPS:\n${JSON.stringify(anonymized, null, 2)}`;
   }
 
   if (DRY_RUN) {
@@ -1657,13 +1651,15 @@ async function main() {
     batch = primaryBucket.tips.slice(0, MAX_TIPS_PER_BATCH);
     postKind = primaryBucket.kind;
 
-    // Two-beat gossip: a second distinct gossip bucket rides along in the
-    // same post, counted as ONE post against the daily + gossip caps.
-    // Trade-rumor posts never carry a secondary — they stay strictly
-    // single-topic.
+    // Two-post gossip: a second distinct gossip bucket ships as its own
+    // independent feed post in the SAME scan cycle. Both posts count as
+    // one slot against the daily + gossip caps, but each has its own
+    // post id so reactions, comments, and whisper-back threads stay
+    // separate. Trade-rumor posts never carry a secondary — they stay
+    // strictly single-topic.
     if (postKind === 'gossip' && secondaryBucket) {
-      secondaryBatch = secondaryBucket.tips.slice(0, Math.max(1, Math.floor(MAX_TIPS_PER_BATCH / 2)));
-      log(`  Second beat bucket ${secondaryBucket.key} (size=${secondaryBucket.tips.length}, using ${secondaryBatch.length} tip(s))`);
+      secondaryBatch = secondaryBucket.tips.slice(0, MAX_TIPS_PER_BATCH);
+      log(`  Second post bucket ${secondaryBucket.key} (size=${secondaryBucket.tips.length}, using ${secondaryBatch.length} tip(s))`);
     }
   }
 
@@ -1719,131 +1715,168 @@ async function main() {
     log(`  [roger-riff] Dice roll failed — no riff this cycle`);
   }
 
-  // Generate post (AI receives Roger directive only if quote is available,
-  // plus assembled lore suffix + recent-post memory when available). The
-  // `mode` flag selects the one-beat / two-beat / mailbag user-prompt shape.
-  const aiMode = postKind === 'mailbag'
-    ? 'mailbag'
-    : (secondaryAnonymized ? 'two-beat' : 'single');
-  const aiBody = await generateAiBody(anonymized, {
-    rogerQuote,
-    lore,
-    recentPostsBlock,
-    mode: aiMode,
-    secondaryAnonymized,
-  });
-  const body = aiBody || templateBody(anonymized);
-  log(`  Post body (${aiBody ? 'AI' : 'template'})${hadRogerRiff ? ' [with Roger riff]' : ''}:\n    ${body.replace(/\n/g, '\n    ')}`);
-
-  // Build post — tipIds covers both the primary and (when present) the
-  // secondary two-beat batch so processed-audit + hash-for-tip indexes
-  // see every tip that shipped.
-  const combinedBatch = secondaryBatch ? [...batch, ...secondaryBatch] : batch;
-  const tipIds = combinedBatch.map((t) => t.id);
-
-  // Phase 7 — whisper-back thread resolution. If any tip in the batch is a
-  // follow-up to an existing rumor, the new post joins that thread. We pick
-  // the most-referenced parent in the batch, then resolve its threadId via
-  // the Redis registry (or mint a new one and stamp the parent).
-  const parentCounts = new Map();
-  for (const tip of combinedBatch) {
-    if (tip && typeof tip.repliesToPostId === 'string' && tip.repliesToPostId.length > 0) {
-      parentCounts.set(tip.repliesToPostId, (parentCounts.get(tip.repliesToPostId) ?? 0) + 1);
-    }
+  // Build the list of "beats" — one per independent feed post we'll ship
+  // this cycle. Most post kinds produce exactly one beat; a two-topic
+  // gossip cycle produces TWO beats (independent post IDs, independent
+  // reactions/threads) even though they share the same cap slot.
+  const beats = [
+    { batch, anonymized, kind: postKind },
+  ];
+  if (secondaryBatch && postKind === 'gossip') {
+    beats.push({
+      batch: secondaryBatch,
+      anonymized: secondaryAnonymized,
+      kind: 'gossip',
+    });
   }
-  let dominantParentId = null;
-  if (parentCounts.size > 0) {
-    let best = -1;
-    for (const [id, count] of parentCounts) {
-      if (count > best) {
-        best = count;
-        dominantParentId = id;
+  log(`  Producing ${beats.length} post(s) this cycle`);
+
+  // Generate bodies in parallel. Only the primary beat gets the Roger
+  // riff — the riff is a once-per-day cameo that shouldn't double up.
+  const aiMode = postKind === 'mailbag' ? 'mailbag' : 'single';
+  const aiBodies = await Promise.all(
+    beats.map((beat, i) => generateAiBody(beat.anonymized, {
+      rogerQuote: i === 0 ? rogerQuote : null,
+      lore,
+      recentPostsBlock,
+      mode: aiMode,
+    })),
+  );
+
+  // Build post objects. Each beat resolves its own whisper-back thread
+  // from its own batch's repliesToPostId, so replies to two different
+  // parent rumors land in two different threads — one per post. We keep
+  // the parent-id mapping in a side Map so it never leaks into the feed
+  // JSON or the API response shape.
+  const combinedBatch = beats.flatMap((b) => b.batch);
+  const builtPosts = [];
+  const parentIdByPostId = new Map();
+  for (let i = 0; i < beats.length; i++) {
+    const beat = beats[i];
+    const aiBody = aiBodies[i];
+    const body = aiBody || templateBody(beat.anonymized);
+    log(`  [beat ${i + 1}/${beats.length}] (${aiBody ? 'AI' : 'template'})${i === 0 && hadRogerRiff ? ' [with Roger riff]' : ''}:\n    ${body.replace(/\n/g, '\n    ')}`);
+
+    const tipIds = beat.batch.map((t) => t.id);
+
+    // Thread resolution — per beat. Whisper-backs in beat 1 and beat 2
+    // threads stay separate.
+    const parentCounts = new Map();
+    for (const tip of beat.batch) {
+      if (tip && typeof tip.repliesToPostId === 'string' && tip.repliesToPostId.length > 0) {
+        parentCounts.set(tip.repliesToPostId, (parentCounts.get(tip.repliesToPostId) ?? 0) + 1);
       }
     }
-  }
-  let threadId = null;
-  if (dominantParentId) {
-    try {
-      const registered = await redis.get(`schefter:thread_of:${dominantParentId}`);
-      if (typeof registered === 'string' && registered.length > 0) {
-        threadId = registered;
-      } else {
-        // Mint a new threadId rooted at the parent rumor so permalinks are
-        // readable. Stamp the parent via thread_of so future whisper-backs
-        // to the same rumor join the same thread.
+    let dominantParentId = null;
+    if (parentCounts.size > 0) {
+      let best = -1;
+      for (const [id, count] of parentCounts) {
+        if (count > best) {
+          best = count;
+          dominantParentId = id;
+        }
+      }
+    }
+    let threadId = null;
+    if (dominantParentId) {
+      try {
+        const registered = await redis.get(`schefter:thread_of:${dominantParentId}`);
+        threadId = typeof registered === 'string' && registered.length > 0
+          ? registered
+          : dominantParentId;
+      } catch {
         threadId = dominantParentId;
       }
-    } catch {
-      threadId = dominantParentId;
     }
+
+    // Distinct timestamps so feed ordering is stable between beats —
+    // primary (i=0) uses `now`, later beats push out by (i * 1000ms).
+    // Feed prepends primary last so primary ends up at index 0 (top).
+    const beatTs = new Date(now.getTime() + i * 1000);
+
+    const post = {
+      id: generatePostId(),
+      timestamp: beatTs.toISOString(),
+      type: 'transaction',
+      transactionSubType: RUMOR_SUB_TYPE,
+      tier: RUMOR_TIER,
+      headline: 'Schefter hearing…',
+      body,
+      authorId: 'claude',
+      franchiseIds: [],
+      tipIds,
+      hadRogerRiff: i === 0 ? hadRogerRiff : false,
+      league: LEAGUE_SLUG,
+      // Every rumor card links back to the tip page so any reader can
+      // whisper a follow-up with a single tap. SchefterPostCard renders
+      // this as a CTA under the body.
+      link: TIP_PAGE_PATH,
+      linkLabel: TIP_PAGE_LINK_LABEL,
+      ...(threadId ? { threadId } : {}),
+    };
+    if (threadId && dominantParentId) {
+      parentIdByPostId.set(post.id, dominantParentId);
+    }
+    builtPosts.push(post);
   }
 
-  const post = {
-    id: generatePostId(),
-    timestamp: now.toISOString(),
-    type: 'transaction',
-    transactionSubType: RUMOR_SUB_TYPE,
-    tier: RUMOR_TIER,
-    headline: 'Schefter hearing…',
-    body,
-    authorId: 'claude',
-    franchiseIds: [],
-    tipIds,
-    hadRogerRiff,
-    league: LEAGUE_SLUG,
-    // Every rumor card links back to the tip page so any reader can
-    // whisper a follow-up with a single tap. SchefterPostCard renders
-    // this as a CTA under the body.
-    link: TIP_PAGE_PATH,
-    linkLabel: TIP_PAGE_LINK_LABEL,
-    ...(threadId ? { threadId } : {}),
-  };
-
-  // GroupMe gets the body plus the absolute tip-page URL on its own line —
-  // the feed card shows the same call-to-action via post.link.
-  const groupMeText = `${post.body}\n\nGot a tip? ${TIP_PAGE_ABSOLUTE_URL}`;
+  const allTipIds = combinedBatch.map((t) => t.id);
+  // Stable cycle-wide GroupMe payload builder — body + tip-page URL.
+  const groupMeTextFor = (p) => `${p.body}\n\nGot a tip? ${TIP_PAGE_ABSOLUTE_URL}`;
 
   if (DRY_RUN) {
-    log('\n  [dry-run] Would append post to feed:');
-    log(JSON.stringify(post, null, 2));
+    log(`\n  [dry-run] Would append ${builtPosts.length} post(s) to feed:`);
+    for (const p of builtPosts) log(JSON.stringify(p, null, 2));
     log('\n  [dry-run] Would remove the following tipIds from queue:');
-    log(`    ${tipIds.join(', ')}`);
+    log(`    ${allTipIds.join(', ')}`);
     if (unusedTips.length > 0) {
       log(`  [dry-run] Would hold ${unusedTips.length} tip(s) for the next cycle: ${unusedTips.map((t) => t.id).join(', ')}`);
     }
-    log(`  [dry-run] Would increment schefter:rumor:posts_today${postKind === 'gossip' ? ' + schefter:rumor:gossip_posts_today' : ''}, set last_post_ts${unusedTips.length > 0 ? ', rewrite queue with leftover tips' : ', DEL first_tip_ts'}`);
+    log(`  [dry-run] Would increment schefter:rumor:posts_today by 1${postKind === 'gossip' ? ' + schefter:rumor:gossip_posts_today by 1' : ''} (even with ${builtPosts.length} posts — counts as one cap slot), set last_post_ts${unusedTips.length > 0 ? ', rewrite queue with leftover tips' : ', DEL first_tip_ts'}`);
     if (hadRogerRiff) {
       log(`  [dry-run] Would set ${ROGER_LAST_RIFF_DATE_KEY}=${todayPt} (ex=48h)`);
     }
-    await postToGroupMe(groupMeText);
+    for (const p of builtPosts) {
+      await postToGroupMe(groupMeTextFor(p));
+    }
     return 0;
   }
 
-  // Write feed
+  // Write feed — prepend in reverse so the primary beat ends up at index 0
+  // (top of the feed). Both posts land in the same fs.writeFile call so
+  // an error on GroupMe can't leave one written and one missing.
   const feed = await loadFeed();
-  feed.posts = [post, ...(feed.posts ?? [])];
+  const existingPosts = feed.posts ?? [];
+  feed.posts = [...builtPosts, ...existingPosts];
   feed.lastScanTimestamp = now.toISOString();
   await fs.writeFile(FEED_PATH, JSON.stringify(feed, null, 2) + '\n');
-  log(`  Appended to feed (total posts: ${feed.posts.length})`);
+  log(`  Appended to feed: ${builtPosts.length} new post(s) (total: ${feed.posts.length})`);
 
-  // GroupMe — body plus the absolute tip-page URL so owners always have a
-  // one-tap path back to whisper a follow-up.
-  await postToGroupMe(groupMeText);
+  // GroupMe — one message per post so each shows up as an independent
+  // reply target in the group chat. Small stagger between to avoid
+  // rate-limiting surprises.
+  for (let i = 0; i < builtPosts.length; i++) {
+    if (i > 0) await new Promise((r) => setTimeout(r, 250));
+    await postToGroupMe(groupMeTextFor(builtPosts[i]));
+  }
 
-  // Append to rolling post history (best-effort — never crashes the run).
-  // Subject is a short tag derived from dominant tip source/scope.
-  const subject = deriveHistorySubject(combinedBatch, anonymized);
+  // Append each post to the rolling history (one entry per post).
   const tipSources = Array.from(new Set(combinedBatch.map((t) => t.source).filter(Boolean)));
-  await appendPostHistory(
-    buildHistoryEntry({
-      id: post.id,
-      timestamp: post.timestamp,
-      body: post.body,
-      subject,
-      tipSources,
-    }),
-    { log, warn },
-  );
+  for (let i = 0; i < builtPosts.length; i++) {
+    const p = builtPosts[i];
+    const beat = beats[i];
+    const subject = deriveHistorySubject(beat.batch, beat.anonymized);
+    await appendPostHistory(
+      buildHistoryEntry({
+        id: p.id,
+        timestamp: p.timestamp,
+        body: p.body,
+        subject,
+        tipSources,
+      }),
+      { log, warn },
+    );
+  }
 
   // Redis updates: increment counter (with TTL to midnight PT), last post ts,
   // rewrite queue with leftovers from unchosen buckets, record processed
@@ -1891,9 +1924,9 @@ async function main() {
       await redis.del(FIRST_TIP_TS_KEY);
     }
 
-    // Processed audit list (TTL 24h)
-    if (tipIds.length > 0) {
-      await redis.lpush(TIPS_PROCESSED_KEY, ...tipIds);
+    // Processed audit list (TTL 24h) — covers tips from every beat.
+    if (allTipIds.length > 0) {
+      await redis.lpush(TIPS_PROCESSED_KEY, ...allTipIds);
       await redis.expire(TIPS_PROCESSED_KEY, PROCESSED_TTL_SEC);
     }
 
@@ -1927,21 +1960,26 @@ async function main() {
     warn(`  Redis post-write update failed: ${err.message}`);
   }
 
-  // Phase 7 — thread registry. If this post joined an existing thread (or
-  // started one from a whisper-back), record it in Redis so future follow-ups
-  // can look up the thread and the permalink page can render the chain.
-  if (threadId) {
+  // Phase 7 — thread registry. If a post joined an existing thread (or
+  // started one from a whisper-back), record it in Redis so future
+  // follow-ups can look up the thread and the permalink page can render
+  // the chain. Each beat has its own (possibly null) threadId, so we
+  // loop and treat them independently.
+  for (const p of builtPosts) {
+    if (!p.threadId) continue;
+    const threadId = p.threadId;
+    const dominantParentId = parentIdByPostId.get(p.id);
     try {
       const threadZsetKey = `schefter:thread:${threadId}`;
       const threadOfParentKey = `schefter:thread_of:${dominantParentId}`;
-      const threadOfNewKey = `schefter:thread_of:${post.id}`;
+      const threadOfNewKey = `schefter:thread_of:${p.id}`;
       const threadTtlSec = 14 * 24 * 60 * 60;
 
-      await redis.zadd(threadZsetKey, { score: new Date(post.timestamp).getTime(), member: post.id });
+      await redis.zadd(threadZsetKey, { score: new Date(p.timestamp).getTime(), member: p.id });
       // If the thread is new (rooted at the parent), also index the parent in
       // the zset so the permalink view always opens with it.
       if (dominantParentId && dominantParentId === threadId) {
-        const parentPost = (feedForAnonymize.posts ?? []).find((p) => p.id === dominantParentId);
+        const parentPost = (feedForAnonymize.posts ?? []).find((pp) => pp.id === dominantParentId);
         if (parentPost) {
           await redis.zadd(threadZsetKey, {
             score: new Date(parentPost.timestamp).getTime(),
@@ -1954,9 +1992,9 @@ async function main() {
       await redis.set(threadOfNewKey, threadId, { ex: threadTtlSec });
       await redis.expire(threadZsetKey, threadTtlSec);
 
-      log(`  [thread] Registered ${post.id} in thread ${threadId}`);
+      log(`  [thread] Registered ${p.id} in thread ${threadId}`);
     } catch (err) {
-      warn(`  [thread] Registry update failed: ${err.message}`);
+      warn(`  [thread] Registry update failed for ${p.id}: ${err.message}`);
     }
   }
 

--- a/scripts/schefter-rumor-scan.mjs
+++ b/scripts/schefter-rumor-scan.mjs
@@ -36,10 +36,13 @@
  * Topic-bucket priority (bucketPriorityScore = (size - 1) * 2 + oldest-age-in-days):
  *   a. Trade rumors (trade_offer source OR topic === "trade")
  *   b. Gossip buckets — largest/oldest wins. When a second distinct gossip
- *      bucket exists, it ships as its OWN independent feed post in the same
- *      cycle (separate post id, reactions, comments, whisper-back thread),
- *      but both posts share one cap slot — MAX_POSTS_PER_DAY /
- *      MAX_GOSSIP_POSTS_PER_DAY (adaptive) each increment by one.
+ *      bucket exists AND the gossip queue has piled up to at least
+ *      SECONDARY_GOSSIP_POST_PRESSURE tips, it ships as its OWN independent
+ *      feed post in the same cycle (separate post id, reactions, comments,
+ *      whisper-back thread), with both posts sharing one cap slot. Below
+ *      that threshold the second bucket waits for the next cycle — the
+ *      quick-double-post is a catch-up mechanism for 2+ days of pile-up,
+ *      not a default cadence.
  *   c. Oldest gossip singleton if nothing else qualifies
  *
  * Special paths:
@@ -131,6 +134,13 @@ const MAX_GOSSIP_POSTS_PER_DAY = 1;
 const MAX_GOSSIP_POSTS_PER_DAY_ADAPTIVE = 2;
 const GOSSIP_BOOST_QUEUE_DEPTH = 6;
 const GOSSIP_BOOST_TIP_AGE_MS = 3 * 24 * 60 * 60 * 1000;
+// The "quick double post" — shipping a secondary gossip post in the same
+// cycle — is reserved for genuine pile-up: a gossip queue of this depth
+// or deeper. With a typical ~1-2 tips/day arrival rate, 4 queued gossip
+// tips means 2+ days of buildup without us clearing it, which is exactly
+// the pattern we want the second post to catch. Below the threshold, the
+// secondary bucket waits its turn on a later cycle.
+const SECONDARY_GOSSIP_POST_PRESSURE = 4;
 const MIN_SPACING_MS = 4 * 60 * 60 * 1000;
 const MIN_MARINATE_MS = 1 * 60 * 60 * 1000;
 const MAX_TIPS_PER_BATCH = 10;
@@ -1657,9 +1667,20 @@ async function main() {
     // post id so reactions, comments, and whisper-back threads stay
     // separate. Trade-rumor posts never carry a secondary — they stay
     // strictly single-topic.
+    //
+    // The secondary only fires under real backlog pressure
+    // (>= SECONDARY_GOSSIP_POST_PRESSURE gossip tips queued). Below that
+    // threshold we ship a single post and let the secondary bucket wait
+    // its turn — the two-post double is a pile-up catch-up mechanism,
+    // not a default cadence.
     if (postKind === 'gossip' && secondaryBucket) {
-      secondaryBatch = secondaryBucket.tips.slice(0, MAX_TIPS_PER_BATCH);
-      log(`  Second post bucket ${secondaryBucket.key} (size=${secondaryBucket.tips.length}, using ${secondaryBatch.length} tip(s))`);
+      const gossipQueueDepth = freshTips.filter((t) => classifyTipKind(t) === 'gossip').length;
+      if (gossipQueueDepth >= SECONDARY_GOSSIP_POST_PRESSURE) {
+        secondaryBatch = secondaryBucket.tips.slice(0, MAX_TIPS_PER_BATCH);
+        log(`  Second post bucket ${secondaryBucket.key} (size=${secondaryBucket.tips.length}, using ${secondaryBatch.length} tip(s)) — pressure ${gossipQueueDepth}/${SECONDARY_GOSSIP_POST_PRESSURE}`);
+      } else {
+        log(`  Holding ${secondaryBucket.key} for next cycle — gossip queue depth ${gossipQueueDepth} < ${SECONDARY_GOSSIP_POST_PRESSURE} (no pile-up pressure)`);
+      }
     }
   }
 

--- a/scripts/schefter-rumor-scan.mjs
+++ b/scripts/schefter-rumor-scan.mjs
@@ -18,7 +18,7 @@
  * Environment:
  *   SCHEFTER_RUMOR_MILL_ENABLED  gate flag (required truthy to run)
  *   SCHEFTER_PUBLIC_BASE_URL     absolute site origin for the tip-page link in GroupMe
- *                                (defaults to https://mflfootballv2.vercel.app)
+ *                                (defaults to https://theleague.us)
  *   UPSTASH_REDIS_REST_URL / TOKEN (or KV_*)  Redis credentials
  *   ANTHROPIC_API_KEY            required for AI post; falls back to template
  *   GROUPME_SCHEFTER_BOT_ID      required to post to GroupMe (Roger is NOT a fallback)
@@ -125,7 +125,7 @@ const QUIET_HOUR_END = 7;    // 7am PT
 // card renders the same destination via post.link / post.linkLabel.
 const TIP_PAGE_PATH = '/theleague/schefter/tip';
 const TIP_PAGE_LINK_LABEL = 'Got a tip? Whisper to Schefter →';
-const PUBLIC_BASE_URL = (process.env.SCHEFTER_PUBLIC_BASE_URL || 'https://mflfootballv2.vercel.app').replace(/\/+$/, '');
+const PUBLIC_BASE_URL = (process.env.SCHEFTER_PUBLIC_BASE_URL || 'https://theleague.us').replace(/\/+$/, '');
 const TIP_PAGE_ABSOLUTE_URL = `${PUBLIC_BASE_URL}${TIP_PAGE_PATH}`;
 
 // ── Logging ──

--- a/scripts/schefter-rumor-scan.mjs
+++ b/scripts/schefter-rumor-scan.mjs
@@ -2,12 +2,13 @@
 /**
  * Schefter Rumor Mill Scanner (Phase 2)
  *
- * Drains anonymous tips from Redis (pushed by POST /api/schefter/tip),
- * runs the editorial gate checks, picks ONE topic bucket (trade rumors
- * first, then multi-tip gossip clusters), and asks Claude to write a
- * focused 1–2 sentence Schefter-voiced rumor post on that single topic.
- * Tips in other buckets stay in the queue and are considered on the next
- * cycle — so a slow-news day can ride the same marinating queue.
+ * Drains anonymous tips from Redis (pushed by POST /api/schefter/tip) and
+ * turns them into a focused Schefter-voiced rumor post. Picks ONE topic
+ * bucket per cycle (trade rumors first, then gossip clusters/singletons
+ * ranked by size + age). Gossip is rationed to 1 post/day by default and
+ * auto-bumps to 2 on busy weeks. Tips in unchosen buckets stay in the
+ * queue with 7-day TTL so slow-news leftovers bubble up over time, and a
+ * Friday mailbag sweeps anything still sitting so it doesn't expire unseen.
  *
  * Runs every 15 min via .github/workflows/schefter-rumor-scan.yml, but also
  * fine to invoke manually:
@@ -27,19 +28,29 @@
  * Gates (in order, all must pass):
  *   1. SCHEFTER_RUMOR_MILL_ENABLED truthy
  *   2. Not in quiet hours (23:00–07:00 PT) — tips held, scanner exits
- *   3. schefter:rumor:posts_today < MAX_POSTS_PER_DAY (trade-rumor-heavy cap)
+ *   3. schefter:rumor:posts_today < MAX_POSTS_PER_DAY
  *   4. If posts_today >= 1, last post must be > MIN_SPACING_MS ago
  *   5. first_tip_ts must be >= MIN_MARINATE_MS old (marinate window)
- *   6. If chosen bucket is "gossip" (non-trade), schefter:rumor:gossip_posts_today < 1
+ *   6. If chosen bucket is "gossip", schefter:rumor:gossip_posts_today < adaptive cap
  *
- * Topic-bucket priority (first match wins):
+ * Topic-bucket priority (bucketPriorityScore = size + oldest-age-in-days):
  *   a. Trade rumors (trade_offer source OR topic === "trade")
- *   b. Gossip bucket with the most tips (clusters of similar tips)
- *   c. Singleton gossip tip — only if its own 1h marinate window has passed
+ *   b. Gossip buckets — largest/oldest wins, with an optional second bucket
+ *      ridden along as a second "quick hit" beat in the same post
+ *   c. Oldest gossip singleton if nothing else qualifies
  *
- * On success: drain ONLY the tips in the chosen bucket, anonymize, generate
- * post (with a "Whisper to Schefter" link), append feed JSON, post GroupMe,
- * update counters. Leftover tips stay in the queue for the next cycle.
+ * Special paths:
+ *   - Friday mailbag: on Friday PT, once per day, sweeps ALL gossip tips
+ *     still in the queue into a bullet-style roundup (HARD RULE 19). Ensures
+ *     every tip gets a shot at the feed before the 7-day TTL fires.
+ *   - Adaptive gossip cap: when gossip queue depth >= 6 OR oldest gossip
+ *     tip is >= 3 days old, the day's gossip cap bumps to 2.
+ *   - Age-aware voice: tips carry ageDays + isStale so the LLM can say
+ *     "still hearing…" / "chatter from earlier this week" on days-old tips.
+ *
+ * On success: drain tips consumed this cycle, rewrite leftovers back to
+ * the queue, anonymize, generate post (with a "Whisper to Schefter" link),
+ * append feed JSON, post GroupMe, update counters.
  */
 
 import { promises as fs } from 'node:fs';
@@ -110,17 +121,32 @@ const ROGER_RIFF_PROBABILITY = 0.07;
 // Trade rumors eat the bulk of our daily post quota; gossip is rationed
 // to at most one per day so the feed doesn't read like a group-chat burn
 // book. With a hard gossip cap of 1/day, the remaining slots are effectively
-// reserved for trade rumors.
+// reserved for trade rumors. When the backlog is deep OR a tip is aging
+// out we bump the gossip cap by one that day — see computeAdaptiveGossipCap.
 const MAX_POSTS_PER_DAY = 3;
 const MAX_GOSSIP_POSTS_PER_DAY = 1;
+const MAX_GOSSIP_POSTS_PER_DAY_ADAPTIVE = 2;
+const GOSSIP_BOOST_QUEUE_DEPTH = 6;
+const GOSSIP_BOOST_TIP_AGE_MS = 3 * 24 * 60 * 60 * 1000;
 const MIN_SPACING_MS = 4 * 60 * 60 * 1000;
 const MIN_MARINATE_MS = 1 * 60 * 60 * 1000;
 const MAX_TIPS_PER_BATCH = 10;
-const TIP_EXPIRY_MS = 24 * 60 * 60 * 1000;
+// Tips survive a full week in the queue — combined with the age-boost in
+// pickPrimaryBucket and the Friday mailbag, this gives every tip multiple
+// chances to land a post before it expires.
+const TIP_EXPIRY_MS = 7 * 24 * 60 * 60 * 1000;
+// A tip this old MUST either reference its date or hedge in-voice.
+const TIP_STALE_THRESHOLD_MS = 3 * 24 * 60 * 60 * 1000;
 const PROCESSED_TTL_SEC = 24 * 60 * 60;
 
 const QUIET_HOUR_START = 23; // 11pm PT
 const QUIET_HOUR_END = 7;    // 7am PT
+
+// Friday mailbag — one big roundup that sweeps the queue so nothing
+// expires unseen. Runs once per Friday PT. Same Redis-key TTL pattern as
+// the other daily counters.
+const FRIDAY_MAILBAG_DONE_KEY = 'schefter:mailbag:done_date';
+const FRIDAY_WEEKDAY_INDEX = 5; // 0=Sun … 5=Fri
 
 // Public URL of the tip page — appended to every GroupMe rumor post so
 // owners always have a one-tap path to whisper back with intel. The feed
@@ -286,8 +312,10 @@ async function postToGroupMe(text) {
  * @param {Array} [feedPosts] - current feed posts, used to resolve parent
  *   rumor snippets for thread-followup scopes. When omitted, followups still
  *   get the thread-followup scope but with no parent headline context.
+ * @param {Date} [now] - reference time for age calculations; defaults to now.
  */
-function anonymizeTips(tips, teams, feedPosts = []) {
+function anonymizeTips(tips, teams, feedPosts = [], now = new Date()) {
+  const refMs = now instanceof Date ? now.getTime() : Date.now();
   // Single-franchise fuzz applies ONLY to web tips. A GroupMe mention of
   // franchise X isn't an anonymity leak — the speaker publicly named it
   // in the group chat. Count only web tips when deciding fuzz.
@@ -312,6 +340,9 @@ function anonymizeTips(tips, teams, feedPosts = []) {
   );
 
   return tips.map((tip) => {
+    const submittedAt = tip.submittedAt ?? refMs;
+    const ageMs = Math.max(0, refMs - submittedAt);
+    const ageDays = Math.floor(ageMs / (24 * 60 * 60 * 1000));
     const safe = {
       id: tip.id,
       topic: tip.topic,
@@ -319,7 +350,12 @@ function anonymizeTips(tips, teams, feedPosts = []) {
       source: tip.source,
       attributable: tip.attributable === true,
       author: tip.attributable && tip.author ? tip.author : undefined,
-      submittedAt: tip.submittedAt,
+      submittedAt,
+      // Age fields let the LLM reference the tip's date or hedge when the
+      // tip has been in the queue for a while. HARD RULE 17 gates the
+      // phrasing so we never claim a tip is fresh when it isn't.
+      ageDays,
+      isStale: ageMs >= TIP_STALE_THRESHOLD_MS,
     };
 
     // Reverse-the-lens framing for hostile tips. Only surface the tipster's
@@ -519,31 +555,59 @@ function buildTopicBuckets(tips) {
 }
 
 /**
- * Pick the single bucket we will post about this cycle.
+ * Score a bucket for priority selection. Higher = better.
+ *
+ * Scoring weights (chosen so clusters normally beat singletons, but
+ * aging-out singletons eventually overtake fresh clusters before they
+ * expire):
+ *   - Each additional tip in the bucket: +2 (a 2-tip cluster = +2, 3-tip = +4)
+ *   - Each day the oldest tip has been queued: +1
+ *
+ * Examples:
+ *   - Fresh 2-tip cluster        → 2 + 0 = 2
+ *   - 2-day-old singleton         → 0 + 2 = 2 (tied; tie-break favors the older one)
+ *   - 5-day-old singleton         → 0 + 5 = 5 (beats the fresh cluster — near expiry)
+ *   - 5-day-old 2-tip cluster     → 2 + 5 = 7 (top of the queue)
+ */
+function bucketPriorityScore(bucket, now = new Date()) {
+  const refMs = now instanceof Date ? now.getTime() : Date.now();
+  const oldestAgeMs = Math.max(0, refMs - (bucket.oldestSubmittedAt ?? refMs));
+  const oldestAgeDays = Math.floor(oldestAgeMs / (24 * 60 * 60 * 1000));
+  const sizeScore = Math.max(0, bucket.tips.length - 1) * 2;
+  return sizeScore + oldestAgeDays;
+}
+
+/**
+ * Pick the bucket(s) to post about this cycle.
  *
  * Priority order:
- *   1. Trade rumors — sorted by bucket size (descending). Ties prefer
- *      trade-offer tips over web trade tips because trade-offer is
- *      structured data from MFL, less noisy than owner speculation.
- *   2. Gossip buckets with ≥2 tips (multi-tip topic clusters) — largest wins.
- *   3. Singleton gossip — only returned when no better bucket exists. Lets
- *      the caller decide to hold it for the next cycle when gossip quota is
- *      already spent today.
+ *   1. Trade rumors — ranked by bucketPriorityScore (size + age boost). Ties
+ *      prefer trade-offer over web-trade because trade-offer is structured
+ *      data from MFL, less noisy than owner speculation.
+ *   2. Gossip buckets with ≥2 tips (multi-tip topic clusters) — bucketPriorityScore ranks.
+ *   3. Singleton gossip — returned when nothing else qualifies. Age boost
+ *      means older singletons rise above newer ones naturally.
  *
- * Returns `null` when nothing qualifies (e.g. only gossip exists but the
- * gossip daily cap is already used).
+ * For gossip posts we also return a SECONDARY bucket when one exists — the
+ * caller wires both into a single two-beat post so two distinct gossip
+ * topics can share one feed card without triggering a wall-of-text feel.
+ * Trade-rumor posts never carry a secondary (they stay strictly one-topic).
+ *
+ * Returns `{ primary, secondary }` or `null` when nothing qualifies.
  */
-function pickPrimaryBucket(buckets, { gossipAllowedToday }) {
+function pickPrimaryBucket(buckets, { gossipAllowedToday, now = new Date() } = {}) {
   const tradeBuckets = buckets.filter((b) => b.kind === 'trade');
   if (tradeBuckets.length > 0) {
     tradeBuckets.sort((a, b) => {
-      if (b.tips.length !== a.tips.length) return b.tips.length - a.tips.length;
+      const sa = bucketPriorityScore(a, now);
+      const sb = bucketPriorityScore(b, now);
+      if (sb !== sa) return sb - sa;
       // Prefer trade-offer over web-trade on ties
       if (a.key === 'trade:offer' && b.key !== 'trade:offer') return -1;
       if (b.key === 'trade:offer' && a.key !== 'trade:offer') return 1;
       return 0;
     });
-    return tradeBuckets[0];
+    return { primary: tradeBuckets[0], secondary: null };
   }
 
   if (!gossipAllowedToday) return null;
@@ -551,17 +615,61 @@ function pickPrimaryBucket(buckets, { gossipAllowedToday }) {
   const gossipBuckets = buckets.filter((b) => b.kind === 'gossip');
   if (gossipBuckets.length === 0) return null;
 
-  const clusters = gossipBuckets.filter((b) => b.tips.length >= 2);
-  if (clusters.length > 0) {
-    clusters.sort((a, b) => b.tips.length - a.tips.length);
-    return clusters[0];
-  }
+  gossipBuckets.sort((a, b) => {
+    const sa = bucketPriorityScore(a, now);
+    const sb = bucketPriorityScore(b, now);
+    if (sb !== sa) return sb - sa;
+    // Ties: older wins so a long-queued tip always beats a fresh one.
+    return a.oldestSubmittedAt - b.oldestSubmittedAt;
+  });
 
-  // Only singletons left. Pick the oldest-submitted one so tips that have
-  // been marinating longest get their turn first. Caller still decides
-  // whether to post or hold based on queue shape.
-  gossipBuckets.sort((a, b) => a.oldestSubmittedAt - b.oldestSubmittedAt);
-  return gossipBuckets[0];
+  const primary = gossipBuckets[0];
+  const secondary = gossipBuckets[1] ?? null;
+  return { primary, secondary };
+}
+
+/**
+ * Adaptive gossip cap — bumps the gossip quota by one for the day when the
+ * backlog is deep enough to risk pile-up. Triggers on either:
+ *   - queue depth ≥ GOSSIP_BOOST_QUEUE_DEPTH, or
+ *   - oldest tip age ≥ GOSSIP_BOOST_TIP_AGE_MS
+ *
+ * A quiet week stays at 1/day; a loud week self-regulates at 2/day.
+ */
+function computeAdaptiveGossipCap(freshTips, now = new Date()) {
+  const refMs = now instanceof Date ? now.getTime() : Date.now();
+  const gossipTips = freshTips.filter((t) => classifyTipKind(t) === 'gossip');
+  if (gossipTips.length === 0) {
+    return { cap: MAX_GOSSIP_POSTS_PER_DAY, reason: 'no gossip in queue' };
+  }
+  const oldestAgeMs = gossipTips.reduce(
+    (acc, t) => Math.max(acc, refMs - (t.submittedAt ?? refMs)),
+    0,
+  );
+  const deepBacklog = gossipTips.length >= GOSSIP_BOOST_QUEUE_DEPTH;
+  const agingTip = oldestAgeMs >= GOSSIP_BOOST_TIP_AGE_MS;
+  if (deepBacklog || agingTip) {
+    const reasons = [
+      deepBacklog ? `backlog=${gossipTips.length}` : null,
+      agingTip ? `oldest=${Math.floor(oldestAgeMs / (24 * 60 * 60 * 1000))}d` : null,
+    ].filter(Boolean);
+    return { cap: MAX_GOSSIP_POSTS_PER_DAY_ADAPTIVE, reason: `adaptive (${reasons.join(', ')})` };
+  }
+  return { cap: MAX_GOSSIP_POSTS_PER_DAY, reason: 'default' };
+}
+
+/**
+ * Friday mailbag helpers. The scanner runs a roundup once per Friday PT
+ * that sweeps all non-trade tips still in the queue — so nothing expires
+ * silently even on a slow week. Runs after the marinate gate passes and
+ * before the normal bucket pick.
+ */
+function isFridayPt(now = new Date()) {
+  const fmt = new Intl.DateTimeFormat('en-US', {
+    timeZone: 'America/Los_Angeles',
+    weekday: 'short',
+  });
+  return fmt.format(now) === 'Fri';
 }
 
 // ── Post generation ──
@@ -703,7 +811,7 @@ Example F — lingering named (framingHint=lingering, escalatedPlayer.tier=named
 `;
 }
 
-async function generateAiBody(anonymized, { rogerQuote, lore, recentPostsBlock } = {}) {
+async function generateAiBody(anonymized, { rogerQuote, lore, recentPostsBlock, mode = 'single', secondaryAnonymized = null } = {}) {
   const apiKey = process.env.ANTHROPIC_API_KEY;
   if (!apiKey) {
     warn('  [rumor-scan] ANTHROPIC_API_KEY not set — using template');
@@ -716,7 +824,7 @@ async function generateAiBody(anonymized, { rogerQuote, lore, recentPostsBlock }
   let system = `You are Claude Schefter — a dynasty fantasy football beat reporter channeling Adam Schefter's rumor-mill energy. You turn owner tips into a columnist-voiced rumor post.
 
 HARD RULES (self-enforce, never violate):
-0. ONE TOPIC ONLY. Every tip in this batch is already pre-filtered to a single topic/thread. NEVER pivot to a second unrelated subject inside the same post. If tips feel like different stories, cover the DOMINANT angle and drop the rest — save them for future posts. No "meanwhile…", no "elsewhere in the league…", no topic hops.
+0. ONE TOPIC per beat. The batch is pre-bucketed so each beat is a single topic/thread. For TRADE-RUMOR posts and MAILBAG posts the rules are different — see rules 18 and 19 for the narrow cases where two distinct gossip beats may share a post. Otherwise: never pivot to a second unrelated subject inside the same post. No "meanwhile…", no "elsewhere in the league…", no topic hops on single-beat posts.
 1. For web tips (source: "web"), NEVER name the tipster and NEVER quote them verbatim — paraphrase with columnist voice.
 2. If a web tip's scope is "division", the division refers to the SUBJECT team's division — NOT where the source is located. Frame it as "a team in the [division]", "a [division]-division squad", or "the [division] is buzzing" — NEVER as "sources in the [division]" (that implies the tipster's location). NEVER name a specific franchise.
 3. If a web tip's scope is "league-wide", stay vague ("an owner tells me", "hearing from multiple corners").
@@ -724,7 +832,7 @@ HARD RULES (self-enforce, never violate):
 5. If a web tip's scope is "commish", you MAY reference the commissioner's office but PREFER institutional framing — "the league office", "the commissioner's office", "the front office" — over the personal "the commish" or "Brandon". Institutional framing tones down heat while still passing on the sentiment. NEVER name the franchise that holds the office.
 6. For GroupMe tips (source: "groupme", scope: "groupme-public", attributable: true): direct attribution is ENCOURAGED. The author publicly @'d Schefter in the group chat — name them. Riff BACK conversationally, second-person where it fits ("Wabbit, I hear you, but…", "Nice try, Jomar — my sources say otherwise"). Light ribbing is in-voice.
 7. If the batch mixes GroupMe and web tips, they are about the SAME topic — attribute the GroupMe author by name while keeping the web tipster anonymous, still one story.
-8. Length: 1–2 sentences. Tight, tease-voice, no throat-clearing. End with "Developing." only when it genuinely fits — don't force it.
+8. Length: 1–2 sentences per beat (a single-beat post is 1–2 sentences; a two-beat gossip post is 2–4 total, one per beat). Tight, tease-voice, no throat-clearing. End with "Developing." only when it genuinely fits — don't force it.
 9. Do NOT include hashtags, emoji, or @-mentions. Plain prose only.
 10. Do NOT reveal how many tips fed this post. No meta commentary about the rumor mill itself.
 11. Thread continuity: if ANY tip in this batch has a \`threadFollowup\` field (Phase 7 whisper-back), open with continuity language — "Following up on yesterday's…", "More on the…", "Circling back to…", "As a reminder…". Use the parentHeadlineSnippet as a cue, but do not quote it. Still respect every fuzz/anonymity rule above. If no tip has threadFollowup, do not use continuity phrasing.
@@ -807,6 +915,24 @@ HARD RULES (self-enforce, never violate):
 
     Do NOT combine A=C with the Style Book bit in the same post (both are "reading the attacker" moves — pick one). Do NOT use on non-hostile tips. Never phrase it as a hard accusation ("X is clearly projecting") — keep it hedged and general. **The barometer: owners who keep sending personal shots RECENTLY earn more A=C in the posts that follow. The reading is a rolling 30-day window, not a lifetime tally — an owner who stops sending mean tips will naturally see their barometer drop over a month. Good behavior improves the dial; bad behavior spins it up; the whole mechanism is invisible to the owner. Owners whose attacks get reciprocated (mutual beef — future signal) earn less A=C because it's a two-way feud, not projection.**
 
+17. AGE-AWARE FRAMING. Each tip carries \`ageDays\` (integer) and \`isStale\` (boolean, true when ageDays >= 3). NEVER claim a stale tip is fresh. When ANY tip in the beat has \`isStale: true\`, you MUST either (a) reference when the whisper started — "the chatter that started earlier this week…", "a whisper from a few days back…", "been hearing this for days now…" — OR (b) explicitly hedge the staleness — "still hearing about…", "this one's been sitting with me…", "hasn't gone away…". Pick ONE device per beat; don't stack them. For tips with ageDays === 0 or 1, treat as fresh ("I'm told…", "just hearing…", "late word…"). Never invent a specific date the tip doesn't have (don't say "Monday" unless the tip was actually whispered on Monday — the scanner supplies integer day counts, not calendar labels, so stick to relative language).
+
+18. TWO-BEAT GOSSIP POSTS (only when the batch contains a \`secondaryBucket\` marker — see user message). Two distinct gossip topics share one post. Rules:
+    - Format as TWO short beats, each 1 sentence. Each beat covers ONE of the two topics. Separate the beats with a line break (\\n\\n) and optionally a dash or bullet (— …) so the reader sees two quick hits instead of a wall of text.
+    - Do NOT try to connect the beats thematically. They are independent blurbs.
+    - Still respect every anonymity / hostile-tip rule above per beat.
+    - The beats may include a transition phrase ("— Also") but NEVER the banned "meanwhile" chain.
+    - Example shape:
+        Beat 1 on topic A.\\n\\n— Beat 2 on topic B.
+
+19. MAILBAG POSTS (only when the user message starts with "MAILBAG:" — Friday news-dump). Bundled roundup of every gossip tip still in the queue that would otherwise expire. Rules:
+    - Open with a brief mailbag framing: "Cleaning out the mailbag before the weekend.", "Friday loose-notes dump.", "Before I log off — a few whispers worth airing out."
+    - Cover up to 6 bullet-style one-liners, one per topic bucket. Each one-liner is a single clause. Line-break between bullets (\\n\\n• …).
+    - Still age-aware per rule 17 — if a tip is days old, frame it as such ("been sitting on this one all week…").
+    - Still anonymized per rules 1–6 and hostile-reframed per rules 12–16.
+    - Close with a quick sign-off: "That's the file. Have a good weekend." or similar. One sentence max.
+    - Length cap: 180 words total.
+
 Voice: "League sources tell me…", "I'm told…", "Hearing…", "A division rival whispers…". Salt, not sugar.`;
 
   if (hasTradeOffer) {
@@ -829,7 +955,14 @@ Voice: "League sources tell me…", "I'm told…", "Hearing…", "A division riv
     ? `\n\n${recentPostsBlock}`
     : '';
 
-  const userMessage = `Synthesize these tips into ONE rumor-mill post. Output plain text only — no JSON, no formatting, no headlines.${rogerDirective}${recentBlock}\n\nTIPS:\n${JSON.stringify(anonymized, null, 2)}`;
+  let userMessage;
+  if (mode === 'mailbag') {
+    userMessage = `MAILBAG: Friday news-dump. Apply HARD RULE 19 — bullet each topic in the GOSSIP_TIPS array as a one-liner (≤6 bullets). Open with a mailbag framing and sign off at the end. Output plain text only — no JSON, no formatting, no headlines.${rogerDirective}${recentBlock}\n\nGOSSIP_TIPS:\n${JSON.stringify(anonymized, null, 2)}`;
+  } else if (mode === 'two-beat' && Array.isArray(secondaryAnonymized) && secondaryAnonymized.length > 0) {
+    userMessage = `Two-beat gossip post: apply HARD RULE 18. Write ONE short sentence for PRIMARY_TIPS, then a blank line and a bullet (— …) with ONE short sentence for SECONDARY_TIPS. Two distinct topics, two quick hits, no "meanwhile" chain. Output plain text only — no JSON, no formatting, no headlines.${rogerDirective}${recentBlock}\n\nPRIMARY_TIPS:\n${JSON.stringify(anonymized, null, 2)}\n\nSECONDARY_TIPS:\n${JSON.stringify(secondaryAnonymized, null, 2)}`;
+  } else {
+    userMessage = `Synthesize these tips into ONE rumor-mill post (single beat, 1–2 sentences, one topic). Output plain text only — no JSON, no formatting, no headlines.${rogerDirective}${recentBlock}\n\nTIPS:\n${JSON.stringify(anonymized, null, 2)}`;
+  }
 
   if (DRY_RUN) {
     log('\n  [dry-run] Full LLM prompt that would be sent:');
@@ -851,7 +984,7 @@ Voice: "League sources tell me…", "I'm told…", "Hearing…", "A division riv
       },
       body: JSON.stringify({
         model: 'claude-haiku-4-5-20251001',
-        max_tokens: 260,
+        max_tokens: mode === 'mailbag' ? 600 : 260,
         system,
         messages: [{ role: 'user', content: userMessage }],
       }),
@@ -1454,41 +1587,102 @@ async function main() {
   }
   log(`  Gates OK (posts_today=${gates.postsToday}, marinated enough)`);
 
-  // Pick one topic-bucket to post about. Trade rumors come first, then
-  // multi-tip gossip clusters, then (rarely) a lone gossip tip. Tips in
-  // other buckets stay in the queue — that's how "slow news day" leftovers
-  // bubble up on the next cycle.
+  const todayPtDate = getPtDateString(now);
+
+  // Friday mailbag check — runs once per Friday PT, sweeps every gossip
+  // tip (any non-trade-offer web/groupme tip) into one roundup so nothing
+  // expires unseen. Trade-offer tips still go through their own path on
+  // non-Friday cycles; mailbag only takes the gossip pile.
+  let mailbagBatch = null;
+  if (isFridayPt(now)) {
+    let mailbagDoneDate = null;
+    try {
+      mailbagDoneDate = await redis.get(FRIDAY_MAILBAG_DONE_KEY);
+    } catch { /* tolerate */ }
+    if (mailbagDoneDate === todayPtDate) {
+      log(`  [mailbag] Already ran today (${todayPtDate}) — skipping Friday dump`);
+    } else {
+      const gossipPool = freshTips.filter((t) => classifyTipKind(t) === 'gossip');
+      if (gossipPool.length === 0) {
+        log('  [mailbag] Friday + no gossip tips in queue — skipping (no dump needed)');
+      } else {
+        mailbagBatch = gossipPool.slice(0, MAX_TIPS_PER_BATCH);
+        log(`  [mailbag] Friday news-dump: ${mailbagBatch.length} gossip tip(s) queued for roundup`);
+      }
+    }
+  }
+
+  // Pick one topic-bucket (or two, for gossip posts) to report. Trade
+  // rumors come first, then the oldest/largest gossip bucket, with an
+  // optional second gossip beat stitched into the same post. Tips in
+  // other buckets stay in the queue — slow-news leftovers bubble up on
+  // the next cycle thanks to the age boost in bucketPriorityScore.
   const buckets = buildTopicBuckets(freshTips);
   log(
     `  Buckets (${buckets.length}): ` +
       buckets.map((b) => `${b.key}[${b.kind}×${b.tips.length}]`).join(', '),
   );
+
   const gossipToday = Number(
     (await redis.get(RUMOR_GOSSIP_POSTS_TODAY_KEY).catch(() => 0)) ?? 0,
   );
-  const gossipAllowedToday = gossipToday < MAX_GOSSIP_POSTS_PER_DAY;
-  log(`  Gossip budget: ${gossipToday}/${MAX_GOSSIP_POSTS_PER_DAY} used today (${gossipAllowedToday ? 'available' : 'spent'})`);
+  const { cap: adaptiveGossipCap, reason: adaptiveReason } = computeAdaptiveGossipCap(freshTips, now);
+  const gossipAllowedToday = gossipToday < adaptiveGossipCap;
+  log(`  Gossip budget: ${gossipToday}/${adaptiveGossipCap} used today — ${adaptiveReason} (${gossipAllowedToday ? 'available' : 'spent'})`);
 
-  const primaryBucket = pickPrimaryBucket(buckets, { gossipAllowedToday });
-  if (!primaryBucket) {
-    log('  No bucket qualifies (gossip cap used, no trade rumors) — holding tips for the next cycle');
-    return 0;
+  // Mailbag takes precedence over the normal bucket pick — drains the
+  // whole gossip pool regardless of clustering. Still subject to the
+  // MAX_POSTS_PER_DAY gate (it consumes one of the day's slots).
+  let primaryBucket = null;
+  let secondaryBucket = null;
+  let postKind; // 'trade' | 'gossip' | 'mailbag'
+  let batch;
+  let secondaryBatch = null;
+
+  if (mailbagBatch) {
+    postKind = 'mailbag';
+    batch = mailbagBatch;
+  } else {
+    const pick = pickPrimaryBucket(buckets, { gossipAllowedToday, now });
+    if (!pick) {
+      log('  No bucket qualifies (gossip cap used, no trade rumors) — holding tips for the next cycle');
+      return 0;
+    }
+    primaryBucket = pick.primary;
+    secondaryBucket = pick.secondary;
+    log(`  Chose bucket ${primaryBucket.key} (kind=${primaryBucket.kind}, size=${primaryBucket.tips.length})`);
+
+    // Cap batch size (within the chosen bucket). Leftovers from other
+    // buckets survive this cycle via the partial-drain path below.
+    batch = primaryBucket.tips.slice(0, MAX_TIPS_PER_BATCH);
+    postKind = primaryBucket.kind;
+
+    // Two-beat gossip: a second distinct gossip bucket rides along in the
+    // same post, counted as ONE post against the daily + gossip caps.
+    // Trade-rumor posts never carry a secondary — they stay strictly
+    // single-topic.
+    if (postKind === 'gossip' && secondaryBucket) {
+      secondaryBatch = secondaryBucket.tips.slice(0, Math.max(1, Math.floor(MAX_TIPS_PER_BATCH / 2)));
+      log(`  Second beat bucket ${secondaryBucket.key} (size=${secondaryBucket.tips.length}, using ${secondaryBatch.length} tip(s))`);
+    }
   }
-  log(`  Chose bucket ${primaryBucket.key} (kind=${primaryBucket.kind}, size=${primaryBucket.tips.length})`);
 
-  // Cap batch size (within the chosen bucket). Leftovers from other buckets
-  // survive this cycle by being rewritten to the queue further down.
-  const batch = primaryBucket.tips.slice(0, MAX_TIPS_PER_BATCH);
-  const postKind = primaryBucket.kind;
-  const unusedTips = freshTips.filter((t) => !batch.some((b) => b.id === t.id));
-  log(`  Processing batch of ${batch.length} (holding ${unusedTips.length} for next cycle)`);
+  const batchIds = new Set([
+    ...batch.map((t) => t.id),
+    ...(secondaryBatch ? secondaryBatch.map((t) => t.id) : []),
+  ]);
+  const unusedTips = freshTips.filter((t) => !batchIds.has(t.id));
+  log(`  Processing batch of ${batch.length}${secondaryBatch ? ` + ${secondaryBatch.length} secondary` : ''} (holding ${unusedTips.length} for next cycle)`);
 
   // Anonymize — load the feed early so whisper-back tips can pull parent
   // headline snippets into their scope.
   const teams = await loadTeams();
   const feedForAnonymize = await loadFeed();
-  const anonymized = anonymizeTips(batch, teams, feedForAnonymize.posts ?? []);
-  log(`  Anonymized ${anonymized.length} tips`);
+  const anonymized = anonymizeTips(batch, teams, feedForAnonymize.posts ?? [], now);
+  const secondaryAnonymized = secondaryBatch
+    ? anonymizeTips(secondaryBatch, teams, feedForAnonymize.posts ?? [], now)
+    : null;
+  log(`  Anonymized ${anonymized.length} tips${secondaryAnonymized ? ` + ${secondaryAnonymized.length} secondary` : ''}`);
 
   // ── Phase 4: Ask Roger 7% riff ──
   // Gate: (a) random roll passes, (b) no riff already posted today PT,
@@ -1497,7 +1691,7 @@ async function main() {
   let rogerQuote = null;
   let hadRogerRiff = false;
   const rogerRoll = Math.random();
-  const todayPt = getPtDateString(now);
+  const todayPt = todayPtDate;
   let lastRiffDate = null;
   try {
     lastRiffDate = await redis.get(ROGER_LAST_RIFF_DATE_KEY);
@@ -1526,20 +1720,33 @@ async function main() {
   }
 
   // Generate post (AI receives Roger directive only if quote is available,
-  // plus assembled lore suffix + recent-post memory when available)
-  const aiBody = await generateAiBody(anonymized, { rogerQuote, lore, recentPostsBlock });
+  // plus assembled lore suffix + recent-post memory when available). The
+  // `mode` flag selects the one-beat / two-beat / mailbag user-prompt shape.
+  const aiMode = postKind === 'mailbag'
+    ? 'mailbag'
+    : (secondaryAnonymized ? 'two-beat' : 'single');
+  const aiBody = await generateAiBody(anonymized, {
+    rogerQuote,
+    lore,
+    recentPostsBlock,
+    mode: aiMode,
+    secondaryAnonymized,
+  });
   const body = aiBody || templateBody(anonymized);
   log(`  Post body (${aiBody ? 'AI' : 'template'})${hadRogerRiff ? ' [with Roger riff]' : ''}:\n    ${body.replace(/\n/g, '\n    ')}`);
 
-  // Build post
-  const tipIds = batch.map((t) => t.id);
+  // Build post — tipIds covers both the primary and (when present) the
+  // secondary two-beat batch so processed-audit + hash-for-tip indexes
+  // see every tip that shipped.
+  const combinedBatch = secondaryBatch ? [...batch, ...secondaryBatch] : batch;
+  const tipIds = combinedBatch.map((t) => t.id);
 
   // Phase 7 — whisper-back thread resolution. If any tip in the batch is a
   // follow-up to an existing rumor, the new post joins that thread. We pick
   // the most-referenced parent in the batch, then resolve its threadId via
   // the Redis registry (or mint a new one and stamp the parent).
   const parentCounts = new Map();
-  for (const tip of batch) {
+  for (const tip of combinedBatch) {
     if (tip && typeof tip.repliesToPostId === 'string' && tip.repliesToPostId.length > 0) {
       parentCounts.set(tip.repliesToPostId, (parentCounts.get(tip.repliesToPostId) ?? 0) + 1);
     }
@@ -1625,8 +1832,8 @@ async function main() {
 
   // Append to rolling post history (best-effort — never crashes the run).
   // Subject is a short tag derived from dominant tip source/scope.
-  const subject = deriveHistorySubject(batch, anonymized);
-  const tipSources = Array.from(new Set(batch.map((t) => t.source).filter(Boolean)));
+  const subject = deriveHistorySubject(combinedBatch, anonymized);
+  const tipSources = Array.from(new Set(combinedBatch.map((t) => t.source).filter(Boolean)));
   await appendPostHistory(
     buildHistoryEntry({
       id: post.id,
@@ -1651,7 +1858,13 @@ async function main() {
       if (newGossipCount === 1) {
         await redis.expire(RUMOR_GOSSIP_POSTS_TODAY_KEY, secondsUntilPtMidnight(now));
       }
-      log(`  Gossip counter: now ${newGossipCount}/${MAX_GOSSIP_POSTS_PER_DAY}`);
+      log(`  Gossip counter: now ${newGossipCount}/${adaptiveGossipCap}`);
+    }
+    if (postKind === 'mailbag') {
+      // Mark today's mailbag done. 48h TTL — the key naturally falls off
+      // before next Friday even if clocks skew.
+      await redis.set(FRIDAY_MAILBAG_DONE_KEY, todayPtDate, { ex: 48 * 60 * 60 });
+      log(`  [mailbag] Marked done for ${todayPtDate}`);
     }
     await redis.set(RUMOR_LAST_POST_TS_KEY, now.getTime());
 
@@ -1687,8 +1900,9 @@ async function main() {
     // Phase 10 — hash_for_tip index. The weekly tip-of-the-week script needs to
     // resolve each contributing tipId back to a hashedOwnerId to award badges.
     // We TTL these at 14 days so the weekly job has a generous window even if
-    // it runs a day or two late.
-    for (const tip of batch) {
+    // it runs a day or two late. Covers both beats of a two-beat gossip post
+    // plus every tip swept into a Friday mailbag.
+    for (const tip of combinedBatch) {
       if (tip && tip.source === 'web' && typeof tip.hashedOwnerId === 'string' && tip.hashedOwnerId.length > 0) {
         try {
           await redis.set(
@@ -1753,7 +1967,7 @@ async function main() {
     const seasonYear = getSeasonYearForTipster(now);
     await incrementTipsterCounters({
       redis,
-      batch,
+      batch: combinedBatch,
       seasonYear,
       dryRun: DRY_RUN,
       log,

--- a/tests/schefter-rumor-topic-focus.test.ts
+++ b/tests/schefter-rumor-topic-focus.test.ts
@@ -240,6 +240,21 @@ describe('rumor-scan two-post gossip — second bucket ships as its own feed pos
     expect(src).toMatch(/if\s*\(postKind\s*===\s*['"]gossip['"]\s*&&\s*secondaryBucket\)/);
   });
 
+  it('gates the secondary post on real pile-up (>= SECONDARY_GOSSIP_POST_PRESSURE gossip tips queued)', () => {
+    // Under the threshold the scanner ships ONE post and holds the second
+    // bucket for the next cycle. The double-post is a catch-up mechanism,
+    // not the default cadence.
+    expect(src).toMatch(/const\s+SECONDARY_GOSSIP_POST_PRESSURE\s*=\s*4\b/);
+    expect(src).toMatch(/if\s*\(gossipQueueDepth\s*>=\s*SECONDARY_GOSSIP_POST_PRESSURE\)/);
+  });
+
+  it('explicitly holds the secondary bucket for the next cycle when pressure is low', () => {
+    // The "else" branch of the pressure gate logs a hold; we assert the
+    // hold-for-next-cycle path exists so a later refactor can't silently
+    // drop it and fall back to always-ship-two.
+    expect(src).toMatch(/Holding\s+\$\{secondaryBucket\.key\}\s+for next cycle/);
+  });
+
   it('builds a beats[] array so each beat turns into an independent post', () => {
     expect(src).toMatch(/const\s+beats\s*=\s*\[\s*\{\s*batch,\s*anonymized,\s*kind:\s*postKind[^}]*\}/);
     expect(src).toMatch(/beats\.push\(\s*\{\s*batch:\s*secondaryBatch/);

--- a/tests/schefter-rumor-topic-focus.test.ts
+++ b/tests/schefter-rumor-topic-focus.test.ts
@@ -98,18 +98,25 @@ describe('rumor-scan bucketing — one topic per post', () => {
   });
 });
 
-describe('rumor-scan LLM prompt — one topic per beat', () => {
+describe('rumor-scan LLM prompt — one topic per post', () => {
   const src = read('scripts/schefter-rumor-scan.mjs');
 
-  it('tells the LLM to stay on ONE TOPIC per beat and refuses "meanwhile…" pivots', () => {
-    expect(src).toMatch(/ONE TOPIC per beat/);
+  it('tells the LLM to stay on ONE TOPIC per post and refuses "meanwhile…" pivots', () => {
+    expect(src).toMatch(/ONE TOPIC per post/);
     expect(src).toMatch(/No "meanwhile/);
   });
 
-  it('caps post length at 1–2 sentences per beat', () => {
+  it('references the two-separate-posts behavior in the one-topic rule', () => {
+    // The rule explicitly mentions that unrelated gossip ships as TWO
+    // posts rather than one blended post — prevents the LLM from
+    // "helpfully" stitching them back together.
+    expect(src).toMatch(/ships them as TWO separate posts/);
+  });
+
+  it('caps post length at 1–2 sentences', () => {
     // HARD RULE 8 is the authoritative cap; the trade-offer playbook
     // must defer to it as well.
-    expect(src).toMatch(/Length:\s*1[–-]2 sentences per beat/);
+    expect(src).toMatch(/Length:\s*1[–-]2 sentences\./);
     expect(src).toMatch(/1[–-]2 sentences TOTAL/);
   });
 
@@ -142,10 +149,12 @@ describe('rumor-scan tip-page link — every post sends readers back to /tip', (
     expect(src).toMatch(/linkLabel:\s*TIP_PAGE_LINK_LABEL/);
   });
 
-  it('appends the absolute tip-page URL to GroupMe posts', () => {
-    expect(src).toMatch(/const\s+groupMeText\s*=\s*`\$\{post\.body\}\\n\\nGot a tip\? \$\{TIP_PAGE_ABSOLUTE_URL\}`/);
-    // The GroupMe call must use groupMeText (not post.body) so the URL ships.
-    expect(src).toMatch(/await\s+postToGroupMe\(groupMeText\)/);
+  it('appends the absolute tip-page URL to every GroupMe post', () => {
+    // Each beat now ships its own GroupMe message via groupMeTextFor(p),
+    // a closure that formats "body\n\nGot a tip? <URL>".
+    expect(src).toMatch(/const\s+groupMeTextFor\s*=\s*\(p\)\s*=>\s*`\$\{p\.body\}\\n\\nGot a tip\? \$\{TIP_PAGE_ABSOLUTE_URL\}`/);
+    expect(src).toMatch(/await\s+postToGroupMe\(groupMeTextFor\(builtPosts\[i\]\)\)/);
+    // No raw-body GroupMe calls remain — every rumor post gets the CTA.
     expect(src).not.toMatch(/await\s+postToGroupMe\(post\.body\)/);
   });
 });
@@ -211,45 +220,83 @@ describe('rumor-scan bucket priority — age boost so old tips rise', () => {
   });
 });
 
-describe('rumor-scan two-beat gossip — second bucket rides along', () => {
+describe('rumor-scan two-post gossip — second bucket ships as its own feed post', () => {
   const src = read('scripts/schefter-rumor-scan.mjs');
 
-  it('pickPrimaryBucket returns {primary, secondary} so gossip posts can carry two beats', () => {
+  it('pickPrimaryBucket returns {primary, secondary} so a second gossip bucket can ride along', () => {
     const pickFn = src.match(/function\s+pickPrimaryBucket[\s\S]+?\n\}\n/);
     expect(pickFn).not.toBeNull();
     expect(pickFn![0]).toMatch(/return\s*\{\s*primary:[^,]+,\s*secondary/);
   });
 
-  it('trade-rumor posts never carry a secondary beat (stays strictly one-topic)', () => {
+  it('trade-rumor posts never carry a secondary (stays strictly one-topic)', () => {
     const pickFn = src.match(/function\s+pickPrimaryBucket[\s\S]+?\n\}\n/);
     expect(pickFn).not.toBeNull();
     // Trade-branch returns secondary: null explicitly.
     expect(pickFn![0]).toMatch(/primary:\s*tradeBuckets\[0\],\s*secondary:\s*null/);
   });
 
-  it('main flow only stitches a secondary into gossip posts (never trade)', () => {
+  it('main flow only adds a secondary beat for gossip posts (never trade)', () => {
     expect(src).toMatch(/if\s*\(postKind\s*===\s*['"]gossip['"]\s*&&\s*secondaryBucket\)/);
   });
 
-  it('HARD RULE 18 enforces two short beats with line-break separator', () => {
-    expect(src).toMatch(/18\.\s*TWO-BEAT GOSSIP POSTS/);
-    expect(src).toMatch(/Separate the beats with a line break/);
+  it('builds a beats[] array so each beat turns into an independent post', () => {
+    expect(src).toMatch(/const\s+beats\s*=\s*\[\s*\{\s*batch,\s*anonymized,\s*kind:\s*postKind[^}]*\}/);
+    expect(src).toMatch(/beats\.push\(\s*\{\s*batch:\s*secondaryBatch/);
   });
 
-  it('passes secondary tips to the LLM via the two-beat user prompt', () => {
-    expect(src).toMatch(/mode:\s*aiMode/);
-    expect(src).toMatch(/secondaryAnonymized/);
-    expect(src).toMatch(/PRIMARY_TIPS/);
-    expect(src).toMatch(/SECONDARY_TIPS/);
+  it('generates one LLM body per beat, in parallel', () => {
+    expect(src).toMatch(/Promise\.all\(\s*beats\.map\(/);
   });
 
-  it('counts a two-beat gossip post as ONE post against the daily caps', () => {
-    // newCount increments once per cycle; the gossip counter also only
-    // increments once when postKind === 'gossip'. No per-beat doubling.
+  it('gives the Roger riff to the PRIMARY beat only (never doubles up)', () => {
+    expect(src).toMatch(/rogerQuote:\s*i\s*===\s*0\s*\?\s*rogerQuote\s*:\s*null/);
+    expect(src).toMatch(/hadRogerRiff:\s*i\s*===\s*0\s*\?\s*hadRogerRiff\s*:\s*false/);
+  });
+
+  it('stamps distinct timestamps per beat so feed ordering is stable', () => {
+    expect(src).toMatch(/new Date\(now\.getTime\(\)\s*\+\s*i\s*\*\s*1000\)/);
+  });
+
+  it('each beat resolves its own whisper-back thread independently', () => {
+    // The thread-resolution loop runs per beat — parent counts are local
+    // to the beat's batch, not the combined batch.
+    expect(src).toMatch(/for \(const tip of beat\.batch\)/);
+  });
+
+  it('writes both posts to the feed in one atomic fs.writeFile call', () => {
+    // Prepend builtPosts in array order so primary lands at index 0
+    // (top of the feed).
+    expect(src).toMatch(/feed\.posts\s*=\s*\[\s*\.\.\.builtPosts,\s*\.\.\.existingPosts\s*\]/);
+    const feedWrites = (src.match(/await fs\.writeFile\(FEED_PATH/g) ?? []).length;
+    expect(feedWrites).toBe(1);
+  });
+
+  it('sends a separate GroupMe message per post (so each is independently replyable)', () => {
+    expect(src).toMatch(/for\s*\(let i\s*=\s*0;\s*i\s*<\s*builtPosts\.length;\s*i\+\+\)\s*\{[\s\S]*?postToGroupMe\(groupMeTextFor\(builtPosts\[i\]\)\)/);
+  });
+
+  it('counts both posts as ONE slot against posts_today and gossip counters', () => {
+    // INCR runs once per cycle even when we ship two posts.
     const incrCount = (src.match(/redis\.incr\(RUMOR_POSTS_TODAY_KEY\)/g) ?? []).length;
     expect(incrCount).toBe(1);
     const gossipIncr = (src.match(/redis\.incr\(RUMOR_GOSSIP_POSTS_TODAY_KEY\)/g) ?? []).length;
     expect(gossipIncr).toBe(1);
+  });
+
+  it('drops the old HARD RULE 18 "TWO-BEAT" rule (posts are now independent)', () => {
+    expect(src).not.toMatch(/TWO-BEAT GOSSIP POSTS/);
+    expect(src).not.toMatch(/Separate the beats with a line break/);
+  });
+
+  it('does not ship SECONDARY_TIPS through the LLM (each beat is a single-topic prompt)', () => {
+    expect(src).not.toMatch(/SECONDARY_TIPS/);
+    expect(src).not.toMatch(/PRIMARY_TIPS/);
+  });
+
+  it('feed posts do NOT leak internal parent-id marker (kept in a side Map)', () => {
+    expect(src).not.toMatch(/_dominantParentId/);
+    expect(src).toMatch(/parentIdByPostId/);
   });
 });
 
@@ -304,8 +351,8 @@ describe('rumor-scan Friday mailbag — once-a-week sweep of pending gossip', ()
     expect(src).toMatch(/redis\.set\(FRIDAY_MAILBAG_DONE_KEY,\s*todayPtDate/);
   });
 
-  it('HARD RULE 19 prescribes bullet-style mailbag voice and caps length', () => {
-    expect(src).toMatch(/19\.\s*MAILBAG POSTS/);
+  it('HARD RULE 18 prescribes bullet-style mailbag voice and caps length', () => {
+    expect(src).toMatch(/18\.\s*MAILBAG POSTS/);
     expect(src).toMatch(/bullet-style one-liners/);
     expect(src).toMatch(/Length cap:\s*180 words/);
   });

--- a/tests/schefter-rumor-topic-focus.test.ts
+++ b/tests/schefter-rumor-topic-focus.test.ts
@@ -22,8 +22,8 @@ function read(rel: string): string {
 describe('rumor-scan daily caps — trade-heavy, gossip-rationed', () => {
   const src = read('scripts/schefter-rumor-scan.mjs');
 
-  it('caps daily posts at 2 (prioritizing trade rumors)', () => {
-    expect(src).toMatch(/const\s+MAX_POSTS_PER_DAY\s*=\s*2\b/);
+  it('caps daily posts at 3 (gossip hard-limited to 1/day, so the other 2 slots go to trade rumors)', () => {
+    expect(src).toMatch(/const\s+MAX_POSTS_PER_DAY\s*=\s*3\b/);
   });
 
   it('rations gossip posts to at most 1 per day', () => {

--- a/tests/schefter-rumor-topic-focus.test.ts
+++ b/tests/schefter-rumor-topic-focus.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Source-level guards for the single-topic rumor-scan pipeline.
+ *
+ * The rumor scanner used to synthesize whatever was in the tip queue into a
+ * single 2–4 sentence post, often blending three unrelated topics. We now
+ * pick ONE topic bucket per cycle (trade rumors first, then multi-tip gossip
+ * clusters), rate-limit gossip to 1 post/day, preserve unused tips for the
+ * next cycle, and link the tip page from every post.
+ *
+ * These tests pin those invariants at the source level so a regression
+ * (e.g. someone re-enables multi-topic synthesis or drops the gossip cap)
+ * surfaces in CI rather than in the feed.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+function read(rel: string): string {
+  return readFileSync(path.join(process.cwd(), rel), 'utf8');
+}
+
+describe('rumor-scan daily caps — trade-heavy, gossip-rationed', () => {
+  const src = read('scripts/schefter-rumor-scan.mjs');
+
+  it('caps daily posts at 2 (prioritizing trade rumors)', () => {
+    expect(src).toMatch(/const\s+MAX_POSTS_PER_DAY\s*=\s*2\b/);
+  });
+
+  it('rations gossip posts to at most 1 per day', () => {
+    expect(src).toMatch(/const\s+MAX_GOSSIP_POSTS_PER_DAY\s*=\s*1\b/);
+  });
+
+  it('tracks the gossip counter in its own Redis key', () => {
+    expect(src).toMatch(/const\s+RUMOR_GOSSIP_POSTS_TODAY_KEY\s*=\s*['"]schefter:rumor:gossip_posts_today['"]/);
+  });
+
+  it('increments the gossip counter only when postKind === "gossip"', () => {
+    expect(src).toMatch(/if\s*\(\s*postKind\s*===\s*['"]gossip['"]\s*\)\s*\{[\s\S]*?redis\.incr\(RUMOR_GOSSIP_POSTS_TODAY_KEY\)/);
+  });
+
+  it('sets a TTL on the gossip counter so it resets at PT midnight', () => {
+    expect(src).toMatch(/redis\.expire\(RUMOR_GOSSIP_POSTS_TODAY_KEY,\s*secondsUntilPtMidnight/);
+  });
+});
+
+describe('rumor-scan bucketing — one topic per post', () => {
+  const src = read('scripts/schefter-rumor-scan.mjs');
+
+  it('defines a buildTopicBuckets helper that groups tips by topic/thread', () => {
+    expect(src).toMatch(/function\s+buildTopicBuckets\(/);
+  });
+
+  it('defines a pickPrimaryBucket helper that honors the gossip budget', () => {
+    expect(src).toMatch(/function\s+pickPrimaryBucket\(\s*buckets\s*,\s*\{\s*gossipAllowedToday\s*\}/);
+  });
+
+  it('prefers trade-offer tips over topic="trade" web tips on a tie (structured beats speculative)', () => {
+    // Inside pickPrimaryBucket the tie-breaker has to favor "trade:offer"
+    // so structured MFL-derived offers outrank owner speculation. This
+    // pins the comparator so a future refactor doesn't accidentally
+    // reverse it.
+    const pickFn = src.match(/function\s+pickPrimaryBucket[\s\S]+?\n\}\n/);
+    expect(pickFn).not.toBeNull();
+    const body = pickFn![0];
+    expect(body).toMatch(/a\.key\s*===\s*['"]trade:offer['"]/);
+    expect(body).toMatch(/return\s*-1/);
+  });
+
+  it('only considers gossip buckets when the gossip daily budget is still open', () => {
+    const pickFn = src.match(/function\s+pickPrimaryBucket[\s\S]+?\n\}\n/);
+    expect(pickFn).not.toBeNull();
+    expect(pickFn![0]).toMatch(/if\s*\(\s*!gossipAllowedToday\s*\)\s*return\s+null/);
+  });
+
+  it('batches tips FROM THE CHOSEN BUCKET ONLY (not the full freshTips list)', () => {
+    // The old code did `const batch = freshTips.slice(0, MAX_TIPS_PER_BATCH)`
+    // which blended every unrelated topic into one post. We now take the
+    // bucket's tips.
+    expect(src).not.toMatch(/const\s+batch\s*=\s*freshTips\.slice/);
+    expect(src).toMatch(/const\s+batch\s*=\s*primaryBucket\.tips\.slice/);
+  });
+
+  it('holds unused tips in Redis for the next cycle instead of DELing them', () => {
+    // The old drain was `redis.del(TIPS_QUEUE_KEY)` followed by DEL on
+    // first_tip_ts. We now RPUSH any leftover tips back so slow-news days
+    // can surface them later.
+    expect(src).toMatch(/const\s+unusedTips\s*=\s*freshTips\.filter/);
+    expect(src).toMatch(/redis\.rpush\(TIPS_QUEUE_KEY,\s*\.\.\.serialized\)/);
+  });
+
+  it('preserves the oldest leftover tip as the new first_tip_ts anchor', () => {
+    // Without this, the marinate gate would stay cleared after a partial
+    // drain and the next cycle would re-fire immediately.
+    expect(src).toMatch(/redis\.set\(FIRST_TIP_TS_KEY,\s*oldest\)/);
+  });
+});
+
+describe('rumor-scan LLM prompt — one topic only', () => {
+  const src = read('scripts/schefter-rumor-scan.mjs');
+
+  it('tells the LLM to stay on ONE TOPIC and refuses "meanwhile…" pivots', () => {
+    expect(src).toMatch(/ONE TOPIC ONLY/);
+    expect(src).toMatch(/No "meanwhile/);
+  });
+
+  it('caps post length at 1–2 sentences (down from 2–4)', () => {
+    // The HARD RULE 8 line is the authoritative cap; the trade-offer
+    // playbook must defer to it as well.
+    expect(src).toMatch(/Length:\s*1[–-]2 sentences/);
+    expect(src).toMatch(/1[–-]2 sentences TOTAL/);
+  });
+
+  it('does not retain the old "mixed batches" multi-topic rule', () => {
+    // The old rule 7 explicitly encouraged blending GroupMe + web tips
+    // across topics — incompatible with single-topic focus.
+    expect(src).not.toMatch(/It's okay for a single post to blend/);
+  });
+});
+
+describe('rumor-scan tip-page link — every post sends readers back to /tip', () => {
+  const src = read('scripts/schefter-rumor-scan.mjs');
+
+  it('defines the tip page path constant', () => {
+    expect(src).toMatch(/const\s+TIP_PAGE_PATH\s*=\s*['"]\/theleague\/schefter\/tip['"]/);
+  });
+
+  it('defines a user-facing CTA label', () => {
+    expect(src).toMatch(/const\s+TIP_PAGE_LINK_LABEL\s*=\s*['"]Got a tip\? Whisper to Schefter →['"]/);
+  });
+
+  it('derives an absolute tip-page URL from SCHEFTER_PUBLIC_BASE_URL (with sensible default)', () => {
+    expect(src).toMatch(/process\.env\.SCHEFTER_PUBLIC_BASE_URL/);
+    expect(src).toMatch(/mflfootballv2\.vercel\.app/);
+    expect(src).toMatch(/const\s+TIP_PAGE_ABSOLUTE_URL\s*=/);
+  });
+
+  it('attaches link + linkLabel to every feed post it generates', () => {
+    expect(src).toMatch(/link:\s*TIP_PAGE_PATH/);
+    expect(src).toMatch(/linkLabel:\s*TIP_PAGE_LINK_LABEL/);
+  });
+
+  it('appends the absolute tip-page URL to GroupMe posts', () => {
+    expect(src).toMatch(/const\s+groupMeText\s*=\s*`\$\{post\.body\}\\n\\nGot a tip\? \$\{TIP_PAGE_ABSOLUTE_URL\}`/);
+    // The GroupMe call must use groupMeText (not post.body) so the URL ships.
+    expect(src).toMatch(/await\s+postToGroupMe\(groupMeText\)/);
+    expect(src).not.toMatch(/await\s+postToGroupMe\(post\.body\)/);
+  });
+});

--- a/tests/schefter-rumor-topic-focus.test.ts
+++ b/tests/schefter-rumor-topic-focus.test.ts
@@ -51,7 +51,9 @@ describe('rumor-scan bucketing — one topic per post', () => {
   });
 
   it('defines a pickPrimaryBucket helper that honors the gossip budget', () => {
-    expect(src).toMatch(/function\s+pickPrimaryBucket\(\s*buckets\s*,\s*\{\s*gossipAllowedToday\s*\}/);
+    // Signature takes the buckets array plus an options object carrying
+    // the day's gossip-allowed flag (and now the cycle clock for age boost).
+    expect(src).toMatch(/function\s+pickPrimaryBucket\(\s*buckets\s*,\s*\{\s*gossipAllowedToday[^}]*\}/);
   });
 
   it('prefers trade-offer tips over topic="trade" web tips on a tie (structured beats speculative)', () => {
@@ -75,9 +77,10 @@ describe('rumor-scan bucketing — one topic per post', () => {
   it('batches tips FROM THE CHOSEN BUCKET ONLY (not the full freshTips list)', () => {
     // The old code did `const batch = freshTips.slice(0, MAX_TIPS_PER_BATCH)`
     // which blended every unrelated topic into one post. We now take the
-    // bucket's tips.
+    // bucket's tips. (The assignment may be a later `let`-based reassignment
+    // because the mailbag path rebinds `batch` without `const`.)
     expect(src).not.toMatch(/const\s+batch\s*=\s*freshTips\.slice/);
-    expect(src).toMatch(/const\s+batch\s*=\s*primaryBucket\.tips\.slice/);
+    expect(src).toMatch(/batch\s*=\s*primaryBucket\.tips\.slice/);
   });
 
   it('holds unused tips in Redis for the next cycle instead of DELing them', () => {
@@ -95,18 +98,18 @@ describe('rumor-scan bucketing — one topic per post', () => {
   });
 });
 
-describe('rumor-scan LLM prompt — one topic only', () => {
+describe('rumor-scan LLM prompt — one topic per beat', () => {
   const src = read('scripts/schefter-rumor-scan.mjs');
 
-  it('tells the LLM to stay on ONE TOPIC and refuses "meanwhile…" pivots', () => {
-    expect(src).toMatch(/ONE TOPIC ONLY/);
+  it('tells the LLM to stay on ONE TOPIC per beat and refuses "meanwhile…" pivots', () => {
+    expect(src).toMatch(/ONE TOPIC per beat/);
     expect(src).toMatch(/No "meanwhile/);
   });
 
-  it('caps post length at 1–2 sentences (down from 2–4)', () => {
-    // The HARD RULE 8 line is the authoritative cap; the trade-offer
-    // playbook must defer to it as well.
-    expect(src).toMatch(/Length:\s*1[–-]2 sentences/);
+  it('caps post length at 1–2 sentences per beat', () => {
+    // HARD RULE 8 is the authoritative cap; the trade-offer playbook
+    // must defer to it as well.
+    expect(src).toMatch(/Length:\s*1[–-]2 sentences per beat/);
     expect(src).toMatch(/1[–-]2 sentences TOTAL/);
   });
 
@@ -146,3 +149,171 @@ describe('rumor-scan tip-page link — every post sends readers back to /tip', (
     expect(src).not.toMatch(/await\s+postToGroupMe\(post\.body\)/);
   });
 });
+
+describe('rumor-scan queue TTL — tips survive a full week', () => {
+  const src = read('scripts/schefter-rumor-scan.mjs');
+
+  it('keeps tips alive for 7 days so the queue can ride a slow news cycle', () => {
+    expect(src).toMatch(/const\s+TIP_EXPIRY_MS\s*=\s*7\s*\*\s*24\s*\*\s*60\s*\*\s*60\s*\*\s*1000/);
+  });
+
+  it('defines a 3-day staleness threshold for age-aware voice', () => {
+    expect(src).toMatch(/const\s+TIP_STALE_THRESHOLD_MS\s*=\s*3\s*\*\s*24\s*\*\s*60\s*\*\s*60\s*\*\s*1000/);
+  });
+});
+
+describe('rumor-scan age metadata — tips carry ageDays + isStale to the LLM', () => {
+  const src = read('scripts/schefter-rumor-scan.mjs');
+
+  it('surfaces ageDays on every anonymized tip', () => {
+    expect(src).toMatch(/ageDays,/);
+  });
+
+  it('surfaces an isStale flag for tips ≥ 3 days old', () => {
+    expect(src).toMatch(/isStale:\s*ageMs\s*>=\s*TIP_STALE_THRESHOLD_MS/);
+  });
+
+  it('passes now into anonymizeTips so age is computed against the cycle clock', () => {
+    expect(src).toMatch(/anonymizeTips\(batch,\s*teams,\s*feedForAnonymize\.posts[^,]*,\s*now\)/);
+  });
+});
+
+describe('rumor-scan LLM — age-aware framing rule', () => {
+  const src = read('scripts/schefter-rumor-scan.mjs');
+
+  it('requires age-reference or hedge phrasing on stale tips (HARD RULE 17)', () => {
+    expect(src).toMatch(/17\.\s*AGE-AWARE FRAMING/);
+    expect(src).toMatch(/NEVER claim a stale tip is fresh/);
+    expect(src).toMatch(/still hearing about/);
+  });
+
+  it('forbids inventing specific calendar labels (only relative phrasing allowed)', () => {
+    expect(src).toMatch(/Never invent a specific date the tip doesn't have/);
+  });
+});
+
+describe('rumor-scan bucket priority — age boost so old tips rise', () => {
+  const src = read('scripts/schefter-rumor-scan.mjs');
+
+  it('exposes a bucketPriorityScore helper that adds a per-day age boost', () => {
+    expect(src).toMatch(/function\s+bucketPriorityScore\(/);
+    expect(src).toMatch(/oldestAgeDays/);
+    expect(src).toMatch(/return\s+sizeScore\s*\+\s*oldestAgeDays/);
+  });
+
+  it('sorts both trade and gossip buckets by bucketPriorityScore (descending)', () => {
+    const pickFn = src.match(/function\s+pickPrimaryBucket[\s\S]+?\n\}\n/);
+    expect(pickFn).not.toBeNull();
+    const body = pickFn![0];
+    // Used in both the trade-branch and the gossip-branch sort comparators.
+    const scoreCalls = body.match(/bucketPriorityScore\(/g) ?? [];
+    expect(scoreCalls.length).toBeGreaterThanOrEqual(4);
+  });
+});
+
+describe('rumor-scan two-beat gossip — second bucket rides along', () => {
+  const src = read('scripts/schefter-rumor-scan.mjs');
+
+  it('pickPrimaryBucket returns {primary, secondary} so gossip posts can carry two beats', () => {
+    const pickFn = src.match(/function\s+pickPrimaryBucket[\s\S]+?\n\}\n/);
+    expect(pickFn).not.toBeNull();
+    expect(pickFn![0]).toMatch(/return\s*\{\s*primary:[^,]+,\s*secondary/);
+  });
+
+  it('trade-rumor posts never carry a secondary beat (stays strictly one-topic)', () => {
+    const pickFn = src.match(/function\s+pickPrimaryBucket[\s\S]+?\n\}\n/);
+    expect(pickFn).not.toBeNull();
+    // Trade-branch returns secondary: null explicitly.
+    expect(pickFn![0]).toMatch(/primary:\s*tradeBuckets\[0\],\s*secondary:\s*null/);
+  });
+
+  it('main flow only stitches a secondary into gossip posts (never trade)', () => {
+    expect(src).toMatch(/if\s*\(postKind\s*===\s*['"]gossip['"]\s*&&\s*secondaryBucket\)/);
+  });
+
+  it('HARD RULE 18 enforces two short beats with line-break separator', () => {
+    expect(src).toMatch(/18\.\s*TWO-BEAT GOSSIP POSTS/);
+    expect(src).toMatch(/Separate the beats with a line break/);
+  });
+
+  it('passes secondary tips to the LLM via the two-beat user prompt', () => {
+    expect(src).toMatch(/mode:\s*aiMode/);
+    expect(src).toMatch(/secondaryAnonymized/);
+    expect(src).toMatch(/PRIMARY_TIPS/);
+    expect(src).toMatch(/SECONDARY_TIPS/);
+  });
+
+  it('counts a two-beat gossip post as ONE post against the daily caps', () => {
+    // newCount increments once per cycle; the gossip counter also only
+    // increments once when postKind === 'gossip'. No per-beat doubling.
+    const incrCount = (src.match(/redis\.incr\(RUMOR_POSTS_TODAY_KEY\)/g) ?? []).length;
+    expect(incrCount).toBe(1);
+    const gossipIncr = (src.match(/redis\.incr\(RUMOR_GOSSIP_POSTS_TODAY_KEY\)/g) ?? []).length;
+    expect(gossipIncr).toBe(1);
+  });
+});
+
+describe('rumor-scan adaptive gossip cap — bumps to 2 when queue piles up', () => {
+  const src = read('scripts/schefter-rumor-scan.mjs');
+
+  it('defines a base cap of 1 and an adaptive cap of 2', () => {
+    expect(src).toMatch(/const\s+MAX_GOSSIP_POSTS_PER_DAY\s*=\s*1\b/);
+    expect(src).toMatch(/const\s+MAX_GOSSIP_POSTS_PER_DAY_ADAPTIVE\s*=\s*2\b/);
+  });
+
+  it('defines the trigger thresholds (queue depth + oldest-tip age)', () => {
+    expect(src).toMatch(/const\s+GOSSIP_BOOST_QUEUE_DEPTH\s*=\s*6\b/);
+    expect(src).toMatch(/const\s+GOSSIP_BOOST_TIP_AGE_MS\s*=\s*3\s*\*\s*24\s*\*\s*60\s*\*\s*60\s*\*\s*1000/);
+  });
+
+  it('exports a computeAdaptiveGossipCap helper that returns {cap, reason}', () => {
+    expect(src).toMatch(/function\s+computeAdaptiveGossipCap\(/);
+    expect(src).toMatch(/return\s*\{\s*cap:\s*MAX_GOSSIP_POSTS_PER_DAY_ADAPTIVE/);
+    expect(src).toMatch(/return\s*\{\s*cap:\s*MAX_GOSSIP_POSTS_PER_DAY,\s*reason:\s*['"]default['"]/);
+  });
+
+  it('main() uses the adaptive cap value (not the hard-coded base) for the gate check', () => {
+    expect(src).toMatch(/gossipAllowedToday\s*=\s*gossipToday\s*<\s*adaptiveGossipCap/);
+  });
+});
+
+describe('rumor-scan Friday mailbag — once-a-week sweep of pending gossip', () => {
+  const src = read('scripts/schefter-rumor-scan.mjs');
+
+  it('defines the mailbag done-date key and weekday index', () => {
+    expect(src).toMatch(/const\s+FRIDAY_MAILBAG_DONE_KEY\s*=\s*['"]schefter:mailbag:done_date['"]/);
+    expect(src).toMatch(/const\s+FRIDAY_WEEKDAY_INDEX\s*=\s*5/);
+  });
+
+  it('exports an isFridayPt helper keyed to America/Los_Angeles', () => {
+    expect(src).toMatch(/function\s+isFridayPt\(/);
+    expect(src).toMatch(/timeZone:\s*['"]America\/Los_Angeles['"]/);
+  });
+
+  it('main() runs the mailbag at most once per Friday PT (short-circuits on stored date)', () => {
+    expect(src).toMatch(/if\s*\(isFridayPt\(now\)\)/);
+    expect(src).toMatch(/mailbagDoneDate\s*===\s*todayPtDate/);
+  });
+
+  it('mailbag sweeps the entire gossip pool (up to MAX_TIPS_PER_BATCH)', () => {
+    expect(src).toMatch(/gossipPool\s*=\s*freshTips\.filter\(\(t\)\s*=>\s*classifyTipKind\(t\)\s*===\s*['"]gossip['"]\)/);
+    expect(src).toMatch(/mailbagBatch\s*=\s*gossipPool\.slice\(0,\s*MAX_TIPS_PER_BATCH\)/);
+  });
+
+  it('stamps FRIDAY_MAILBAG_DONE_KEY after a successful mailbag post', () => {
+    expect(src).toMatch(/redis\.set\(FRIDAY_MAILBAG_DONE_KEY,\s*todayPtDate/);
+  });
+
+  it('HARD RULE 19 prescribes bullet-style mailbag voice and caps length', () => {
+    expect(src).toMatch(/19\.\s*MAILBAG POSTS/);
+    expect(src).toMatch(/bullet-style one-liners/);
+    expect(src).toMatch(/Length cap:\s*180 words/);
+  });
+
+  it('user-prompt mode is "mailbag" on Friday mailbag cycles', () => {
+    expect(src).toMatch(/const\s+aiMode\s*=\s*postKind\s*===\s*['"]mailbag['"]/);
+    expect(src).toMatch(/if\s*\(mode\s*===\s*['"]mailbag['"]\)/);
+    expect(src).toMatch(/GOSSIP_TIPS:/);
+  });
+});
+

--- a/tests/schefter-rumor-topic-focus.test.ts
+++ b/tests/schefter-rumor-topic-focus.test.ts
@@ -128,9 +128,9 @@ describe('rumor-scan tip-page link — every post sends readers back to /tip', (
     expect(src).toMatch(/const\s+TIP_PAGE_LINK_LABEL\s*=\s*['"]Got a tip\? Whisper to Schefter →['"]/);
   });
 
-  it('derives an absolute tip-page URL from SCHEFTER_PUBLIC_BASE_URL (with sensible default)', () => {
+  it('derives an absolute tip-page URL from SCHEFTER_PUBLIC_BASE_URL (defaults to theleague.us)', () => {
     expect(src).toMatch(/process\.env\.SCHEFTER_PUBLIC_BASE_URL/);
-    expect(src).toMatch(/mflfootballv2\.vercel\.app/);
+    expect(src).toMatch(/https:\/\/theleague\.us/);
     expect(src).toMatch(/const\s+TIP_PAGE_ABSOLUTE_URL\s*=/);
   });
 

--- a/tests/schefter-rumor-topic-focus.test.ts
+++ b/tests/schefter-rumor-topic-focus.test.ts
@@ -120,8 +120,8 @@ describe('rumor-scan LLM prompt — one topic only', () => {
 describe('rumor-scan tip-page link — every post sends readers back to /tip', () => {
   const src = read('scripts/schefter-rumor-scan.mjs');
 
-  it('defines the tip page path constant', () => {
-    expect(src).toMatch(/const\s+TIP_PAGE_PATH\s*=\s*['"]\/theleague\/schefter\/tip['"]/);
+  it('defines the tip page path constant (canonical /schefter/tip on theleague.us)', () => {
+    expect(src).toMatch(/const\s+TIP_PAGE_PATH\s*=\s*['"]\/schefter\/tip['"]/);
   });
 
   it('defines a user-facing CTA label', () => {

--- a/tests/schefter-scanner-ordering.test.ts
+++ b/tests/schefter-scanner-ordering.test.ts
@@ -60,14 +60,13 @@ describe('schefter-rumor-scan.mjs — main rumor-mill ordering', () => {
   it('writes the feed to disk BEFORE posting to GroupMe (live path)', () => {
     // Feed-first is the invariant. The main rumor-mill post pipeline already
     // honored this; pinning it ensures future refactors don't swap the order.
-    // GroupMe text now includes a tip-page URL appended to post.body, so we
-    // match the live-call variable (groupMeText) instead of the old literal.
+    // Each beat ships its own GroupMe message via groupMeTextFor(builtPosts[i]).
     //
-    // The DRY_RUN block also calls postToGroupMe(groupMeText), so `indexOf`
-    // alone would land on the dry-run call. Use `lastIndexOf` to land on the
-    // live call and assert the feed write precedes it.
+    // The DRY_RUN block also calls postToGroupMe, so `indexOf` alone would
+    // land on the dry-run call. Use `lastIndexOf` to land on the live call
+    // and assert the feed write precedes it.
     const writeIdx = src.indexOf('await fs.writeFile(FEED_PATH');
-    const groupMeIdx = src.lastIndexOf('await postToGroupMe(groupMeText)');
+    const groupMeIdx = src.lastIndexOf('await postToGroupMe(groupMeTextFor(builtPosts[i])');
     expect(writeIdx).toBeGreaterThan(-1);
     expect(groupMeIdx).toBeGreaterThan(-1);
     expect(writeIdx).toBeLessThan(groupMeIdx);

--- a/tests/schefter-scanner-ordering.test.ts
+++ b/tests/schefter-scanner-ordering.test.ts
@@ -57,11 +57,17 @@ describe('schefter-scan.mjs — scanPendingTrades feed-vs-GroupMe ordering', () 
 describe('schefter-rumor-scan.mjs — main rumor-mill ordering', () => {
   const src = read('scripts/schefter-rumor-scan.mjs');
 
-  it('writes the feed to disk BEFORE posting to GroupMe', () => {
+  it('writes the feed to disk BEFORE posting to GroupMe (live path)', () => {
     // Feed-first is the invariant. The main rumor-mill post pipeline already
     // honored this; pinning it ensures future refactors don't swap the order.
+    // GroupMe text now includes a tip-page URL appended to post.body, so we
+    // match the live-call variable (groupMeText) instead of the old literal.
+    //
+    // The DRY_RUN block also calls postToGroupMe(groupMeText), so `indexOf`
+    // alone would land on the dry-run call. Use `lastIndexOf` to land on the
+    // live call and assert the feed write precedes it.
     const writeIdx = src.indexOf('await fs.writeFile(FEED_PATH');
-    const groupMeIdx = src.indexOf('await postToGroupMe(post.body)');
+    const groupMeIdx = src.lastIndexOf('await postToGroupMe(groupMeText)');
     expect(writeIdx).toBeGreaterThan(-1);
     expect(groupMeIdx).toBeGreaterThan(-1);
     expect(writeIdx).toBeLessThan(groupMeIdx);

--- a/tests/schefter-whisper-back.test.ts
+++ b/tests/schefter-whisper-back.test.ts
@@ -90,7 +90,9 @@ describe('Phase 7 — scanner thread persistence', () => {
 
   it('records thread_of mapping for both parent and new post', () => {
     expect(scanner).toMatch(/thread_of:\$\{dominantParentId\}/);
-    expect(scanner).toMatch(/thread_of:\$\{post\.id\}/);
+    // Loop variable is `p` now (we iterate over builtPosts per beat), but
+    // the key shape is the same: `thread_of:${postId}`.
+    expect(scanner).toMatch(/thread_of:\$\{(?:post|p)\.id\}/);
   });
 
   it('tells the LLM to open with continuity language when a threadFollowup is present', () => {


### PR DESCRIPTION
End-to-end overhaul of the rumor-mill scanner so owner tips get reported
more reliably (target: ≥90% within a week) while keeping posts tight and
on-topic.

## What changes

### One topic per post
The scanner used to synthesize the entire tip queue into a single 2–4
sentence post that blended up to three unrelated subjects. Now every
post covers **one topic**, picked via a bucketing pass:

1. **Trade rumors first** (`source === 'trade_offer'` OR `topic === 'trade'`)
2. **Multi-tip gossip clusters** (largest bucket wins; age-boosted)
3. **Oldest gossip singleton** when nothing else qualifies

Scoring: `bucketPriorityScore = (size - 1) * 2 + oldestAgeDays`. Clusters
normally beat singletons, but a 5-day-old singleton (score 5) overtakes
a fresh 2-tip cluster (score 2) so near-expiry tips rise naturally.

### Tips page link on every post
- Feed card: `post.link = /schefter/tip` + `linkLabel = "Got a tip? Whisper to Schefter →"` (rendered as a CTA under the body via SchefterPostCard).
- GroupMe: body + absolute URL (`https://theleague.us/schefter/tip`) appended on its own line.
- Base URL overridable via `SCHEFTER_PUBLIC_BASE_URL`.

### 7-day queue TTL + age-aware voice
- `TIP_EXPIRY_MS`: 24h → 7d. Tips survive a full week in Redis so slow-news days can clear the backlog.
- Every anonymized tip carries `ageDays` + `isStale` (true at 3+ days).
- **HARD RULE 17** requires Schefter to either reference when the whisper started ("the chatter that started earlier this week…") or hedge ("still hearing about…") on stale tips. Calendar labels banned; only relative phrasing.

### Two independent posts on pile-up
When the gossip queue is genuinely deep, the scanner ships a **second independent feed post** in the same cycle — separate post ID, reactions, comments, and whisper-back thread. Both posts share one cap slot (posts_today and gossip_posts_today each INCR once).

The double-post is gated on real pressure, not default cadence:
- `SECONDARY_GOSSIP_POST_PRESSURE = 4` — gossip queue depth must be ≥ 4 for the second post to fire.
- Below the threshold the second bucket waits for the next cycle.

Behavioral matrix:
| Gossip tips queued | Distinct buckets | Ships |
|---|---|---|
| 2 | 2 | 1 post (holds secondary) |
| 3 | 2 | 1 post (holds secondary) |
| 4 | 2 | **2 posts** |
| 5 | 3 | 2 posts (holds 3rd) |
| 4 | 1 | 1 post (no secondary exists) |

### Adaptive gossip cap
`computeAdaptiveGossipCap` bumps the daily gossip cap from **1 → 2** when:
- gossip queue depth ≥ 6, OR
- oldest gossip tip ≥ 3 days old

Quiet weeks stay at 1/day. Loud weeks self-regulate at 2/day.

### Friday mailbag
On Friday PT, once per day, the scanner runs a special **mailbag** path
that sweeps every queued gossip tip into one bullet-style roundup post
(HARD RULE 18, ≤180 words, up to 6 bullets). Guarantees no tip expires
unseen. Stamped via `schefter:mailbag:done_date` with a 48h TTL.

### Daily caps
- `MAX_POSTS_PER_DAY = 3` (unchanged — trade rumors + gossip share these slots)
- `MAX_GOSSIP_POSTS_PER_DAY = 1` default, `MAX_GOSSIP_POSTS_PER_DAY_ADAPTIVE = 2` on pile-up weeks

### Partial queue drain
Queue was fully DEL'd after every post. Now only tips from the chosen
bucket(s) are drained; leftovers are RPUSH'd back with `first_tip_ts`
re-anchored at the oldest survivor so the marinate gate stays accurate.

## Tests

- `tests/schefter-rumor-topic-focus.test.ts` — **57 source-level invariants** covering bucket helpers, tie-breakers, queue preservation, TTL, age metadata + rule, two-independent-posts wiring, adaptive cap thresholds, Friday mailbag path, tip-page link in feed + GroupMe, pressure-gate.
- `tests/schefter-scanner-ordering.test.ts` — updated to match new `groupMeTextFor(builtPosts[i])` call site while keeping the feed-before-GroupMe invariant.
- `tests/schefter-whisper-back.test.ts` — relaxed `thread_of` regex to accept the new per-post loop variable.

All **335 schefter tests pass**.

## Commits

1. `feat(schefter): one topic per rumor post, gossip rationed, tips-page link`
2. `chore(schefter): default public base URL to https://theleague.us`
3. `chore(schefter): drop /theleague prefix from tip-page link`
4. `chore(schefter): MAX_POSTS_PER_DAY back to 3`
5. `feat(schefter): 7d tip TTL, age-aware voice, two-beat gossip, adaptive cap, Friday mailbag`
6. `feat(schefter): ship two-beat gossip as two independent feed posts`
7. `feat(schefter): gate two-post gossip on real pile-up pressure`

## Deploy notes

- The 24h→7d TTL bump means any tips currently sitting in Redis that you thought would expire tonight will now hang around for a week. Harmless for fresh queues.
- Queue rewrite on partial drain has a minor race window (DEL → RPUSH non-atomic) — fine at 15 min cadence.
- First Friday after deploy: mailbag path fires — spot-check the bullet formatting.
- First two-post gossip cycle: confirm both GroupMe messages land with independent reactions on theleague.us.

https://claude.ai/code/session_01BoG6jXhTw6QLStY1Lsbjbg