### PR TITLE
feat: phase-aware collapsible side nav

### DIFF
--- a/src/components/nav/NavLinks.astro
+++ b/src/components/nav/NavLinks.astro
@@ -2,40 +2,34 @@
 /**
  * NavLinks Component
  *
- * Scrollable navigation links section for the unified navigation drawer.
- * Renders grouped sections with section titles, icons, and visibility logic.
+ * Scrollable navigation links rendered as a series of collapsible sections
+ * (multi-open WAI-ARIA disclosure pattern, NOT an accordion — opening one
+ * section never closes another).
  *
- * Features:
- * - Scrollable middle section (fills space between header and footer)
- * - Grouped sections with visual separation
- * - Active state highlighting for current page
- * - Collapsed mode with icon-only display and tooltips
- * - Visibility filtering (admin, owner, league-specific)
- * - External link indicators
- * - Touch-friendly targets (44px minimum)
- * - Dark mode support via design tokens
- *
- * @example
- * <NavLinks
- *   sections={navConfig.sections}
- *   league="theleague"
- *   currentPath="/theleague/rosters"
- *   isCollapsed={false}
- *   franchiseId="0001"
- * />
+ * Behavior:
+ * - Section order is league-phase aware (in-season vs off-season).
+ * - Per-section open/closed state persists via cookie+localStorage; a
+ *   section's open state is keyed by its `id`, so adding/removing sections
+ *   in the future is non-destructive (unknown ids fall back to default).
+ * - The section that contains the active link is force-expanded on render
+ *   without overwriting the user's stored preference.
+ * - In collapsed-drawer mode (icon-only) the section header buttons hide
+ *   entirely — every visible link renders flat with its tooltip.
  */
 
-import type { NavLinksProps, NavSection, NavLink, LeagueSlug } from '../../types/nav';
+import type { NavLinksProps, NavSection, NavLink, LeagueSlug, LeaguePhase, NavSectionDefaultOpen } from '../../types/nav';
+import { NAV_COOKIES } from '../../types/nav';
 import { getAFLPreference, getAFLTeamData } from '../../utils/team-preferences';
 import { resolveLeaguePath } from '../../utils/nav-utils';
 import { spriteUrl } from '../../utils/sprite-url';
+import { getLeaguePhase } from '../../utils/league-phase';
 
 interface Props extends NavLinksProps {
   /** Admin franchise IDs for visibility checks */
   adminFranchiseIds?: string[];
   /** Strip /theleague prefix from links (true on theleague.us domain) */
   hideLeaguePrefix?: boolean;
-  /** Whether the user is a commissioner (renders admin links hidden instead of omitting) */
+  /** Whether the user is a commissioner */
   isCommissioner?: boolean;
   /** Whether commish mode is currently active */
   isCommishMode?: boolean;
@@ -65,307 +59,256 @@ const AFL_TIER_LINKS = {
   },
 } as const;
 
-/**
- * Get the league path prefix
- */
 function getLeaguePrefix(leagueSlug: LeagueSlug): string {
   return leagueSlug === 'afl' ? '/afl-fantasy' : '/theleague';
 }
 
-/**
- * Check if a link should be visible based on visibility rules
- */
-function isLinkVisible(link: NavLink, franchiseId?: string, adminIds: string[] = []): boolean {
-  // Check visibility restriction
-  if (link.visibility === 'admin') {
-    return !!franchiseId && adminIds.includes(franchiseId);
-  }
-  if (link.visibility === 'owner') {
-    return !!franchiseId;
-  }
-  return true; // public visibility (default)
+function isLinkVisible(link: NavLink, fid?: string, adminIds: string[] = []): boolean {
+  if (link.visibility === 'admin') return !!fid && adminIds.includes(fid);
+  if (link.visibility === 'owner') return !!fid;
+  return true;
 }
 
-/**
- * Check if a section should be visible
- */
-function isSectionVisible(section: NavSection, league: LeagueSlug, franchiseId?: string, adminIds: string[] = []): boolean {
-  // Check league restriction
-  if (section.leagueOnly && section.leagueOnly !== league) {
-    return false;
-  }
-
-  // Check section-level visibility
-  if (section.visibility === 'admin') {
-    return !!franchiseId && adminIds.includes(franchiseId);
-  }
-  if (section.visibility === 'owner') {
-    return !!franchiseId;
-  }
-
-  // Check if section has any visible links
-  const visibleLinks = section.links.filter((link) => {
-    // Check link's league restriction
-    if (link.leagueOnly && link.leagueOnly !== league) {
-      return false;
-    }
-    return isLinkVisible(link, franchiseId, adminIds);
+function isSectionVisible(section: NavSection, lg: LeagueSlug, fid?: string, adminIds: string[] = []): boolean {
+  if (section.leagueOnly && section.leagueOnly !== lg) return false;
+  if (section.visibility === 'admin') return !!fid && adminIds.includes(fid);
+  if (section.visibility === 'owner') return !!fid;
+  const visible = section.links.filter((l) => {
+    if (l.leagueOnly && l.leagueOnly !== lg) return false;
+    return isLinkVisible(l, fid, adminIds);
   });
-
-  return visibleLinks.length > 0;
+  return visible.length > 0;
 }
 
-/**
- * Resolve the final href for a link
- */
-function resolveHref(link: NavLink, league: LeagueSlug): string {
-  // External URL takes precedence
-  if (link.url) {
-    return link.url;
-  }
-
-  // URL template (would need variable substitution)
-  if (link.urlTemplate) {
-    return link.urlTemplate;
-  }
-
-  // Internal path - prepend league prefix, then strip if on theleague.us
+function resolveHref(link: NavLink, lg: LeagueSlug): string {
+  if (link.url) return link.url;
+  if (link.urlTemplate) return link.urlTemplate;
   if (link.path) {
-    const prefix = getLeaguePrefix(league);
+    const prefix = getLeaguePrefix(lg);
     return resolveLeaguePath(`${prefix}${link.path}`, hideLeaguePrefix);
   }
-
   return '#';
 }
 
-/**
- * Get the display label for a link (supports AFL override)
- */
-function getLabel(link: NavLink, league: LeagueSlug): string {
-  if (league === 'afl' && link.labelAFL) {
-    return link.labelAFL;
-  }
+function getLabel(link: NavLink, lg: LeagueSlug): string {
+  if (lg === 'afl' && link.labelAFL) return link.labelAFL;
   return link.label;
 }
 
-function getAflCompetitionOverride(link: NavLink, league: LeagueSlug, franchiseId?: string): { label: string; iconUrl: string } | null {
-  if (league !== 'afl' || link.id !== 'premier-league') {
-    return null;
-  }
-
-  const tier =
-    aflPreference?.competitionId ||
-    (franchiseId ? getAFLTeamData(franchiseId)?.tier : null);
-
+function getAflCompetitionOverride(link: NavLink, lg: LeagueSlug, fid?: string): { label: string; iconUrl: string } | null {
+  if (lg !== 'afl' || link.id !== 'premier-league') return null;
+  const tier = aflPreference?.competitionId || (fid ? getAFLTeamData(fid)?.tier : null);
   return AFL_TIER_LINKS[tier as keyof typeof AFL_TIER_LINKS] ?? AFL_TIER_LINKS['Premier League'];
 }
 
-/**
- * Get the icon for a link (supports AFL override)
- */
-function getIcon(link: NavLink, league: LeagueSlug): string {
-  if (league === 'afl' && link.iconAFL) {
-    return link.iconAFL;
-  }
+function getIcon(link: NavLink, lg: LeagueSlug): string {
+  if (lg === 'afl' && link.iconAFL) return link.iconAFL;
   return link.icon;
 }
 
 /**
- * Check if a link is active based on current path (including query string)
- *
- * Priority:
- * 1. Exact match (path + query string) - highest priority
- * 2. If link has query params, require exact match (don't match base path only)
- * 3. If link has no query params, match base path only
+ * Match link against current path (with query-string awareness).
+ * Mirrors the prior implementation so link highlighting behavior is unchanged.
  */
-function isActive(link: NavLink, currentPath: string, league: LeagueSlug): boolean {
-  const href = resolveHref(link, league);
-
-  // Don't mark external links as active
-  if (link.external || link.url) {
-    return false;
-  }
-
-  // Normalize currentPath to match generated hrefs (strip prefix on theleague.us)
-  const normalizedCurrentPath = resolveLeaguePath(currentPath, hideLeaguePrefix);
-
-  // Exact match (path + query string)
-  if (normalizedCurrentPath === href) {
-    return true;
-  }
-
-  // Check if the link has query params
-  const linkHasQueryParams = href.includes('?');
-
-  // If link has query params, require exact match (already checked above)
-  if (linkHasQueryParams) {
-    return false;
-  }
-
-  // For links without query params, match if current path starts with link path
-  // but only if current path has no query string OR has different query string
-  const currentBasePath = normalizedCurrentPath.split('?')[0];
-  const currentHasQueryParams = normalizedCurrentPath.includes('?');
-
-  // If current page has query params, don't match against a link without query params
-  // This prevents /rosters from being active when on /rosters?view=nextyear
-  if (currentHasQueryParams) {
-    return false;
-  }
-
-  return currentBasePath === href;
+function isActive(link: NavLink, currPath: string, lg: LeagueSlug): boolean {
+  const href = resolveHref(link, lg);
+  if (link.external || link.url) return false;
+  const norm = resolveLeaguePath(currPath, hideLeaguePrefix);
+  if (norm === href) return true;
+  const linkHasQS = href.includes('?');
+  if (linkHasQS) return false;
+  const currBase = norm.split('?')[0];
+  const currHasQS = norm.includes('?');
+  if (currHasQS) return false;
+  return currBase === href;
 }
 
 /**
- * Filter sections and links based on visibility rules.
- * For commissioners, admin links are included but may be hidden (toggled client-side).
+ * Resolve a section's default open state for the current phase.
+ * Used when the user has no stored preference for this section.
+ */
+function defaultOpenForPhase(rule: NavSectionDefaultOpen | undefined, phase: LeaguePhase): boolean {
+  switch (rule) {
+    case 'always':
+      return true;
+    case 'in-season':
+      return phase === 'in-season';
+    case 'off-season':
+      return phase === 'off-season';
+    case 'never':
+    case undefined:
+    default:
+      return false;
+  }
+}
+
+/**
+ * Parse the persisted per-section state cookie. Unknown keys are ignored,
+ * malformed JSON falls back to an empty map (self-healing).
+ */
+function parseStoredSectionState(raw: string | undefined): Record<string, 'open' | 'closed'> {
+  if (!raw) return {};
+  try {
+    const parsed = JSON.parse(decodeURIComponent(raw));
+    if (parsed && typeof parsed === 'object') return parsed as Record<string, 'open' | 'closed'>;
+  } catch {
+    // ignore malformed cookie
+  }
+  return {};
+}
+
+/**
+ * Filter + dedup links and tag the section as admin-only when every visible
+ * link is admin-restricted (matches prior behavior so commish-mode toggling
+ * still works).
  */
 function getVisibleSections(): Array<NavSection & { _adminOnly?: boolean }> {
   return sections
     .filter((section) => {
-      // For commissioners, always include sections that have admin links
-      if (isCommissioner && section.links.some(l => l.visibility === 'admin')) {
-        return true;
-      }
+      if (isCommissioner && section.links.some((l) => l.visibility === 'admin')) return true;
       return isSectionVisible(section, league, franchiseId, adminFranchiseIds);
     })
     .map((section) => {
       const filteredLinks = section.links.filter((link) => {
-        // Check link's league restriction
-        if (link.leagueOnly && link.leagueOnly !== league) {
-          return false;
-        }
-        // Commissioners see admin links (rendered hidden if not in commish mode)
-        if (link.visibility === 'admin' && isCommissioner) {
-          return true;
-        }
+        if (link.leagueOnly && link.leagueOnly !== league) return false;
+        if (link.visibility === 'admin' && isCommissioner) return true;
         return isLinkVisible(link, franchiseId, adminFranchiseIds);
       });
-
-      // Track if ALL links in this section are admin-only
-      const allAdmin = filteredLinks.length > 0 && filteredLinks.every(l => l.visibility === 'admin');
-
+      const allAdmin = filteredLinks.length > 0 && filteredLinks.every((l) => l.visibility === 'admin');
       return { ...section, links: filteredLinks, _adminOnly: allAdmin };
     })
-    .filter(s => s.links.length > 0);
+    .filter((s) => s.links.length > 0);
 }
 
-const visibleSections = getVisibleSections();
+const phase: LeaguePhase = getLeaguePhase();
+
+const visibleSections = getVisibleSections().sort((a, b) => {
+  const ao = a.phaseOrder ? (phase === 'in-season' ? a.phaseOrder.inSeason : a.phaseOrder.offSeason) : 999;
+  const bo = b.phaseOrder ? (phase === 'in-season' ? b.phaseOrder.inSeason : b.phaseOrder.offSeason) : 999;
+  return ao - bo;
+});
+
+const storedState = parseStoredSectionState(Astro.cookies.get(NAV_COOKIES.NAV_SECTIONS)?.value);
+
+// Pre-compute initial open/closed state for SSR. Active-link section forces
+// open on render but never overwrites the user's stored preference.
+const sectionRenderInfo = visibleSections.map((section) => {
+  const containsActive = section.links.some((l) => isActive(l, currentPath, league));
+  const stored = storedState[section.id];
+  const defaultOpen = defaultOpenForPhase(section.defaultOpen, phase);
+  const userPrefers = stored === 'open' ? true : stored === 'closed' ? false : defaultOpen;
+  const initiallyOpen = containsActive || userPrefers;
+  return { section, initiallyOpen, containsActive };
+});
 ---
 
 <nav
   class="nav-links"
   aria-label="Main navigation"
+  data-nav-phase={phase}
 >
   <ul class="nav-links__list" role="list">
-    {visibleSections.map((section, sectionIndex) => {
+    {sectionRenderInfo.map(({ section, initiallyOpen, containsActive }) => {
       const isAdminSection = (section as any)._adminOnly;
       const hideAdminSection = isAdminSection && isCommissioner && !isCommishMode;
+      const sectionId = section.id;
+      const headerId = `nav-section-header-${sectionId}`;
+      const regionId = `nav-section-region-${sectionId}`;
       return (
-      <li
-        class="nav-links__section"
-        key={section.id}
-        data-section-visibility={isAdminSection ? 'admin' : undefined}
-        style={hideAdminSection ? 'display: none;' : undefined}
-      >
-        <h2
-          class="nav-links__section-title"
-          id={`nav-section-${section.id}`}
+        <li
+          class="nav-links__section"
+          data-section-id={sectionId}
+          data-section-visibility={isAdminSection ? 'admin' : undefined}
+          data-section-default={section.defaultOpen ?? 'never'}
+          data-contains-active={containsActive ? 'true' : undefined}
+          style={hideAdminSection ? 'display: none;' : undefined}
         >
-          {section.label}
-        </h2>
+          <h2 class="nav-links__section-heading">
+            <button
+              type="button"
+              id={headerId}
+              class="nav-links__section-toggle"
+              aria-expanded={initiallyOpen ? 'true' : 'false'}
+              aria-controls={regionId}
+              data-section-toggle
+            >
+              <span class="nav-links__section-label">{section.label}</span>
+              <svg class="nav-links__section-chevron" viewBox="0 0 24 24" aria-hidden="true">
+                <use href={`${spriteUrl}#icon-chevron-right`} />
+              </svg>
+            </button>
+          </h2>
 
-        <ul
-          class="nav-links__section-links"
-          role="list"
-          aria-labelledby={`nav-section-${section.id}`}
-        >
-          {section.links.map((link) => {
-            const href = resolveHref(link, league);
-            const aflOverride = getAflCompetitionOverride(link, league, franchiseId);
-            const label = aflOverride?.label ?? getLabel(link, league);
-            const icon = getIcon(link, league);
-            const iconUrl = aflOverride?.iconUrl ?? null;
-            const active = isActive(link, currentPath, league);
-            const isExternal = link.external;
-            const isAdminLink = link.visibility === 'admin';
-            const hideAdmin = isAdminLink && isCommissioner && !isCommishMode;
-            return (
-              <li
-                class="nav-links__item"
-                key={link.id}
-                data-visibility={isAdminLink ? 'admin' : undefined}
-                style={hideAdmin ? 'display: none;' : undefined}
-              >
-                <a
-                  href={href}
-                  class:list={[
-                    'nav-links__link',
-                    { 'nav-links__link--active': active },
-                  ]}
-                  {...(isExternal && {
-                    target: '_blank',
-                    rel: 'noopener noreferrer',
-                  })}
-                  data-astro-reload
-                  aria-current={active ? 'page' : undefined}
-                >
-                  {/* Icon */}
-                  <span class="nav-links__icon" aria-hidden="true">
-                    {iconUrl ? (
-                      <img src={iconUrl} alt="" loading="lazy" />
-                    ) : (
-                      <svg width="24" height="24" viewBox="0 0 24 24">
-                        <use href={`${spriteUrl}#icon-${icon}`} />
-                      </svg>
-                    )}
-                  </span>
-
-                  {/* Label */}
-                  <span class="nav-links__label">
-                    {label}
-                  </span>
-
-                  {/* Badge (if present) */}
-                  {link.badge && link.badge > 0 && (
-                    <span
-                      class="nav-links__badge"
-                      aria-label={`${link.badge} notifications`}
+          <div
+            id={regionId}
+            role="region"
+            aria-labelledby={headerId}
+            class="nav-links__section-region"
+            hidden={!initiallyOpen}
+          >
+            <ul class="nav-links__section-links" role="list">
+              {section.links.map((link) => {
+                const href = resolveHref(link, league);
+                const aflOverride = getAflCompetitionOverride(link, league, franchiseId);
+                const label = aflOverride?.label ?? getLabel(link, league);
+                const icon = getIcon(link, league);
+                const iconUrl = aflOverride?.iconUrl ?? null;
+                const active = isActive(link, currentPath, league);
+                const isExternal = link.external;
+                const isAdminLink = link.visibility === 'admin';
+                const hideAdmin = isAdminLink && isCommissioner && !isCommishMode;
+                return (
+                  <li
+                    class="nav-links__item"
+                    data-visibility={isAdminLink ? 'admin' : undefined}
+                    style={hideAdmin ? 'display: none;' : undefined}
+                  >
+                    <a
+                      href={href}
+                      class:list={['nav-links__link', { 'nav-links__link--active': active }]}
+                      {...(isExternal && { target: '_blank', rel: 'noopener noreferrer' })}
+                      data-astro-reload
+                      aria-current={active ? 'page' : undefined}
                     >
-                      {link.badge > 99 ? '99+' : link.badge}
-                    </span>
-                  )}
-
-                  {/* External link indicator */}
-                  {isExternal && (
-                    <span class="nav-links__external" aria-hidden="true">
-                      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                        <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
-                        <polyline points="15 3 21 3 21 9" />
-                        <line x1="10" y1="14" x2="21" y2="3" />
-                      </svg>
-                    </span>
-                  )}
-                </a>
-              </li>
-            );
-          })}
-        </ul>
-
-        {/* Section separator - not after last section */}
-        {sectionIndex < visibleSections.length - 1 && (
-          <hr class="nav-links__separator" aria-hidden="true" />
-        )}
-      </li>
-    );
+                      <span class="nav-links__icon" aria-hidden="true">
+                        {iconUrl ? (
+                          <img src={iconUrl} alt="" loading="lazy" />
+                        ) : (
+                          <svg width="24" height="24" viewBox="0 0 24 24">
+                            <use href={`${spriteUrl}#icon-${icon}`} />
+                          </svg>
+                        )}
+                      </span>
+                      <span class="nav-links__label">{label}</span>
+                      {link.badge && link.badge > 0 && (
+                        <span class="nav-links__badge" aria-label={`${link.badge} notifications`}>
+                          {link.badge > 99 ? '99+' : link.badge}
+                        </span>
+                      )}
+                      {isExternal && (
+                        <span class="nav-links__external" aria-hidden="true">
+                          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+                            <polyline points="15 3 21 3 21 9" />
+                            <line x1="10" y1="14" x2="21" y2="3" />
+                          </svg>
+                        </span>
+                      )}
+                    </a>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        </li>
+      );
     })}
   </ul>
 </nav>
 
 <style>
   /* ============================================
-   * NAV LINKS CONTAINER
-   * Scrollable section that fills remaining space
+   * NAV LINKS CONTAINER — scrollable middle pane
    * ============================================ */
   .nav-links {
     flex: 1;
@@ -373,31 +316,15 @@ const visibleSections = getVisibleSections();
     overflow-x: hidden;
     padding: var(--nav-spacing-lg, 16px) var(--nav-spacing-lg, 16px);
 
-    /* Custom scrollbar */
     scrollbar-width: thin;
     scrollbar-color: var(--nav-scrollbar-thumb, #d1d5db) var(--nav-scrollbar-track, transparent);
   }
 
-  .nav-links::-webkit-scrollbar {
-    width: var(--nav-scrollbar-width, 6px);
-  }
+  .nav-links::-webkit-scrollbar { width: var(--nav-scrollbar-width, 6px); }
+  .nav-links::-webkit-scrollbar-track { background: var(--nav-scrollbar-track, transparent); }
+  .nav-links::-webkit-scrollbar-thumb { background: var(--nav-scrollbar-thumb, #d1d5db); border-radius: var(--nav-border-radius-sm, 4px); }
+  .nav-links::-webkit-scrollbar-thumb:hover { background: var(--nav-scrollbar-thumb-hover, #9ca3af); }
 
-  .nav-links::-webkit-scrollbar-track {
-    background: var(--nav-scrollbar-track, transparent);
-  }
-
-  .nav-links::-webkit-scrollbar-thumb {
-    background: var(--nav-scrollbar-thumb, #d1d5db);
-    border-radius: var(--nav-border-radius-sm, 4px);
-  }
-
-  .nav-links::-webkit-scrollbar-thumb:hover {
-    background: var(--nav-scrollbar-thumb-hover, #9ca3af);
-  }
-
-  /* ============================================
-   * LISTS
-   * ============================================ */
   .nav-links__list,
   .nav-links__section-links {
     list-style: none;
@@ -409,7 +336,7 @@ const visibleSections = getVisibleSections();
    * SECTION
    * ============================================ */
   .nav-links__section {
-    margin-bottom: 20px;
+    margin-bottom: 4px;
   }
 
   .nav-links__section:last-child {
@@ -417,17 +344,78 @@ const visibleSections = getVisibleSections();
   }
 
   /* ============================================
-   * SECTION TITLE
+   * SECTION HEADING + TOGGLE
+   * Heading wraps the button: heading provides outline
+   * landmarks, button provides interactive semantics.
    * ============================================ */
-  .nav-links__section-title {
+  .nav-links__section-heading {
+    margin: 0;
+    padding: 0;
+  }
+
+  .nav-links__section-toggle {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    background: none;
+    border: none;
+    padding: 8px;
+    min-height: 36px;
+    color: var(--nav-section-color, #b22222);
+    font-family: inherit;
     font-size: var(--nav-section-font-size, 0.75rem);
     font-weight: var(--nav-section-font-weight, 700);
-    color: var(--nav-section-color, #b22222);
     text-transform: uppercase;
     letter-spacing: var(--nav-section-letter-spacing, 0.05em);
-    margin: 0 0 var(--nav-section-margin-bottom, 12px) 0;
-    padding: 0 var(--nav-spacing-sm, 8px);
     line-height: 1.5;
+    cursor: pointer;
+    border-radius: 6px;
+    text-align: left;
+    transition: var(--nav-hover-transition);
+  }
+
+  .nav-links__section-toggle:hover {
+    background: var(--nav-hover-bg);
+  }
+
+  .nav-links__section-toggle:focus-visible {
+    outline: none;
+    box-shadow: var(--nav-focus-ring);
+    outline-offset: var(--nav-focus-ring-offset);
+  }
+
+  .nav-links__section-label {
+    flex: 1;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .nav-links__section-chevron {
+    flex-shrink: 0;
+    width: 14px;
+    height: 14px;
+    fill: currentColor;
+    transition: transform 200ms cubic-bezier(0.4, 0, 0.2, 1);
+  }
+
+  /* Rotate chevron when section is open */
+  .nav-links__section-toggle[aria-expanded='true'] .nav-links__section-chevron {
+    transform: rotate(90deg);
+  }
+
+  /* ============================================
+   * REGION (link list container)
+   * Use [hidden] for instant show/hide — no height
+   * animation hacks. Cheap, accessible, predictable.
+   * ============================================ */
+  .nav-links__section-region {
+    padding-top: 4px;
+    padding-bottom: 8px;
+  }
+
+  .nav-links__section-region[hidden] {
+    display: none;
   }
 
   /* ============================================
@@ -442,9 +430,6 @@ const visibleSections = getVisibleSections();
     margin-bottom: 0;
   }
 
-  /* ============================================
-   * LINK
-   * ============================================ */
   .nav-links__link {
     display: flex;
     align-items: center;
@@ -468,7 +453,6 @@ const visibleSections = getVisibleSections();
     outline-offset: var(--nav-focus-ring-offset);
   }
 
-  /* Active link */
   .nav-links__link--active {
     background: var(--color-primary, #1c497c);
     color: #ffffff;
@@ -480,7 +464,6 @@ const visibleSections = getVisibleSections();
     color: #ffffff;
   }
 
-  /* Override icon color for active state */
   .nav-links__link--active .nav-links__icon :global(svg) {
     fill: #ffffff;
   }
@@ -510,7 +493,7 @@ const visibleSections = getVisibleSections();
   }
 
   /* ============================================
-   * LABEL
+   * LABEL / BADGE / EXTERNAL
    * ============================================ */
   .nav-links__label {
     flex: 1;
@@ -521,9 +504,6 @@ const visibleSections = getVisibleSections();
     text-overflow: ellipsis;
   }
 
-  /* ============================================
-   * BADGE
-   * ============================================ */
   .nav-links__badge {
     display: flex;
     align-items: center;
@@ -539,9 +519,6 @@ const visibleSections = getVisibleSections();
     flex-shrink: 0;
   }
 
-  /* ============================================
-   * EXTERNAL LINK INDICATOR
-   * ============================================ */
   .nav-links__external {
     display: flex;
     align-items: center;
@@ -553,51 +530,37 @@ const visibleSections = getVisibleSections();
     opacity: 0.6;
   }
 
-  .nav-links__external svg {
-    width: 100%;
-    height: 100%;
-  }
-
-  .nav-links__link:hover .nav-links__external {
-    opacity: 1;
-  }
+  .nav-links__external svg { width: 100%; height: 100%; }
+  .nav-links__link:hover .nav-links__external { opacity: 1; }
 
   /* ============================================
-   * SEPARATOR
+   * COLLAPSED DRAWER MODE (icon-only)
+   * Drawer-level class .nav-drawer--collapsed lives
+   * on a wrapping element; if it's ever introduced
+   * we hide section headers entirely so the link
+   * column reads as a flat icon list.
    * ============================================ */
-  .nav-links__separator {
-    border: none;
-    border-top: 1px solid var(--nav-border-subtle);
-    margin: var(--nav-spacing-lg) 0;
+  :global(.nav-drawer--collapsed) .nav-links__section-heading {
+    display: none;
   }
 
-  /* ============================================
-   * VISUALLY HIDDEN (accessible hiding)
-   * ============================================ */
-  .visually-hidden {
-    position: absolute !important;
-    width: 1px !important;
-    height: 1px !important;
-    padding: 0 !important;
-    margin: -1px !important;
-    overflow: hidden !important;
-    clip: rect(0, 0, 0, 0) !important;
-    white-space: nowrap !important;
-    border: 0 !important;
+  :global(.nav-drawer--collapsed) .nav-links__section-region[hidden] {
+    display: block;
   }
 
   /* ============================================
    * REDUCED MOTION
    * ============================================ */
   @media (prefers-reduced-motion: reduce) {
-    .nav-links__link {
+    .nav-links__link,
+    .nav-links__section-toggle,
+    .nav-links__section-chevron {
       transition: none;
     }
   }
 
   /* ============================================
    * TOUCH DEVICE ADJUSTMENTS
-   * Ensure touch targets are at least 44x44px
    * ============================================ */
   @media (pointer: coarse) {
     .nav-links__link {
@@ -605,5 +568,85 @@ const visibleSections = getVisibleSections();
       padding-top: var(--nav-spacing-md);
       padding-bottom: var(--nav-spacing-md);
     }
+    .nav-links__section-toggle {
+      min-height: 44px;
+    }
   }
 </style>
+
+<script>
+  /**
+   * Section disclosure toggle + persistence.
+   *
+   * Persists each section's open/closed state in two places:
+   *   - localStorage (long-lived, survives Safari ITP edge cases)
+   *   - cookie 'nav-sections-v1' (so the SSR render matches user preference
+   *     immediately on next page load — no post-hydration flash)
+   *
+   * Active-section auto-expand is handled server-side and is intentionally
+   * NOT written to storage: navigating away returns the section to its
+   * stored preference, matching the VS Code pattern.
+   */
+  const COOKIE_KEY = 'nav-sections-v1';
+  const STORAGE_KEY = 'nav.sections.v1';
+
+  function readState(): Record<string, 'open' | 'closed'> {
+    // Prefer localStorage (richer, no parsing surprises). Fall back to cookie
+    // if storage is blocked (private mode, third-party blockers).
+    try {
+      const raw = window.localStorage.getItem(STORAGE_KEY);
+      if (raw) {
+        const parsed = JSON.parse(raw);
+        if (parsed && typeof parsed === 'object') return parsed;
+      }
+    } catch {}
+    const match = document.cookie.split(';').map((c) => c.trim()).find((c) => c.startsWith(COOKIE_KEY + '='));
+    if (match) {
+      try {
+        return JSON.parse(decodeURIComponent(match.slice(COOKIE_KEY.length + 1)));
+      } catch {}
+    }
+    return {};
+  }
+
+  function writeState(state: Record<string, 'open' | 'closed'>): void {
+    const json = JSON.stringify(state);
+    try { window.localStorage.setItem(STORAGE_KEY, json); } catch {}
+    const expires = new Date();
+    expires.setFullYear(expires.getFullYear() + 1);
+    document.cookie = `${COOKIE_KEY}=${encodeURIComponent(json)};expires=${expires.toUTCString()};path=/;SameSite=Lax`;
+  }
+
+  function bindSectionToggles(): void {
+    const toggles = document.querySelectorAll<HTMLButtonElement>('[data-section-toggle]');
+    toggles.forEach((btn) => {
+      // Avoid double-binding when astro:page-load fires after View Transitions
+      if (btn.dataset.bound === '1') return;
+      btn.dataset.bound = '1';
+      btn.addEventListener('click', () => {
+        const sectionEl = btn.closest<HTMLElement>('[data-section-id]');
+        if (!sectionEl) return;
+        const sectionId = sectionEl.dataset.sectionId;
+        if (!sectionId) return;
+        const regionId = btn.getAttribute('aria-controls');
+        const region = regionId ? document.getElementById(regionId) : null;
+        const isOpen = btn.getAttribute('aria-expanded') === 'true';
+        const next = !isOpen;
+        btn.setAttribute('aria-expanded', next ? 'true' : 'false');
+        if (region) {
+          if (next) region.removeAttribute('hidden');
+          else region.setAttribute('hidden', '');
+        }
+        const state = readState();
+        state[sectionId] = next ? 'open' : 'closed';
+        writeState(state);
+      });
+    });
+  }
+
+  document.addEventListener('astro:page-load', bindSectionToggles);
+  // Astro view transitions fire astro:page-load on initial load too, but in
+  // case this script is included on a page without VT, ensure first-load wiring.
+  if (document.readyState !== 'loading') bindSectionToggles();
+  else document.addEventListener('DOMContentLoaded', bindSectionToggles);
+</script>

--- a/src/config/nav-config.json
+++ b/src/config/nav-config.json
@@ -1,53 +1,80 @@
 {
   "sections": [
     {
-      "id": "popular",
-      "label": "Popular",
+      "id": "news-updates",
+      "label": "News & Updates",
+      "phaseOrder": { "inSeason": 2, "offSeason": 1 },
+      "defaultOpen": "always",
       "links": [
         {
-          "id": "forum",
-          "label": "Message Board",
-          "icon": "comments",
-          "url": "https://theleague.us/forum/index.php",
+          "id": "news",
+          "label": "News",
+          "icon": "news",
+          "path": "/news",
           "external": false,
           "leagueOnly": "theleague",
-          "description": "Discussion forum for league members"
+          "description": "The Schefter Report — breaking news, transactions, and league chatter"
         },
         {
-          "id": "rosters",
-          "label": "Roster/Salary",
-          "labelAFL": "Rosters",
-          "icon": "banknote",
-          "iconAFL": "helmet",
-          "path": "/rosters",
-          "external": false,
-          "description": "View all team rosters and salary cap details"
-        },
-        {
-          "id": "players",
-          "label": "Free Agents",
-          "icon": "binoculars",
-          "path": "/players",
+          "id": "tip-schefter",
+          "label": "Tip Schefter",
+          "icon": "user-secret",
+          "path": "/schefter/tip",
           "external": false,
           "leagueOnly": "theleague",
-          "description": "Browse available free agents with ADP and points data"
+          "description": "Drop an anonymous tip into the Schefter Rumor Mill"
         },
         {
-          "id": "next-year",
-          "label": "League Planner",
-          "icon": "chalkboard",
-          "path": "/rosters?view=planner",
+          "id": "league-calendar",
+          "label": "League Calendar",
+          "icon": "calendar",
+          "path": "/calendar",
           "external": false,
           "leagueOnly": "theleague",
-          "description": "Phase-aware offseason planner with free agent needs analysis"
+          "description": "View upcoming league events and deadlines"
         },
         {
-          "id": "draft-predictor",
-          "label": "Draft Order",
-          "icon": "draft-podium",
-          "path": "/draft-predictor",
+          "id": "whats-new",
+          "label": "What's New",
+          "icon": "star",
+          "path": "/whats-new",
           "external": false,
-          "description": "View projected draft order"
+          "leagueOnly": "theleague",
+          "description": "See the latest features and improvements"
+        }
+      ]
+    },
+    {
+      "id": "this-week",
+      "label": "This Week",
+      "phaseOrder": { "inSeason": 1, "offSeason": 4 },
+      "defaultOpen": "in-season",
+      "links": [
+        {
+          "id": "submit-lineup",
+          "label": "Set Lineup",
+          "icon": "lineup",
+          "path": "/theleague/lineup",
+          "external": false,
+          "leagueOnly": "theleague",
+          "description": "Set your starting lineup"
+        },
+        {
+          "id": "coach-tab",
+          "label": "Coach Tab",
+          "icon": "submit",
+          "path": "/rosters?view=coach",
+          "external": false,
+          "leagueOnly": "theleague",
+          "description": "Coach mode with matchups & odds"
+        },
+        {
+          "id": "live-scoring",
+          "label": "Live Scoring",
+          "icon": "goals",
+          "urlTemplate": "https://{host}/{year}/home/{leagueId}?MODULE=MESSAGE6",
+          "external": true,
+          "description": "Real-time scoring on MFL"
         },
         {
           "id": "standings",
@@ -75,62 +102,56 @@
           "description": "Playoff bracket and results"
         },
         {
-          "id": "league-calendar",
-          "label": "League Calendar",
-          "icon": "calendar",
-          "path": "/calendar",
+          "id": "players",
+          "label": "Free Agents",
+          "icon": "binoculars",
+          "path": "/players",
           "external": false,
           "leagueOnly": "theleague",
-          "description": "View upcoming league events and deadlines"
+          "description": "Browse available free agents with ADP and points data"
         },
         {
-          "id": "whats-new",
-          "label": "What's New",
-          "icon": "star",
-          "path": "/whats-new",
-          "external": false,
-          "leagueOnly": "theleague",
-          "description": "See the latest features and improvements"
-        },
-        {
-          "id": "rules",
-          "label": "Rules",
-          "icon": "gavel",
-          "path": "/rules",
-          "external": false,
-          "leagueOnly": "theleague",
-          "description": "League rules and bylaws"
+          "id": "add-drop",
+          "label": "Add/Drop",
+          "icon": "plus",
+          "urlTemplate": "https://{host}/{year}/add_drop?L={leagueId}",
+          "external": true,
+          "description": "Add or drop players on MFL"
         }
       ]
     },
     {
-      "id": "my-team",
-      "label": "My Team",
+      "id": "offseason-war-room",
+      "label": "Offseason War Room",
+      "phaseOrder": { "inSeason": 5, "offSeason": 2 },
+      "defaultOpen": "off-season",
       "leagueOnly": "theleague",
       "links": [
         {
-          "id": "coach-tab",
-          "label": "Coach Tab",
-          "icon": "submit",
-          "path": "/rosters?view=coach",
+          "id": "mock-draft",
+          "label": "Mock Draft",
+          "icon": "podium-persona",
+          "path": "/mock-draft",
           "external": false,
-          "description": "Coach mode with matchups & odds"
+          "leagueOnly": "theleague",
+          "description": "Run a mock auction or rookie draft simulation"
         },
         {
-          "id": "contracts",
-          "label": "Contracts",
-          "icon": "file-text",
-          "path": "/contracts/manage",
+          "id": "draft-predictor",
+          "label": "Draft Order",
+          "icon": "draft-podium",
+          "path": "/draft-predictor",
           "external": false,
-          "description": "View and manage your contract declarations"
+          "description": "View projected draft order"
         },
         {
-          "id": "trade-builder",
-          "label": "Trade Builder",
-          "icon": "transactions-2",
-          "path": "/trade-builder",
+          "id": "next-year",
+          "label": "League Planner",
+          "icon": "chalkboard",
+          "path": "/rosters?view=planner",
           "external": false,
-          "description": "Simulate trades and see cap impact"
+          "leagueOnly": "theleague",
+          "description": "Phase-aware offseason planner with free agent needs analysis"
         },
         {
           "id": "import-rankings",
@@ -138,6 +159,7 @@
           "icon": "clipboard",
           "path": "/import-rankings",
           "external": false,
+          "leagueOnly": "theleague",
           "description": "Import player rankings from external sites using bookmarklets"
         },
         {
@@ -148,45 +170,60 @@
           "external": false,
           "visibility": "admin",
           "description": "Personalized player rankings with drag-and-drop reordering"
-        },
-        {
-          "id": "submit-lineup",
-          "label": "Set Lineup",
-          "icon": "lineup",
-          "path": "/theleague/lineup",
-          "external": false,
-          "description": "Set your starting lineup"
-        },
-        {
-          "id": "tip-schefter",
-          "label": "Tip Schefter",
-          "icon": "news",
-          "path": "/theleague/schefter/tip",
-          "external": false,
-          "leagueOnly": "theleague",
-          "description": "Drop an anonymous tip into the Schefter Rumor Mill"
-        },
-        {
-          "id": "add-drop",
-          "label": "Add/Drop",
-          "icon": "plus",
-          "urlTemplate": "https://{host}/{year}/add_drop?L={leagueId}",
-          "external": true,
-          "description": "Add or drop players on MFL"
-        },
-        {
-          "id": "live-scoring",
-          "label": "Live Scoring",
-          "icon": "goals",
-          "urlTemplate": "https://{host}/{year}/home/{leagueId}?MODULE=MESSAGE6",
-          "external": true,
-          "description": "Real-time scoring on MFL"
         }
       ]
     },
     {
-      "id": "reports",
-      "label": "Advanced Reports",
+      "id": "cap-contracts",
+      "label": "Cap & Contracts",
+      "phaseOrder": { "inSeason": 3, "offSeason": 3 },
+      "defaultOpen": "never",
+      "leagueOnly": "theleague",
+      "links": [
+        {
+          "id": "rosters",
+          "label": "Roster/Salary",
+          "labelAFL": "Rosters",
+          "icon": "banknote",
+          "iconAFL": "helmet",
+          "path": "/rosters",
+          "external": false,
+          "description": "View all team rosters and salary cap details"
+        },
+        {
+          "id": "contracts",
+          "label": "Contracts",
+          "icon": "file-text",
+          "path": "/contracts/manage",
+          "external": false,
+          "leagueOnly": "theleague",
+          "description": "View and manage your contract declarations"
+        },
+        {
+          "id": "trade-builder",
+          "label": "Trade Builder",
+          "icon": "transactions-2",
+          "path": "/trade-builder",
+          "external": false,
+          "leagueOnly": "theleague",
+          "description": "Simulate trades and see cap impact"
+        },
+        {
+          "id": "projected-free-agents",
+          "label": "Projected Free Agents",
+          "icon": "binoculars-front",
+          "path": "/projected-free-agents",
+          "external": false,
+          "leagueOnly": "theleague",
+          "description": "Players in their final contract year heading to free agency"
+        }
+      ]
+    },
+    {
+      "id": "league-history",
+      "label": "League History",
+      "phaseOrder": { "inSeason": 4, "offSeason": 5 },
+      "defaultOpen": "never",
       "leagueOnly": "theleague",
       "links": [
         {
@@ -246,22 +283,33 @@
           "external": false,
           "leagueOnly": "theleague",
           "description": "See when each franchise owner last visited the site"
-        },
-        {
-          "id": "projected-free-agents",
-          "label": "Projected Free Agents",
-          "icon": "binoculars",
-          "path": "/projected-free-agents",
-          "external": false,
-          "leagueOnly": "theleague",
-          "description": "Players in their final contract year heading to free agency"
         }
       ]
     },
     {
-      "id": "leagues",
-      "label": "Leagues",
+      "id": "reference",
+      "label": "Reference",
+      "phaseOrder": { "inSeason": 6, "offSeason": 6 },
+      "defaultOpen": "never",
       "links": [
+        {
+          "id": "rules",
+          "label": "Rules",
+          "icon": "gavel",
+          "path": "/rules",
+          "external": false,
+          "leagueOnly": "theleague",
+          "description": "League rules and bylaws"
+        },
+        {
+          "id": "suggestions",
+          "label": "Suggestions",
+          "icon": "info",
+          "path": "/suggestions",
+          "external": false,
+          "leagueOnly": "theleague",
+          "description": "Submit feature requests and feedback"
+        },
         {
           "id": "theleague-site",
           "label": "TheLeague.us",
@@ -314,7 +362,10 @@
     "/about": "/about",
     "/rules": "/rules",
     "/activity": "/activity",
-    "/search": "/search"
+    "/search": "/search",
+    "/news": "/news",
+    "/mock-draft": "/mock-draft",
+    "/suggestions": "/suggestions"
   },
   "verifyTeamUrl": {
     "theleague": "https://{host}/{year}/home/{leagueId}?MODULE=MESSAGE20",

--- a/src/config/nav-config.json
+++ b/src/config/nav-config.json
@@ -220,60 +220,19 @@
       ]
     },
     {
-      "id": "league-history",
-      "label": "League History",
+      "id": "league-reports",
+      "label": "League Reports",
       "phaseOrder": { "inSeason": 4, "offSeason": 5 },
       "defaultOpen": "never",
       "leagueOnly": "theleague",
       "links": [
         {
-          "id": "league-summary",
-          "label": "League Summary",
-          "icon": "spreadsheet",
-          "path": "/league-summary",
-          "external": false,
-          "description": "Compare all teams across cap, roster, and contract metrics over 5 years"
-        },
-        {
-          "id": "salary-benchmarks",
-          "label": "Salary Analytics",
+          "id": "stats-hub",
+          "label": "Stats & Reports",
           "icon": "bar-chart",
-          "path": "/salary",
+          "path": "/stats",
           "external": false,
-          "description": "Compare salary spending across positions"
-        },
-        {
-          "id": "salary-history",
-          "label": "Historical Salary Trends",
-          "icon": "standings-2",
-          "path": "/salary-history",
-          "external": false,
-          "description": "Historical salary cap trends"
-        },
-        {
-          "id": "salary-archive",
-          "label": "Salary Archive",
-          "icon": "vault",
-          "path": "/salary-archive",
-          "external": false,
-          "description": "Historical salary spreadsheets (2009–2025)"
-        },
-        {
-          "id": "mvp",
-          "label": "Salary-Adjusted MVPs",
-          "icon": "standings",
-          "path": "/mvp",
-          "external": false,
-          "description": "Top performers relative to salary"
-        },
-        {
-          "id": "dead-money",
-          "label": "Dead Money Awards",
-          "icon": "tombstone",
-          "path": "/dead-money",
-          "external": false,
-          "leagueOnly": "theleague",
-          "description": "Worst contracts and roster efficiency by season"
+          "description": "League analytics hub — salary benchmarks, awards, projected free agents, and team comparisons"
         },
         {
           "id": "owner-activity",
@@ -281,50 +240,40 @@
           "icon": "activity",
           "path": "/activity",
           "external": false,
-          "leagueOnly": "theleague",
           "description": "See when each franchise owner last visited the site"
         }
       ]
     },
     {
-      "id": "reference",
-      "label": "Reference",
+      "id": "rules",
+      "label": "Rules",
       "phaseOrder": { "inSeason": 6, "offSeason": 6 },
       "defaultOpen": "never",
+      "leagueOnly": "theleague",
       "links": [
         {
           "id": "rules",
-          "label": "Rules",
+          "label": "Constitution",
           "icon": "gavel",
           "path": "/rules",
           "external": false,
-          "leagueOnly": "theleague",
           "description": "League rules and bylaws"
         },
         {
+          "id": "ask-roger",
+          "label": "Ask Roger",
+          "icon": "whistle",
+          "path": "/rules-chat",
+          "external": false,
+          "description": "Ask our AI rules expert any rules question"
+        },
+        {
           "id": "suggestions",
-          "label": "Suggestions",
-          "icon": "info",
+          "label": "Suggestion Box",
+          "icon": "commenting",
           "path": "/suggestions",
           "external": false,
-          "leagueOnly": "theleague",
-          "description": "Submit feature requests and feedback"
-        },
-        {
-          "id": "theleague-site",
-          "label": "TheLeague.us",
-          "icon": "shield",
-          "url": "https://theleague.us",
-          "external": true,
-          "description": "TheLeague main website"
-        },
-        {
-          "id": "afl-site",
-          "label": "AFL Fantasy",
-          "icon": "helmet",
-          "url": "https://afl-fantasy.com",
-          "external": true,
-          "description": "AFL Fantasy main website"
+          "description": "Pitch rule changes, suggest features, or float ideas"
         }
       ]
     }
@@ -365,7 +314,9 @@
     "/search": "/search",
     "/news": "/news",
     "/mock-draft": "/mock-draft",
-    "/suggestions": "/suggestions"
+    "/suggestions": "/suggestions",
+    "/stats": "/stats",
+    "/rules-chat": "/rules-chat"
   },
   "verifyTeamUrl": {
     "theleague": "https://{host}/{year}/home/{leagueId}?MODULE=MESSAGE20",

--- a/src/types/nav.ts
+++ b/src/types/nav.ts
@@ -87,6 +87,29 @@ export interface NavLink {
 }
 
 /**
+ * Calendar phase used to drive section ordering and default open state.
+ * - 'in-season': Labor Day → Feb 14 cutoff (regular season + playoffs + comp picks)
+ * - 'off-season': Feb 14 cutoff → Labor Day (auction, rookie draft, summer)
+ */
+export type LeaguePhase = 'in-season' | 'off-season';
+
+/**
+ * When a section should be open by default (before the user's stored preference).
+ * - 'always': open in both phases
+ * - 'in-season' | 'off-season': open only during that phase
+ * - 'never': always start collapsed
+ */
+export type NavSectionDefaultOpen = 'always' | 'in-season' | 'off-season' | 'never';
+
+/**
+ * Per-phase ordering for a section. Lower number = nearer the top of the nav.
+ */
+export interface NavSectionPhaseOrder {
+  inSeason: number;
+  offSeason: number;
+}
+
+/**
  * Navigation section (group of links)
  */
 export interface NavSection {
@@ -105,11 +128,11 @@ export interface NavSection {
   /** Restrict section to specific league */
   leagueOnly?: LeagueSlug;
 
-  /** Whether section is collapsible (future feature) */
-  collapsible?: boolean;
+  /** Per-phase ordering. If absent, section keeps its config-file order. */
+  phaseOrder?: NavSectionPhaseOrder;
 
-  /** Whether section starts collapsed (future feature) */
-  defaultCollapsed?: boolean;
+  /** Default expanded state (overridden by user's persisted preference) */
+  defaultOpen?: NavSectionDefaultOpen;
 }
 
 /**
@@ -343,6 +366,9 @@ export const NAV_COOKIES = {
 
   /** Stores commissioner mode toggle state */
   COMMISH_MODE: 'commish-mode',
+
+  /** Stores per-section open/closed state as JSON: { [sectionId]: 'open' | 'closed' } */
+  NAV_SECTIONS: 'nav-sections-v1',
 } as const;
 
 /**

--- a/src/utils/league-phase.ts
+++ b/src/utils/league-phase.ts
@@ -1,0 +1,51 @@
+/**
+ * League Phase Detection
+ *
+ * Splits the dynasty calendar into two phases that drive nav-section ordering
+ * and default open state:
+ *
+ *   - 'in-season'   Labor Day  → Feb 14 cutoff   (reg season, playoffs, comp picks)
+ *   - 'off-season'  Feb 14 cutoff → Labor Day    (auction, rookie draft, summer)
+ *
+ * These boundaries match the existing league-year cutoffs in `league-year.ts`,
+ * so a single calendar drives every season-aware behavior in the app.
+ */
+
+import type { LeaguePhase } from '../types/nav';
+
+/** First Monday in September of the given year. */
+function getLaborDay(year: number): Date {
+  const septFirst = new Date(year, 8, 1);
+  const dow = septFirst.getDay(); // 0 = Sun
+  const offset = dow === 1 ? 0 : dow === 0 ? 1 : 8 - dow;
+  return new Date(year, 8, 1 + offset, 0, 0, 0, 0);
+}
+
+/**
+ * Feb 14 @ 8:45 PM PT cutoff (matches league-year.ts).
+ * Stored in UTC: Feb 15 04:45 UTC = Feb 14 20:45 PST.
+ */
+function getFebCutoff(year: number): Date {
+  return new Date(Date.UTC(year, 1, 15, 4, 45, 0, 0));
+}
+
+/**
+ * Determine which calendar phase the league is in for a given date.
+ *
+ * In-season window:  Labor Day (this year) ≤ date < Feb 14 cutoff (next year)
+ * Off-season window: Feb 14 cutoff (this year) ≤ date < Labor Day (this year)
+ */
+export function getLeaguePhase(referenceDate: Date = new Date()): LeaguePhase {
+  const year = referenceDate.getFullYear();
+  const febCutoff = getFebCutoff(year);
+  const laborDay = getLaborDay(year);
+
+  // Before Feb 14 cutoff this year → still in-season from last Labor Day's window.
+  if (referenceDate < febCutoff) return 'in-season';
+
+  // Feb 14 cutoff … Labor Day → off-season.
+  if (referenceDate < laborDay) return 'off-season';
+
+  // After Labor Day → new season starts.
+  return 'in-season';
+}


### PR DESCRIPTION
Reorganize the side nav into six collapsible sections grouped by
dynasty-owner workflow rather than generic IA, ordered and expanded
by current league phase (in-season Sept→Feb14, off-season otherwise).

Sections (offseason ordering):
  1. News & Updates    (open always)
  2. Offseason War Room (open off-season; closed in-season)
  3. Cap & Contracts
  4. This Week         (open in-season; closed off-season)
  5. League History
  6. Reference

Order flips for in-season so This Week sits at the top and the
War Room moves below the fold.

Other changes driven by activity-tracker data (top offseason pages
that were missing or buried):
  - Add News (#5–6 globally) and Mock Draft (#3 globally) — neither
    was in the nav before
  - Promote Tip Schefter (#2 globally) out of "My Team" into the new
    News & Updates section
  - Remove the Message Board forum link (deprecated)
  - Move League Calendar (#4) to the top section

Implementation:
  - Multi-open WAI-ARIA disclosure pattern (not a single-open
    accordion) — opening one section never closes another
  - Per-section state persisted in localStorage AND a mirrored cookie
    `nav-sections-v1` so the SSR render matches user preference on
    first paint (no hydration flash)
  - The section containing the active link force-expands on render
    but never overwrites the stored preference (VS Code pattern)
  - New `getLeaguePhase()` helper in src/utils/league-phase.ts uses
    the existing Feb 14 + Labor Day cutoffs as phase boundaries
  - NavSection gains `phaseOrder` and `defaultOpen` config fields