### PR TITLE
Add trade-bait rumor detection to Schefter feed

### DIFF
--- a/.claude/plans/schefter-trade-bait-rumors.md
+++ b/.claude/plans/schefter-trade-bait-rumors.md
@@ -7,7 +7,7 @@
 
 ## TL;DR
 
-When owners add players to their MFL trade block (the "trade bait" list — signaling availability, not an offer), Schefter turns that into natural rumor-mill posts. Core mechanic: a **settle window** debounces per-franchise activity so a dump of six players fires as one clustered post, not six. Adds that cancel out within the window emit nothing. Structured payload (position counts + names + owner comments) lets the LLM pick the right voice: single name on one-offs, positional-theme language on clusters. Launches with a silent seed + one hand-fired "State of the Block" kickoff post.
+When owners add players to their MFL trade block (the "trade bait" list — signaling availability, not an offer), Schefter turns that into natural rumor-mill posts. Core mechanic: a **settle window** debounces per-franchise activity so a dump of six players fires as one clustered post, not six. Adds that cancel out within the window emit nothing. Structured payload (position counts + names + owner comments) lets the LLM pick the right voice: single name on one-offs, positional-theme language on clusters. Launches with a **silent seed only** — no announcement post; the feature debuts on the first real owner delta post-deploy.
 
 ---
 
@@ -188,6 +188,23 @@ Structured data in + concise English `text` = LLM picks the right voice.
 
 ---
 
+## Post CTA — Trade Builder, Not Tip Page
+
+Every rumor post today carries a single CTA: `link = TIP_PAGE_PATH` / `linkLabel = "Got a tip? Whisper to Schefter →"` (`schefter-rumor-scan.mjs:182-184, 1917-1918`). GroupMe payloads append `TIP_PAGE_ABSOLUTE_URL`.
+
+For trade_bait posts this is the wrong destination — a reader who sees "Pigskins dumped three RBs" wants to open the block in the trade builder, not the tip form.
+
+**Override contract** (driven off the primary bucket):
+
+- When the primary bucket is a `trade_bait` bucket with a single `franchiseHint`, override the post:
+  - `link` → `/theleague/trade-builder?b=<franchiseHint>`
+  - `linkLabel` → `Open in Trade Builder →` (generic — franchise name is already in the body via attribution)
+  - GroupMe suffix → absolute trade-builder URL (`${PUBLIC_BASE_URL}/theleague/trade-builder?b=<franchiseHint>`) in place of the tip-page URL
+- Any other bucket (including mixed buckets that happen to include a trade_bait tip) retains the existing tip-page CTA.
+- Trade-builder query-param precedent: `rosters.astro:2413` / `:6981` already link with `?b=<franchiseId>` — same convention.
+
+**Implementation note:** simplest to compute both CTAs per post and pick based on primary-bucket introspection in the same block that sets `link`/`linkLabel` today (`schefter-rumor-scan.mjs:1901-1920`). Expose a helper like `resolveCta(primaryBucket)` returning `{ link, linkLabel, groupMeUrl }` so the post-build site and the `groupMeTextFor` builder stay in sync.
+
 ## Bucket Integration
 
 Reuses the existing rumor-scan bucketing with minimal changes:
@@ -205,9 +222,9 @@ No changes needed to `pickPrimaryBucket` — the existing gossip-bucket selectio
 
 **Problem:** 17 players currently on the block. A naive first run would interpret all 17 as fresh adds and flood.
 
-**Solution:** silent seed + optional kickoff post.
+**Decision:** silent seed only. No kickoff post, no launch announcement — the feature starts existing, and the first real owner delta is the first post.
 
-### Silent seed (automatic, always runs first)
+### Silent seed (automatic, first run)
 
 On the first detection pass where `feed.tradeBaitState` is absent or a franchise has no entry:
 - Set `committedBlock = currentBlock` for every franchise
@@ -217,31 +234,9 @@ On the first detection pass where `feed.tradeBaitState` is absent or a franchise
 
 Next real delta (post-seed) is the first real post. Clean debut; no noise.
 
-### Optional kickoff post (hand-fired, one-time)
+### Rejected: hand-fired kickoff post
 
-A CLI flag on the scan script for the launch moment:
-
-```bash
-node scripts/schefter-scan.mjs --kickoff-trade-bait
-```
-
-When the flag is present AND `feed.tradeBaitState` is empty (belt-and-suspenders: can't re-fire on accident):
-
-1. Run the fetch + franchise mapping
-2. Generate ONE aggregate tip with the full current block as `meta.adds` across all franchises, grouped
-3. LLM prompt variant: "State of the Block — launch day inventory. Acknowledge this is a snapshot, not breaking news. Hit 3–5 headliners across the league. Tease that Schefter is now tracking the block going forward."
-4. Post to feed + GroupMe
-5. Seed state (same as silent seed)
-6. Done — subsequent scans operate normally
-
-Kickoff post is NEVER cron-invoked. Only the commish (or Brandon, directly) runs it when the feature's debut is ready.
-
-### Voice constraint for kickoff
-
-- Present tense only — no "added this week" / "listed yesterday" claims (MFL doesn't expose timestamps)
-- One post, ≤ 4 sentences in the body
-- Names 3–5 players max, prioritizing stars
-- Signs off with a "tracking going forward" beat
+Earlier draft included a `--kickoff-trade-bait` CLI flag for a "State of the Block" snapshot post on launch day. Dropped in favor of letting the feature surface organically on the first real owner action. If demand materializes later, the flag is an easy additive layer — state schema + tip payload already support it.
 
 ---
 
@@ -264,7 +259,7 @@ Kickoff post is NEVER cron-invoked. Only the commish (or Brandon, directly) runs
 
 **Modify:**
 - `scripts/fetch-trade-bait.mjs` — preserve franchise mapping, emit new `tradeBait-by-franchise.json` alongside existing flat cache
-- `scripts/schefter-scan.mjs` — new detector section mirroring the pending-trade watcher; `--kickoff-trade-bait` flag handling
+- `scripts/schefter-scan.mjs` — new detector section mirroring the pending-trade watcher
 - `scripts/schefter-rumor-scan.mjs` — recognize `source: 'trade_bait'` and `topic: 'trade_bait'` in bucketing + anonymization (bypass anonymization since `attributable: true`)
 - `.claude/agents/schefter.md` (or the rumor-mill skill doc) — add trade_bait voice directive block
 
@@ -281,7 +276,7 @@ Kickoff post is NEVER cron-invoked. Only the commish (or Brandon, directly) runs
 6. Re-add after silent remove → new post fires
 7. `MAX_SETTLE_WAIT_MS` force-fires when drift never stabilizes
 8. Pure removes never fire
-9. Kickoff flag fires once, then no-ops on repeat runs (state already seeded)
+9. CTA override — trade_bait primary bucket sets `link = /theleague/trade-builder?b=<franchiseId>`; non-trade_bait buckets keep tip-page CTA
 
 ---
 
@@ -299,15 +294,14 @@ Kickoff post is NEVER cron-invoked. Only the commish (or Brandon, directly) runs
 - Verify clustering language vs. singleton language on real posts
 - Iterate on prompt if voice is off
 
-### Phase 3 — Kickoff post
-- Implement `--kickoff-trade-bait` flag
-- Dry-run to preview the post
-- Brandon fires it on launch day; announce in GroupMe
-
-### Phase 4 (future) — Staleness surfacing
+### Phase 3 (future) — Staleness surfacing
 - Track `listedAt` per player from state
 - Optional post: "X has been on the block for 3 weeks with no takers"
 - Opt-in; easy to layer once v1 is stable
+
+### Phase 4 (future, if demand) — Hand-fired "State of the Block" post
+- Restore the `--kickoff-trade-bait` path if we later decide an announcement post is worth it
+- State schema + tip payload already support it; purely additive
 
 ---
 

--- a/.claude/plans/schefter-trade-bait-rumors.md
+++ b/.claude/plans/schefter-trade-bait-rumors.md
@@ -1,0 +1,338 @@
+# Schefter Trade-Bait Rumors
+
+**Status:** Planning
+**Date:** 2026-04-22
+**Parent plan:** [schefter-rumor-mill.md](./schefter-rumor-mill.md)
+**Sibling:** [schefter-trade-offer-rumors.md](./schefter-trade-offer-rumors.md)
+
+## TL;DR
+
+When owners add players to their MFL trade block (the "trade bait" list — signaling availability, not an offer), Schefter turns that into natural rumor-mill posts. Core mechanic: a **settle window** debounces per-franchise activity so a dump of six players fires as one clustered post, not six. Adds that cancel out within the window emit nothing. Structured payload (position counts + names + owner comments) lets the LLM pick the right voice: single name on one-offs, positional-theme language on clusters. Launches with a silent seed + one hand-fired "State of the Block" kickoff post.
+
+---
+
+## Goals & Non-Goals
+
+**Goals**
+- Detect adds/removes on every franchise's trade block
+- Fire one post per settled franchise-dump, not one per player
+- Let the LLM naturally say "Hall hit the block" on singletons and "RB fire sale in Pacific" on clusters
+- Launch without flooding the feed with ~17 pre-existing listings
+- Surface MFL `willGiveUp`/`willTake` owner comments when present
+
+**Non-Goals**
+- Not replacing the pending-trade rumor lane (different trigger, different voice)
+- No per-player "still on the block after N days" nagging in v1 (layer later if wanted)
+- No reverse-lens "who's shopping" tipster analysis — the owner *wants* this known, attribution is fine
+
+---
+
+## Architecture Overview
+
+```
+┌─ fetch-trade-bait.mjs (prebuild + cron)    ┐
+│   writes per-franchise snapshot             │
+│                                              │
+├─ schefter-scan.mjs (cron, every 15m)         ├──► tip queue ──► schefter-rumor-scan.mjs
+│   diffs current vs. committedBlock,          │      (Redis)      (existing flow, gossip bucket)
+│   respects SETTLE_WINDOW,                    │
+│   emits ONE source='trade_bait' tip per     │
+│   settled franchise with all net adds        │
+└──────────────────────────────────────────────┘
+```
+
+The trade-bait detector lives in `schefter-scan.mjs` alongside the existing pending-trade watcher (same cadence, same feed state file, same posting pipeline). It does **not** bypass the gossip cap — trade-bait is attributable gossip, not a transactional event.
+
+---
+
+## Data Layer Changes
+
+### 1. Richer fetch shape
+
+`scripts/fetch-trade-bait.mjs` currently flattens the MFL response to a bare `string[]` of player IDs (line 82), discarding the franchise mapping. Extend it to preserve structure in a new file, keeping the existing flat cache intact for the UI:
+
+```jsonc
+// data/theleague/mfl-feeds/<year>/tradeBait-by-franchise.json
+{
+  "fetchedAt": 1714000000000,
+  "franchises": {
+    "0001": {
+      "playerIds": ["15255", "16610"],
+      "willGiveUpComment": "Looking for WR depth, pref dynasty.",
+      "willTakeComment": "Any early-round rookie pick."
+    },
+    "0005": { "playerIds": ["13593"] }
+  }
+}
+```
+
+The flat `tradeBait.json` stays as-is (UI dependencies, caching contract).
+
+### 2. Feed-state extension
+
+Add to `feed.json` next to `pendingTradeWatermark`:
+
+```jsonc
+{
+  "tradeBaitState": {
+    "0001": {
+      "committedBlock": ["15255", "16610"],
+      "observedBlock":  ["15255", "16610", "16195"],
+      "firstChangeTs":  1714000000000,
+      "lastChangeTs":   1714000900000
+    }
+  }
+}
+```
+
+- `committedBlock` — what we last told the rumor mill about
+- `observedBlock` — what we saw on MFL at the last scan
+- `firstChangeTs` / `lastChangeTs` — drift timers; null when the franchise is settled
+
+---
+
+## Per-Scan Detection Logic
+
+For each franchise in the fetch result:
+
+```
+current      = currentBlock set (from fetch)
+state        = feed.tradeBaitState[franchiseId]
+
+// Update drift timers
+if current != state.observedBlock:
+  state.lastChangeTs  = now
+  if !state.firstChangeTs: state.firstChangeTs = now
+  state.observedBlock = current
+
+// Compute net deltas
+netAdds    = current - state.committedBlock
+netRemoves = state.committedBlock - current
+
+// Settled case — no drift either direction
+if netAdds empty AND netRemoves empty:
+  clear state.firstChangeTs, state.lastChangeTs
+  continue
+
+// Still drifting
+if now - state.lastChangeTs < SETTLE_WINDOW:
+  continue   // quiet, come back next scan
+
+// Settled after drift — emit (or silently sync)
+if netAdds not empty:
+  emitTradeBaitTip(franchiseId, netAdds, netRemoves, ownerComments)
+state.committedBlock = current
+clear state.firstChangeTs, state.lastChangeTs
+```
+
+**Why this works:**
+- Owner dumps 6 players over 20 min → each scan resets `lastChangeTs` → one post after 45 min of quiet.
+- Owner adds X then removes X within the window → `netAdds` never includes X → silent.
+- Pure removes → no tip, watermark absorbs silently.
+- Re-adds (list → remove → list) → silent remove advances `committedBlock`, re-add re-surfaces as netAdds, fires. Correct.
+
+---
+
+## Tunable Constants
+
+| Constant | Default | Rationale |
+|----------|---------|-----------|
+| `SETTLE_WINDOW_MS` | 45 min | Long enough to consolidate a cleanup session, short enough that lone listings hit the feed within an hour |
+| `MAX_SETTLE_WAIT_MS` | 6 hr | Safety cap — if an owner tweaks their block all day, force-emit once rather than holding forever |
+| `MIN_ADDS_TO_FIRE` | 1 | No floor; single player is valid breaking news |
+| `MAX_ADDS_PER_TIP` | 10 | Defensive — if someone dumps 20 players, truncate and flag so the LLM doesn't list them all |
+
+`MAX_SETTLE_WAIT_MS` fires when `now - firstChangeTs >= MAX_SETTLE_WAIT_MS`, regardless of `lastChangeTs`. Belt + suspenders.
+
+---
+
+## Tip Payload Contract
+
+Structured data in + concise English `text` = LLM picks the right voice.
+
+```ts
+{
+  id: 'sf_tradebait_<franchiseId>_<fireTs>',
+  source: 'trade_bait',
+  topic: 'trade_bait',            // NEW topic key — don't collide with web 'trade' tips
+  attributable: true,
+  author: '<Franchise Name>',
+  franchiseHint: '<franchiseId>',
+  submittedAt: <fireTs>,
+  text: 'Pacific Pigskins added to block: Breece Hall (RB, age 26), '
+      + 'Josh Jacobs (RB, age 27), Kenneth Walker (RB, age 25). '
+      + "Owner note: 'looking for WR depth.'",
+  meta: {
+    adds: [
+      { id: '15255', name: 'Breece Hall', pos: 'RB', nflTeam: 'NYJ', age: 26 },
+      { id: '16610', name: 'Josh Jacobs', pos: 'RB', nflTeam: 'LV',  age: 27 },
+      { id: '13593', name: 'Kenneth Walker', pos: 'RB', nflTeam: 'SEA', age: 25 }
+    ],
+    removes: [],                  // context only; usually not surfaced
+    byPos:   { RB: 3 },           // precomputed counts
+    totalAdds: 3,
+    ownerWillGiveUp: 'looking for WR depth',
+    ownerWillTake:   ''
+  }
+}
+```
+
+### LLM voice directive (added to Rumor Mill Mode prompt)
+
+> **trade_bait tips** are owners publicly listing players on the block. Attribution IS allowed — name the franchise. Use `meta.byPos` and `meta.totalAdds` to pick framing:
+> - **totalAdds === 1** → lead with the player's name. "Hall hit the block."
+> - **totalAdds >= 3 AND one position ≥ 60% of byPos** → positional theme. "RB fire sale in <division>." Name 2–3 headliners max.
+> - **totalAdds >= 3 mixed** → "spring cleaning" / "roster purge" framing. Name the 2 biggest names.
+> - When `meta.ownerWillGiveUp` or `meta.ownerWillTake` is non-empty, you MAY quote or paraphrase — these are public owner notes on MFL, not anonymous tips.
+> - Never invent a listing date — MFL doesn't expose one. Use present tense.
+
+---
+
+## Bucket Integration
+
+Reuses the existing rumor-scan bucketing with minimal changes:
+
+- Bucket key: `topic:trade_bait:<franchiseId>` — one bucket per franchise per cycle
+- Bucket kind: `gossip` (competes for gossip cap, not trade-offer lane)
+- Priority: standard `bucketPriorityScore` (size + age) — a trade-bait tip with 5 adds will naturally out-rank a single-source web gossip tip
+- Quiet hours: respected (held until 7am PT)
+
+No changes needed to `pickPrimaryBucket` — the existing gossip-bucket selection handles it.
+
+---
+
+## Initial Release Strategy
+
+**Problem:** 17 players currently on the block. A naive first run would interpret all 17 as fresh adds and flood.
+
+**Solution:** silent seed + optional kickoff post.
+
+### Silent seed (automatic, always runs first)
+
+On the first detection pass where `feed.tradeBaitState` is absent or a franchise has no entry:
+- Set `committedBlock = currentBlock` for every franchise
+- Set `observedBlock = currentBlock`
+- Leave drift timers null
+- Emit **nothing**
+
+Next real delta (post-seed) is the first real post. Clean debut; no noise.
+
+### Optional kickoff post (hand-fired, one-time)
+
+A CLI flag on the scan script for the launch moment:
+
+```bash
+node scripts/schefter-scan.mjs --kickoff-trade-bait
+```
+
+When the flag is present AND `feed.tradeBaitState` is empty (belt-and-suspenders: can't re-fire on accident):
+
+1. Run the fetch + franchise mapping
+2. Generate ONE aggregate tip with the full current block as `meta.adds` across all franchises, grouped
+3. LLM prompt variant: "State of the Block — launch day inventory. Acknowledge this is a snapshot, not breaking news. Hit 3–5 headliners across the league. Tease that Schefter is now tracking the block going forward."
+4. Post to feed + GroupMe
+5. Seed state (same as silent seed)
+6. Done — subsequent scans operate normally
+
+Kickoff post is NEVER cron-invoked. Only the commish (or Brandon, directly) runs it when the feature's debut is ready.
+
+### Voice constraint for kickoff
+
+- Present tense only — no "added this week" / "listed yesterday" claims (MFL doesn't expose timestamps)
+- One post, ≤ 4 sentences in the body
+- Names 3–5 players max, prioritizing stars
+- Signs off with a "tracking going forward" beat
+
+---
+
+## Edge Cases & Guards
+
+| Case | Handling |
+|------|----------|
+| Franchise adds + removes same player mid-window | `netAdds` stays empty. Silent. |
+| Franchise adds X, we emit, then removes X | Silent remove. `committedBlock` drops X. Future re-add fires again correctly. |
+| MFL fetch fails | Skip this cycle. Don't touch state. Retry next scan. |
+| Franchise has willGiveUp comment change with no player change | Currently ignored. Comment updates alone don't fire a post. (Could surface later if noisy enough.) |
+| `MAX_ADDS_PER_TIP` exceeded | Truncate `meta.adds` to the top 10 by salary/age rank. Set `meta.truncated = true` so LLM hedges. |
+| State file corrupted / missing mid-run | Treat as seed event for affected franchises. Silent. |
+| Franchise removed entirely from league | Drop from `tradeBaitState` on next scan (defensive, unlikely). |
+| Player traded while on block | MFL drops them from tradeBait automatically. `netRemoves` absorbs silently. |
+
+---
+
+## Files to Create / Modify
+
+**Modify:**
+- `scripts/fetch-trade-bait.mjs` — preserve franchise mapping, emit new `tradeBait-by-franchise.json` alongside existing flat cache
+- `scripts/schefter-scan.mjs` — new detector section mirroring the pending-trade watcher; `--kickoff-trade-bait` flag handling
+- `scripts/schefter-rumor-scan.mjs` — recognize `source: 'trade_bait'` and `topic: 'trade_bait'` in bucketing + anonymization (bypass anonymization since `attributable: true`)
+- `.claude/agents/schefter.md` (or the rumor-mill skill doc) — add trade_bait voice directive block
+
+**New:**
+- `data/theleague/mfl-feeds/<year>/tradeBait-by-franchise.json` — fetch output (generated, gitignored if desired)
+- `tests/trade-bait-detector.test.ts` — unit tests for the diff/settle logic (pure function)
+
+**Test cases to lock in:**
+1. First-run seeds silently
+2. Single add → fires after SETTLE_WINDOW with 1 player
+3. Six adds over 20 min → one post with all 6
+4. Add + remove same player within window → silent
+5. Add, settle, fire, then remove → silent remove, `committedBlock` updated
+6. Re-add after silent remove → new post fires
+7. `MAX_SETTLE_WAIT_MS` force-fires when drift never stabilizes
+8. Pure removes never fire
+9. Kickoff flag fires once, then no-ops on repeat runs (state already seeded)
+
+---
+
+## Phased Rollout
+
+### Phase 1 — Detector + silent seed
+- Extend fetch script with franchise mapping
+- Add detector + state schema to `schefter-scan.mjs`
+- Pure unit tests for diff/settle logic
+- Deploy with silent seed; verify no posts fire on first runs
+- Wait 1–2 owner actions to validate end-to-end
+
+### Phase 2 — Voice tuning
+- Add `trade_bait` directive to rumor-mill prompt
+- Verify clustering language vs. singleton language on real posts
+- Iterate on prompt if voice is off
+
+### Phase 3 — Kickoff post
+- Implement `--kickoff-trade-bait` flag
+- Dry-run to preview the post
+- Brandon fires it on launch day; announce in GroupMe
+
+### Phase 4 (future) — Staleness surfacing
+- Track `listedAt` per player from state
+- Optional post: "X has been on the block for 3 weeks with no takers"
+- Opt-in; easy to layer once v1 is stable
+
+---
+
+## Risks & Open Questions
+
+1. **Owner comments as attack vector.** `willGiveUp`/`willTake` are free-form owner text. The LLM will paraphrase them. Low risk — owners wrote those comments for public consumption — but worth flagging: don't let the LLM treat comments as adjudicated facts. The prompt should hedge ("the Pigskins say they're…").
+
+2. **Fetch frequency.** Existing trade-bait fetch is prebuild-only. The detector needs it on every 15-min scan cycle, not just prebuild. Either call the fetcher inline from `schefter-scan.mjs` or schedule it as a sibling cron.
+
+3. **Owner who strategically adds 1 player/day.** They could monopolize the feed (7 posts over 7 days). Mitigation: existing gossip cap (3/day, 4hr spacing) already protects. No special logic needed.
+
+4. **Pending-trade overlap.** If a player is on the block AND then gets traded, two posts fire (trade_bait rumor, then pending-trade rumor). Acceptable — they're distinct events. Revisit if it feels redundant in practice.
+
+5. **First-scan timing vs. deploy window.** If deploy lands mid-cleanup (owner tweaking block at that exact moment), the seed captures a transient state. Minor — `MAX_SETTLE_WAIT_MS` and the next real delta recover. Not worth engineering around.
+
+---
+
+## Success Criteria
+
+- First two weeks post-launch: zero flood events (>3 trade_bait posts in a single day)
+- Single-player adds fire as single-player posts (no generic cluster framing)
+- Multi-player dumps of one position fire as positional-theme posts (verified by eyeballing 3+ examples)
+- Kickoff post lands cleanly with no follow-up flood on the next scan cycle
+- Owner comments surface at least once in the first month's posts (proves the pathway works)
+
+---
+
+**Next step:** Brandon confirms scope + SETTLE_WINDOW default (45 min). Then implement Phase 1 detector with unit tests; deploy with silent seed; observe.

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,16 @@
+# Merge drivers — keep rebase conflicts to a minimum.
+# See CLAUDE.md "Merge conflicts" section for the full policy.
+
+# package.json: concatenate both sides' added deps. Conflicts on the same
+# key still surface, but pure-add conflicts (different sections) auto-fix.
+package.json merge=union
+
+# Lock files: never try to hand-merge. Regenerate via `pnpm install` post-rebase.
+pnpm-lock.yaml merge=binary
+
+# Auto-generated league/feed snapshots — main is always more recent than a
+# branch (cron writes there), so keeping incoming wins on conflict.
+src/data/theleague/schefter-feed.json merge=binary
+src/data/theleague/post-history.json merge=binary
+data/theleague/mfl-feeds/** merge=binary
+data/afl-fantasy/mfl-feeds/** merge=binary

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,3 +71,44 @@ window tests and fetches the ESPN draft date; if ESPN disagrees with the
 committed `nfl-draft-dates-fetched.json`, the workflow fails so the drift
 surfaces in the Actions tab. To accept a new date, run
 `pnpm fetch:nfl-draft-date` locally and commit the change.
+
+## Merge conflicts — always rebase, resolve autonomously
+
+Only Brandon and Claude commit to this repo, and conflicts are almost
+always one of three patterns. **Default to `git rebase origin/main` (never
+merge).** Do not stop and ask before resolving — fix it, run the relevant
+tests, push, and report what you did.
+
+Resolution rules by file pattern:
+
+1. **`package.json`** — union both sides. New deps from main + new deps
+   from the branch should both end up in the file. `.gitattributes`
+   declares `merge=union` so this happens automatically; if union picks
+   up duplicate entries (same key on both sides), drop the older version
+   spec and keep the newer.
+2. **`pnpm-lock.yaml`** — never hand-resolve. After `package.json` settles,
+   run `pnpm install` to regenerate the lock; commit the regenerated file
+   as part of the resolution.
+3. **Auto-generated data files** (`src/data/theleague/schefter-feed.json`,
+   `data/<league>/mfl-feeds/**`, `src/data/theleague/post-history.json`,
+   any `*-feed.json` or `*.lock`) — prefer `--theirs` (incoming main).
+   These are written by cron jobs; the branch's snapshot is stale by
+   definition. Do not try to merge content row-by-row.
+4. **Source code (`scripts/`, `src/`, `tests/`)** — read both sides,
+   integrate the intent. New imports / new helpers stack additively. If
+   the same function body changed on both sides, keep main's structural
+   change and re-apply the branch's behavioral change on top. Run
+   `pnpm test:unit` (or the targeted test file) after every non-trivial
+   resolution.
+5. **CLAUDE.md / docs** — additive. Both sides' new sections survive,
+   reordered if needed. Never drop a section.
+
+After every resolution, before pushing:
+- `pnpm test:unit` must pass at the same baseline as pre-rebase (compare
+  failure count — pre-existing failures are OK; new failures block).
+- `node --check` every `.mjs` you touched.
+- Force-push with lease: `git push --force-with-lease`. Never plain
+  `--force` on a shared branch.
+
+`git rerere` is enabled (see `.git/config`); identical conflicts on
+re-rebase replay automatically. Do not turn it off.

--- a/scripts/fetch-trade-bait.mjs
+++ b/scripts/fetch-trade-bait.mjs
@@ -57,29 +57,55 @@ const year = String(now >= febCutoff ? Math.max(baseYear + 1, now.getFullYear())
 const outDir = path.join('data', leagueName, 'mfl-feeds', year);
 fs.mkdirSync(outDir, { recursive: true });
 
+const extractPlayerIds = (willGiveUp) => {
+  if (!willGiveUp) return [];
+  const ids = typeof willGiveUp === 'string'
+    ? willGiveUp.split(',').map((id) => id.trim())
+    : [String(willGiveUp)];
+  return ids.filter((id) => id && /^\d{4,}$/.test(id));
+};
+
+/**
+ * Parse the MFL tradeBait response into two shapes:
+ *   - flat: unique player-id array (legacy; UI consumes this)
+ *   - byFranchise: { [franchiseId]: { playerIds, willGiveUpComment, willTakeComment } }
+ *     Fresh shape needed by the Schefter trade-bait detector so it can
+ *     diff per-franchise activity instead of league-wide aggregates.
+ */
 const parseTradeBait = (data) => {
   const playerIds = new Set();
-  if (typeof data === 'object' && data !== null) {
-    let tradeBaitArray = data?.tradeBaits?.tradeBait;
-    if (tradeBaitArray && !Array.isArray(tradeBaitArray)) {
-      tradeBaitArray = [tradeBaitArray];
-    }
-    if (Array.isArray(tradeBaitArray)) {
-      tradeBaitArray.forEach((item) => {
-        if (item.willGiveUp) {
-          const ids = typeof item.willGiveUp === 'string'
-            ? item.willGiveUp.split(',').map(id => id.trim())
-            : [item.willGiveUp];
-          ids.forEach((id) => {
-            if (id && /^\d{4,}$/.test(id)) {
-              playerIds.add(id);
-            }
-          });
-        }
-      });
-    }
+  const byFranchise = {};
+  if (typeof data !== 'object' || data === null) {
+    return { flat: [], byFranchise };
   }
-  return Array.from(playerIds);
+  let tradeBaitArray = data?.tradeBaits?.tradeBait;
+  if (tradeBaitArray && !Array.isArray(tradeBaitArray)) {
+    tradeBaitArray = [tradeBaitArray];
+  }
+  if (!Array.isArray(tradeBaitArray)) return { flat: [], byFranchise };
+
+  for (const item of tradeBaitArray) {
+    const ids = extractPlayerIds(item?.willGiveUp);
+    ids.forEach((id) => playerIds.add(id));
+
+    // MFL uses `franchise_id` on tradeBait entries. Fall back to other
+    // common capitalizations just in case the API changes.
+    const franchiseId = String(
+      item?.franchise_id ?? item?.franchiseId ?? item?.franchise ?? '',
+    ).trim();
+    if (!franchiseId) continue;
+
+    byFranchise[franchiseId] = {
+      playerIds: ids,
+      willGiveUpComment: typeof item?.willGiveUpComments === 'string'
+        ? item.willGiveUpComments.trim()
+        : '',
+      willTakeComment: typeof item?.willTakeComments === 'string'
+        ? item.willTakeComments.trim()
+        : '',
+    };
+  }
+  return { flat: Array.from(playerIds), byFranchise };
 };
 
 const url = `${host}/${year}/export?TYPE=tradeBait&L=${leagueId}&JSON=1`;
@@ -89,10 +115,19 @@ try {
   const res = await fetch(url);
   if (!res.ok) throw new Error(`HTTP ${res.status}`);
   const text = await res.text();
-  const parsed = parseTradeBait(JSON.parse(text));
+  const { flat, byFranchise } = parseTradeBait(JSON.parse(text));
   const file = path.join(outDir, 'tradeBait.json');
-  fs.writeFileSync(file, JSON.stringify(parsed, null, 2), 'utf8');
-  console.log(`Saved ${parsed.length} trade bait player(s) -> ${file}`);
+  fs.writeFileSync(file, JSON.stringify(flat, null, 2), 'utf8');
+  console.log(`Saved ${flat.length} trade bait player(s) -> ${file}`);
+
+  const byFranchiseFile = path.join(outDir, 'tradeBait-by-franchise.json');
+  const byFranchisePayload = {
+    fetchedAt: Date.now(),
+    franchises: byFranchise,
+  };
+  fs.writeFileSync(byFranchiseFile, JSON.stringify(byFranchisePayload, null, 2), 'utf8');
+  const franchiseCount = Object.keys(byFranchise).length;
+  console.log(`Saved per-franchise trade bait (${franchiseCount} franchise(s)) -> ${byFranchiseFile}`);
 } catch (err) {
   console.error(`Failed to fetch trade bait: ${err.message}`);
   // Don't fail the build — trade bait is non-critical

--- a/scripts/lib/schefter-bucket-logic.mjs
+++ b/scripts/lib/schefter-bucket-logic.mjs
@@ -19,6 +19,7 @@ export function classifyTipKind(tip) {
 /**
  * Group tips into single-topic buckets. Bucket keys:
  *   - trade_offer tips           → 'trade:offer'
+ *   - trade_bait tips            → 'topic:trade_bait:<franchiseId>'
  *   - whisper-back followups     → 'thread:<parentPostId>'
  *   - web/groupme tips           → 'topic:<topic>:<scope>'
  *
@@ -27,7 +28,8 @@ export function classifyTipKind(tip) {
  * (one about a specific franchise, one league-wide) don't collapse into
  * a single combined post. Multi-source clustering still works: two
  * tippers naming the SAME franchise on the SAME topic share a key and
- * cluster correctly.
+ * cluster correctly. Trade-bait tips key per-franchise so an owner's
+ * dump only ever produces one post per cycle.
  */
 export function buildTopicBuckets(tips) {
   const map = new Map();
@@ -35,6 +37,9 @@ export function buildTopicBuckets(tips) {
     let key;
     if (tip.source === 'trade_offer') {
       key = 'trade:offer';
+    } else if (tip.source === 'trade_bait') {
+      const scope = tip.franchiseHint ?? 'league-wide';
+      key = `topic:trade_bait:${scope}`;
     } else if (typeof tip.repliesToPostId === 'string' && tip.repliesToPostId.length > 0) {
       key = `thread:${tip.repliesToPostId}`;
     } else {

--- a/scripts/lib/trade-bait-detector.mjs
+++ b/scripts/lib/trade-bait-detector.mjs
@@ -1,0 +1,264 @@
+/**
+ * Trade-bait drift detector — pure, stateless.
+ *
+ * Owners add players to their MFL "trade bait" list to publicly signal
+ * availability. The scanner wants to turn those changes into rumor-mill
+ * posts without flooding the feed when an owner dumps a bunch of players
+ * over a short window. This module owns that debouncing logic.
+ *
+ * Mental model (per franchise):
+ *   - committedBlock  : the block we last told the rumor mill about
+ *   - observedBlock   : the block we saw on MFL at the last scan
+ *   - firstChangeTs   : when drift from committedBlock started (null when settled)
+ *   - lastChangeTs    : when the observedBlock last moved (null when settled)
+ *
+ * Each scan updates drift timers, computes netAdds/netRemoves against the
+ * committed state, and either holds for more quiet (drifting) or emits a
+ * tip and advances committedBlock to the current state (settled).
+ *
+ * Edge behavior (codified; see tests/trade-bait-detector.test.ts):
+ *   - First run: no prior entry → seed silently, emit nothing.
+ *   - Add + remove same player within the window → netAdds stays empty, silent.
+ *   - Pure removes → no tip; committedBlock advances so a future re-add fires.
+ *   - Stuck drift: firstChangeTs ≥ MAX_SETTLE_WAIT_MS → force-emit regardless.
+ *
+ * The detector never touches I/O. Callers supply `now`, current block data,
+ * prior state; the return value is a new state object plus zero-or-more
+ * tips to enqueue.
+ */
+
+/** Default 45 minute settle window — long enough to absorb a cleanup session. */
+export const DEFAULT_SETTLE_WINDOW_MS = 45 * 60 * 1000;
+
+/** Default 6 hour absolute cap — prevents a fidgety owner from blocking posts forever. */
+export const DEFAULT_MAX_SETTLE_WAIT_MS = 6 * 60 * 60 * 1000;
+
+/** Truncate `meta.adds` to this many — avoids an unreadable 20-player dump. */
+export const MAX_ADDS_PER_TIP = 10;
+
+/**
+ * Normalize a player-id array into a canonical sorted unique array.
+ * The detector's equality checks depend on canonical ordering.
+ */
+export function normalizeBlock(ids) {
+  if (!Array.isArray(ids)) return [];
+  const out = new Set();
+  for (const id of ids) {
+    if (id === null || id === undefined) continue;
+    const s = String(id).trim();
+    if (s.length > 0) out.add(s);
+  }
+  return [...out].sort();
+}
+
+function setDiff(aArr, bArr) {
+  const b = new Set(bArr);
+  const out = [];
+  for (const x of aArr) if (!b.has(x)) out.push(x);
+  return out;
+}
+
+function arraysEqual(a, b) {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+  return true;
+}
+
+/**
+ * Run the detector against a single franchise.
+ *
+ * @param {object} args
+ * @param {string} args.franchiseId
+ * @param {string[]} args.currentIds - Raw current block from MFL
+ * @param {object|undefined} args.prevEntry - feed.tradeBaitState[franchiseId]
+ * @param {number} args.nowMs
+ * @param {number} args.settleWindowMs
+ * @param {number} args.maxSettleWaitMs
+ * @returns {{
+ *   emit: boolean,
+ *   reason: 'seed' | 'settled' | 'max_wait' | 'no_change' | 'drifting' | 'silent_sync',
+ *   nextEntry: { committedBlock: string[], observedBlock: string[], firstChangeTs: number|null, lastChangeTs: number|null },
+ *   netAdds: string[],
+ *   netRemoves: string[],
+ *   truncated: boolean,
+ * }}
+ */
+export function detectFranchiseChange({
+  franchiseId,
+  currentIds,
+  prevEntry,
+  nowMs,
+  settleWindowMs = DEFAULT_SETTLE_WINDOW_MS,
+  maxSettleWaitMs = DEFAULT_MAX_SETTLE_WAIT_MS,
+}) {
+  const current = normalizeBlock(currentIds);
+
+  // ── Seed ─────────────────────────────────────────────────────────────
+  // No prior entry → record what's on MFL as the committed state and emit
+  // nothing. The feature's first post will be the first real delta after
+  // this scan. Intentional: prevents a 17-player flood on launch day.
+  if (!prevEntry) {
+    return {
+      emit: false,
+      reason: 'seed',
+      nextEntry: {
+        committedBlock: current,
+        observedBlock: current,
+        firstChangeTs: null,
+        lastChangeTs: null,
+      },
+      netAdds: [],
+      netRemoves: [],
+      truncated: false,
+    };
+  }
+
+  const committed = normalizeBlock(prevEntry.committedBlock);
+  const prevObserved = normalizeBlock(prevEntry.observedBlock ?? committed);
+  const prevFirst = Number.isFinite(prevEntry.firstChangeTs) ? prevEntry.firstChangeTs : null;
+  const prevLast = Number.isFinite(prevEntry.lastChangeTs) ? prevEntry.lastChangeTs : null;
+
+  const observedChanged = !arraysEqual(current, prevObserved);
+  const lastChangeTs = observedChanged ? nowMs : prevLast;
+  const firstChangeTs = observedChanged && prevFirst === null ? nowMs : prevFirst;
+
+  const netAdds = setDiff(current, committed);
+  const netRemoves = setDiff(committed, current);
+
+  // ── No drift from committed ──────────────────────────────────────────
+  // Owner may be flipping a single player in and out — observedBlock can
+  // change even when committed equality holds. Reset drift timers so the
+  // settle window doesn't carry stale history into the next real delta.
+  if (netAdds.length === 0 && netRemoves.length === 0) {
+    return {
+      emit: false,
+      reason: 'no_change',
+      nextEntry: {
+        committedBlock: committed,
+        observedBlock: current,
+        firstChangeTs: null,
+        lastChangeTs: null,
+      },
+      netAdds: [],
+      netRemoves: [],
+      truncated: false,
+    };
+  }
+
+  // ── Still drifting ───────────────────────────────────────────────────
+  // The max-wait fuse (firstChangeTs + maxSettleWaitMs) breaks a stalemate
+  // where an owner keeps tweaking every few minutes. Otherwise hold until
+  // (now - lastChangeTs) ≥ settleWindowMs so dumps coalesce cleanly.
+  const driftStart = firstChangeTs ?? lastChangeTs ?? nowMs;
+  const maxWaitElapsed = nowMs - driftStart >= maxSettleWaitMs;
+  const settled = lastChangeTs === null || nowMs - lastChangeTs >= settleWindowMs;
+
+  if (!settled && !maxWaitElapsed) {
+    return {
+      emit: false,
+      reason: 'drifting',
+      nextEntry: {
+        committedBlock: committed,
+        observedBlock: current,
+        firstChangeTs,
+        lastChangeTs,
+      },
+      netAdds,
+      netRemoves,
+      truncated: false,
+    };
+  }
+
+  // ── Ready to advance ─────────────────────────────────────────────────
+  // Pure-remove case emits no tip but still advances committedBlock so a
+  // future re-add re-surfaces correctly. Any netAdds → emit.
+  const truncated = netAdds.length > MAX_ADDS_PER_TIP;
+  return {
+    emit: netAdds.length > 0,
+    reason: netAdds.length > 0 ? (maxWaitElapsed && !settled ? 'max_wait' : 'settled') : 'silent_sync',
+    nextEntry: {
+      committedBlock: current,
+      observedBlock: current,
+      firstChangeTs: null,
+      lastChangeTs: null,
+    },
+    netAdds,
+    netRemoves,
+    truncated,
+  };
+}
+
+/**
+ * Run the detector across every franchise in a single fetch snapshot.
+ *
+ * @param {object} args
+ * @param {object<string, { playerIds: string[], willGiveUpComment?: string, willTakeComment?: string }>} args.currentByFranchise
+ * @param {object<string, object>} args.prevState - feed.tradeBaitState (may be empty/undefined)
+ * @param {number} args.nowMs
+ * @param {number} [args.settleWindowMs]
+ * @param {number} [args.maxSettleWaitMs]
+ * @returns {{
+ *   nextState: object,
+ *   emissions: Array<{ franchiseId: string, netAdds: string[], netRemoves: string[], truncated: boolean, reason: string, willGiveUpComment?: string, willTakeComment?: string }>,
+ *   reasons: object<string, string>,
+ * }}
+ */
+export function detectTradeBaitChanges({
+  currentByFranchise,
+  prevState,
+  nowMs,
+  settleWindowMs = DEFAULT_SETTLE_WINDOW_MS,
+  maxSettleWaitMs = DEFAULT_MAX_SETTLE_WAIT_MS,
+}) {
+  const nextState = {};
+  const emissions = [];
+  const reasons = {};
+  const safePrev = prevState && typeof prevState === 'object' ? prevState : {};
+  const seen = new Set();
+
+  for (const [franchiseId, entry] of Object.entries(currentByFranchise ?? {})) {
+    seen.add(franchiseId);
+    const result = detectFranchiseChange({
+      franchiseId,
+      currentIds: entry?.playerIds ?? [],
+      prevEntry: safePrev[franchiseId],
+      nowMs,
+      settleWindowMs,
+      maxSettleWaitMs,
+    });
+    nextState[franchiseId] = result.nextEntry;
+    reasons[franchiseId] = result.reason;
+    if (result.emit) {
+      emissions.push({
+        franchiseId,
+        netAdds: result.netAdds,
+        netRemoves: result.netRemoves,
+        truncated: result.truncated,
+        reason: result.reason,
+        willGiveUpComment: entry?.willGiveUpComment ?? '',
+        willTakeComment: entry?.willTakeComment ?? '',
+      });
+    }
+  }
+
+  // Franchises that disappeared from the current fetch (e.g. removed from
+  // league, or block cleared to zero and MFL stopped returning them) —
+  // treat as "block went empty" for diff purposes so any stored adds clear.
+  // We model "empty block" explicitly so firstChangeTs can advance cleanly.
+  for (const [franchiseId, prevEntry] of Object.entries(safePrev)) {
+    if (seen.has(franchiseId)) continue;
+    const result = detectFranchiseChange({
+      franchiseId,
+      currentIds: [],
+      prevEntry,
+      nowMs,
+      settleWindowMs,
+      maxSettleWaitMs,
+    });
+    nextState[franchiseId] = result.nextEntry;
+    reasons[franchiseId] = result.reason;
+    // Absent franchise never emits adds (current is empty) — only pure removes.
+  }
+
+  return { nextState, emissions, reasons };
+}

--- a/scripts/schefter-rumor-scan.mjs
+++ b/scripts/schefter-rumor-scan.mjs
@@ -60,7 +60,7 @@
  *
  * Special paths:
  *   - Friday mailbag: on Friday PT, once per day, sweeps ALL gossip tips
- *     still in the queue into a bullet-style roundup (HARD RULE 18). Ensures
+ *     still in the queue into a bullet-style roundup (HARD RULE 20). Ensures
  *     every tip gets a shot at the feed before the 7-day TTL fires.
  *   - Adaptive gossip cap: when gossip queue depth >= 6 OR oldest gossip
  *     tip is >= 3 days old, the day's gossip cap bumps to 2.
@@ -192,6 +192,48 @@ const TIP_PAGE_PATH = '/schefter/tip';
 const TIP_PAGE_LINK_LABEL = 'Got a tip? Whisper to Schefter →';
 const PUBLIC_BASE_URL = (process.env.SCHEFTER_PUBLIC_BASE_URL || 'https://theleague.us').replace(/\/+$/, '');
 const TIP_PAGE_ABSOLUTE_URL = `${PUBLIC_BASE_URL}${TIP_PAGE_PATH}`;
+
+// Trade-bait rumors send readers to the Trade Builder instead of the tip
+// page — the owner has publicly listed players, so the natural next click
+// is to build a counter-offer with those players pre-loaded. The ?b=<id>
+// param is the same convention the rosters page uses (see rosters.astro).
+const TRADE_BUILDER_LINK_LABEL = 'Open in Trade Builder →';
+const TRADE_BUILDER_GROUPME_PREFIX = 'Counter on the block?';
+
+function buildTradeBuilderPath(franchiseId) {
+  return `/theleague/trade-builder?b=${encodeURIComponent(franchiseId)}`;
+}
+
+/**
+ * Resolve the CTA for a post based on its primary bucket. Trade-bait
+ * posts targeted at a single franchise swap the default tip-page CTA
+ * for a Trade Builder deep-link; everything else uses the tip page.
+ * Returns all three rendering targets (feed link, feed label, GroupMe
+ * URL suffix) so the post builder + groupMeTextFor stay in sync.
+ */
+function resolveCta(primaryBucket) {
+  const tips = primaryBucket?.tips ?? [];
+  const allTradeBait = tips.length > 0 && tips.every((t) => t.source === 'trade_bait');
+  if (allTradeBait) {
+    const franchiseIds = new Set(tips.map((t) => t.franchiseHint).filter(Boolean));
+    if (franchiseIds.size === 1) {
+      const [fid] = franchiseIds;
+      const path = buildTradeBuilderPath(fid);
+      return {
+        link: path,
+        linkLabel: TRADE_BUILDER_LINK_LABEL,
+        groupMePrefix: TRADE_BUILDER_GROUPME_PREFIX,
+        groupMeUrl: `${PUBLIC_BASE_URL}${path}`,
+      };
+    }
+  }
+  return {
+    link: TIP_PAGE_PATH,
+    linkLabel: TIP_PAGE_LINK_LABEL,
+    groupMePrefix: 'Got a tip?',
+    groupMeUrl: TIP_PAGE_ABSOLUTE_URL,
+  };
+}
 
 // ── Logging ──
 
@@ -505,6 +547,35 @@ function anonymizeTips(tips, teams, feedPosts = [], now = new Date()) {
       return safe;
     }
 
+    // Trade-bait: owner publicly listed players on the block. Attribution
+    // is the WHOLE POINT — the franchise put this on MFL for the league to
+    // see, so we name them. No fuzz, no redaction. Pass the structured
+    // adds/byPos/ownerComment payload through so the LLM can pick framing
+    // (singleton name vs. positional theme vs. spring-cleaning).
+    if (tip.source === 'trade_bait') {
+      const hint = tip.franchiseHint;
+      const team = teams.get(hint);
+      const franchiseName = tip.author || pickTeamName(team) || `Team ${hint}`;
+      safe.author = franchiseName;
+      safe.attributable = true;
+      safe.scope = {
+        kind: 'trade-bait',
+        franchise: franchiseName,
+        division: team?.division,
+      };
+      if (tip.meta && typeof tip.meta === 'object') {
+        safe.meta = {
+          adds: Array.isArray(tip.meta.adds) ? tip.meta.adds : [],
+          byPos: tip.meta.byPos ?? {},
+          totalAdds: tip.meta.totalAdds ?? (Array.isArray(tip.meta.adds) ? tip.meta.adds.length : 0),
+          ownerWillGiveUp: tip.meta.ownerWillGiveUp ?? '',
+          ownerWillTake: tip.meta.ownerWillTake ?? '',
+          truncated: tip.meta.truncated === true,
+        };
+      }
+      return safe;
+    }
+
     const hint = tip.franchiseHint;
     if (!hint || hint === 'league-wide') {
       safe.scope = { kind: 'league-wide' };
@@ -605,6 +676,8 @@ function anonymizeTips(tips, teams, feedPosts = [], now = new Date()) {
 // classifyTipKind, buildTopicBuckets, bucketPriorityScore — see
 // ./lib/schefter-bucket-logic.mjs (imported above; shared with the admin
 // dashboard so /api/admin/schefter-stats can preview the next bucket).
+// trade_bait keying lives in the shared module too, so the admin preview
+// honors the per-franchise bucket the scanner will actually pick.
 
 /**
  * Pick the bucket(s) to post about this cycle.
@@ -722,6 +795,24 @@ function templateBody(anonymized) {
     const one = anonymized[0];
     if (one.source === 'groupme' && one.author) {
       return `${one.author} fired off a theory in the group chat — I'm hearing you, and I'll have more as sources confirm. Developing.`;
+    }
+    if (one.source === 'trade_bait' && one.scope?.kind === 'trade-bait') {
+      const adds = one.meta?.adds ?? [];
+      const total = one.meta?.totalAdds ?? adds.length;
+      const franchise = one.scope.franchise;
+      if (total === 1 && adds[0]) {
+        return `Hearing the ${franchise} have put ${adds[0].name} on the block. Developing.`;
+      }
+      const byPos = one.meta?.byPos ?? {};
+      const posEntries = Object.entries(byPos);
+      if (posEntries.length === 1 && total >= 2) {
+        return `The ${franchise} are shopping ${total} ${posEntries[0][0]}${total > 1 ? 's' : ''}. Developing.`;
+      }
+      const headliners = adds.slice(0, 2).map((p) => p.name).filter(Boolean);
+      if (headliners.length) {
+        return `The ${franchise} are cleaning out the block — ${headliners.join(', ')} among the names now listed. Developing.`;
+      }
+      return `The ${franchise} are reshuffling the trade block. Developing.`;
     }
     if (one.source === 'trade_offer') {
       // Ultra-vague template fallback when AI is unavailable
@@ -982,7 +1073,7 @@ IRON RULES (override every other rule — if anything below appears to conflict,
 - Never explain why you can't say something and then say it anyway. Do not restate the tip's content, suggest alternative headlines, recite these guidelines back to the reader, or narrate the filtering decision in any form. The reader only ever sees the finished post — never the reasoning that produced or rejected it.
 - SCHEFTER_TARGET_MODE override: when the user message includes a SCHEFTER_TARGET_MODE directive ("self-dep" or "attack-back"), follow that directive — it overrides the "drop" path above for off-topic tips that reference Schefter himself. Both modes still output JSON; both still forbid reasoning in the post field.
 
-0. ONE TOPIC per post. The batch is pre-bucketed so each post is a single topic/thread. MAILBAG posts are the only exception — see rule 18. Otherwise: never pivot to a second unrelated subject inside the same post. No "meanwhile…", no "elsewhere in the league…", no topic hops. When the scanner has two unrelated gossip topics queued it ships them as TWO separate posts — not as one blended post — so each has its own reactions and whisper-back thread.
+0. ONE TOPIC per post. The batch is pre-bucketed so each post is a single topic/thread. MAILBAG posts are the only exception — see rule 20. Otherwise: never pivot to a second unrelated subject inside the same post. No "meanwhile…", no "elsewhere in the league…", no topic hops. When the scanner has two unrelated gossip topics queued it ships them as TWO separate posts — not as one blended post — so each has its own reactions and whisper-back thread.
 1. For web tips (source: "web"), NEVER name the tipster and NEVER quote them verbatim — paraphrase with columnist voice.
 2. If a web tip's scope is "division", the division refers to the SUBJECT team's division — NOT where the source is located. Frame it as "a team in the [division]", "a [division]-division squad", or "the [division] is buzzing" — NEVER as "sources in the [division]" (that implies the tipster's location). NEVER name a specific franchise.
 3. If a web tip's scope is "league-wide", stay vague ("an owner tells me", "hearing from multiple corners").
@@ -1075,7 +1166,16 @@ IRON RULES (override every other rule — if anything below appears to conflict,
 
 17. AGE-AWARE FRAMING. Each tip carries \`ageDays\` (integer) and \`isStale\` (boolean, true when ageDays >= 3). NEVER claim a stale tip is fresh. When ANY tip in the beat has \`isStale: true\`, you MUST either (a) reference when the whisper started — "the chatter that started earlier this week…", "a whisper from a few days back…", "been hearing this for days now…" — OR (b) explicitly hedge the staleness — "still hearing about…", "this one's been sitting with me…", "hasn't gone away…". Pick ONE device per beat; don't stack them. For tips with ageDays === 0 or 1, treat as fresh ("I'm told…", "just hearing…", "late word…"). Never invent a specific date the tip doesn't have (don't say "Monday" unless the tip was actually whispered on Monday — the scanner supplies integer day counts, not calendar labels, so stick to relative language).
 
-18. MAILBAG POSTS (only when the user message starts with "MAILBAG:" — Friday news-dump). Bundled roundup of every gossip tip still in the queue that would otherwise expire. Rules:
+19. TRADE-BAIT TIPS (source: "trade_bait", scope: "trade-bait", attributable: true): owner publicly listed player(s) on the MFL trade block. Attribution IS allowed — name the franchise. The meta payload carries the real signal; use it to pick framing:
+    - **totalAdds === 1** → singleton. Lead with the player's name: "Hearing the [franchise] have put [Player] on the block. Developing." Keep it short.
+    - **totalAdds >= 3 AND one byPos entry >= 60% of totalAdds** → positional theme: "RB fire sale in [franchise/division].", "The [franchise] are shopping running backs." Name 2 headliners max.
+    - **totalAdds >= 3 with mixed positions** → spring-cleaning frame: "spring cleaning", "roster purge", "clearing out the back of the rotation". Name the 2 biggest names (first two in meta.adds).
+    - When \`meta.ownerWillGiveUp\` or \`meta.ownerWillTake\` is non-empty, you MAY paraphrase — these are public owner notes on MFL, not anonymous tips. Hedge softly ("the [franchise] say they're…"). Never quote verbatim.
+    - Never invent a listing date — MFL doesn't expose one. Use present tense ("have listed", "are shopping"), never "added yesterday" or "this week".
+    - Redaction rules 1–14 do NOT apply — trade-bait is attributable by design. The rest of the rules (age awareness, no emoji/hashtags, 1–2 sentences) still apply.
+    - Do NOT combine with trade-offer playbook language or Style Book framing. This is neutral beat-reporter reporting on a public listing.
+
+20. MAILBAG POSTS (only when the user message starts with "MAILBAG:" — Friday news-dump). Bundled roundup of every gossip tip still in the queue that would otherwise expire. Rules:
     - Open with a brief mailbag framing: "Cleaning out the mailbag before the weekend.", "Friday loose-notes dump.", "Before I log off — a few whispers worth airing out."
     - Cover up to 6 bullet-style one-liners, one per topic bucket. Each one-liner is a single clause. Line-break between bullets (\\n\\n• …).
     - Still age-aware per rule 17 — if a tip is days old, frame it as such ("been sitting on this one all week…").
@@ -1128,7 +1228,7 @@ A GroupMe author just took an off-topic personal shot at Schefter. This is the r
 
   let userMessage;
   if (mode === 'mailbag') {
-    userMessage = `MAILBAG: Friday news-dump. Apply HARD RULE 18 — bullet each topic in the GOSSIP_TIPS array as a one-liner (≤6 bullets). Open with a mailbag framing and sign off at the end. ${jsonContract} (Newlines inside the post string are fine for bullets.)${rogerDirective}${schefterModeDirective}${recentBlock}\n\nGOSSIP_TIPS:\n${JSON.stringify(anonymized, null, 2)}`;
+    userMessage = `MAILBAG: Friday news-dump. Apply HARD RULE 20 — bullet each topic in the GOSSIP_TIPS array as a one-liner (≤6 bullets). Open with a mailbag framing and sign off at the end. ${jsonContract} (Newlines inside the post string are fine for bullets.)${rogerDirective}${schefterModeDirective}${recentBlock}\n\nGOSSIP_TIPS:\n${JSON.stringify(anonymized, null, 2)}`;
   } else {
     userMessage = `Synthesize these tips into ONE rumor-mill post (1–2 sentences, one topic). ${jsonContract}${rogerDirective}${schefterModeDirective}${recentBlock}\n\nTIPS:\n${JSON.stringify(anonymized, null, 2)}`;
   }
@@ -1988,7 +2088,13 @@ async function main() {
   // JSON or the API response shape.
   const combinedBatch = beats.flatMap((b) => b.batch);
   const builtPosts = [];
+  const ctaByPostId = new Map();
   const parentIdByPostId = new Map();
+  // Each beat has its own bucket — primary uses primaryBucket, secondary
+  // (gossip-only) uses secondaryBucket. Resolve CTA per-beat so a gossip
+  // secondary attached to a trade_bait primary doesn't inherit the wrong
+  // Trade Builder link.
+  const beatBuckets = [primaryBucket, secondaryBucket];
   for (let i = 0; i < beats.length; i++) {
     const beat = beats[i];
     const aiBody = aiBodies[i];
@@ -2032,6 +2138,12 @@ async function main() {
     // Feed prepends primary last so primary ends up at index 0 (top).
     const beatTs = new Date(now.getTime() + i * 1000);
 
+    // CTA: most rumor cards link back to the tip page so readers can
+    // whisper a follow-up. Trade-bait rumors about a single franchise
+    // swap the link for a Trade Builder deep-link pre-loaded with that
+    // franchise, since the natural next step is to build a counter.
+    const cta = resolveCta(beatBuckets[i]);
+
     const post = {
       id: generatePostId(),
       timestamp: beatTs.toISOString(),
@@ -2045,13 +2157,11 @@ async function main() {
       tipIds,
       hadRogerRiff: i === 0 ? hadRogerRiff : false,
       league: LEAGUE_SLUG,
-      // Every rumor card links back to the tip page so any reader can
-      // whisper a follow-up with a single tap. SchefterPostCard renders
-      // this as a CTA under the body.
-      link: TIP_PAGE_PATH,
-      linkLabel: TIP_PAGE_LINK_LABEL,
+      link: cta.link,
+      linkLabel: cta.linkLabel,
       ...(threadId ? { threadId } : {}),
     };
+    ctaByPostId.set(post.id, cta);
     if (threadId && dominantParentId) {
       parentIdByPostId.set(post.id, dominantParentId);
     }
@@ -2059,8 +2169,15 @@ async function main() {
   }
 
   const allTipIds = combinedBatch.map((t) => t.id);
-  // Stable cycle-wide GroupMe payload builder — body + tip-page URL.
-  const groupMeTextFor = (p) => `${p.body}\n\nGot a tip? ${TIP_PAGE_ABSOLUTE_URL}`;
+  // GroupMe payload — per-post CTA. Trade-bait posts link into the Trade
+  // Builder; every other post carries the tip-page CTA.
+  const groupMeTextFor = (p) => {
+    const cta = ctaByPostId.get(p.id) ?? {
+      groupMePrefix: 'Got a tip?',
+      groupMeUrl: TIP_PAGE_ABSOLUTE_URL,
+    };
+    return `${p.body}\n\n${cta.groupMePrefix} ${cta.groupMeUrl}`;
+  };
 
   if (DRY_RUN) {
     log(`\n  [dry-run] Would append ${builtPosts.length} post(s) to feed:`);

--- a/scripts/schefter-scan.mjs
+++ b/scripts/schefter-scan.mjs
@@ -24,6 +24,7 @@ import {
   buildHistoryEntry,
 } from './lib/schefter-lore.mjs';
 import { shouldFireReminder } from './lib/roger-reminder-window.mjs';
+import { detectTradeBaitChanges } from './lib/trade-bait-detector.mjs';
 
 const projectRoot = path.resolve(fileURLToPath(new URL('..', import.meta.url)));
 const MFL_HOST = process.env.MFL_HOST || 'api.myfantasyleague.com';
@@ -939,6 +940,263 @@ async function scanPendingTrades(league) {
   if (dropped.length) console.log(`  [rumor-mill] Dropped ${dropped.length} resolved trade(s) from watermark`);
   console.log(`  Wrote ${newPosts.length} pending-trade rumor post(s). Watermark size: ${feed.pendingTradeWatermark.length}`);
   return newPosts.length;
+}
+
+// ── Schefter Rumor Mill: Trade-Bait Detector ──
+// Owners add players to their MFL trade block to publicly signal availability.
+// This scan diffs per-franchise blocks against a committed state, debounces
+// activity via a per-franchise settle window (so a six-player dump fires as
+// one post, not six), and enqueues attributable rumor-bait tips into the
+// same Redis tips queue that the rumor-mill scanner consumes. The detector
+// itself is pure (scripts/lib/trade-bait-detector.mjs) and unit-tested;
+// everything here is I/O glue.
+//
+// Silent-seed launch: on the first run for a league, the detector records
+// the current block as the committed state and emits nothing. The feature
+// surfaces on the first real owner delta post-deploy.
+
+const TRADE_BAIT_SOURCE = 'trade_bait';
+const TRADE_BAIT_TOPIC = 'trade_bait';
+
+async function fetchTradeBaitRaw(leagueId, year) {
+  const url = `https://${MFL_HOST}/${year}/export?TYPE=tradeBait&L=${leagueId}&JSON=1`;
+  const res = await fetch(url, { headers: { 'User-Agent': 'schefter-scan/1.0' } });
+  if (!res.ok) throw new Error(`MFL HTTP ${res.status}`);
+  const text = await res.text();
+  if (text.trim().startsWith('<')) throw new Error('MFL returned HTML for tradeBait');
+  return JSON.parse(text);
+}
+
+function parseTradeBaitByFranchise(data) {
+  const out = {};
+  let entries = data?.tradeBaits?.tradeBait;
+  if (!entries) return out;
+  if (!Array.isArray(entries)) entries = [entries];
+  for (const item of entries) {
+    const franchiseId = String(
+      item?.franchise_id ?? item?.franchiseId ?? item?.franchise ?? '',
+    ).trim();
+    if (!franchiseId) continue;
+    const ids = item?.willGiveUp
+      ? (typeof item.willGiveUp === 'string'
+          ? item.willGiveUp.split(',').map((s) => s.trim())
+          : [String(item.willGiveUp)])
+      : [];
+    out[franchiseId] = {
+      playerIds: ids.filter((id) => id && /^\d{4,}$/.test(id)),
+      willGiveUpComment: typeof item?.willGiveUpComments === 'string'
+        ? item.willGiveUpComments.trim()
+        : '',
+      willTakeComment: typeof item?.willTakeComments === 'string'
+        ? item.willTakeComments.trim()
+        : '',
+    };
+  }
+  return out;
+}
+
+/**
+ * Minimal Upstash Redis adapter — mirrors the pattern in
+ * schefter-rumor-scan.mjs so both scripts can share the tips queue.
+ * Returns null when credentials are missing (the trade-bait scan then
+ * skips so we don't silently advance committedBlock without enqueueing).
+ */
+async function getTradeBaitRedis() {
+  const url =
+    process.env.UPSTASH_REDIS_REST_URL ||
+    process.env.KV_REST_API_URL ||
+    process.env.STORAGE_REST_API_URL;
+  const token =
+    process.env.UPSTASH_REDIS_REST_TOKEN ||
+    process.env.KV_REST_API_TOKEN ||
+    process.env.STORAGE_REST_API_TOKEN;
+  if (!url || !token) return null;
+  try {
+    const { Redis } = await import('@upstash/redis');
+    return new Redis({ url, token });
+  } catch (err) {
+    console.warn(`  [trade-bait] Redis import failed: ${err.message}`);
+    return null;
+  }
+}
+
+const TIPS_QUEUE_KEY = 'schefter:tips:queue';
+const FIRST_TIP_TS_KEY = 'schefter:tips:first_tip_ts';
+
+function buildTradeBaitTip({
+  franchiseId,
+  emission,
+  franchiseName,
+  players,
+  nowMs,
+}) {
+  const addedPlayers = emission.netAdds.map((id) => {
+    const p = players.get(id);
+    return {
+      id,
+      name: p?.name ?? `Player ${id}`,
+      pos: p?.position ?? '',
+      nflTeam: p?.nflTeam ?? '',
+    };
+  });
+
+  const byPos = {};
+  for (const p of addedPlayers) {
+    if (!p.pos) continue;
+    byPos[p.pos] = (byPos[p.pos] ?? 0) + 1;
+  }
+
+  const displayedAdds = addedPlayers.slice(0, 10);
+  const truncated = emission.truncated || addedPlayers.length > displayedAdds.length;
+
+  const nameList = displayedAdds
+    .map((p) => p.pos ? `${p.name} (${p.pos})` : p.name)
+    .join(', ');
+  const commentSuffix = emission.willGiveUpComment
+    ? ` Owner note: "${emission.willGiveUpComment}"`
+    : '';
+  const text = `${franchiseName} added to the trade block: ${nameList}.${commentSuffix}`;
+
+  const id = `sf_tradebait_${franchiseId}_${nowMs}`;
+  return {
+    id,
+    source: TRADE_BAIT_SOURCE,
+    topic: TRADE_BAIT_TOPIC,
+    attributable: true,
+    author: franchiseName,
+    franchiseHint: franchiseId,
+    submittedAt: nowMs,
+    text,
+    meta: {
+      adds: displayedAdds,
+      removes: emission.netRemoves,
+      byPos,
+      totalAdds: addedPlayers.length,
+      ownerWillGiveUp: emission.willGiveUpComment ?? '',
+      ownerWillTake: emission.willTakeComment ?? '',
+      truncated,
+      reason: emission.reason,
+    },
+  };
+}
+
+async function scanTradeBait(league) {
+  if (!process.env.SCHEFTER_RUMOR_MILL_ENABLED ||
+      process.env.SCHEFTER_RUMOR_MILL_ENABLED === '0' ||
+      process.env.SCHEFTER_RUMOR_MILL_ENABLED.toLowerCase() === 'false') {
+    return 0;
+  }
+  if (league.slug !== 'theleague') return 0;
+
+  console.log(`\n=== Scanning Trade Bait (Rumor Mill) for ${league.slug} ===`);
+
+  const feed = await loadFeed(league.feedPath);
+  const prevState = feed.tradeBaitState && typeof feed.tradeBaitState === 'object'
+    ? feed.tradeBaitState
+    : {};
+
+  const now = new Date();
+  const year = now.getMonth() >= 1 ? now.getFullYear() : now.getFullYear() - 1;
+
+  let raw;
+  try {
+    raw = await fetchTradeBaitRaw(league.leagueId, year);
+  } catch (err) {
+    console.log(`  [trade-bait] Fetch failed: ${err.message} — holding state`);
+    return 0;
+  }
+  const currentByFranchise = parseTradeBaitByFranchise(raw);
+  const franchiseCount = Object.keys(currentByFranchise).length;
+  console.log(`  [trade-bait] MFL returned ${franchiseCount} franchise(s) with listings`);
+
+  const { nextState, emissions, reasons } = detectTradeBaitChanges({
+    currentByFranchise,
+    prevState,
+    nowMs: now.getTime(),
+  });
+
+  const changeSummary = Object.entries(reasons)
+    .filter(([, reason]) => reason !== 'seed' && reason !== 'no_change')
+    .map(([fid, reason]) => `${fid}=${reason}`);
+  if (changeSummary.length) {
+    console.log(`  [trade-bait] Drift summary: ${changeSummary.join(', ')}`);
+  } else if (!Object.keys(prevState).length) {
+    console.log('  [trade-bait] Silent-seed run — no tips emitted, state captured');
+  } else {
+    console.log('  [trade-bait] Nothing drifting — state unchanged');
+  }
+
+  if (emissions.length === 0) {
+    if (DRY_RUN) {
+      console.log('  [dry-run] Would write tradeBaitState (no tips to enqueue)');
+      return 0;
+    }
+    // Always persist state even on no-op so seed + no-change advances
+    // drop the drift timers and committed blocks stay current.
+    feed.tradeBaitState = nextState;
+    await fs.writeFile(league.feedPath, JSON.stringify(feed, null, 2) + '\n');
+    return 0;
+  }
+
+  // We have tips to enqueue. Redis is required — without it we cannot push
+  // to the rumor-mill queue, so we must NOT advance committedBlock (which
+  // would swallow the signal). Back off cleanly instead.
+  const redis = await getTradeBaitRedis();
+  if (!redis && !DRY_RUN) {
+    console.warn('  [trade-bait] Redis unavailable — holding state, will retry next cycle');
+    return 0;
+  }
+
+  const teams = await loadTeamsWithShortNames(league.configPath);
+  const players = await loadPlayers(league.playersPath(year));
+  const tips = emissions.map((emission) => {
+    const team = teams.get(emission.franchiseId);
+    const franchiseName = pickTeamDisplayName(team) ?? `Team ${emission.franchiseId}`;
+    return buildTradeBaitTip({
+      franchiseId: emission.franchiseId,
+      emission,
+      franchiseName,
+      players,
+      nowMs: now.getTime(),
+    });
+  });
+
+  for (const tip of tips) {
+    console.log(`  [trade-bait] emit ${tip.id} — ${tip.meta.totalAdds} add(s), byPos=${JSON.stringify(tip.meta.byPos)}`);
+  }
+
+  if (DRY_RUN) {
+    console.log('  [dry-run] Would enqueue the following trade-bait tip(s):');
+    for (const tip of tips) console.log(JSON.stringify(tip, null, 2));
+    console.log('  [dry-run] Would write tradeBaitState advancing committedBlock');
+    return 0;
+  }
+
+  // Ensure the first-tip anchor exists so rumor-scan's marinate gate passes.
+  try {
+    const existing = await redis.get(FIRST_TIP_TS_KEY);
+    if (!existing) await redis.set(FIRST_TIP_TS_KEY, now.getTime());
+  } catch (err) {
+    console.warn(`  [trade-bait] first_tip_ts anchor failed: ${err.message}`);
+  }
+
+  try {
+    for (const tip of tips) {
+      await redis.rpush(TIPS_QUEUE_KEY, JSON.stringify(tip));
+    }
+    console.log(`  [trade-bait] Enqueued ${tips.length} tip(s) to Redis`);
+  } catch (err) {
+    console.warn(`  [trade-bait] Redis push failed: ${err.message} — holding state`);
+    return 0;
+  }
+
+  // Only after the push succeeds do we advance committedBlock. If any part
+  // of the push failed above, the early return kept committedBlock on the
+  // prior value so the next cycle retries cleanly.
+  feed.tradeBaitState = nextState;
+  await fs.writeFile(league.feedPath, JSON.stringify(feed, null, 2) + '\n');
+
+  return tips.length;
 }
 
 // ── ESPN Integration ──
@@ -1865,6 +2123,8 @@ for (const league of LEAGUES) {
     totalPosts += await scanLeague(league);
     // Scan pending trades (Schefter Rumor Mill — Phase 1)
     totalPosts += await scanPendingTrades(league);
+    // Scan trade bait (per-franchise availability listings → rumor-mill tips)
+    totalPosts += await scanTradeBait(league);
     // Scan ESPN contributors
     totalPosts += await scanEspn(league);
     // Scan event reminders (Ask Roger)

--- a/tests/schefter-rumor-topic-focus.test.ts
+++ b/tests/schefter-rumor-topic-focus.test.ts
@@ -45,9 +45,14 @@ describe('rumor-scan daily caps — trade-heavy, gossip-rationed', () => {
 
 describe('rumor-scan bucketing — one topic per post', () => {
   const src = read('scripts/schefter-rumor-scan.mjs');
+  // classifyTipKind / buildTopicBuckets / bucketPriorityScore moved to a
+  // shared module so the admin dashboard can preview the next bucket.
+  // The scanner imports from there; function-body assertions now read
+  // the shared module's source.
+  const bucketSrc = read('scripts/lib/schefter-bucket-logic.mjs');
 
   it('defines a buildTopicBuckets helper that groups tips by topic/thread', () => {
-    expect(src).toMatch(/function\s+buildTopicBuckets\(/);
+    expect(bucketSrc).toMatch(/function\s+buildTopicBuckets\(/);
   });
 
   it('defines a pickPrimaryBucket helper that honors the gossip budget', () => {
@@ -60,7 +65,7 @@ describe('rumor-scan bucketing — one topic per post', () => {
     // Real MFL pending offers are the trade-rumor headline material.
     // Web/groupme tips with topic === 'trade' are speculation and ride
     // the gossip lane subject to the gossip cap.
-    const fn = src.match(/function\s+classifyTipKind[\s\S]+?\n\}/);
+    const fn = bucketSrc.match(/function\s+classifyTipKind[\s\S]+?\n\}/);
     expect(fn).not.toBeNull();
     const body = fn![0];
     expect(body).toMatch(/source\s*===\s*['"]trade_offer['"]\)\s*return\s+['"]trade['"]/);
@@ -74,7 +79,7 @@ describe('rumor-scan bucketing — one topic per post', () => {
     // `topic:<topic>:<franchiseHint || 'league-wide'>` so they bucket
     // independently and ship as two separate posts (subject to the
     // pressure gate).
-    const fn = src.match(/function\s+buildTopicBuckets[\s\S]+?\n\}/);
+    const fn = bucketSrc.match(/function\s+buildTopicBuckets[\s\S]+?\n\}/);
     expect(fn).not.toBeNull();
     const body = fn![0];
     expect(body).toMatch(/key\s*=\s*`topic:\$\{topic\}:\$\{scope\}`/);
@@ -271,11 +276,12 @@ describe('rumor-scan LLM — age-aware framing rule', () => {
 
 describe('rumor-scan bucket priority — age boost so old tips rise', () => {
   const src = read('scripts/schefter-rumor-scan.mjs');
+  const bucketSrc = read('scripts/lib/schefter-bucket-logic.mjs');
 
   it('exposes a bucketPriorityScore helper that adds a per-day age boost', () => {
-    expect(src).toMatch(/function\s+bucketPriorityScore\(/);
-    expect(src).toMatch(/oldestAgeDays/);
-    expect(src).toMatch(/return\s+sizeScore\s*\+\s*oldestAgeDays/);
+    expect(bucketSrc).toMatch(/function\s+bucketPriorityScore\(/);
+    expect(bucketSrc).toMatch(/oldestAgeDays/);
+    expect(bucketSrc).toMatch(/return\s+sizeScore\s*\+\s*oldestAgeDays/);
   });
 
   it('sorts both trade and gossip buckets by bucketPriorityScore (descending)', () => {

--- a/tests/schefter-rumor-topic-focus.test.ts
+++ b/tests/schefter-rumor-topic-focus.test.ts
@@ -158,14 +158,26 @@ describe('rumor-scan tip-page link — every post sends readers back to /tip', (
   });
 
   it('attaches link + linkLabel to every feed post it generates', () => {
-    expect(src).toMatch(/link:\s*TIP_PAGE_PATH/);
-    expect(src).toMatch(/linkLabel:\s*TIP_PAGE_LINK_LABEL/);
+    // Default CTA for non-trade-bait posts still resolves to the tip page.
+    expect(src).toMatch(/const\s+TIP_PAGE_PATH\s*=\s*['"]\/schefter\/tip['"]/);
+    expect(src).toMatch(/const\s+TIP_PAGE_LINK_LABEL\s*=/);
+    // Post builder pulls link/linkLabel from a per-beat CTA object, which
+    // falls back to the tip-page default for everything that isn't
+    // trade_bait with a single franchise.
+    expect(src).toMatch(/link:\s*cta\.link/);
+    expect(src).toMatch(/linkLabel:\s*cta\.linkLabel/);
+    expect(src).toMatch(/link:\s*TIP_PAGE_PATH,\s*\n\s*linkLabel:\s*TIP_PAGE_LINK_LABEL/);
   });
 
-  it('appends the absolute tip-page URL to every GroupMe post', () => {
-    // Each beat now ships its own GroupMe message via groupMeTextFor(p),
-    // a closure that formats "body\n\nGot a tip? <URL>".
-    expect(src).toMatch(/const\s+groupMeTextFor\s*=\s*\(p\)\s*=>\s*`\$\{p\.body\}\\n\\nGot a tip\? \$\{TIP_PAGE_ABSOLUTE_URL\}`/);
+  it('appends a per-post CTA URL to every GroupMe post (tip page by default)', () => {
+    // Each beat ships its own GroupMe message via groupMeTextFor(p), which
+    // resolves the CTA per-post through ctaByPostId. Trade-bait posts swap
+    // the tip-page URL for a Trade Builder deep-link; everything else
+    // falls back to the tip-page CTA.
+    expect(src).toMatch(/const\s+groupMeTextFor\s*=\s*\(p\)\s*=>\s*\{/);
+    expect(src).toMatch(/ctaByPostId\.get\(p\.id\)/);
+    expect(src).toMatch(/groupMeUrl:\s*TIP_PAGE_ABSOLUTE_URL/);
+    expect(src).toMatch(/\$\{cta\.groupMePrefix\}\s*\$\{cta\.groupMeUrl\}/);
     expect(src).toMatch(/await\s+postToGroupMe\(groupMeTextFor\(builtPosts\[i\]\)\)/);
     // No raw-body GroupMe calls remain — every rumor post gets the CTA.
     expect(src).not.toMatch(/await\s+postToGroupMe\(post\.body\)/);
@@ -422,8 +434,10 @@ describe('rumor-scan Friday mailbag — once-a-week sweep of pending gossip', ()
     expect(src).toMatch(/redis\.set\(FRIDAY_MAILBAG_DONE_KEY,\s*todayPtDate/);
   });
 
-  it('HARD RULE 18 prescribes bullet-style mailbag voice and caps length', () => {
-    expect(src).toMatch(/18\.\s*MAILBAG POSTS/);
+  it('HARD RULE 20 prescribes bullet-style mailbag voice and caps length', () => {
+    // Rule was renumbered from 18 → 20 when the trade-bait directive
+    // (rule 19) was inserted between age-aware framing and the mailbag.
+    expect(src).toMatch(/20\.\s*MAILBAG POSTS/);
     expect(src).toMatch(/bullet-style one-liners/);
     expect(src).toMatch(/Length cap:\s*180 words/);
   });

--- a/tests/trade-bait-detector.test.ts
+++ b/tests/trade-bait-detector.test.ts
@@ -1,0 +1,270 @@
+import { describe, it, expect } from 'vitest';
+// @ts-expect-error — sibling .mjs module, no .d.ts
+import {
+  detectFranchiseChange,
+  detectTradeBaitChanges,
+  normalizeBlock,
+  DEFAULT_SETTLE_WINDOW_MS,
+  DEFAULT_MAX_SETTLE_WAIT_MS,
+  MAX_ADDS_PER_TIP,
+// @ts-expect-error — sibling .mjs module, no .d.ts
+} from '../scripts/lib/trade-bait-detector.mjs';
+
+/**
+ * These tests lock in the per-franchise debouncing logic for Schefter's
+ * trade-bait rumor feed. The detector is the whole contract for the
+ * feature — if any of these flip red, the scanner is going to either
+ * flood the feed or swallow a legitimate listing.
+ *
+ * Timeline convention used throughout: `now` starts at 1_000_000, one
+ * "minute" = 60_000, one "hour" = 3_600_000. The default settle window
+ * is 45 min (2_700_000ms).
+ */
+
+const T0 = 1_000_000;
+const MIN = 60_000;
+const HOUR = 60 * MIN;
+const SETTLE = DEFAULT_SETTLE_WINDOW_MS;
+const MAX_WAIT = DEFAULT_MAX_SETTLE_WAIT_MS;
+
+function run(prevEntry: any, currentIds: string[], nowMs: number, opts: any = {}) {
+  return detectFranchiseChange({
+    franchiseId: '0001',
+    currentIds,
+    prevEntry,
+    nowMs,
+    settleWindowMs: opts.settleWindowMs ?? SETTLE,
+    maxSettleWaitMs: opts.maxSettleWaitMs ?? MAX_WAIT,
+  });
+}
+
+describe('normalizeBlock', () => {
+  it('dedupes, trims, and sorts for stable comparison', () => {
+    expect(normalizeBlock(['b', 'a', 'a', ' c '])).toEqual(['a', 'b', 'c']);
+  });
+  it('tolerates non-array input', () => {
+    expect(normalizeBlock(undefined)).toEqual([]);
+    expect(normalizeBlock(null as any)).toEqual([]);
+  });
+});
+
+describe('detectFranchiseChange — per-franchise', () => {
+  it('first run seeds silently — no emission even with 17 players already on the block', () => {
+    const current = Array.from({ length: 17 }, (_, i) => String(10000 + i));
+    const r = run(undefined, current, T0);
+    expect(r.emit).toBe(false);
+    expect(r.reason).toBe('seed');
+    expect(r.nextEntry.committedBlock).toEqual(normalizeBlock(current));
+    expect(r.nextEntry.observedBlock).toEqual(normalizeBlock(current));
+    expect(r.nextEntry.firstChangeTs).toBeNull();
+    expect(r.nextEntry.lastChangeTs).toBeNull();
+  });
+
+  it('single add fires after the settle window — 1 player tip', () => {
+    // T0: seed
+    const seed = run(undefined, ['A'], T0);
+    expect(seed.emit).toBe(false);
+
+    // T0+1min: owner adds B → drifting
+    const mid = run(seed.nextEntry, ['A', 'B'], T0 + MIN);
+    expect(mid.emit).toBe(false);
+    expect(mid.reason).toBe('drifting');
+    expect(mid.netAdds).toEqual(['B']);
+
+    // T0+1min + settle window: same observed block → settled → emit
+    const out = run(mid.nextEntry, ['A', 'B'], T0 + MIN + SETTLE);
+    expect(out.emit).toBe(true);
+    expect(out.reason).toBe('settled');
+    expect(out.netAdds).toEqual(['B']);
+    expect(out.netRemoves).toEqual([]);
+    expect(out.nextEntry.committedBlock).toEqual(['A', 'B']);
+    expect(out.nextEntry.firstChangeTs).toBeNull();
+  });
+
+  it('six adds over 20 minutes coalesce into one post', () => {
+    const seed = run(undefined, [], T0);
+    const adds = ['A', 'B', 'C', 'D', 'E', 'F'];
+    let state = seed.nextEntry;
+    let now = T0;
+    for (let i = 0; i < adds.length; i++) {
+      now += 4 * MIN; // each add arrives 4 min after the prior
+      const current = adds.slice(0, i + 1);
+      const step = run(state, current, now);
+      expect(step.emit).toBe(false);
+      expect(step.reason).toBe('drifting');
+      state = step.nextEntry;
+    }
+    // Let the settle window clear after the last change at T0 + 24min
+    const fired = run(state, adds, now + SETTLE);
+    expect(fired.emit).toBe(true);
+    expect(fired.reason).toBe('settled');
+    expect(fired.netAdds.sort()).toEqual([...adds].sort());
+  });
+
+  it('add and remove of the same player inside the window is silent', () => {
+    const seed = run(undefined, ['A'], T0);
+    const add = run(seed.nextEntry, ['A', 'B'], T0 + MIN);
+    expect(add.reason).toBe('drifting');
+    const removed = run(add.nextEntry, ['A'], T0 + 2 * MIN);
+    // observedBlock changed back to committed so netAdds and netRemoves are empty
+    expect(removed.emit).toBe(false);
+    expect(removed.reason).toBe('no_change');
+    expect(removed.nextEntry.firstChangeTs).toBeNull();
+    expect(removed.nextEntry.lastChangeTs).toBeNull();
+  });
+
+  it('add → settle → emit → remove fires silently and advances committedBlock', () => {
+    const seed = run(undefined, ['A'], T0);
+    const driftStep = run(seed.nextEntry, ['A', 'B'], T0 + MIN);
+    const emitted = run(driftStep.nextEntry, ['A', 'B'], T0 + MIN + SETTLE);
+    expect(emitted.emit).toBe(true);
+    // Later: owner quietly removes B
+    const removed = run(emitted.nextEntry, ['A'], T0 + 2 * HOUR);
+    const settledRemove = run(removed.nextEntry, ['A'], T0 + 2 * HOUR + SETTLE);
+    expect(settledRemove.emit).toBe(false);
+    expect(settledRemove.reason).toBe('silent_sync');
+    expect(settledRemove.nextEntry.committedBlock).toEqual(['A']);
+  });
+
+  it('re-add after a silent remove emits again on the next settle', () => {
+    // Start committed = [A, B]
+    let state = {
+      committedBlock: ['A', 'B'],
+      observedBlock: ['A', 'B'],
+      firstChangeTs: null,
+      lastChangeTs: null,
+    };
+    // Remove B silently
+    const remove = run(state, ['A'], T0);
+    const removeSettled = run(remove.nextEntry, ['A'], T0 + SETTLE);
+    expect(removeSettled.emit).toBe(false);
+    expect(removeSettled.reason).toBe('silent_sync');
+    state = removeSettled.nextEntry;
+
+    // Re-add B
+    const readd = run(state, ['A', 'B'], T0 + HOUR);
+    expect(readd.emit).toBe(false);
+    const readdFire = run(readd.nextEntry, ['A', 'B'], T0 + HOUR + SETTLE);
+    expect(readdFire.emit).toBe(true);
+    expect(readdFire.netAdds).toEqual(['B']);
+  });
+
+  it('max settle wait force-fires even when the owner keeps tweaking', () => {
+    const seed = run(undefined, ['A'], T0);
+    let state = seed.nextEntry;
+    // Owner keeps bouncing a different player in and out so lastChangeTs resets every 5 min
+    let now = T0;
+    for (let i = 0; i < 100; i++) {
+      now += 5 * MIN;
+      if (now - T0 >= MAX_WAIT + MIN) break;
+      const current = i % 2 === 0 ? ['A', 'X'] : ['A', 'Y'];
+      const step = run(state, current, now);
+      state = step.nextEntry;
+    }
+    // At this point now is past T0 + MAX_WAIT. The drift started at the
+    // first flip (T0 + 5min) — max-wait fires.
+    const final = run(state, ['A', 'X'], now);
+    expect(final.emit).toBe(true);
+    expect(final.reason === 'max_wait' || final.reason === 'settled').toBe(true);
+    expect(final.netAdds).toContain('X');
+  });
+
+  it('pure removes never fire — emit=false, silent_sync when window clears', () => {
+    const state = {
+      committedBlock: ['A', 'B', 'C'],
+      observedBlock: ['A', 'B', 'C'],
+      firstChangeTs: null,
+      lastChangeTs: null,
+    };
+    const r = run(state, ['A'], T0);
+    expect(r.emit).toBe(false);
+    expect(r.reason).toBe('drifting');
+    const rSettled = run(r.nextEntry, ['A'], T0 + SETTLE);
+    expect(rSettled.emit).toBe(false);
+    expect(rSettled.reason).toBe('silent_sync');
+    expect(rSettled.netAdds).toEqual([]);
+    expect(rSettled.netRemoves.sort()).toEqual(['B', 'C']);
+    expect(rSettled.nextEntry.committedBlock).toEqual(['A']);
+  });
+
+  it('flags truncated when netAdds exceeds MAX_ADDS_PER_TIP', () => {
+    const state = {
+      committedBlock: [],
+      observedBlock: [],
+      firstChangeTs: null,
+      lastChangeTs: null,
+    };
+    const huge = Array.from({ length: MAX_ADDS_PER_TIP + 5 }, (_, i) => `P${i}`);
+    const step = run(state, huge, T0);
+    const fired = run(step.nextEntry, huge, T0 + SETTLE);
+    expect(fired.emit).toBe(true);
+    expect(fired.truncated).toBe(true);
+    expect(fired.netAdds.length).toBe(MAX_ADDS_PER_TIP + 5);
+  });
+});
+
+describe('detectTradeBaitChanges — whole-snapshot', () => {
+  it('seeds every franchise silently on first run', () => {
+    const current = {
+      '0001': { playerIds: ['A', 'B'] },
+      '0005': { playerIds: ['C'] },
+    };
+    const { nextState, emissions } = detectTradeBaitChanges({
+      currentByFranchise: current,
+      prevState: undefined,
+      nowMs: T0,
+    });
+    expect(emissions).toEqual([]);
+    expect(Object.keys(nextState).sort()).toEqual(['0001', '0005']);
+    expect(nextState['0001'].committedBlock).toEqual(['A', 'B']);
+  });
+
+  it('emits per-franchise on independent timelines', () => {
+    // Franchise 0001 has been drifting with B added and the window is clear;
+    // franchise 0005 has been settled on C the whole time.
+    const now = T0 + 2 * HOUR;
+    const prev: Record<string, any> = {
+      '0001': {
+        committedBlock: ['A'],
+        observedBlock: ['A', 'B'],
+        firstChangeTs: now - SETTLE - MIN,
+        lastChangeTs: now - SETTLE - MIN,
+      },
+      '0005': { committedBlock: ['C'], observedBlock: ['C'], firstChangeTs: null, lastChangeTs: null },
+    };
+    const current = {
+      '0001': {
+        playerIds: ['A', 'B'],
+        willGiveUpComment: 'looking for WR depth',
+        willTakeComment: '',
+      },
+      '0005': { playerIds: ['C'] },
+    };
+    const { emissions, nextState } = detectTradeBaitChanges({
+      currentByFranchise: current,
+      prevState: prev,
+      nowMs: now,
+    });
+    expect(emissions.length).toBe(1);
+    expect(emissions[0].franchiseId).toBe('0001');
+    expect(emissions[0].netAdds).toEqual(['B']);
+    expect(emissions[0].willGiveUpComment).toBe('looking for WR depth');
+    expect(nextState['0001'].committedBlock).toEqual(['A', 'B']);
+    expect(nextState['0005'].committedBlock).toEqual(['C']);
+  });
+
+  it('handles a franchise that dropped out of the fetch (block went empty)', () => {
+    const prev = {
+      '0001': { committedBlock: ['A'], observedBlock: ['A'], firstChangeTs: null, lastChangeTs: null },
+    };
+    const { emissions, nextState } = detectTradeBaitChanges({
+      currentByFranchise: {},
+      prevState: prev,
+      nowMs: T0,
+    });
+    expect(emissions).toEqual([]);
+    // Drift starts now — next cycle past the window will silent_sync
+    expect(nextState['0001'].firstChangeTs).toBe(T0);
+    expect(nextState['0001'].committedBlock).toEqual(['A']);
+  });
+});


### PR DESCRIPTION
## Summary

Implements a new trade-bait rumor lane for the Schefter rumor mill that detects when owners add players to their MFL trade block and surfaces those changes as attributable gossip posts. The feature uses per-franchise debouncing to coalesce rapid changes (e.g., a six-player dump over 20 minutes) into a single post rather than flooding the feed.

## Key Changes

- **Trade-bait detector module** (`scripts/lib/trade-bait-detector.mjs`): Pure, stateless logic that tracks per-franchise drift windows and emits tips only after a configurable settle period (default 45 min) with a safety cap (6 hr max wait). Handles edge cases like add-then-remove within the window (silent) and pure removes (no tip, but advances committed state).

- **Scanner integration** (`scripts/schefter-scan.mjs`): New `scanTradeBait()` function that fetches MFL trade-bait data, runs the detector, and enqueues tips to the same Redis queue as other rumor-mill posts. Implements silent-seed launch so the feature debuts on the first real owner delta post-deploy, not on 17 pre-existing listings.

- **Fetch enrichment** (`scripts/fetch-trade-bait.mjs`): Extended to preserve per-franchise structure (player IDs + owner comments) in a new `tradeBait-by-franchise.json` file alongside the existing flat cache, enabling the detector to diff by franchise rather than league-wide.

- **Rumor-scan CTA override** (`scripts/schefter-rumor-scan.mjs`): Trade-bait posts now link to the Trade Builder (`/theleague/trade-builder?b=<franchiseId>`) instead of the tip page, since readers seeing "Pigskins dumped three RBs" want to build a counter-offer, not submit a new tip. Introduces `resolveCta()` helper to compute link/label/GroupMe URL per post based on primary bucket.

- **Tip anonymization & templating**: Trade-bait tips are marked `attributable: true` with the franchise name as author (owner publicly listed these players, so attribution is the point). LLM voice directive added to pick framing based on `meta.byPos` and `meta.totalAdds` (singleton name vs. positional theme vs. spring-cleaning).

- **Feed state extension**: New `feed.tradeBaitState` object tracks per-franchise `committedBlock`, `observedBlock`, and drift timers (`firstChangeTs`, `lastChangeTs`) to implement the settle window and max-wait safety cap.

- **Comprehensive test suite** (`tests/trade-bait-detector.test.ts`): 270 lines of unit tests locking in debouncing behavior: seed silence, single-add fire, six-add coalesce, add-then-remove silence, pure-remove silence, max-wait force-fire, and re-add re-surface.

## Notable Implementation Details

- **Silent seed only**: First run records current block as committed state and emits nothing. Feature surfaces organically on first real owner delta, avoiding a 17-player flood on launch day.

- **Settle window + max-wait belt-and-suspenders**: Default 45-min settle window debounces cleanup sessions; 6-hr max-wait cap prevents a fidgety owner from blocking posts forever.

- **Structured payload for LLM**: Tips include `meta.adds` (player details), `meta.byPos` (position counts), and owner comments, letting the LLM naturally say "Hall hit the block" on singletons and "RB fire sale in Pacific" on clusters.

- **Bucket integration**: Trade-bait tips use `topic:trade_bait:<franchiseId>` bucket key, compete for gossip cap (not a separate lane), and respect quiet hours like other gossip.

- **Edge case handling**: Add-then-remove within window is silent (netAdds stays empty). Pure removes advance committedBlock silently so future re-adds re-surface correctly. Truncation flag set when netAdds exceeds 10 so LLM hedges on huge dumps.

https://claude.ai/code/session_01CPruHykb14ZfA3VJTYHtzG