### PR TITLE
fix(mock-draft): only the logged-in team can submit picks

### DIFF
--- a/party/draft-room.ts
+++ b/party/draft-room.ts
@@ -356,10 +356,12 @@ export default class DraftRoomServer implements Party.Server {
       return;
     }
 
-    // In mock drafts, allow the session creator to pick for any team on the clock
+    // Only the on-clock franchise's owner can submit a pick. Other teams are
+    // AI-driven via autoPick — letting a connected user (even the creator)
+    // pick for them races with the auto-pick microtask and can leave a slot
+    // with a synthetic playerId that renders blank on the board.
     const currentFranchise = session.draftOrder[session.currentPickIndex];
-    const isCreator = msg.franchiseId === session.createdBy;
-    if (currentFranchise !== msg.franchiseId && !isCreator) {
+    if (currentFranchise !== msg.franchiseId) {
       sender.send(JSON.stringify({ type: 'error', message: 'Not your turn' }));
       return;
     }

--- a/src/components/theleague/draft-room/DraftRoom.tsx
+++ b/src/components/theleague/draft-room/DraftRoom.tsx
@@ -250,14 +250,16 @@ export default function DraftRoom({ pageData, userTeamId, mode = 'live', mockSes
   const currentTeam = currentPick ? teamMap.get(currentPick.franchiseId) || null : null;
 
   // Is it the user's turn?
-  // Live: only when the on-clock pick is for the user's franchise.
-  // Mock: the creator is authorised to pick for any team (server auto-picks
-  //   franchises whose real owner isn't connected; this keeps the creator
-  //   able to intervene if the server hasn't caught up or an override is
-  //   wanted).
-  const isUserTurn = isMock
-    ? !!(currentPick && !state.draftComplete)
-    : !!(currentPick && userTeamId && currentPick.franchiseId === userTeamId);
+  // Both live and mock drafts: only when the on-clock pick is for the user's
+  // own franchise. AI teams are picked by the server's auto-pick — letting
+  // the user click for them just confuses the UI ("Make Your Pick" while
+  // someone else is on the clock) and races the auto-pick microtask.
+  const isUserTurn = !!(
+    currentPick &&
+    userTeamId &&
+    currentPick.franchiseId === userTeamId &&
+    !state.draftComplete
+  );
 
   // Previous pick for timer calculation
   const previousPick = useMemo(() => {


### PR DESCRIPTION
Previously the session creator could pick for any team on the clock, and
the UI showed "Make Your Pick" for the creator at every slot. When the
creator clicked a player while an AI team was on the clock, the pick was
attributed to that AI team — and racing the queued AI auto-pick microtask
could leave the slot with a synthetic auto-{timestamp} playerId, which
renders blank on the board (the user's report: "Mock draft for ninjas
always skips his pick").

Now isUserTurn is true only when the user's own franchise is on the clock
(same in mock and live), and the server rejects picks from anyone other
than the on-clock franchise owner. AI teams are picked exclusively by the
server's autoPick.

https://claude.ai/code/session_01LscXcRz8iWNLzz8joGakYn