### PR TITLE
feat: add Stats & Reports hub at /theleague/stats

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -124,9 +124,7 @@ const mflYear = getCurrentLeagueYear();
 				<li><a href="https://afl-fantasy.com">AFL</a></li>
 				<li><hr></li>
 				<li><a href="/theleague/assets">The League Assets</a></li>
-				<li><a href="/theleague/salary">Salary Analytics</a></li>
-				<li><a href="/theleague/salary-history">Salary Trend Data</a></li>
-				<li><a href="/theleague/mvp">Salary-Adjusted MVPs</a></li>
+				<li><a href="/theleague/stats">Stats &amp; Reports</a></li>
 				<li><a href="{`https://www49.myfantasyleague.com/${mflYear}/home/13522?MODULE=MESSAGE14`}">Roster/Cap</a></li>
 			</ul>
 		</div>

--- a/src/components/theleague/RelatedReports.astro
+++ b/src/components/theleague/RelatedReports.astro
@@ -1,0 +1,197 @@
+---
+/**
+ * RelatedReports — sibling-page discovery strip for the Stats & Reports hub.
+ *
+ * Renders a "Related reports" section at the bottom of a report page,
+ * showing other pages that share the same `subcategory` in
+ * page-directory.json. Falls back to nothing if there are no siblings.
+ *
+ * Usage:
+ *   <RelatedReports currentId="salary-analytics" />
+ */
+import { resolveLeaguePath } from '../../utils/nav-utils';
+import { spriteUrl } from '../../utils/sprite-url';
+import pageDirectory from '../../data/page-directory.json';
+
+interface Props {
+  /** The `id` of the current page in page-directory.json. */
+  currentId: string;
+}
+
+interface PageEntry {
+  id: string;
+  title: string;
+  description: string;
+  path: string;
+  icon: string;
+  category: string;
+  subcategory?: string;
+  visibility: string;
+  popularity: number;
+}
+
+const { currentId } = Astro.props;
+const hideLeaguePrefix = Astro.locals.hideLeaguePrefix ?? false;
+const r = (path: string) => resolveLeaguePath(path, hideLeaguePrefix);
+
+const allPages = pageDirectory as PageEntry[];
+const current = allPages.find((p) => p.id === currentId);
+const siblings = current?.subcategory
+  ? allPages
+    .filter((p) =>
+      p.id !== currentId &&
+      p.subcategory === current.subcategory &&
+      p.visibility === 'all'
+    )
+    .sort((a, b) => b.popularity - a.popularity)
+  : [];
+---
+
+{siblings.length > 0 ? (
+  <aside class="related-reports" aria-labelledby="related-reports-heading">
+    <div class="related-reports__header">
+      <h2 class="related-reports__title" id="related-reports-heading">Related reports</h2>
+      <a href={r('/theleague/stats')} class="related-reports__cta">
+        All stats &amp; reports
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" aria-hidden="true">
+          <path d="M5 12h14M12 5l7 7-7 7"/>
+        </svg>
+      </a>
+    </div>
+    <div class="related-reports__grid">
+      {siblings.map((page) => (
+        <a class="related-reports__card" href={r(`/theleague${page.path}`)}>
+          <svg class="related-reports__icon" width="20" height="20" aria-hidden="true">
+            <use href={`${spriteUrl}#icon-${page.icon}`} />
+          </svg>
+          <div class="related-reports__text">
+            <span class="related-reports__name">{page.title}</span>
+            <span class="related-reports__desc">{page.description}</span>
+          </div>
+        </a>
+      ))}
+    </div>
+  </aside>
+) : (
+  <aside class="related-reports related-reports--solo" aria-labelledby="related-reports-heading">
+    <div class="related-reports__header">
+      <h2 class="related-reports__title" id="related-reports-heading">More stats &amp; reports</h2>
+      <a href={r('/theleague/stats')} class="related-reports__cta">
+        Back to Stats &amp; Reports
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" aria-hidden="true">
+          <path d="M5 12h14M12 5l7 7-7 7"/>
+        </svg>
+      </a>
+    </div>
+  </aside>
+)}
+
+<style>
+  .related-reports {
+    --rr-accent: var(--color-primary, #1c497c);
+    margin-top: 2.5rem;
+    padding: 1.5rem;
+    background: var(--content-bg, #fff);
+    border: 1px solid var(--content-border, #e2e8f0);
+    border-radius: var(--radius-md, 0.5rem);
+    box-shadow: var(--shadow-md);
+  }
+
+  .related-reports__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 1rem;
+    gap: 1rem;
+  }
+
+  .related-reports__title {
+    font-size: 0.75rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    padding-left: 0.625rem;
+    border-left: 2px solid var(--rr-accent);
+    margin: 0;
+    line-height: 1;
+    color: var(--color-gray-700, #374151);
+  }
+
+  .related-reports__cta {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--rr-accent);
+    text-decoration: none;
+    transition: gap 0.15s ease;
+    white-space: nowrap;
+  }
+
+  .related-reports__cta:hover {
+    gap: 0.5rem;
+  }
+
+  .related-reports__grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 0.5rem;
+  }
+
+  .related-reports__card {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.75rem;
+    padding: 0.75rem;
+    border-radius: var(--radius-md, 0.5rem);
+    background: var(--color-gray-50, #f9fafb);
+    text-decoration: none;
+    transition: background 0.15s ease, transform 0.15s ease;
+  }
+
+  .related-reports__card:hover {
+    background: var(--color-gray-100, #f3f4f6);
+    transform: translateY(-1px);
+  }
+
+  .related-reports__icon {
+    flex-shrink: 0;
+    color: var(--rr-accent);
+    margin-top: 0.125rem;
+  }
+
+  .related-reports__text {
+    display: flex;
+    flex-direction: column;
+    gap: 0.125rem;
+    min-width: 0;
+  }
+
+  .related-reports__name {
+    font-size: 0.8125rem;
+    font-weight: 600;
+    color: var(--color-gray-800, #1f2937);
+    line-height: 1.3;
+  }
+
+  .related-reports__desc {
+    font-size: 0.6875rem;
+    color: var(--color-gray-500, #6b7280);
+    line-height: 1.4;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  @media (max-width: 640px) {
+    .related-reports {
+      padding: 1.25rem;
+    }
+
+    .related-reports__grid {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/src/components/theleague/hp-sections/HpQuickLinks.astro
+++ b/src/components/theleague/hp-sections/HpQuickLinks.astro
@@ -40,7 +40,13 @@ const sorted = [...visible].sort((a, b) => {
   return b.popularity - a.popularity;
 });
 
-const pages = sorted.slice(0, 8);
+// Pin the Stats & Reports hub so it always surfaces on the homepage.
+const PINNED_IDS = ['stats'];
+const pinned = PINNED_IDS
+  .map(id => visible.find(p => p.id === id))
+  .filter((p): p is PageEntry => Boolean(p));
+const rest = sorted.filter(p => !PINNED_IDS.includes(p.id));
+const pages = [...pinned, ...rest].slice(0, 8);
 ---
 
 <section class="hp-links" aria-label="Quick links">

--- a/src/data/page-directory.json
+++ b/src/data/page-directory.json
@@ -253,12 +253,24 @@
     "popularity": 20
   },
   {
+    "id": "stats",
+    "title": "Stats & Reports",
+    "description": "Hub for league analytics — salary benchmarks, awards, projected free agents, and multi-year team comparisons",
+    "path": "/stats",
+    "icon": "bar-chart",
+    "category": "reports",
+    "tags": ["stats", "reports", "analytics", "hub", "stats hub", "advanced reports", "analysis", "data", "salary", "awards", "mvp", "dead money", "projected free agents", "league summary", "salary history", "salary archive", "benchmarks", "comparisons"],
+    "visibility": "all",
+    "popularity": 70
+  },
+  {
     "id": "league-summary",
     "title": "League Summary",
     "description": "Compare all teams across cap, roster, and contract metrics over 5 years",
     "path": "/league-summary",
     "icon": "spreadsheet",
     "category": "reports",
+    "subcategory": "team-comparisons",
     "tags": ["league summary", "summary", "compare", "comparison", "all teams", "overview", "table", "spreadsheet", "grid", "metrics", "cap", "roster", "contracts", "5 year", "five year", "multi year", "trend", "trends", "analysis", "snapshot", "health", "strength", "weakness", "gap", "projected cap space", "cap space", "room", "available money", "budget", "flexibility", "dead money", "dead cap", "wasted", "sunk cost", "bad contracts", "effective cap space", "usable cap", "net cap", "average age", "age", "old", "young", "aging", "window", "rebuild", "contend", "players under contract", "locked in", "committed", "signed", "retained", "expiring contracts", "expiring", "upcoming free agents", "unrestricted", "walk", "leaving", "positional depth", "depth", "deep", "shallow", "thin", "stacked", "qb depth", "rb depth", "wr depth", "te depth", "pk depth", "def depth", "avg contract length", "contract length", "duration", "short", "long", "years remaining", "committed salary", "committed salary percent", "locked up", "percentage", "roster holes", "holes", "needs", "weak spots", "gaps", "missing", "top player retention", "retention", "kept", "star players", "core", "best players", "salary weighted age", "weighted age", "expensive age", "positional spend", "positional spend percent", "spending by position", "qb spend", "rb spend", "wr spend", "te spend", "allocation", "investment", "draft capital", "draft picks", "picks", "future picks", "capital", "ammunition", "assets", "trade assets"],
     "visibility": "all",
     "popularity": 72
@@ -270,6 +282,7 @@
     "path": "/salary",
     "icon": "bar-chart",
     "category": "reports",
+    "subcategory": "salary-analytics",
     "tags": ["salary", "salaries", "analytics", "analysis", "benchmark", "benchmarks", "spending", "spend", "money", "cap", "position", "positions", "average", "median", "market", "value", "price", "cost", "expensive", "cheap", "bargain", "overpaid", "underpaid", "qb", "rb", "wr", "te", "chart", "graph", "bar chart", "comparison", "compare", "breakdown", "distribution", "position breakdown", "top earners", "franchise tag", "extension", "team option", "top 3 avg", "top 5 avg", "top 10 avg", "starter avg", "starter med", "avg salary", "med salary", "quarterback", "running back", "wide receiver", "tight end", "kicker", "defense", "export to excel", "original spreadsheet"],
     "visibility": "all",
     "popularity": 73
@@ -281,6 +294,7 @@
     "path": "/salary-history",
     "icon": "standings-2",
     "category": "reports",
+    "subcategory": "salary-analytics",
     "tags": ["salary history", "history", "historical", "trends", "trend", "over time", "year over year", "change", "growth", "chart", "line chart", "graph", "timeline", "past", "previous", "cap", "spending", "evolution", "progression", "salary trends over time", "franchise tag", "extension", "team option", "top 3 salaries", "top 5 salaries", "top 10 salaries", "qb", "rb", "wr", "te", "k", "def", "view data as table"],
     "visibility": "all",
     "popularity": 38
@@ -292,6 +306,7 @@
     "path": "/salary-archive",
     "icon": "vault",
     "category": "reports",
+    "subcategory": "salary-analytics",
     "tags": ["salary archive", "archive", "historical", "old", "past", "previous", "spreadsheet", "spreadsheets", "download", "excel", "csv", "2009", "2010", "2011", "2012", "2013", "2014", "2015", "2016", "2017", "2018", "2019", "2020", "2021", "2022", "2023", "2024", "2025", "season", "year", "vault", "records", "data dump"],
     "visibility": "all",
     "popularity": 18
@@ -303,6 +318,7 @@
     "path": "/mvp",
     "icon": "standings",
     "category": "reports",
+    "subcategory": "awards",
     "tags": ["mvp", "mvps", "most valuable", "best", "top", "performers", "performance", "salary adjusted", "value", "bang for buck", "efficient", "efficiency", "production", "points per dollar", "bargain", "steal", "outperform", "overperform", "rankings", "award", "awards", "season", "weekly", "gm mvp awards", "team of the year", "all-time team", "all-time mvps", "quarterback", "running back", "wide receiver", "tight end", "kicker", "defense", "points", "contract", "cost per point"],
     "visibility": "all",
     "popularity": 52
@@ -314,6 +330,7 @@
     "path": "/dead-money",
     "icon": "tombstone",
     "category": "reports",
+    "subcategory": "awards",
     "tags": ["dead money", "dead cap", "worst", "bad", "bust", "busts", "overpaid", "underperform", "waste", "wasted", "money", "contracts", "expensive", "disappointment", "regret", "cut", "release", "sunk cost", "tombstone", "rip", "awards", "shame", "wall of shame", "jerry jones award", "brock osweiler award", "starting lineup", "full roster", "all-time", "financial mismanagement", "cost per point", "quarterback", "running back", "wide receiver", "tight end", "kicker", "defense", "flex"],
     "visibility": "all",
     "popularity": 42
@@ -336,6 +353,7 @@
     "path": "/projected-free-agents",
     "icon": "binoculars",
     "category": "reports",
+    "subcategory": "free-agency",
     "tags": ["projected", "free agents", "expiring", "contracts", "final year", "upcoming", "salary", "cap", "free agency", "projections", "offseason", "auction", "targets", "ending", "contract year", "available", "report", "scouting", "fa", "expiring contracts"],
     "visibility": "all",
     "popularity": 60

--- a/src/pages/theleague/dead-money.astro
+++ b/src/pages/theleague/dead-money.astro
@@ -1,6 +1,7 @@
 ---
 import TheLeagueLayout from '../../layouts/TheLeagueLayout.astro';
 import Breadcrumbs from '../../components/theleague/Breadcrumbs.astro';
+import RelatedReports from '../../components/theleague/RelatedReports.astro';
 import leagueConfig from '../../data/theleague.config.json';
 import { DEFAULT_HEADSHOT_URL, getPlayerImageUrl } from '../../constants/roster-constants';
 import { getCurrentSeasonYear } from '../../utils/league-year';
@@ -586,6 +587,8 @@ const formatCostPerPoint = (costPerPoint: number) => {
         );
       })}
     </section>
+
+    <RelatedReports currentId="dead-money" />
   </section>
 </TheLeagueLayout>
 

--- a/src/pages/theleague/dead-money.astro
+++ b/src/pages/theleague/dead-money.astro
@@ -1,5 +1,6 @@
 ---
 import TheLeagueLayout from '../../layouts/TheLeagueLayout.astro';
+import Breadcrumbs from '../../components/theleague/Breadcrumbs.astro';
 import leagueConfig from '../../data/theleague.config.json';
 import { DEFAULT_HEADSHOT_URL, getPlayerImageUrl } from '../../constants/roster-constants';
 import { getCurrentSeasonYear } from '../../utils/league-year';
@@ -257,6 +258,11 @@ const formatCostPerPoint = (costPerPoint: number) => {
   <div class="visually-hidden" role="status" aria-live="polite" aria-atomic="true" id="filter-announcer"></div>
   <section class="dead-money">
     <header class="page-header">
+      <Breadcrumbs items={[
+        { label: 'The League', href: '/theleague' },
+        { label: 'Stats & Reports', href: '/theleague/stats' },
+        { label: 'Dead Money Awards' },
+      ]} />
       <h1>The Dead Money Awards</h1>
       <p class="page-subtitle">
         Celebrating the league's finest examples of financial mismanagement.

--- a/src/pages/theleague/league-summary.astro
+++ b/src/pages/theleague/league-summary.astro
@@ -1,5 +1,6 @@
 ---
 import TheLeagueLayout from '../../layouts/TheLeagueLayout.astro';
+import Breadcrumbs from '../../components/theleague/Breadcrumbs.astro';
 import LeagueSummaryTable from '../../components/theleague/LeagueSummaryTable.astro';
 import leagueConfig from '../../data/theleague.config.json';
 import { SALARY_YEARS } from '../../utils/salary-calculations';
@@ -212,6 +213,11 @@ const teamsForDisplay = teamSummaries.map((team) => {
 
 <TheLeagueLayout title="League Summary">
   <div class="league-summary-container">
+    <Breadcrumbs items={[
+      { label: 'The League', href: '/theleague' },
+      { label: 'Stats & Reports', href: '/theleague/stats' },
+      { label: 'League Summary' },
+    ]} />
     <h1>League Summary <span class="subtitle">{displayYears[0]}–{displayYears[displayYears.length - 1]}</span></h1>
 
     <LeagueSummaryTable

--- a/src/pages/theleague/league-summary.astro
+++ b/src/pages/theleague/league-summary.astro
@@ -1,6 +1,7 @@
 ---
 import TheLeagueLayout from '../../layouts/TheLeagueLayout.astro';
 import Breadcrumbs from '../../components/theleague/Breadcrumbs.astro';
+import RelatedReports from '../../components/theleague/RelatedReports.astro';
 import LeagueSummaryTable from '../../components/theleague/LeagueSummaryTable.astro';
 import leagueConfig from '../../data/theleague.config.json';
 import { SALARY_YEARS } from '../../utils/salary-calculations';
@@ -225,6 +226,8 @@ const teamsForDisplay = teamSummaries.map((team) => {
       years={displayYears}
       categories={CATEGORY_DEFINITIONS}
     />
+
+    <RelatedReports currentId="league-summary" />
   </div>
 </TheLeagueLayout>
 

--- a/src/pages/theleague/mvp.astro
+++ b/src/pages/theleague/mvp.astro
@@ -1,5 +1,6 @@
 ---
 import TheLeagueLayout from '../../layouts/TheLeagueLayout.astro';
+import Breadcrumbs from '../../components/theleague/Breadcrumbs.astro';
 import leagueConfig from '../../data/theleague.config.json';
 import { DEFAULT_HEADSHOT_URL, getPlayerImageUrl } from '../../constants/roster-constants';
 import { getCurrentSeasonYear } from '../../utils/league-year';
@@ -255,6 +256,11 @@ const getNflLogo = (team: string) => {
 <TheLeagueLayout title="MFL MVPs">
   <section class="mvp-history">
     <header>
+      <Breadcrumbs items={[
+        { label: 'The League', href: '/theleague' },
+        { label: 'Stats & Reports', href: '/theleague/stats' },
+        { label: 'Salary-Adjusted MVPs' },
+      ]} />
       <h1>GM MVP Awards</h1>
       <p>
         Most efficient contracts by season, calculated as points scored divided

--- a/src/pages/theleague/mvp.astro
+++ b/src/pages/theleague/mvp.astro
@@ -1,6 +1,7 @@
 ---
 import TheLeagueLayout from '../../layouts/TheLeagueLayout.astro';
 import Breadcrumbs from '../../components/theleague/Breadcrumbs.astro';
+import RelatedReports from '../../components/theleague/RelatedReports.astro';
 import leagueConfig from '../../data/theleague.config.json';
 import { DEFAULT_HEADSHOT_URL, getPlayerImageUrl } from '../../constants/roster-constants';
 import { getCurrentSeasonYear } from '../../utils/league-year';
@@ -591,6 +592,8 @@ const getNflLogo = (team: string) => {
         );
       })}
     </section>
+
+    <RelatedReports currentId="mvp" />
   </section>
 </TheLeagueLayout>
 

--- a/src/pages/theleague/players.astro
+++ b/src/pages/theleague/players.astro
@@ -9,6 +9,7 @@
  */
 import TheLeagueLayout from '../../layouts/TheLeagueLayout.astro';
 import PlayerDetailsModal from '../../components/theleague/PlayerDetailsModal.astro';
+import { resolveLeaguePath } from '../../utils/nav-utils';
 import { positionOrder } from '../../constants/roster-constants';
 import { getCurrentLeagueYear, getCurrentSeasonYear } from '../../utils/league-year';
 import { getPlayerMap } from '../../utils/player-map';
@@ -559,6 +560,9 @@ const nflTeamsJson = JSON.stringify(nflTeamsList);
 // Admin gate: Value view is only visible to admin franchises (same auth as nav sidebar)
 const authUser = getAuthUser(Astro.request);
 const isAdmin = !!authUser && isCommissionerOrAdmin(authUser);
+
+const hideLeaguePrefix = Astro.locals.hideLeaguePrefix ?? false;
+const r = (path: string) => resolveLeaguePath(path, hideLeaguePrefix);
 ---
 
 <TheLeagueLayout title="Free Agents | TheLeague">
@@ -601,6 +605,12 @@ const isAdmin = !!authUser && isCommissionerOrAdmin(authUser);
           <h1 class="hero-title">Free Agents</h1>
           <span class="hero-count">{freeAgents.length} available players</span>
         </div>
+        <a href={r('/theleague/projected-free-agents')} class="hero-cross-link">
+          See projected FAs
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" aria-hidden="true">
+            <path d="M5 12h14M12 5l7 7-7 7"/>
+          </svg>
+        </a>
       </div>
 
       <!-- Search -->
@@ -2657,6 +2667,23 @@ const isAdmin = !!authUser && isCommissionerOrAdmin(authUser);
     justify-content: space-between;
     align-items: baseline;
     margin-bottom: 1.25rem;
+    gap: 1rem;
+    flex-wrap: wrap;
+  }
+  .hero-cross-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    font-size: 0.8125rem;
+    font-weight: 600;
+    color: var(--color-primary, #1c497c);
+    text-decoration: none;
+    transition: gap 0.15s ease;
+    white-space: nowrap;
+  }
+  .hero-cross-link:hover {
+    gap: 0.5rem;
+    text-decoration: underline;
   }
   .hero-title-group {
     display: flex;

--- a/src/pages/theleague/projected-free-agents.astro
+++ b/src/pages/theleague/projected-free-agents.astro
@@ -11,6 +11,7 @@
 export const prerender = false;
 
 import TheLeagueLayout from '../../layouts/TheLeagueLayout.astro';
+import Breadcrumbs from '../../components/theleague/Breadcrumbs.astro';
 import PlayerDetailsModal from '../../components/theleague/PlayerDetailsModal.astro';
 import { positionOrder } from '../../constants/roster-constants';
 import { getCurrentLeagueYear, getCurrentSeasonYear } from '../../utils/league-year';
@@ -342,6 +343,11 @@ function formatSalary(salary: number): string {
 
 <TheLeagueLayout title="Projected Free Agents | TheLeague">
   <div class="pfa-page">
+    <Breadcrumbs items={[
+      { label: 'The League', href: '/theleague' },
+      { label: 'Stats & Reports', href: '/theleague/stats' },
+      { label: 'Projected Free Agents' },
+    ]} />
     <!-- Hero -->
     <div class="pfa-hero">
       <div class="hero-top">

--- a/src/pages/theleague/projected-free-agents.astro
+++ b/src/pages/theleague/projected-free-agents.astro
@@ -12,7 +12,9 @@ export const prerender = false;
 
 import TheLeagueLayout from '../../layouts/TheLeagueLayout.astro';
 import Breadcrumbs from '../../components/theleague/Breadcrumbs.astro';
+import RelatedReports from '../../components/theleague/RelatedReports.astro';
 import PlayerDetailsModal from '../../components/theleague/PlayerDetailsModal.astro';
+import { resolveLeaguePath } from '../../utils/nav-utils';
 import { positionOrder } from '../../constants/roster-constants';
 import { getCurrentLeagueYear, getCurrentSeasonYear } from '../../utils/league-year';
 import { getPlayerMap } from '../../utils/player-map';
@@ -339,6 +341,9 @@ function formatSalary(salary: number): string {
   if (salary >= 1_000) return `$${(salary / 1_000).toFixed(0)}K`;
   return `$${salary}`;
 }
+
+const hideLeaguePrefix = Astro.locals.hideLeaguePrefix ?? false;
+const r = (path: string) => resolveLeaguePath(path, hideLeaguePrefix);
 ---
 
 <TheLeagueLayout title="Projected Free Agents | TheLeague">
@@ -355,6 +360,12 @@ function formatSalary(salary: number): string {
           <h1 class="hero-title">Projected Free Agents</h1>
           <span class="hero-subtitle">{currentYear} players in their final contract year</span>
         </div>
+        <a href={r('/theleague/players')} class="hero-cross-link">
+          Browse current Free Agents
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" aria-hidden="true">
+            <path d="M5 12h14M12 5l7 7-7 7"/>
+          </svg>
+        </a>
       </div>
     </div>
 
@@ -469,6 +480,8 @@ function formatSalary(salary: number): string {
     <div class="pfa-empty" id="pfa-empty" style="display: none;">
       <p>No expiring contracts found matching your filters.</p>
     </div>
+
+    <RelatedReports currentId="projected-free-agents" />
   </div>
   <PlayerDetailsModal />
 
@@ -928,6 +941,14 @@ function formatSalary(salary: number): string {
     padding: 2rem 0 1.25rem;
   }
 
+  .hero-top {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 1rem;
+    flex-wrap: wrap;
+  }
+
   .hero-title {
     font-size: 1.35rem;
     font-weight: 700;
@@ -941,6 +962,23 @@ function formatSalary(salary: number): string {
     color: var(--color-gray-400, #9ca3af);
     margin-top: 0.25rem;
     display: block;
+  }
+
+  .hero-cross-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    font-size: 0.8125rem;
+    font-weight: 600;
+    color: var(--color-primary, #1c497c);
+    text-decoration: none;
+    transition: gap 0.15s ease;
+    white-space: nowrap;
+  }
+
+  .hero-cross-link:hover {
+    gap: 0.5rem;
+    text-decoration: underline;
   }
 
   /* ── Metrics ── */

--- a/src/pages/theleague/salary-archive.astro
+++ b/src/pages/theleague/salary-archive.astro
@@ -1,6 +1,7 @@
 ---
 import TheLeagueLayout from '../../layouts/TheLeagueLayout.astro';
 import Breadcrumbs from '../../components/theleague/Breadcrumbs.astro';
+import RelatedReports from '../../components/theleague/RelatedReports.astro';
 import archiveLinks from '../../data/theleague/salary-archive-links.json';
 ---
 
@@ -45,6 +46,8 @@ import archiveLinks from '../../data/theleague/salary-archive-links.json';
         ))}
       </tbody>
     </table>
+
+    <RelatedReports currentId="salary-archive" />
   </section>
 </TheLeagueLayout>
 

--- a/src/pages/theleague/salary-archive.astro
+++ b/src/pages/theleague/salary-archive.astro
@@ -1,22 +1,21 @@
 ---
 import TheLeagueLayout from '../../layouts/TheLeagueLayout.astro';
-import { resolveLeaguePath } from '../../utils/nav-utils';
+import Breadcrumbs from '../../components/theleague/Breadcrumbs.astro';
 import archiveLinks from '../../data/theleague/salary-archive-links.json';
-
-const hideLeaguePrefix = Astro.locals.hideLeaguePrefix ?? false;
-const r = (path: string) => resolveLeaguePath(path, hideLeaguePrefix);
 ---
 
 <TheLeagueLayout title="Salary Archive">
   <section class="salary-archive">
     <header class="salary-archive__intro">
+      <Breadcrumbs items={[
+        { label: 'The League', href: '/theleague' },
+        { label: 'Stats & Reports', href: '/theleague/stats' },
+        { label: 'Salary Archive' },
+      ]} />
       <h1>Salary Archive</h1>
       <p>
         Historical salary spreadsheets from 2009&ndash;2025. These Google Sheets
         were manually maintained before salary data was generated from the MFL API.
-      </p>
-      <p class="salary-archive__back">
-        <a href={r("/theleague/salary")}>&larr; Back to Salary Analytics</a>
       </p>
     </header>
 

--- a/src/pages/theleague/salary-history.astro
+++ b/src/pages/theleague/salary-history.astro
@@ -1,5 +1,6 @@
 ---
 import TheLeagueLayout from '../../layouts/TheLeagueLayout.astro';
+import Breadcrumbs from '../../components/theleague/Breadcrumbs.astro';
 
 const summaryModules = import.meta.glob(
   '../../data/mfl-salary-averages-*.json',
@@ -89,6 +90,11 @@ function formatCurrency(val: number | null): string {
 <TheLeagueLayout title="Salary Trends">
   <section class="salary-history">
     <header class="page-hero">
+      <Breadcrumbs items={[
+        { label: 'The League', href: '/theleague' },
+        { label: 'Stats & Reports', href: '/theleague/stats' },
+        { label: 'Salary Trends' },
+      ]} />
       <h1 class="page-hero__title">Salary Trends Over Time</h1>
       <p class="page-hero__desc">
         Tracking the average of the top three (franchise tag), top five

--- a/src/pages/theleague/salary-history.astro
+++ b/src/pages/theleague/salary-history.astro
@@ -1,6 +1,7 @@
 ---
 import TheLeagueLayout from '../../layouts/TheLeagueLayout.astro';
 import Breadcrumbs from '../../components/theleague/Breadcrumbs.astro';
+import RelatedReports from '../../components/theleague/RelatedReports.astro';
 
 const summaryModules = import.meta.glob(
   '../../data/mfl-salary-averages-*.json',
@@ -207,6 +208,8 @@ function formatCurrency(val: number | null): string {
         </p>
       </div>
     )}
+
+    <RelatedReports currentId="salary-history" />
   </section>
 </TheLeagueLayout>
 

--- a/src/pages/theleague/salary.astro
+++ b/src/pages/theleague/salary.astro
@@ -1,7 +1,7 @@
 ---
 import TheLeagueLayout from '../../layouts/TheLeagueLayout.astro';
 import Breadcrumbs from '../../components/theleague/Breadcrumbs.astro';
-import { resolveLeaguePath } from '../../utils/nav-utils';
+import RelatedReports from '../../components/theleague/RelatedReports.astro';
 import leagueAssets from '../../data/theleague.assets.json';
 import archiveUrls from '../../data/theleague/salary-archive-urls.json';
 
@@ -141,9 +141,6 @@ const serializedConfig = JSON.stringify({
   franchiseMeta: franchiseLookup,
   archiveUrls: archiveUrls ?? {},
 });
-
-const hideLeaguePrefix = Astro.locals.hideLeaguePrefix ?? false;
-const r = (path: string) => resolveLeaguePath(path, hideLeaguePrefix);
 ---
 
 <TheLeagueLayout title="Salary Analytics">
@@ -303,14 +300,7 @@ const r = (path: string) => resolveLeaguePath(path, hideLeaguePrefix);
       })}
     </div>
 
-    <nav class="salary-footer" aria-label="Related pages">
-      <a href={r("/theleague/salary-archive")} class="salary-footer__link">
-        View Historical Spreadsheets (2009&ndash;2025) &rarr;
-      </a>
-      <a href={r("/theleague/salary-history")} class="salary-footer__link">
-        View Salary Trends Over Time &rarr;
-      </a>
-    </nav>
+    <RelatedReports currentId="salary-analytics" />
   </section>
 </TheLeagueLayout>
 
@@ -700,30 +690,6 @@ const r = (path: string) => resolveLeaguePath(path, hideLeaguePrefix);
     margin: 0;
     text-align: center;
     padding: 1.5rem 0;
-  }
-
-  /* ── Footer Links ── */
-  .salary-footer {
-    display: flex;
-    gap: 1.5rem;
-    padding-top: 0.5rem;
-    flex-wrap: wrap;
-  }
-
-  .salary-footer__link {
-    font-size: 0.8125rem;
-    font-weight: 500;
-    color: var(--color-primary, #1c497c);
-    text-decoration: none;
-  }
-
-  .salary-footer__link:hover {
-    text-decoration: underline;
-  }
-
-  .salary-footer__link:focus-visible {
-    outline: 2px solid var(--color-primary, #1c497c);
-    outline-offset: 2px;
   }
 
   /* ── Visually Hidden ── */

--- a/src/pages/theleague/salary.astro
+++ b/src/pages/theleague/salary.astro
@@ -1,5 +1,6 @@
 ---
 import TheLeagueLayout from '../../layouts/TheLeagueLayout.astro';
+import Breadcrumbs from '../../components/theleague/Breadcrumbs.astro';
 import { resolveLeaguePath } from '../../utils/nav-utils';
 import leagueAssets from '../../data/theleague.assets.json';
 import archiveUrls from '../../data/theleague/salary-archive-urls.json';
@@ -148,6 +149,11 @@ const r = (path: string) => resolveLeaguePath(path, hideLeaguePrefix);
 <TheLeagueLayout title="Salary Analytics">
   <section class="salary-analytics" aria-labelledby="salary-title">
     <header class="page-hero">
+      <Breadcrumbs items={[
+        { label: 'The League', href: '/theleague' },
+        { label: 'Stats & Reports', href: '/theleague/stats' },
+        { label: 'Salary Analytics' },
+      ]} />
       <h1 class="page-hero__title" id="salary-title">Salary Analytics</h1>
       <p class="page-hero__desc">
         Franchise tag figures use the average of the top three salaries at a

--- a/src/pages/theleague/stats.astro
+++ b/src/pages/theleague/stats.astro
@@ -1,0 +1,241 @@
+---
+/**
+ * Stats & Reports — hub page that ties together all analytics, awards, and
+ * historical-data pages. Pages are grouped by `subcategory` from the shared
+ * page-directory.json so the hub stays in sync with /search and homepage
+ * quick-links.
+ */
+import TheLeagueLayout from '../../layouts/TheLeagueLayout.astro';
+import Breadcrumbs from '../../components/theleague/Breadcrumbs.astro';
+import { resolveLeaguePath } from '../../utils/nav-utils';
+import { spriteUrl } from '../../utils/sprite-url';
+import pageDirectory from '../../data/page-directory.json';
+
+const hideLeaguePrefix = Astro.locals.hideLeaguePrefix ?? false;
+const r = (path: string) => resolveLeaguePath(path, hideLeaguePrefix);
+
+interface PageEntry {
+  id: string;
+  title: string;
+  description: string;
+  path: string;
+  icon: string;
+  category: string;
+  subcategory?: string;
+  visibility: string;
+  popularity: number;
+}
+
+const allPages = pageDirectory as PageEntry[];
+
+const SECTIONS: { id: string; title: string; description: string }[] = [
+  {
+    id: 'team-comparisons',
+    title: 'Team Comparisons',
+    description: 'Side-by-side cap, contract, and roster metrics across the league.',
+  },
+  {
+    id: 'salary-analytics',
+    title: 'Salary Analytics',
+    description: 'Position benchmarks, multi-year trends, and the historical archive.',
+  },
+  {
+    id: 'awards',
+    title: 'Awards',
+    description: 'The best (and worst) contract value in league history.',
+  },
+  {
+    id: 'free-agency',
+    title: 'Free Agency',
+    description: 'Forward-looking views of the market and expiring deals.',
+  },
+];
+
+// Group pages by subcategory, preserving the directory's popularity ordering
+const pagesBySubcategory = new Map<string, PageEntry[]>();
+for (const section of SECTIONS) {
+  pagesBySubcategory.set(
+    section.id,
+    allPages
+      .filter((p) => p.subcategory === section.id && p.visibility === 'all')
+      .sort((a, b) => b.popularity - a.popularity)
+  );
+}
+---
+
+<TheLeagueLayout title="Stats & Reports">
+  <div class="stats-hub">
+    <header class="stats-hub__header">
+      <Breadcrumbs items={[
+        { label: 'The League', href: '/theleague' },
+        { label: 'Stats & Reports' },
+      ]} />
+      <h1 class="stats-hub__title">Stats &amp; Reports</h1>
+      <p class="stats-hub__subtitle">
+        League analytics in one place — salary benchmarks, awards, projected free agents, and multi-year team comparisons.
+      </p>
+    </header>
+
+    <div class="stats-hub__sections">
+      {SECTIONS.map((section) => {
+        const pages = pagesBySubcategory.get(section.id) ?? [];
+        if (pages.length === 0) return null;
+        return (
+          <section class="stats-section" aria-labelledby={`stats-section-${section.id}`}>
+            <div class="stats-section__heading">
+              <h2 class="stats-section__title" id={`stats-section-${section.id}`}>{section.title}</h2>
+              <p class="stats-section__desc">{section.description}</p>
+            </div>
+            <div class="stats-section__grid">
+              {pages.map((page) => (
+                <a class="stats-card" href={r(`/theleague${page.path}`)}>
+                  <svg class="stats-card__icon" width="22" height="22" aria-hidden="true">
+                    <use href={`${spriteUrl}#icon-${page.icon}`} />
+                  </svg>
+                  <div class="stats-card__text">
+                    <span class="stats-card__name">{page.title}</span>
+                    <span class="stats-card__desc">{page.description}</span>
+                  </div>
+                </a>
+              ))}
+            </div>
+          </section>
+        );
+      })}
+    </div>
+  </div>
+</TheLeagueLayout>
+
+<style>
+  .stats-hub {
+    --hub-accent: var(--color-primary, #1c497c);
+    width: 100%;
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 1.25rem 1.125rem;
+    box-sizing: border-box;
+  }
+
+  .stats-hub__header {
+    margin-bottom: 1.75rem;
+  }
+
+  .stats-hub__title {
+    font-size: 1.75rem;
+    font-weight: 700;
+    color: var(--color-gray-900, #111827);
+    line-height: 1.2;
+    margin: 0 0 0.5rem 0;
+  }
+
+  .stats-hub__subtitle {
+    font-size: 0.9375rem;
+    color: var(--color-gray-600, #4b5563);
+    line-height: 1.5;
+    margin: 0;
+    max-width: 60ch;
+  }
+
+  .stats-hub__sections {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+  }
+
+  .stats-section {
+    background: var(--content-bg, #fff);
+    border: 1px solid var(--content-border, #e2e8f0);
+    border-radius: var(--radius-md, 0.5rem);
+    box-shadow: var(--shadow-md);
+    padding: 1.5rem;
+  }
+
+  .stats-section__heading {
+    margin-bottom: 1rem;
+  }
+
+  .stats-section__title {
+    font-size: 0.75rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    padding-left: 0.625rem;
+    border-left: 2px solid var(--hub-accent);
+    margin: 0 0 0.5rem 0;
+    line-height: 1;
+    color: var(--color-gray-700, #374151);
+  }
+
+  .stats-section__desc {
+    font-size: 0.8125rem;
+    color: var(--color-gray-500, #6b7280);
+    line-height: 1.5;
+    margin: 0;
+  }
+
+  .stats-section__grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 0.625rem;
+  }
+
+  .stats-card {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.75rem;
+    padding: 0.875rem;
+    border-radius: var(--radius-md, 0.5rem);
+    background: var(--color-gray-50, #f9fafb);
+    text-decoration: none;
+    transition: background 0.15s ease, transform 0.15s ease;
+  }
+
+  .stats-card:hover {
+    background: var(--color-gray-100, #f3f4f6);
+    transform: translateY(-1px);
+  }
+
+  .stats-card__icon {
+    flex-shrink: 0;
+    color: var(--hub-accent);
+    margin-top: 0.125rem;
+  }
+
+  .stats-card__text {
+    display: flex;
+    flex-direction: column;
+    gap: 0.1875rem;
+    min-width: 0;
+  }
+
+  .stats-card__name {
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: var(--color-gray-800, #1f2937);
+    line-height: 1.3;
+  }
+
+  .stats-card__desc {
+    font-size: 0.75rem;
+    color: var(--color-gray-500, #6b7280);
+    line-height: 1.4;
+  }
+
+  @media (max-width: 640px) {
+    .stats-hub {
+      padding: 1rem 0.875rem;
+    }
+
+    .stats-section {
+      padding: 1.25rem;
+    }
+
+    .stats-section__grid {
+      grid-template-columns: 1fr;
+    }
+
+    .stats-hub__title {
+      font-size: 1.5rem;
+    }
+  }
+</style>


### PR DESCRIPTION
Consolidates 7 analytics report pages (League Summary, Salary Analytics,
Salary Trends, Salary Archive, Salary-Adjusted MVPs, Dead Money Awards,
Projected Free Agents) into a single hub grouped by subcategory.

- New /theleague/stats hub renders 4 themed sections (Team Comparisons,
  Salary Analytics, Awards, Free Agency) sourced from page-directory.json
- All 7 report pages now have breadcrumbs trailing through the hub
- Header hamburger replaces 3 individual salary links with one Stats entry
- HpQuickLinks pins Stats & Reports as the first tile on the homepage

https://claude.ai/code/session_01LwFVXhaWSiFMN96tAN9yr4