### PR TITLE
fix: enable scroll within draft board on mobile

### DIFF
--- a/src/styles/draft-room.css
+++ b/src/styles/draft-room.css
@@ -2134,9 +2134,24 @@
 @media (max-width: 767px) {
   .dr-mobile-tabs { display: block; }
 
+  /* Board tab fills the remaining viewport and scrolls internally so all picks
+   * in the round are reachable. Without this, .dr-panel-board defaults to its
+   * content height while .draft-room clips overflow, so picks past the fold
+   * are unscrollable. */
   .draft-room[data-active-mobile-tab="board"] .dr-panel-board {
-    display: block;
-    flex: none;
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    min-height: 0;
+  }
+  .draft-room[data-active-mobile-tab="board"] .dr-board {
+    flex: 1;
+    min-height: 0;
+  }
+  .draft-room[data-active-mobile-tab="board"] .dr-board__scroll {
+    flex: 1;
+    min-height: 0;
+    -webkit-overflow-scrolling: touch;
   }
   .draft-room:not([data-active-mobile-tab="board"]) .dr-panel-board {
     display: none;


### PR DESCRIPTION
On mobile the board tab clipped picks past the fold because
.dr-panel-board sat at its content height while .draft-room had
overflow:hidden — there was no flex chain making .dr-board__scroll a
true scroll container. Make the board panel fill the remaining
viewport and propagate flex:1/min-height:0 down so the picks list
scrolls within the visible area.

https://claude.ai/code/session_019CCEsbmM3vskagxNNarpM6