### PR TITLE
fix(schefter): trade rumors are gossip, split bucket by scope, redact franchise names from tip text

### DIFF
--- a/scripts/schefter-rumor-scan.mjs
+++ b/scripts/schefter-rumor-scan.mjs
@@ -34,16 +34,29 @@
  *   6. If chosen bucket is "gossip", schefter:rumor:gossip_posts_today < adaptive cap
  *
  * Topic-bucket priority (bucketPriorityScore = (size - 1) * 2 + oldest-age-in-days):
- *   a. Trade rumors (trade_offer source OR topic === "trade")
- *   b. Gossip buckets — largest/oldest wins. When a second distinct gossip
- *      bucket exists AND the gossip queue has piled up to at least
- *      SECONDARY_GOSSIP_POST_PRESSURE tips, it ships as its OWN independent
- *      feed post in the same cycle (separate post id, reactions, comments,
- *      whisper-back thread), with both posts sharing one cap slot. Below
- *      that threshold the second bucket waits for the next cycle — the
- *      quick-double-post is a catch-up mechanism for 2+ days of pile-up,
- *      not a default cadence.
+ *   a. Trade-offer bucket — actual MFL pending offers (source === "trade_offer").
+ *      This is the only "trade" lane. Web/groupme tips with topic === "trade"
+ *      are speculation, not confirmed offers — they ride the gossip lane.
+ *   b. Gossip buckets — largest/oldest wins. Gossip covers commish, roster,
+ *      prediction, "other", AND web/groupme trade-rumor speculation. When
+ *      a second distinct gossip bucket exists AND the gossip queue has
+ *      piled up to at least SECONDARY_GOSSIP_POST_PRESSURE tips, it ships
+ *      as its OWN independent feed post in the same cycle (separate post
+ *      id, reactions, comments, whisper-back thread), with both posts
+ *      sharing one cap slot. Below that threshold the second bucket waits
+ *      for the next cycle — the quick-double-post is a catch-up mechanism
+ *      for 2+ days of pile-up, not a default cadence.
  *   c. Oldest gossip singleton if nothing else qualifies
+ *
+ * Web/groupme bucket key is `topic:<topic>:<franchiseHint || "league-wide">`
+ * so two trade-rumor tips with different scopes (one named-franchise, one
+ * league-wide) split into separate buckets and ship as separate posts.
+ *
+ * Anonymization redacts franchise-name mentions from raw tip `text` when
+ * the scope is fuzzed (single-source franchise → division, league-wide,
+ * commish). The tipster could type "the Geeks are looking for an RB" but
+ * the LLM sees "[a team] are looking for an RB" — anonymity by deletion,
+ * not by polite request.
  *
  * Special paths:
  *   - Friday mailbag: on Friday PT, once per day, sweeps ALL gossip tips
@@ -288,6 +301,57 @@ function pickTeamName(team) {
   return team.nameShort || team.nameMedium || team.name || null;
 }
 
+/**
+ * Build a list of all known franchise-name tokens (long/medium/short/abbrev)
+ * across the teams map. Used to redact franchise mentions from tip text
+ * when the tip's scope has been fuzzed away from naming a specific franchise.
+ *
+ * Keeps tokens length-sorted descending so a regex alternation matches the
+ * longest form first (e.g. "Nashville Geeks" wins over "Geeks").
+ */
+function collectFranchiseNameTokens(teams) {
+  const tokens = new Set();
+  for (const team of teams.values()) {
+    for (const field of ['name', 'nameMedium', 'nameShort', 'abbrev']) {
+      const v = team?.[field];
+      if (typeof v === 'string' && v.trim().length >= 2) {
+        tokens.add(v.trim());
+      }
+    }
+  }
+  return [...tokens].sort((a, b) => b.length - a.length);
+}
+
+function escapeRegExp(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Redact franchise-name mentions from anonymized tip text.
+ *
+ * The safe.scope guides what stays:
+ *   - kind === 'franchise-multi-source' → keep ONLY the named franchise
+ *     (HARD RULE 4 lets Schefter name it), redact every other team
+ *   - kind === 'division' / 'commish' / 'league-wide' → redact every team
+ *
+ * Matches are case-insensitive with word boundaries. Replaces with
+ * "[a team]" so the LLM literally cannot leak a name even if the tipster
+ * typed one in the raw text. Returns the redacted string (no mutation).
+ */
+function redactFranchiseNamesInText(text, teams, { keepFranchise } = {}) {
+  if (typeof text !== 'string' || text.length === 0) return text;
+  const tokens = collectFranchiseNameTokens(teams);
+  if (tokens.length === 0) return text;
+  const keepLower = typeof keepFranchise === 'string' ? keepFranchise.toLowerCase() : null;
+  let out = text;
+  for (const token of tokens) {
+    if (keepLower && token.toLowerCase() === keepLower) continue;
+    const re = new RegExp(`\\b${escapeRegExp(token)}\\b`, 'gi');
+    out = out.replace(re, '[a team]');
+  }
+  return out;
+}
+
 // ── GroupMe ──
 
 async function postToGroupMe(text) {
@@ -502,6 +566,16 @@ function anonymizeTips(tips, teams, feedPosts = [], now = new Date()) {
       safe.intraDivision = true;
     }
 
+    // Text redaction — strip franchise mentions from `text` so the LLM can't
+    // leak a name even when the tipster typed one in. Multi-source scope
+    // keeps the named franchise (HARD RULE 4 lets Schefter use it); every
+    // other scope fuzzes to "[a team]" for ALL franchise names. GroupMe and
+    // trade_offer paths returned earlier and bypass this block.
+    const keepFranchise = safe.scope?.kind === 'franchise-multi-source'
+      ? safe.scope.franchise
+      : null;
+    safe.text = redactFranchiseNamesInText(safe.text, teams, { keepFranchise });
+
     return safe;
   });
 }
@@ -510,28 +584,33 @@ function anonymizeTips(tips, teams, feedPosts = [], now = new Date()) {
 
 /**
  * Classify each tip into a "kind" that drives daily-cap accounting.
- *   - trade  : source === 'trade_offer' OR topic === 'trade'
- *   - gossip : everything else (commish beef, predictions, roster gripes,
- *              off-topic shots, GroupMe riffs). Rationed to 1 post/day.
+ *   - trade  : source === 'trade_offer' ONLY. Real MFL pending offers are
+ *              the trade-rumor headline material — they get priority over
+ *              every other bucket and aren't subject to the gossip cap.
+ *   - gossip : everything else, INCLUDING web/groupme tips with topic === 'trade'.
+ *              An owner saying "I think the Geeks are looking for an RB" is
+ *              speculation, not a confirmed offer — it rides the gossip lane
+ *              with commish beef, roster gripes, and predictions, and is
+ *              subject to MAX_GOSSIP_POSTS_PER_DAY (adaptive).
  */
 function classifyTipKind(tip) {
   if (!tip) return 'gossip';
   if (tip.source === 'trade_offer') return 'trade';
-  if (tip.topic === 'trade') return 'trade';
   return 'gossip';
 }
 
 /**
  * Group tips into single-topic buckets. Bucket keys:
- *   - trade_offer tips         → 'trade:offer'
- *   - web/groupme trade tips   → 'trade:web'
- *   - whisper-back followups   → 'thread:<parentPostId>'
- *   - everything else          → 'topic:<topic>' (commish / roster / prediction / other)
+ *   - trade_offer tips           → 'trade:offer'
+ *   - whisper-back followups     → 'thread:<parentPostId>'
+ *   - web/groupme tips           → 'topic:<topic>:<scope>'
  *
- * Trade-offer tips and web trade tips land in separate buckets because they
- * read as different stories even though both are trade rumors — we only want
- * one in a given post. When multiple trade buckets exist, the priority
- * selector prefers the larger one (ties broken by trade-offer > web).
+ * Web/groupme keys include the franchiseHint (or 'league-wide') as a
+ * scope discriminator so two `topic: 'trade'` tips from different sources
+ * (one about a specific franchise, one league-wide) don't collapse into
+ * a single combined post. Multi-source clustering still works: two
+ * tippers naming the SAME franchise on the SAME topic share a key and
+ * cluster correctly.
  */
 function buildTopicBuckets(tips) {
   const map = new Map();
@@ -539,12 +618,14 @@ function buildTopicBuckets(tips) {
     let key;
     if (tip.source === 'trade_offer') {
       key = 'trade:offer';
-    } else if (tip.topic === 'trade') {
-      key = 'trade:web';
     } else if (typeof tip.repliesToPostId === 'string' && tip.repliesToPostId.length > 0) {
       key = `thread:${tip.repliesToPostId}`;
     } else {
-      key = `topic:${tip.topic ?? 'other'}`;
+      const topic = tip.topic ?? 'other';
+      const scope = tip.franchiseHint && tip.franchiseHint !== 'league-wide'
+        ? tip.franchiseHint
+        : 'league-wide';
+      key = `topic:${topic}:${scope}`;
     }
     let bucket = map.get(key);
     if (!bucket) {
@@ -594,33 +675,29 @@ function bucketPriorityScore(bucket, now = new Date()) {
  * Pick the bucket(s) to post about this cycle.
  *
  * Priority order:
- *   1. Trade rumors — ranked by bucketPriorityScore (size + age boost). Ties
- *      prefer trade-offer over web-trade because trade-offer is structured
- *      data from MFL, less noisy than owner speculation.
- *   2. Gossip buckets with ≥2 tips (multi-tip topic clusters) — bucketPriorityScore ranks.
+ *   1. Trade-offer bucket — actual MFL pending offers. Always wins. Web/
+ *      groupme trade-rumor speculation does NOT live here — it rides the
+ *      gossip lane (see classifyTipKind).
+ *   2. Gossip buckets — bucketPriorityScore (size + age boost) ranks them.
+ *      Includes commish, roster, prediction, "other", AND web/groupme
+ *      trade rumor tips.
  *   3. Singleton gossip — returned when nothing else qualifies. Age boost
  *      means older singletons rise above newer ones naturally.
  *
  * For gossip posts we also return a SECONDARY bucket when one exists —
  * the caller ships the secondary as its OWN independent feed post so
  * each gossip topic has separate reactions and whisper-back threads.
- * Both posts consume exactly one slot from the daily cap. Trade-rumor
- * posts never carry a secondary (they stay strictly single-topic).
+ * Both posts consume exactly one slot from the daily cap. The trade-
+ * offer post never carries a secondary (single-topic only).
  *
  * Returns `{ primary, secondary }` or `null` when nothing qualifies.
  */
 function pickPrimaryBucket(buckets, { gossipAllowedToday, now = new Date() } = {}) {
   const tradeBuckets = buckets.filter((b) => b.kind === 'trade');
   if (tradeBuckets.length > 0) {
-    tradeBuckets.sort((a, b) => {
-      const sa = bucketPriorityScore(a, now);
-      const sb = bucketPriorityScore(b, now);
-      if (sb !== sa) return sb - sa;
-      // Prefer trade-offer over web-trade on ties
-      if (a.key === 'trade:offer' && b.key !== 'trade:offer') return -1;
-      if (b.key === 'trade:offer' && a.key !== 'trade:offer') return 1;
-      return 0;
-    });
+    // Only one bucket key (trade:offer) maps to kind === 'trade' under the
+    // new classification, but sort defensively in case that ever changes.
+    tradeBuckets.sort((a, b) => bucketPriorityScore(b, now) - bucketPriorityScore(a, now));
     return { primary: tradeBuckets[0], secondary: null };
   }
 

--- a/tests/schefter-rumor-topic-focus.test.ts
+++ b/tests/schefter-rumor-topic-focus.test.ts
@@ -56,16 +56,29 @@ describe('rumor-scan bucketing — one topic per post', () => {
     expect(src).toMatch(/function\s+pickPrimaryBucket\(\s*buckets\s*,\s*\{\s*gossipAllowedToday[^}]*\}/);
   });
 
-  it('prefers trade-offer tips over topic="trade" web tips on a tie (structured beats speculative)', () => {
-    // Inside pickPrimaryBucket the tie-breaker has to favor "trade:offer"
-    // so structured MFL-derived offers outrank owner speculation. This
-    // pins the comparator so a future refactor doesn't accidentally
-    // reverse it.
-    const pickFn = src.match(/function\s+pickPrimaryBucket[\s\S]+?\n\}\n/);
-    expect(pickFn).not.toBeNull();
-    const body = pickFn![0];
-    expect(body).toMatch(/a\.key\s*===\s*['"]trade:offer['"]/);
-    expect(body).toMatch(/return\s*-1/);
+  it('classifies ONLY trade_offer tips as the trade kind (web/groupme trade rumors are gossip)', () => {
+    // Real MFL pending offers are the trade-rumor headline material.
+    // Web/groupme tips with topic === 'trade' are speculation and ride
+    // the gossip lane subject to the gossip cap.
+    const fn = src.match(/function\s+classifyTipKind[\s\S]+?\n\}/);
+    expect(fn).not.toBeNull();
+    const body = fn![0];
+    expect(body).toMatch(/source\s*===\s*['"]trade_offer['"]\)\s*return\s+['"]trade['"]/);
+    // No fall-through that promotes topic === 'trade' to 'trade' kind.
+    expect(body).not.toMatch(/topic\s*===\s*['"]trade['"]\)\s*return\s+['"]trade['"]/);
+  });
+
+  it('web/groupme bucket key includes the franchise scope so different scopes split into separate posts', () => {
+    // Two `topic: 'trade'` web tips — one naming a franchise, one
+    // league-wide — must NOT collapse into one post. The key is
+    // `topic:<topic>:<franchiseHint || 'league-wide'>` so they bucket
+    // independently and ship as two separate posts (subject to the
+    // pressure gate).
+    const fn = src.match(/function\s+buildTopicBuckets[\s\S]+?\n\}/);
+    expect(fn).not.toBeNull();
+    const body = fn![0];
+    expect(body).toMatch(/key\s*=\s*`topic:\$\{topic\}:\$\{scope\}`/);
+    expect(body).toMatch(/scope\s*=\s*tip\.franchiseHint[\s\S]*?['"]league-wide['"]/);
   });
 
   it('only considers gossip buckets when the gossip daily budget is still open', () => {
@@ -156,6 +169,49 @@ describe('rumor-scan tip-page link — every post sends readers back to /tip', (
     expect(src).toMatch(/await\s+postToGroupMe\(groupMeTextFor\(builtPosts\[i\]\)\)/);
     // No raw-body GroupMe calls remain — every rumor post gets the CTA.
     expect(src).not.toMatch(/await\s+postToGroupMe\(post\.body\)/);
+  });
+});
+
+describe('rumor-scan text redaction — franchise names cannot leak through tip text', () => {
+  const src = read('scripts/schefter-rumor-scan.mjs');
+
+  it('exposes a redactFranchiseNamesInText helper', () => {
+    expect(src).toMatch(/function\s+redactFranchiseNamesInText\(/);
+  });
+
+  it('collects every franchise name form (long/medium/short/abbrev) for matching', () => {
+    expect(src).toMatch(/function\s+collectFranchiseNameTokens\(/);
+    const fn = src.match(/function\s+collectFranchiseNameTokens[\s\S]+?\n\}/);
+    expect(fn).not.toBeNull();
+    expect(fn![0]).toMatch(/['"]name['"],\s*['"]nameMedium['"],\s*['"]nameShort['"],\s*['"]abbrev['"]/);
+  });
+
+  it('replaces matched franchise names with a generic "[a team]" placeholder', () => {
+    const fn = src.match(/function\s+redactFranchiseNamesInText[\s\S]+?\n\}/);
+    expect(fn).not.toBeNull();
+    expect(fn![0]).toMatch(/replace\(re,\s*['"]\[a team\]['"]\)/);
+  });
+
+  it('keeps the named franchise on multi-source scope, redacts everything else', () => {
+    // The keepFranchise param lets HARD RULE 4's named-franchise stay
+    // while still scrubbing collateral mentions of OTHER teams.
+    const fn = src.match(/function\s+redactFranchiseNamesInText[\s\S]+?\n\}/);
+    expect(fn).not.toBeNull();
+    expect(fn![0]).toMatch(/keepFranchise/);
+  });
+
+  it('uses word-boundary case-insensitive regex (so "Geeks" matches but "geeky" does not)', () => {
+    const fn = src.match(/function\s+redactFranchiseNamesInText[\s\S]+?\n\}/);
+    expect(fn).not.toBeNull();
+    expect(fn![0]).toMatch(/new RegExp\(`\\\\b\$\{escapeRegExp\(token\)\}\\\\b`,\s*['"]gi['"]\)/);
+  });
+
+  it('runs redaction at the end of the web-tip anonymization path', () => {
+    // The keep-franchise lookup uses the just-set safe.scope so the
+    // multi-source named franchise survives while every other team
+    // gets stripped from the raw text the LLM sees.
+    expect(src).toMatch(/safe\.scope\?\.kind\s*===\s*['"]franchise-multi-source['"]/);
+    expect(src).toMatch(/safe\.text\s*=\s*redactFranchiseNamesInText\(safe\.text,\s*teams,/);
   });
 });
 


### PR DESCRIPTION
Three small bug fixes for the tip-post pipeline. All three surfaced when a user submitted two web tips ("Geeks looking for RB help in the draft" and "multiple teams will be looking to move up and down") and the scanner combined them into one post AND named the Geeks despite single-source scope — a HARD RULE 2 violation.

## Changes

### 1. `classifyTipKind` — only real offers are trade-tier
Web/groupme tips with `topic: 'trade'` used to be classified `trade` kind and skip the gossip cap. They're speculation, not confirmed offers — reclassified to `gossip` so they ride the gossip cap like everything else. Only `source === 'trade_offer'` (actual MFL pending offers) remains `trade`-tier and gets the priority lane.

### 2. Bucket key for web/groupme tips includes scope
Old key: `topic:<topic>` — two `topic: 'trade'` tips with different franchise scopes collapsed into one bucket and shipped as one blended post.

New key: `topic:<topic>:<franchiseHint || 'league-wide'>` — different scopes split into separate buckets. Multi-source clustering still works (two tippers naming the same franchise/topic share a key).

### 3. Redact franchise names from tip `text`
Anonymization fuzzes the `scope` field but left the raw `text` alone, so the LLM saw the tipster's verbatim franchise mention and leaked it despite HARD RULE 2.

New `redactFranchiseNamesInText()` helper strips every franchise name (long/medium/short/abbrev) from `text` whenever the scope was fuzzed. Replaces with `[a team]`. Multi-source scope (HARD RULE 4 lets Schefter use the name) keeps that one name and redacts only OTHER teams. Word-boundary case-insensitive — `Geeks` triggers, `geeky` doesn't.

## Behavioral check on the redaction helper

| Input | `keepFranchise` | Output |
|---|---|---|
| `the Geeks are zeroed in on RBs` | — | `the [a team] are zeroed in on RBs` |
| `the Geeks are zeroed in on RBs` | `Geeks` | `the Geeks are zeroed in on RBs` |
| `Magicians and Pigskins both want the same WR` | — | `[a team] and [a team] both want the same WR` |
| `NSH might be calling around` | — | `[a team] might be calling around` |
| `something geeky is happening` | — | unchanged (word boundary) |

## Tests

- 7 new source-level invariants in `tests/schefter-rumor-topic-focus.test.ts` covering the three changes (classifier output, bucket key shape, redaction helper tokens + replacement + keep-franchise + regex shape + invocation site).
- Updated existing tests that pinned the old behavior (`trade:offer` tiebreak comment removed; now-obsolete web-trade branch assertions replaced).
- **All 342 schefter tests pass.**

## Context

This branch is off the latest `main` (post PR #115 squash-merge and PR #116 out-of-bounds-tip fix). The `/schefter/tip` page and all the infrastructure from PR #115 is already live; this PR is just the three follow-up bug fixes.

https://claude.ai/code/session_01BoG6jXhTw6QLStY1Lsbjbg