### PR TITLE
fix: tidy draft + mock-draft mobile header and timer banner

### DIFF
--- a/src/components/theleague/Header.astro
+++ b/src/components/theleague/Header.astro
@@ -23,9 +23,11 @@ interface Props {
   year?: string | number;
   staticHost?: string;
   hideLeaguePrefix?: boolean;
+  hideMobileNavIcons?: boolean;
 }
 
 const hideLeaguePrefix = Astro.props.hideLeaguePrefix ?? false;
+const hideMobileNavIcons = Astro.props.hideMobileNavIcons ?? false;
 
 const envHost =
   (import.meta.env.PUBLIC_MFL_HOST as string | undefined) ||
@@ -118,7 +120,7 @@ const liveScoringUrl = `https://${league.host}/${year}/home/${league.leagueId}?M
       </div>
       <div class="col right">
         <!-- Desktop Navigation Icons -->
-        <nav class="desktop-nav" aria-label="Main navigation">
+        <nav class:list={["desktop-nav", { "desktop-nav--hide-mobile": hideMobileNavIcons }]} aria-label="Main navigation">
           {!isAFL && (
             <a href="/theleague/schefter/tip" class="nav-icon-link" title="Tip Schefter">
               <svg class="nav-icon" aria-hidden="true">
@@ -640,6 +642,19 @@ const liveScoringUrl = `https://${league.host}/${year}/home/${league.leagueId}?M
   @media (max-width: 960px) {
     .theleague-header {
       padding-bottom: 1rem;
+    }
+  }
+
+  /* Page-level opt-out: hide the horizontal nav-icon strip on mobile so
+   * dense pages (e.g. Draft Room, Mock Draft) get more vertical room. */
+  @media (max-width: 991px) {
+    .desktop-nav.desktop-nav--hide-mobile {
+      display: none;
+    }
+    /* Header collapses to a single tight row; no empty space below the logo. */
+    .theleague-header:has(.desktop-nav--hide-mobile) {
+      padding: 0.5rem 0;
+      margin-bottom: 0.75rem;
     }
   }
 

--- a/src/layouts/TheLeagueLayout.astro
+++ b/src/layouts/TheLeagueLayout.astro
@@ -37,9 +37,10 @@ export interface Props {
 	leagueId?: string;
 	year?: string | number;
 	staticHost?: string;
+	hideMobileNavIcons?: boolean;
 }
 
-const { title, host, leagueId, year, staticHost } = Astro.props as Props;
+const { title, host, leagueId, year, staticHost, hideMobileNavIcons } = Astro.props as Props;
 const navOpenCookie = Astro.cookies.get(NAV_COOKIES.NAV_OPEN);
 const shouldOpenOnDesktop = navOpenCookie?.value === 'true';
 
@@ -197,6 +198,7 @@ const sections = getVisibleSections(league, myteam, adminFranchiseIds);
 				year={year}
 				staticHost={staticHost}
 				hideLeaguePrefix={hideLeaguePrefix}
+				hideMobileNavIcons={hideMobileNavIcons}
 			/>
 			<main>
 				<slot />

--- a/src/pages/theleague/draft-room.astro
+++ b/src/pages/theleague/draft-room.astro
@@ -137,7 +137,7 @@ const pageData: DraftRoomPageData = {
 };
 ---
 
-<TheLeagueLayout title="Draft Room | The League">
+<TheLeagueLayout title="Draft Room | The League" hideMobileNavIcons>
   <DraftRoom
     client:load
     pageData={JSON.stringify(pageData)}

--- a/src/pages/theleague/mock-draft/[sessionId].astro
+++ b/src/pages/theleague/mock-draft/[sessionId].astro
@@ -76,7 +76,7 @@ const pageData: DraftRoomPageData = {
 };
 ---
 
-<TheLeagueLayout title="Mock Draft Room | The League">
+<TheLeagueLayout title="Mock Draft Room | The League" hideMobileNavIcons>
   <DraftRoom
     client:load
     pageData={JSON.stringify(pageData)}

--- a/src/styles/draft-room.css
+++ b/src/styles/draft-room.css
@@ -430,8 +430,34 @@
 }
 
 @media (max-width: 640px) {
-  .dr-team-avatar { width: 36px; height: 36px; }
+  /* Stack the banner so team identity + clock/actions never collide on
+   * narrow screens (especially in mock mode where 3 buttons share the row
+   * with the timer). */
+  .dr-timer-banner {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.5rem;
+    padding: 0.5rem 0.75rem;
+    min-height: var(--dr-timer-height-mobile);
+  }
+  .dr-timer-banner__team {
+    width: 100%;
+    gap: 0.5rem;
+  }
+  .dr-team-avatar { width: 32px; height: 32px; }
   .dr-team-name { font-size: 0.9375rem; }
+  .dr-team-eyebrow { font-size: 0.5625rem; }
+
+  .dr-timer-banner__meter {
+    width: 100%;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    row-gap: 0.375rem;
+  }
+  .dr-timer-banner__meter-text { text-align: left; }
+  .dr-timer-clock { font-size: var(--dr-timer-font-size-mobile); }
+  .dr-timer-banner__complete .dr-timer-clock { font-size: 1.125rem; }
 }
 
 /* ── Draft Board Header Toolbar ──


### PR DESCRIPTION
Mobile draft pages were showing the full nav-icon strip below the logo
and the timer banner squashed the team avatar/name into the clock and
mock-mode action buttons. Added a `hideMobileNavIcons` prop on
TheLeagueLayout/Header to drop the nav-icon row under 992px on the live
draft room and mock draft session room, and stacked
.dr-timer-banner on ≤640px so the team block sits cleanly above the
clock + actions row.