### PR TITLE
fix(mock-draft): stop skipping picks + only draft as your own team

### DIFF
--- a/party/draft-room.ts
+++ b/party/draft-room.ts
@@ -356,10 +356,12 @@ export default class DraftRoomServer implements Party.Server {
       return;
     }
 
-    // In mock drafts, allow the session creator to pick for any team on the clock
+    // Only the on-clock franchise's owner can submit a pick. Other teams are
+    // AI-driven via autoPick — letting a connected user (even the creator)
+    // pick for them races with the auto-pick microtask and can leave a slot
+    // with a synthetic playerId that renders blank on the board.
     const currentFranchise = session.draftOrder[session.currentPickIndex];
-    const isCreator = msg.franchiseId === session.createdBy;
-    if (currentFranchise !== msg.franchiseId && !isCreator) {
+    if (currentFranchise !== msg.franchiseId) {
       sender.send(JSON.stringify({ type: 'error', message: 'Not your turn' }));
       return;
     }

--- a/src/components/theleague/draft-room/DraftRoom.tsx
+++ b/src/components/theleague/draft-room/DraftRoom.tsx
@@ -250,14 +250,16 @@ export default function DraftRoom({ pageData, userTeamId, mode = 'live', mockSes
   const currentTeam = currentPick ? teamMap.get(currentPick.franchiseId) || null : null;
 
   // Is it the user's turn?
-  // Live: only when the on-clock pick is for the user's franchise.
-  // Mock: the creator is authorised to pick for any team (server auto-picks
-  //   franchises whose real owner isn't connected; this keeps the creator
-  //   able to intervene if the server hasn't caught up or an override is
-  //   wanted).
-  const isUserTurn = isMock
-    ? !!(currentPick && !state.draftComplete)
-    : !!(currentPick && userTeamId && currentPick.franchiseId === userTeamId);
+  // Both live and mock drafts: only when the on-clock pick is for the user's
+  // own franchise. AI teams are picked by the server's auto-pick — letting
+  // the user click for them just confuses the UI ("Make Your Pick" while
+  // someone else is on the clock) and races the auto-pick microtask.
+  const isUserTurn = !!(
+    currentPick &&
+    userTeamId &&
+    currentPick.franchiseId === userTeamId &&
+    !state.draftComplete
+  );
 
   // Previous pick for timer calculation
   const previousPick = useMemo(() => {

--- a/src/pages/api/mock-draft/create.ts
+++ b/src/pages/api/mock-draft/create.ts
@@ -173,9 +173,24 @@ export const POST: APIRoute = async ({ request }) => {
     const allPlayers: any[] = allPlayersRaw
       ? (Array.isArray(allPlayersRaw) ? allPlayersRaw : [allPlayersRaw])
       : [];
-    const rookiePool = allPlayers.filter(
-      (p: any) => p.status === 'R' || p.draft_year === leagueYearStr,
-    );
+    // Mirror the client's `buildDraftPlayers` filter: this league only drafts
+    // skill positions + PK/DEF. Source feeds (dynasty ADP, KTC, Sleeper) include
+    // IDPs (LB/DE/DT/CB/S) which are valid rookies but render blank on the
+    // board because the client's playerMap excludes them. Drop them at the
+    // source so AI auto-picks never produce a slot the UI can't render.
+    const DRAFTABLE = new Set(['QB', 'RB', 'WR', 'TE', 'PK', 'DEF']);
+    const normPos = (pos: string): string => {
+      if (!pos) return '';
+      const upper = pos.toUpperCase();
+      if (upper.startsWith('TM') || upper === 'DEF' || upper === 'D/ST') return 'DEF';
+      if (upper === 'PK' || upper === 'K') return 'PK';
+      return upper;
+    };
+    const rookiePool = allPlayers.filter((p: any) => {
+      const isRookie = p.status === 'R' || p.draft_year === leagueYearStr;
+      if (!isRookie) return false;
+      return DRAFTABLE.has(normPos(p.position || ''));
+    });
     const rookieIdSet = new Set(rookiePool.map((p: any) => p.id));
 
     // Normalized "first last" → MFL id for fuzzy matching (rookies only;


### PR DESCRIPTION
## Summary

Two related fixes for the mock-draft room.

### 1. Skipped picks (the actual bug)

Source feeds (dynasty ADP, KTC, Sleeper) include IDP rookies — LB/DE/DT/CB/S — alongside skill positions. The AI auto-pick happily picked them when they came up in the rankings, but the client's `playerMap` is filtered to draftable positions only (QB/RB/WR/TE/PK/DEF) so `playerMap.get(IDPId)` returned `undefined` and the slot rendered blank.

In the report, the "always-skipped" Ninjas slot is pick 1.07. Dynasty ADP rank 7 is **Sonny Styles (LB)** — not draftable. Pick 1.06 picked dynasty #6 (Jordyn Tyson, WR), pick 1.07 picked dynasty #7 (Sonny Styles, LB) → blank.

Fix: filter the server-side rookie pool to draftable positions in `create.ts`, mirroring the client's `buildDraftPlayers`. Now every ID the auto-pick can return is one the UI can render.

### 2. Only the logged-in team can be drafted as

Per the user request: previously the session creator could pick for any team on the clock, and the UI showed "Make Your Pick" to the creator at every slot regardless of whose turn it actually was. That made it easy to accidentally pick for an AI team and also raced the queued auto-pick microtask.

Fix: `isUserTurn` is now `currentPick.franchiseId === userTeamId` in both mock and live mode, and the server rejects any pick whose `franchiseId` doesn't match the on-clock team. AI teams are picked exclusively by `autoPick`. "My Rank" still works as a ranking source for AI teams.

## Test plan

- [ ] Start a mock draft with all defaults; verify pick 1.07 lands on KC Concepcion (or whatever the next draftable rookie is) instead of going blank
- [ ] Verify "Make Your Pick" only appears when the user's own team is on the clock
- [ ] Verify the user can't click a player while an AI team is on the clock
- [ ] Verify Pause / Go Back / Reset Draft still work (still creator-only)
- [ ] Verify the user's timer still runs when their own team is on the clock and the auto-pick fires on timeout

https://claude.ai/code/session_01LscXcRz8iWNLzz8joGakYn

---
_Generated by [Claude Code](https://claude.ai/code/session_01LscXcRz8iWNLzz8joGakYn)_