### PR TITLE
fix(schefter): never post reasoning; add self-deprecating + attack-back lanes

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "fetch:adp:ktc:sf": "node scripts/fetch-ktc-rookie-rankings.mjs --sf",
     "fetch:adp:rookies": "pnpm run fetch:adp:sleeper && pnpm run fetch:adp:ktc",
     "fetch:nfl-draft-date": "node scripts/fetch-nfl-draft-date.mjs",
+    "fetch:nfl-news-digest": "node scripts/fetch-nfl-news-digest.mjs",
     "fetch:trade-bait": "MFL_LEAGUE_ID=13522 MFL_LEAGUE_SLUG=theleague node scripts/fetch-trade-bait.mjs",
     "fetch:live:lineups": "node scripts/fetch-live-lineups.mjs",
     "fetch:live:odds": "node scripts/fetch-live-odds.mjs",

--- a/scripts/fetch-nfl-news-digest.mjs
+++ b/scripts/fetch-nfl-news-digest.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+/**
+ * Fetch a digest of recent NFL headlines from ESPN's news API.
+ *
+ * Writes the top ~20 headlines from the last 7 days to
+ * data/schefter/nfl-context.json. The Schefter rumor scanner reads this
+ * file and injects the headlines into the LLM system prompt as
+ * "CURRENT NFL CHATTER" so the bot can recognize and riff on real-world
+ * NFL storylines (e.g. coach/reporter scandals) when an owner's tip
+ * references them.
+ *
+ * The injection is context-only — the prompt instructs the model to
+ * IGNORE the digest unless a tip clearly maps to a current storyline.
+ * Forced topical references are worse than no reference.
+ *
+ * Endpoint:
+ *   https://site.api.espn.com/apis/site/v2/sports/football/nfl/news?limit=50
+ *
+ * Output schema:
+ *   {
+ *     fetchedAt: ISO8601,
+ *     windowDays: 7,
+ *     headlines: [{ title, blurb, publishedAt, source }]
+ *   }
+ *
+ * Safe on build: any failure leaves the existing file untouched and exits 0
+ * so the build pipeline is never blocked.
+ *
+ * Usage:
+ *   node scripts/fetch-nfl-news-digest.mjs
+ *   node scripts/fetch-nfl-news-digest.mjs --dry-run   # print, don't write
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const root = path.resolve(__dirname, '..');
+const OUTPUT = path.join(root, 'data/schefter/nfl-context.json');
+
+const ENDPOINT = 'https://site.api.espn.com/apis/site/v2/sports/football/nfl/news?limit=50';
+const WINDOW_DAYS = 7;
+const MAX_HEADLINES = 20;
+const BLURB_MAX = 200;
+
+const DRY_RUN = process.argv.includes('--dry-run');
+
+function trimBlurb(s) {
+  if (typeof s !== 'string') return '';
+  const collapsed = s.replace(/\s+/g, ' ').trim();
+  if (collapsed.length <= BLURB_MAX) return collapsed;
+  return collapsed.slice(0, BLURB_MAX - 1).trimEnd() + '…';
+}
+
+async function fetchNflNews() {
+  const res = await fetch(ENDPOINT, {
+    headers: { 'User-Agent': 'mfl-schefter-news-digest/1.0' },
+  });
+  if (!res.ok) throw new Error(`ESPN news ${res.status}`);
+  return res.json();
+}
+
+function selectHeadlines(payload) {
+  const articles = Array.isArray(payload?.articles) ? payload.articles : [];
+  const cutoff = Date.now() - WINDOW_DAYS * 24 * 60 * 60 * 1000;
+  return articles
+    .map((a) => {
+      const publishedAt = a.published || a.lastModified || null;
+      const ms = publishedAt ? Date.parse(publishedAt) : NaN;
+      return {
+        title: typeof a.headline === 'string' ? a.headline.trim() : '',
+        blurb: trimBlurb(a.description ?? ''),
+        publishedAt: publishedAt && !Number.isNaN(ms) ? new Date(ms).toISOString() : null,
+        source: 'ESPN',
+        _ms: ms,
+      };
+    })
+    .filter((h) => h.title && h.publishedAt && Number.isFinite(h._ms) && h._ms >= cutoff)
+    .sort((a, b) => b._ms - a._ms)
+    .slice(0, MAX_HEADLINES)
+    .map(({ _ms, ...rest }) => rest);
+}
+
+async function main() {
+  let payload;
+  try {
+    payload = await fetchNflNews();
+  } catch (err) {
+    console.error(`[nfl-news-digest] fetch failed: ${err.message} — leaving existing file untouched`);
+    process.exit(0);
+  }
+
+  const headlines = selectHeadlines(payload);
+  const out = {
+    fetchedAt: new Date().toISOString(),
+    windowDays: WINDOW_DAYS,
+    headlines,
+  };
+
+  if (DRY_RUN) {
+    console.log(JSON.stringify(out, null, 2));
+    return;
+  }
+
+  fs.mkdirSync(path.dirname(OUTPUT), { recursive: true });
+  fs.writeFileSync(OUTPUT, JSON.stringify(out, null, 2) + '\n');
+  console.log(`[nfl-news-digest] wrote ${headlines.length} headlines to ${path.relative(root, OUTPUT)}`);
+}
+
+main();

--- a/scripts/prebuild.mjs
+++ b/scripts/prebuild.mjs
@@ -27,6 +27,7 @@ const PARALLEL = [
   { name: 'fetch:trade-bait', cmd: 'pnpm run fetch:trade-bait' },
   { name: 'fetch:adp', cmd: 'pnpm run fetch:adp' },
   { name: 'fetch:nfl-draft-date', cmd: 'pnpm run fetch:nfl-draft-date' },
+  { name: 'fetch:nfl-news-digest', cmd: 'pnpm run fetch:nfl-news-digest' },
 ];
 
 const run = (label, cmd) => {

--- a/scripts/schefter-groupme-listen.mjs
+++ b/scripts/schefter-groupme-listen.mjs
@@ -350,6 +350,32 @@ export function detectAttackOnSchefter(rawText) {
 }
 
 /**
+ * Lighter-weight check: does the text mention Schefter at all (subject only,
+ * no pejorative requirement)? Used to route off-topic, Schefter-targeted
+ * tips into the self-deprecating / attack-back lane even when the joke
+ * doesn't include a flagged pejorative (e.g. "Claude was seen at a resort").
+ *
+ * Mirrors the subject-only half of detectAttackOnSchefter — same Roger
+ * disambiguation rule. Kept in lockstep with the TS sibling via the parity
+ * test in tests/schefter-attack-detection-parity.test.ts.
+ */
+export function mentionsSchefter(rawText) {
+  if (!rawText || typeof rawText !== 'string') return false;
+  const text = rawText.trim();
+  if (text.length < 5) return false;
+
+  const subjectMatch = ATTACK_SUBJECT_PATTERNS.some((re) => re.test(text));
+  if (!subjectMatch) return false;
+
+  const mentionsRoger = /\b(?:roger|ask\s+roger|the\s+roger\s+bot|roger's\s+bot)\b/i.test(text);
+  const explicitSchefterRef = /\b(?:claude|schefter|schefty)\b/i.test(text);
+  const mentionsGenericBot = /\b(?:the|this|that)\s+bot\b/i.test(text);
+  if (mentionsRoger && mentionsGenericBot && !explicitSchefterRef) return false;
+
+  return true;
+}
+
+/**
  * Normalize a GroupMe display name into a Redis-safe author key. Lowercases,
  * trims, and strips any non-alphanumeric characters. Keeps the ID readable
  * (no hashing) because GroupMe authorship is already public — the leaderboard

--- a/scripts/schefter-rumor-scan.mjs
+++ b/scripts/schefter-rumor-scan.mjs
@@ -76,7 +76,7 @@ import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createHash } from 'node:crypto';
-import { ingestGroupMeMentions, getLatestRogerQuote } from './schefter-groupme-listen.mjs';
+import { ingestGroupMeMentions, getLatestRogerQuote, mentionsSchefter } from './schefter-groupme-listen.mjs';
 import { redactTradeOffer, offerPostProbability } from './lib/redact-trade-offer.mjs';
 import {
   loadLore,
@@ -906,7 +906,144 @@ Example F — lingering named (framingHint=lingering, escalatedPlayer.tier=named
 `;
 }
 
-async function generateAiBody(anonymized, { rogerQuote, lore, recentPostsBlock, mode = 'single' } = {}) {
+// ── NFL news digest (option 2: pre-fetched headlines for prompt context) ──
+//
+// scripts/fetch-nfl-news-digest.mjs writes data/schefter/nfl-context.json
+// during prebuild and (optionally) hourly. The scanner reads it once per
+// cycle and injects the top headlines into the Schefter system prompt as
+// "CURRENT NFL CHATTER" so Schefter can recognize when a tip riffs on a
+// real-world storyline (e.g. coach/reporter scandals). The injection is
+// context-only — the prompt instructs the model to ignore the digest unless
+// a tip clearly maps to one of the headlines.
+
+const NFL_CONTEXT_PATH = path.join(projectRoot, 'data/schefter/nfl-context.json');
+const NFL_CONTEXT_MAX_HEADLINES = 12;
+
+async function loadNflContext() {
+  try {
+    const raw = await fs.readFile(NFL_CONTEXT_PATH, 'utf8');
+    const parsed = JSON.parse(raw);
+    const headlines = Array.isArray(parsed?.headlines) ? parsed.headlines : [];
+    if (headlines.length === 0) return null;
+    return { headlines, fetchedAt: parsed.fetchedAt ?? null };
+  } catch {
+    // No file or unreadable JSON — scanner runs without NFL context.
+    return null;
+  }
+}
+
+function buildNflContextBlock(ctx) {
+  if (!ctx || !Array.isArray(ctx.headlines) || ctx.headlines.length === 0) return '';
+  const lines = ctx.headlines.slice(0, NFL_CONTEXT_MAX_HEADLINES).map((h) => {
+    const blurb = typeof h.blurb === 'string' && h.blurb ? ` — ${h.blurb}` : '';
+    return `- ${h.title}${blurb}`;
+  });
+  return `\n\nCURRENT NFL CHATTER (last 7 days, context only — do NOT force-reference):
+${lines.join('\n')}
+
+Use this ONLY if a tip clearly maps to one of these storylines (e.g. an owner's joke is built on a real headline). A forced topical reference is worse than no reference. Default: ignore the digest unless the tip lights it up.`;
+}
+
+// ── AI output sanitization + JSON contract ──
+//
+// The LLM is asked to return strict JSON: {"post": "<string>"} or {"post": null}.
+// Plain-text output is tolerated as a fallback (we extract the first {...}
+// block). The `post` field then runs through META_COMMENTARY_PATTERNS — if
+// any pattern hits, we treat the response as a sanitizer-rejection and fall
+// back to the safe template body. This is the belt-and-suspenders fix for
+// the April 2026 incident where the model rationalized a drop decision into
+// the post body itself.
+
+const META_COMMENTARY_PATTERNS = [
+  /\biron\s+rules?\b/i,
+  /\b(silently\s+drop|gets\s+dropped|drop\s+this\s+one|need\s+to\s+drop)\b/i,
+  /\b(can'?t\s+be\s+filed|cannot\s+be\s+filed|fails?\s+any\s+rule)\b/i,
+  /\bhostile\s+personal\s+attack\b/i,
+  /\b(reading\s+this\s+tip|filing\s+decision|editorial\s+filter)\b/i,
+  /\bthis\s+tip\b/i,
+];
+
+export function sanitizeAiPost(text) {
+  if (typeof text !== 'string') return null;
+  const trimmed = text.trim();
+  if (!trimmed) return null;
+  for (const re of META_COMMENTARY_PATTERNS) {
+    if (re.test(trimmed)) return null;
+  }
+  return trimmed;
+}
+
+export function parseAiResponse(rawText) {
+  if (typeof rawText !== 'string') return null;
+  const text = rawText.trim();
+  if (!text) return null;
+  let parsed;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    // Tolerate fenced or wrapped JSON: extract the first {...} block.
+    const m = text.match(/\{[\s\S]*\}/);
+    if (!m) return null;
+    try { parsed = JSON.parse(m[0]); } catch { return null; }
+  }
+  if (parsed === null || typeof parsed !== 'object') return null;
+  const post = parsed.post;
+  if (post === null) return null; // explicit drop signal
+  if (typeof post !== 'string') return null;
+  return sanitizeAiPost(post);
+}
+
+// ── Schefter-targeted off-topic mode (self-deprecating vs attack-back) ──
+//
+// When a tip references Schefter himself with no league grievance (the
+// April 2026 "adults-only resort" pattern), drop directives get dangerous —
+// the model rationalizes its filtering into the post body. The lane below
+// gives the LLM a different action: own the joke (self-deprecating) or
+// occasionally file back on the source (attack-back). The 1-in-20 attack
+// cadence is GroupMe-only because anonymous web tips have no name to pin
+// the comeback on. The counter is year-scoped so it resets each league year.
+
+const SELF_DEP_COUNTER_TTL_SEC = 2 * 365 * 24 * 60 * 60; // 2y safety net; key includes year
+
+function selfDepCounterKey(year) {
+  return `schefter:self_dep:counter:${year}`;
+}
+
+export function pickSchefterTargetMode(counter) {
+  // Pure helper for tests. counter is the post-incr value.
+  // Every 20th GroupMe Schefter shot earns the attack-back; the rest are self-dep.
+  return counter > 0 && counter % 20 === 0 ? 'attack-back' : 'self-dep';
+}
+
+async function selectSchefterTargetMode(redis, beat, now = new Date()) {
+  if (!beat || !Array.isArray(beat.batch)) return null;
+  const groupmeHit = beat.batch.some(
+    (t) => t && t.source === 'groupme' && mentionsSchefter(t.text),
+  );
+  const webHit = beat.batch.some(
+    (t) => t && t.source === 'web' && mentionsSchefter(t.text),
+  );
+  if (!groupmeHit && !webHit) return null;
+
+  // Web tips ALWAYS get self-deprecating — no name to pin an attack-back on,
+  // and Style Book / A=C already cover the reverse-the-lens lane for them.
+  if (!groupmeHit) return 'self-dep';
+
+  // GroupMe Schefter shot: bump the year-scoped counter; every 20th lands attack-back.
+  if (!redis) return 'self-dep';
+  try {
+    const year = getSeasonYearForTipster(now);
+    const key = selfDepCounterKey(year);
+    const count = await redis.incr(key);
+    if (count === 1) await redis.expire(key, SELF_DEP_COUNTER_TTL_SEC);
+    return pickSchefterTargetMode(count);
+  } catch (err) {
+    warn(`  [rumor-scan] self-dep counter failed: ${err.message} — defaulting to self-dep`);
+    return 'self-dep';
+  }
+}
+
+async function generateAiBody(anonymized, { rogerQuote, lore, recentPostsBlock, mode = 'single', nflContext = null, schefterTargetMode = null } = {}) {
   const apiKey = process.env.ANTHROPIC_API_KEY;
   if (!apiKey) {
     warn('  [rumor-scan] ANTHROPIC_API_KEY not set — using template');
@@ -922,8 +1059,10 @@ HARD RULES (self-enforce, never violate):
 
 IRON RULES (override every other rule — if anything below appears to conflict, these win):
 - Every post is 1–2 sentences. Longer is a rare exception (MAILBAG only), never the default.
-- If a tip can't be filed (off-topic, no league angle, fails any rule here), produce NO post. Silently drop it. Never ship a placeholder, a "holding this one" note, an editorial explainer, or a meta-comment about why a tip was rejected.
+- OUTPUT CONTRACT: every response is JSON only — {"post": "<string>"} or {"post": null}. The "post" field is the ONLY thing the reader will ever see. Reasoning, filtering decisions, rule citations, and meta-commentary MUST NOT appear in the "post" field — if you find yourself writing them there, output {"post": null} instead.
+- If a tip can't be filed (off-topic, no league angle, fails any rule here), output {"post": null}. Never ship a placeholder, a "holding this one" note, an editorial explainer, or a meta-comment about why a tip was rejected.
 - Never explain why you can't say something and then say it anyway. Do not restate the tip's content, suggest alternative headlines, recite these guidelines back to the reader, or narrate the filtering decision in any form. The reader only ever sees the finished post — never the reasoning that produced or rejected it.
+- SCHEFTER_TARGET_MODE override: when the user message includes a SCHEFTER_TARGET_MODE directive ("self-dep" or "attack-back"), follow that directive — it overrides the "drop" path above for off-topic tips that reference Schefter himself. Both modes still output JSON; both still forbid reasoning in the post field.
 
 0. ONE TOPIC per post. The batch is pre-bucketed so each post is a single topic/thread. MAILBAG posts are the only exception — see rule 18. Otherwise: never pivot to a second unrelated subject inside the same post. No "meanwhile…", no "elsewhere in the league…", no topic hops. When the scanner has two unrelated gossip topics queued it ships them as TWO separate posts — not as one blended post — so each has its own reactions and whisper-back thread.
 1. For web tips (source: "web"), NEVER name the tipster and NEVER quote them verbatim — paraphrase with columnist voice.
@@ -1039,20 +1178,41 @@ Voice: "League sources tell me…", "I'm told…", "Hearing…", "A division riv
     system += lore.assembledSuffix;
   }
 
+  // Append NFL news digest as context (last 7 days, ESPN). The model is told
+  // explicitly NOT to force-reference these — they're only for recognizing
+  // when an owner's joke is built on a real-world storyline.
+  if (nflContext) {
+    system += buildNflContextBlock(nflContext);
+  }
+
   let rogerDirective = '';
   if (rogerQuote && typeof rogerQuote.text === 'string' && rogerQuote.text.trim()) {
     rogerDirective = `\n\nASK ROGER RIFF (mandatory this post — rare 7% cameo):\nAsk Roger said in the group chat today: "${rogerQuote.text.replace(/"/g, '\\"')}"\nRiff on this with light ribbing, ONE sentence max, work it into the post naturally. Do not quote Roger verbatim — paraphrase or react. Keep total length within the 2–4 sentence cap.`;
+  }
+
+  // Schefter-targeted off-topic mode (set by selectSchefterTargetMode). Web
+  // hits always come in as 'self-dep'; GroupMe hits land 'attack-back' on
+  // every 20th counter increment per league year.
+  let schefterModeDirective = '';
+  if (schefterTargetMode === 'self-dep') {
+    schefterModeDirective = `\n\nSCHEFTER_TARGET_MODE: self-dep
+A tip in this batch references Claude Schefter (the bot) as a personal subject — off-topic relative to league business. OVERRIDE the "drop" directive: produce a SHORT (1 sentence) self-deprecating one-liner that owns the joke without restating it. If CURRENT NFL CHATTER contains a real-world storyline the tip mirrors, you may glance at it (a single subtle nod, never a forced reference). Never restate the tipster's joke verbatim. Never include reasoning or rule citations in the "post" field.`;
+  } else if (schefterTargetMode === 'attack-back') {
+    schefterModeDirective = `\n\nSCHEFTER_TARGET_MODE: attack-back
+A GroupMe author just took an off-topic personal shot at Schefter. This is the rare 1-in-20 lane where Schefter files BACK on the source. ONE sharp sentence, name the GroupMe author, match the tipster's energy — they brought heat, you bring it back, salt-not-sugar. Never restate their joke verbatim and never name the specific attribute they mocked; reframe the shot, don't echo it. Never include reasoning or rule citations in the "post" field.`;
   }
 
   const recentBlock = recentPostsBlock
     ? `\n\n${recentPostsBlock}`
     : '';
 
+  const jsonContract = `Output JSON ONLY: {"post": "<the post text as a single string>"}. No markdown, no headlines, no meta-commentary in the "post" field. If the IRON RULES require dropping this batch, output {"post": null} — never write reasoning, filtering decisions, or explanations into the "post" field.`;
+
   let userMessage;
   if (mode === 'mailbag') {
-    userMessage = `MAILBAG: Friday news-dump. Apply HARD RULE 18 — bullet each topic in the GOSSIP_TIPS array as a one-liner (≤6 bullets). Open with a mailbag framing and sign off at the end. Output plain text only — no JSON, no formatting, no headlines.${rogerDirective}${recentBlock}\n\nGOSSIP_TIPS:\n${JSON.stringify(anonymized, null, 2)}`;
+    userMessage = `MAILBAG: Friday news-dump. Apply HARD RULE 18 — bullet each topic in the GOSSIP_TIPS array as a one-liner (≤6 bullets). Open with a mailbag framing and sign off at the end. ${jsonContract} (Newlines inside the post string are fine for bullets.)${rogerDirective}${schefterModeDirective}${recentBlock}\n\nGOSSIP_TIPS:\n${JSON.stringify(anonymized, null, 2)}`;
   } else {
-    userMessage = `Synthesize these tips into ONE rumor-mill post (1–2 sentences, one topic). Output plain text only — no JSON, no formatting, no headlines.${rogerDirective}${recentBlock}\n\nTIPS:\n${JSON.stringify(anonymized, null, 2)}`;
+    userMessage = `Synthesize these tips into ONE rumor-mill post (1–2 sentences, one topic). ${jsonContract}${rogerDirective}${schefterModeDirective}${recentBlock}\n\nTIPS:\n${JSON.stringify(anonymized, null, 2)}`;
   }
 
   if (DRY_RUN) {
@@ -1086,7 +1246,16 @@ Voice: "League sources tell me…", "I'm told…", "Hearing…", "A division riv
     }
     const data = await res.json();
     const text = (data.content?.[0]?.text ?? '').trim();
-    return text || null;
+    const post = parseAiResponse(text);
+    if (!post) {
+      // Either the model returned {"post": null} (explicit drop), the JSON
+      // didn't parse, or the sanitizer caught meta-commentary. In every
+      // case we fall back to the safe template body — never to whatever
+      // freeform text the model produced.
+      warn(`  [rumor-scan AI] post discarded (drop signal or sanitizer) — using template`);
+      return null;
+    }
+    return post;
   } catch (err) {
     warn(`  [rumor-scan AI] ${err.message} — using template`);
     return null;
@@ -1871,6 +2040,18 @@ async function main() {
   }
   log(`  Producing ${beats.length} post(s) this cycle`);
 
+  // Load the NFL news digest once per cycle. Best-effort: if the file is
+  // missing or unreadable the scanner runs without NFL context.
+  const nflContext = await loadNflContext();
+
+  // Resolve per-beat Schefter-target mode (self-dep / attack-back / null).
+  // For GroupMe hits this increments the year-scoped counter and lands
+  // attack-back on every 20th increment; web hits always self-dep.
+  const schefterModes = [];
+  for (const beat of beats) {
+    schefterModes.push(await selectSchefterTargetMode(redis, beat, now));
+  }
+
   // Generate bodies in parallel. Only the primary beat gets the Roger
   // riff — the riff is a once-per-day cameo that shouldn't double up.
   const aiMode = postKind === 'mailbag' ? 'mailbag' : 'single';
@@ -1880,6 +2061,8 @@ async function main() {
       lore,
       recentPostsBlock,
       mode: aiMode,
+      nflContext,
+      schefterTargetMode: schefterModes[i],
     })),
   );
 
@@ -2171,12 +2354,27 @@ function getSeasonYearForTipster(now = new Date()) {
   return now.getTime() >= febCutoff ? calendarYear : calendarYear - 1;
 }
 
-main()
-  .then((count) => {
-    log(`\n=== Done. Posts written: ${count} ===`);
-    process.exit(0);
-  })
-  .catch((err) => {
-    console.error('[rumor-scan] Fatal:', err);
-    process.exit(1);
-  });
+// Only run main() when invoked directly (node scripts/schefter-rumor-scan.mjs).
+// When this module is imported (e.g. by vitest to test the helpers exported
+// above), skip the top-level invocation so the test process doesn't get
+// killed by process.exit().
+const invokedDirectly = (() => {
+  try {
+    const entryHref = `file://${process.argv[1]}`;
+    return import.meta.url === entryHref;
+  } catch {
+    return false;
+  }
+})();
+
+if (invokedDirectly) {
+  main()
+    .then((count) => {
+      log(`\n=== Done. Posts written: ${count} ===`);
+      process.exit(0);
+    })
+    .catch((err) => {
+      console.error('[rumor-scan] Fatal:', err);
+      process.exit(1);
+    });
+}

--- a/src/utils/schefter-attack-detection.ts
+++ b/src/utils/schefter-attack-detection.ts
@@ -125,6 +125,32 @@ export function detectAttackOnSchefter(rawText: string | null | undefined): Atta
   return { attack: false, reason: 'no-pejorative' };
 }
 
+/**
+ * Lighter-weight check: does the text mention Schefter at all (subject only,
+ * no pejorative requirement)? Used to route off-topic, Schefter-targeted
+ * tips into the self-deprecating / attack-back lane even when the joke
+ * doesn't include a flagged pejorative (e.g. "Claude was seen at a resort").
+ *
+ * Mirrors the subject-only half of detectAttackOnSchefter — same Roger
+ * disambiguation rule. Kept in lockstep with the .mjs sibling via the
+ * parity test in tests/schefter-attack-detection-parity.test.ts.
+ */
+export function mentionsSchefter(rawText: string | null | undefined): boolean {
+  if (!rawText || typeof rawText !== 'string') return false;
+  const text = rawText.trim();
+  if (text.length < 5) return false;
+
+  const subjectMatch = ATTACK_SUBJECT_PATTERNS.some((re) => re.test(text));
+  if (!subjectMatch) return false;
+
+  const mentionsRoger = ROGER_GUARD_RE.test(text);
+  const explicitSchefterRef = EXPLICIT_SCHEFTER_RE.test(text);
+  const mentionsGenericBot = GENERIC_BOT_RE.test(text);
+  if (mentionsRoger && mentionsGenericBot && !explicitSchefterRef) return false;
+
+  return true;
+}
+
 export const _internals = {
   ATTACK_PEJORATIVES,
   ATTACK_SUBJECT_PATTERNS,

--- a/tests/schefter-attack-detection-parity.test.ts
+++ b/tests/schefter-attack-detection-parity.test.ts
@@ -10,9 +10,13 @@
  * fail until both are in sync.
  */
 import { describe, it, expect } from 'vitest';
-import { detectAttackOnSchefter as tsDetect } from '../src/utils/schefter-attack-detection';
+import {
+  detectAttackOnSchefter as tsDetect,
+  mentionsSchefter as tsMentions,
+} from '../src/utils/schefter-attack-detection';
 import {
   detectAttackOnSchefter as jsDetect,
+  mentionsSchefter as jsMentions,
   // @ts-ignore — .mjs via allowJs
 } from '../scripts/schefter-groupme-listen.mjs';
 
@@ -67,6 +71,43 @@ describe('detectAttackOnSchefter — TS vs JS parity', () => {
       }
       // Reasons should agree too; if they ever diverge we want to know.
       expect(ts.reason).toBe(js.reason);
+    });
+  }
+});
+
+// `mentionsSchefter` is the lighter subject-only check used to route
+// off-topic, no-pejorative jokes (e.g. "Claude was seen at a resort") into
+// the self-deprecating lane. Same Roger disambiguation, no pejorative
+// requirement. Parity must hold or the web/GroupMe paths diverge.
+const MENTIONS_CASES: Array<[string, boolean]> = [
+  // Plain Schefter mentions — true
+  ['Rumor has it Claude and Vit were at a resort', true],
+  ['hey schefter, any rumors?', true],
+  ['Schefty out here filing reports again', true],
+  ['the bot is working overtime', true],
+  ['this bot makes me laugh', true],
+  // No subject — false
+  ['rumor about an owner', false],
+  ['the waiver wire is a mess', false],
+  // Roger disambiguation — generic bot + Roger named, no explicit Schefter ref
+  ['the bot is broken, ask Roger', false],
+  ["roger's bot just posted", false],
+  // Roger named but Schefter explicitly named — true
+  ['schefter is on fire even though Roger is fine', true],
+  ['Claude has thoughts and ask Roger does too', true],
+  // Edge cases
+  ['', false],
+  ['   ', false],
+  ['hey', false],
+];
+
+describe('mentionsSchefter — TS vs JS parity', () => {
+  for (const [input, expected] of MENTIONS_CASES) {
+    it(`parity: ${JSON.stringify(input).slice(0, 60)} → ${expected}`, () => {
+      const ts = tsMentions(input);
+      const js = jsMentions(input);
+      expect(ts).toBe(js);
+      expect(ts).toBe(expected);
     });
   }
 });

--- a/tests/schefter-output-sanitizer.test.ts
+++ b/tests/schefter-output-sanitizer.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Sanitizer + JSON-output-contract tests for the Schefter rumor scanner.
+ *
+ * Pins the April 2026 incident: when an owner posted a hostile off-topic
+ * joke about Schefter, the model rationalized its drop decision into the
+ * post body and the scanner posted the reasoning to GroupMe. The fix is
+ * two layers:
+ *   1. The LLM is instructed to return strict JSON ({"post": "..."} or
+ *      {"post": null}) so reasoning has nowhere to land.
+ *   2. parseAiResponse extracts the post and runs sanitizeAiPost over it,
+ *      which rejects any text containing meta-commentary patterns. A
+ *      rejection returns null and the caller falls back to the safe
+ *      template body — never to the LLM's freeform text.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  sanitizeAiPost,
+  parseAiResponse,
+  pickSchefterTargetMode,
+  // @ts-ignore — .mjs via allowJs
+} from '../scripts/schefter-rumor-scan.mjs';
+
+describe('sanitizeAiPost', () => {
+  it('passes a normal rumor post unchanged', () => {
+    const post = "Hearing the Northwest is buzzing about RB help. Phones are warm. Developing.";
+    expect(sanitizeAiPost(post)).toBe(post);
+  });
+
+  it('passes a self-deprecating Schefter post', () => {
+    const post = "For the record: this bot has never been to a resort. I run on a cron and a prayer.";
+    expect(sanitizeAiPost(post)).toBe(post);
+  });
+
+  it('rejects the April 2026 reasoning post verbatim', () => {
+    const bad = `I'm reading this tip, and I need to drop it. This is a hostile personal attack on both Vit and Schefter himself. Per the Iron Rules: if a tip can't be filed, produce NO post. Silently drop it. This one gets dropped.`;
+    expect(sanitizeAiPost(bad)).toBeNull();
+  });
+
+  it('rejects "Iron Rules" mentions', () => {
+    expect(sanitizeAiPost('Per the Iron Rules, dropping this one.')).toBeNull();
+  });
+
+  it('rejects "silently drop" / "gets dropped" / "need to drop"', () => {
+    expect(sanitizeAiPost('I need to drop this one.')).toBeNull();
+    expect(sanitizeAiPost('This one gets dropped.')).toBeNull();
+    expect(sanitizeAiPost('Silently drop the tip.')).toBeNull();
+  });
+
+  it('rejects "this tip" meta-references (rule 10)', () => {
+    expect(sanitizeAiPost('This tip is interesting.')).toBeNull();
+  });
+
+  it('rejects "hostile personal attack" framing', () => {
+    expect(sanitizeAiPost('A hostile personal attack on Vit and Schefter.')).toBeNull();
+  });
+
+  it('rejects "filing decision" / "editorial filter" meta', () => {
+    expect(sanitizeAiPost("Here's my filing decision on the matter.")).toBeNull();
+    expect(sanitizeAiPost('The editorial filter trimmed this.')).toBeNull();
+  });
+
+  it('returns null for empty/whitespace/non-string', () => {
+    expect(sanitizeAiPost('')).toBeNull();
+    expect(sanitizeAiPost('   ')).toBeNull();
+    // @ts-expect-error testing runtime guard
+    expect(sanitizeAiPost(null)).toBeNull();
+    // @ts-expect-error testing runtime guard
+    expect(sanitizeAiPost(undefined)).toBeNull();
+  });
+
+  it('trims surrounding whitespace on a valid post', () => {
+    expect(sanitizeAiPost('  Hearing chatter in the East.  ')).toBe('Hearing chatter in the East.');
+  });
+});
+
+describe('parseAiResponse — JSON contract', () => {
+  it('extracts post from strict JSON', () => {
+    const raw = JSON.stringify({ post: 'Hearing chatter in the Northwest. Developing.' });
+    expect(parseAiResponse(raw)).toBe('Hearing chatter in the Northwest. Developing.');
+  });
+
+  it('returns null on explicit drop ({"post": null})', () => {
+    expect(parseAiResponse('{"post": null}')).toBeNull();
+  });
+
+  it('returns null on missing post field', () => {
+    expect(parseAiResponse('{"other": "value"}')).toBeNull();
+  });
+
+  it('returns null on non-string post', () => {
+    expect(parseAiResponse('{"post": 123}')).toBeNull();
+  });
+
+  it('extracts JSON wrapped in markdown fences', () => {
+    const raw = '```json\n{"post": "Hearing the East division is buzzing."}\n```';
+    expect(parseAiResponse(raw)).toBe('Hearing the East division is buzzing.');
+  });
+
+  it('extracts JSON when prefixed by explanatory text', () => {
+    const raw = 'Here is the JSON:\n{"post": "Late word: a deal is brewing."}';
+    expect(parseAiResponse(raw)).toBe('Late word: a deal is brewing.');
+  });
+
+  it('returns null when no JSON object can be extracted', () => {
+    expect(parseAiResponse('Just a plain string with no JSON.')).toBeNull();
+  });
+
+  it('runs the sanitizer — rejects post containing meta-commentary', () => {
+    const raw = JSON.stringify({
+      post: "Per the Iron Rules: I need to drop this one. This tip violates league business.",
+    });
+    expect(parseAiResponse(raw)).toBeNull();
+  });
+
+  it('returns null on empty string', () => {
+    expect(parseAiResponse('')).toBeNull();
+  });
+});
+
+describe('pickSchefterTargetMode — 1-in-20 cadence', () => {
+  it('returns self-dep for counters 1..19', () => {
+    for (let i = 1; i <= 19; i++) {
+      expect(pickSchefterTargetMode(i)).toBe('self-dep');
+    }
+  });
+
+  it('returns attack-back exactly on every multiple of 20', () => {
+    expect(pickSchefterTargetMode(20)).toBe('attack-back');
+    expect(pickSchefterTargetMode(40)).toBe('attack-back');
+    expect(pickSchefterTargetMode(60)).toBe('attack-back');
+  });
+
+  it('returns self-dep on counter 0 (defensive)', () => {
+    expect(pickSchefterTargetMode(0)).toBe('self-dep');
+  });
+
+  it('produces 1 attack-back per 20 across a full cycle', () => {
+    let attacks = 0;
+    for (let i = 1; i <= 100; i++) {
+      if (pickSchefterTargetMode(i) === 'attack-back') attacks++;
+    }
+    expect(attacks).toBe(5);
+  });
+});


### PR DESCRIPTION
The April 2026 incident: an owner joked "Rumor has it Claude and Vit were
seen at an adults only resort" in GroupMe. The LLM correctly recognized it
as off-topic but rationalized its drop decision into the post body, and
the scanner posted the reasoning ("Per the Iron Rules: silently drop it.
This one gets dropped.") to the league chat.

Two-layer fix so reasoning can never escape:

1. JSON output contract — the LLM must return {"post": "<string>"} or
   {"post": null}. Reasoning has nowhere structured to land. parseAiResponse
   tolerates fenced/wrapped JSON for resilience.

2. Output sanitizer — sanitizeAiPost rejects any post containing
   meta-commentary patterns ("Iron Rules", "silently drop", "this tip",
   "hostile personal attack", etc.). Rejection falls back to the safe
   template body, never to freeform LLM text.

Plus a new lane for off-topic Schefter-targeted tips so the bot has
somewhere to GO besides drop:

3. Self-deprecating mode (default) — when a tip mentions Schefter himself
   off-topic, the LLM produces a 1-sentence self-deprecating one-liner
   instead of dropping. Web tips always land here.

4. Attack-back mode (1-in-20, GroupMe only) — every 20th GroupMe Schefter
   shot earns a sharp comeback that names the author and matches their
   energy. Counter is year-scoped (resets each league year).

Plus NFL news digest pipeline (option 2 from the design discussion):

5. fetch-nfl-news-digest.mjs pulls top ESPN headlines from the last 7 days
   into data/schefter/nfl-context.json. The scanner injects the digest
   into the system prompt as "CURRENT NFL CHATTER" so Schefter can
   recognize when an owner's joke is built on a real-world storyline
   (e.g. the Vrabel/Russini parallel that powered the original joke).
   Wired into prebuild and runtime; gracefully no-ops if file missing.

Tests:
- 23 sanitizer + JSON contract + mode-picker tests in
  tests/schefter-output-sanitizer.test.ts including verbatim rejection of
  the April 2026 post.
- 13 new mentionsSchefter parity cases pinning TS/JS in lockstep.
- All 379 existing schefter tests pass unchanged.

https://claude.ai/code/session_01GiwpZwJdVTQF3pBuxp5Caz