### PR TITLE
Integrate trade-builder drafts as soft shopping signals

### DIFF
--- a/scripts/lib/redact-trade-offer.mjs
+++ b/scripts/lib/redact-trade-offer.mjs
@@ -236,7 +236,7 @@ export function redactTradeOffer({
 /**
  * Per-run probability for posting a trade-offer rumor.
  *
- * Flat p=0.0075 per 15-minute scanner run. With 96 runs/day this compounds
+ * Base p=0.0075 per 15-minute scanner run. With 96 runs/day this compounds
  * cumulatively to ~54% by 24h, ~79% by 48h, and ~99% by day 6.4. No guaranteed
  * post — unposted offers can fail forever; that's the design.
  *
@@ -244,12 +244,30 @@ export function redactTradeOffer({
  * picking up") is handled in scanTradeOffers, not here. The probability itself
  * does not change with age.
  *
+ * Exponential scaling on shopping volume: when the *effective* distinct
+ * offerers for the most-shopped player in this offer is ≥2, multiply the
+ * base by `OFFER_VOLUME_BOOST_FACTOR ^ (effectiveOfferers - 1)` and cap at
+ * `OFFER_VOLUME_BOOST_MAX` so the per-run probability never exceeds ~3%.
+ * Effective count blends real submitted offerers (full weight) with saved
+ * trade-builder drafts (0.4 weight, computed in the scanner).
+ *
+ * The exponential growth is intentional — it keeps the per-run probability
+ * vague at low volume (owner can't tell whether their move tipped Schefter)
+ * while accelerating the pass on heavily-shopped players. Combined with the
+ * tier-cap on draft-only contribution, this gives Schefter speed without
+ * letting him name names from soft signals.
+ *
  * Exported for tests & dry-run logging.
  */
 export const OFFER_POST_PROBABILITY = 0.0075;
+export const OFFER_VOLUME_BOOST_FACTOR = 1.5;
+export const OFFER_VOLUME_BOOST_MAX = 4;
 
-export function offerPostProbability() {
-  return OFFER_POST_PROBABILITY;
+export function offerPostProbability(effectiveOfferers = 1) {
+  const n = Number.isFinite(effectiveOfferers) ? Math.max(1, effectiveOfferers) : 1;
+  const raw = Math.pow(OFFER_VOLUME_BOOST_FACTOR, n - 1);
+  const multiplier = Math.min(OFFER_VOLUME_BOOST_MAX, raw);
+  return OFFER_POST_PROBABILITY * multiplier;
 }
 
 export { bucketVolumeHint, tierForDistinctOfferers, classifyAsset, parseAssetString };

--- a/scripts/lib/scan-draft-trades.mjs
+++ b/scripts/lib/scan-draft-trades.mjs
@@ -1,0 +1,180 @@
+/**
+ * Trade-Builder Drafts as a Tip Source.
+ *
+ * Reads each franchise's saved draft trades from `dt:{franchiseId}` (written by
+ * src/pages/api/trades/drafts.ts) and projects them into Redis sorted sets that
+ * the rumor scanner reads alongside real pending-offer history.
+ *
+ * Drafts are intentional saves — the owner clicked "save" on a trade they were
+ * building. That's a much weaker signal than a submitted offer, but stronger
+ * than ephemeral builder activity. So we model drafts as a discounted,
+ * shorter-lived input that can NEVER on its own create a rumor (the rumor
+ * pipeline only iterates real `offerMap` entries) and can NEVER unlock the
+ * `named` escalation tier (capped at `tightened_circle` in the consumer).
+ *
+ * Reasoning is captured in CLAUDE.md and the rumor-scan Phase 6b block.
+ *
+ * Redis keys (this module owns the writes):
+ *   schefter:tb_drafts:player:{playerId}  ZSET  member="{fid}:{draftId}" score=updatedAt
+ *   schefter:tb_drafts:owner:{fid}        ZSET  member=draftId           score=updatedAt
+ *
+ * Both decay to a 3-day window each run.
+ *
+ * Pure-ish: requires a redis client, but no file I/O. Caller passes the team
+ * map; we walk only the franchise ids the league actually has.
+ */
+
+export const TB_DRAFT_PLAYER_KEY_PREFIX = 'schefter:tb_drafts:player:';
+export const TB_DRAFT_OWNER_KEY_PREFIX = 'schefter:tb_drafts:owner:';
+export const TB_DRAFT_WINDOW_MS = 3 * 24 * 60 * 60 * 1000;
+export const TB_DRAFT_KEY_TTL_SEC = 7 * 24 * 60 * 60;
+/**
+ * Soft discount applied when blending draft offerers with real submitted
+ * offerers. 1 saved draft = 0.4 of a real offer for count-based tier and
+ * probability calculations. Drafts can elevate a player from `base` to
+ * `tightened_circle` but never past it — that cap is enforced in the
+ * rumor scanner where it has access to both real and draft counts.
+ */
+export const TB_DRAFT_OFFERER_WEIGHT = 0.4;
+
+/**
+ * Walk every franchise's saved drafts hash, refresh the sorted-set windows,
+ * and return summary counts for logging.
+ *
+ * @param {object} args
+ * @param {any}    args.redis        Upstash Redis client
+ * @param {Map}    args.teams        Map<franchiseId, { division, ... }>
+ * @param {boolean} args.dryRun
+ * @param {(...a: any[]) => void} [args.log]
+ * @param {(...a: any[]) => void} [args.warn]
+ * @returns {Promise<{ ownersScanned: number, draftsScanned: number, playerEntries: number }>}
+ */
+export async function scanDraftTrades({ redis, teams, dryRun, log = () => {}, warn = () => {} }) {
+  const summary = { ownersScanned: 0, draftsScanned: 0, playerEntries: 0 };
+  if (!redis || !teams) return summary;
+
+  const nowMs = Date.now();
+  const windowStart = nowMs - TB_DRAFT_WINDOW_MS;
+
+  for (const [fid] of teams) {
+    let drafts;
+    try {
+      drafts = await redis.get(`dt:${fid}`);
+    } catch (err) {
+      warn(`  [tb-drafts] read dt:${fid} failed: ${err.message}`);
+      continue;
+    }
+    if (!Array.isArray(drafts) || drafts.length === 0) continue;
+    summary.ownersScanned += 1;
+
+    const ownerKey = TB_DRAFT_OWNER_KEY_PREFIX + fid;
+
+    for (const draft of drafts) {
+      const updatedAt = Number(draft?.updatedAt ?? draft?.createdAt ?? 0);
+      if (!Number.isFinite(updatedAt) || updatedAt <= 0) continue;
+      // Skip stale drafts — outside the 3-day window.
+      if (updatedAt < windowStart) continue;
+
+      const draftId = String(draft?.id ?? '');
+      if (!draftId) continue;
+
+      // Identify owner's side of the trade. The franchise that saved the
+      // draft is, by definition, one of the two parties — match teamA / teamB
+      // by franchiseId. If neither side resolves to the owner, skip; that's
+      // a corrupt/abandoned draft (e.g. owner cleared the team selector).
+      const sides = [draft.teamA, draft.teamB].filter(Boolean);
+      const ownerSide = sides.find((s) => String(s?.franchiseId ?? '').padStart(4, '0') === String(fid).padStart(4, '0'));
+      if (!ownerSide) continue;
+
+      // "Players offered" = players on owner's own side. That's the trade-
+      // block signal we want — owner is building a draft to ship them out.
+      const offered = Array.isArray(ownerSide.playerIds) ? ownerSide.playerIds : [];
+      if (offered.length === 0 && (!Array.isArray(ownerSide.draftPicks) || ownerSide.draftPicks.length === 0)) {
+        // Empty owner side (e.g. just receiving — that's "interest", not
+        // "shopping"; skip for now, scanner doesn't model interest yet).
+        continue;
+      }
+      summary.draftsScanned += 1;
+
+      if (!dryRun) {
+        try {
+          await redis.zadd(ownerKey, { score: updatedAt, member: draftId });
+        } catch (err) {
+          warn(`  [tb-drafts] owner zadd failed for ${fid}: ${err.message}`);
+        }
+      }
+
+      for (const pid of offered) {
+        if (!pid) continue;
+        const pKey = TB_DRAFT_PLAYER_KEY_PREFIX + pid;
+        if (!dryRun) {
+          try {
+            await redis.zadd(pKey, { score: updatedAt, member: `${fid}:${draftId}` });
+            await redis.expire(pKey, TB_DRAFT_KEY_TTL_SEC);
+          } catch (err) {
+            warn(`  [tb-drafts] player zadd failed for ${pid}: ${err.message}`);
+          }
+        }
+        summary.playerEntries += 1;
+      }
+    }
+
+    // Trim owner key to the 3-day window and refresh TTL.
+    if (!dryRun) {
+      try {
+        await redis.zremrangebyscore(ownerKey, 0, windowStart);
+        await redis.expire(ownerKey, TB_DRAFT_KEY_TTL_SEC);
+      } catch (err) {
+        warn(`  [tb-drafts] owner trim/expire failed for ${fid}: ${err.message}`);
+      }
+    }
+  }
+
+  log(
+    `  [tb-drafts] owners=${summary.ownersScanned} drafts=${summary.draftsScanned} ` +
+      `playerEntries=${summary.playerEntries}`,
+  );
+  return summary;
+}
+
+/**
+ * Read the set of distinct franchise ids that have a saved draft involving
+ * `playerId` within the rolling 3-day window. The rumor scanner blends this
+ * with the real-offer offerer set when computing player escalation tier.
+ *
+ * Pure read — never mutates.
+ */
+export async function getDraftOfferersForPlayer({ redis, playerId, nowMs = Date.now() }) {
+  if (!redis || !playerId) return new Set();
+  const key = TB_DRAFT_PLAYER_KEY_PREFIX + playerId;
+  const windowStart = nowMs - TB_DRAFT_WINDOW_MS;
+  let members = [];
+  try {
+    members = await redis.zrange(key, windowStart, nowMs, { byScore: true });
+  } catch {
+    return new Set();
+  }
+  const fids = new Set();
+  for (const m of members ?? []) {
+    const fid = String(m).split(':')[0];
+    if (fid) fids.add(fid);
+  }
+  return fids;
+}
+
+/**
+ * Read the count of distinct draft entries an owner has open in the 3-day
+ * window. Returned as a *raw* count — the consumer applies
+ * `TB_DRAFT_OFFERER_WEIGHT` when blending with real submitted-offer counts.
+ */
+export async function getOwnerDraftCount({ redis, franchiseId, nowMs = Date.now() }) {
+  if (!redis || !franchiseId) return 0;
+  const key = TB_DRAFT_OWNER_KEY_PREFIX + franchiseId;
+  const windowStart = nowMs - TB_DRAFT_WINDOW_MS;
+  try {
+    const members = await redis.zrange(key, windowStart, nowMs, { byScore: true });
+    return Array.isArray(members) ? members.length : 0;
+  } catch {
+    return 0;
+  }
+}

--- a/scripts/schefter-rumor-scan.mjs
+++ b/scripts/schefter-rumor-scan.mjs
@@ -77,7 +77,17 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createHash } from 'node:crypto';
 import { ingestGroupMeMentions, getLatestRogerQuote, mentionsSchefter } from './schefter-groupme-listen.mjs';
-import { redactTradeOffer, offerPostProbability } from './lib/redact-trade-offer.mjs';
+import {
+  redactTradeOffer,
+  offerPostProbability,
+  tierForDistinctOfferers,
+} from './lib/redact-trade-offer.mjs';
+import {
+  scanDraftTrades,
+  getDraftOfferersForPlayer,
+  getOwnerDraftCount,
+  TB_DRAFT_OFFERER_WEIGHT,
+} from './lib/scan-draft-trades.mjs';
 import {
   loadLore,
   loadPostHistory,
@@ -1300,6 +1310,17 @@ async function scanTradeOffers({ redis, dryRun }) {
   const teams = await loadTeamsWithDivisions();
   const players = await loadPlayers(year);
 
+  // Step 0: fold each franchise's saved trade-builder drafts into the
+  // shopping-signal sorted sets. Drafts feed the player-escalation tier
+  // (capped at tightened_circle) and owner volume hint via discounted
+  // weight, but never on their own create a rumor — the loop below only
+  // iterates real pending offers from MFL / owner reports.
+  try {
+    await scanDraftTrades({ redis, teams, dryRun, log, warn });
+  } catch (err) {
+    warn(`  [offer-scan] tb-drafts scan failed: ${err.message} — continuing without draft signals`);
+  }
+
   // Step 1: figure out which offerIds are in commish-approval state
   // (Phase 1 handles those — skip them here).
   const commishPending = await fetchCommishPendingOfferIds(LEAGUE_ID, year, mflCookie);
@@ -1444,7 +1465,8 @@ async function scanTradeOffers({ redis, dryRun }) {
       .map((s) => s.trim())
       .filter((tok) => tok && !/^(DP_|FP_|BB_)/.test(tok));
 
-    const playerHistory = new Map(); // playerId -> distinct offerer count last 21d
+    const playerHistory = new Map();    // playerId -> effective distinct offerer count
+    const playerDraftStats = new Map(); // playerId -> { realCount, draftCount, effectiveCount, capped }
     for (const pid of playerIds) {
       const pKey = PLAYER_OFFER_HISTORY_PREFIX + pid;
       // Add the offer to the player history only on first sighting so a single
@@ -1465,12 +1487,40 @@ async function scanTradeOffers({ redis, dryRun }) {
       } catch {
         members = [];
       }
-      const distinctFids = new Set(
+      const realFids = new Set(
         (members || []).map((m) => String(m).split(':')[0]),
       );
       // Include the current offering franchise (it was just added — or would be in live mode)
-      distinctFids.add(offeringFid);
-      playerHistory.set(pid, distinctFids.size);
+      realFids.add(offeringFid);
+
+      // Blend in trade-builder draft signals (3-day window, weight=0.4).
+      // Drafts contribute distinct franchise ids that DO NOT already have a
+      // real offer logged for this player. This is a *softer* shopping signal,
+      // intentional but not committed.
+      const draftFids = await getDraftOfferersForPlayer({ redis, playerId: pid, nowMs });
+      const newDraftFids = new Set();
+      for (const f of draftFids) {
+        if (!realFids.has(f)) newDraftFids.add(f);
+      }
+
+      const realCount = realFids.size;
+      const draftCount = newDraftFids.size;
+      const blended = realCount + TB_DRAFT_OFFERER_WEIGHT * draftCount;
+      let effectiveCount = Math.floor(blended);
+
+      // Tier cap: drafts can elevate base → tightened_circle (n=3) but
+      // MUST NOT unlock the `named` tier (n>=4) on their own. The named
+      // tier authorizes Schefter to drop a player's name in the post —
+      // gated to *real* submitted offers only.
+      const realTier = tierForDistinctOfferers(realCount);
+      let capped = false;
+      if (realTier !== 'named' && tierForDistinctOfferers(effectiveCount) === 'named') {
+        effectiveCount = 3;
+        capped = true;
+      }
+
+      playerHistory.set(pid, effectiveCount);
+      playerDraftStats.set(pid, { realCount, draftCount, effectiveCount, capped });
     }
 
     // Counts
@@ -1488,6 +1538,19 @@ async function scanTradeOffers({ redis, dryRun }) {
       } catch {
         divisionOfferCount7d = 0;
       }
+    }
+
+    // Blend owner draft volume into the 7-day count. Drafts saved by this
+    // owner are an aggressiveness signal — they bump volumeHint toward
+    // serial without affecting whether a player can be named (that's gated
+    // separately by playerHistory's tier cap above).
+    const ownerDraftCount = await getOwnerDraftCount({
+      redis,
+      franchiseId: offeringFid,
+      nowMs,
+    });
+    if (ownerDraftCount > 0) {
+      ownerOfferCount7d += Math.floor(TB_DRAFT_OFFERER_WEIGHT * ownerDraftCount);
     }
 
     // In dry-run mode we didn't mutate, so nudge counts up by 1 to simulate "this offer counts"
@@ -1512,24 +1575,37 @@ async function scanTradeOffers({ redis, dryRun }) {
       continue;
     }
 
-    // Dice roll — flat p=0.0075 per run, independent of owner volume and age.
-    // Cumulative curve (1 - (1-p)^n) puts most passes in the 1–7 day window.
-    const probability = offerPostProbability();
+    // Dice roll — base p=0.0075 per run, scaled exponentially by the most-
+    // shopped player's effective distinct-offerer count (real + 0.4*draft).
+    // Capped at 4× base. Cumulative curve still keeps most passes in the
+    // 1–7 day window for low-volume players; serial-shopped players
+    // accelerate. Owner can't tell whether their submission or any
+    // particular other-team draft tipped the dice — that's the point.
+    const maxEffectiveOfferers = playerHistory.size > 0
+      ? Math.max(1, ...Array.from(playerHistory.values()))
+      : 1;
+    const probability = offerPostProbability(maxEffectiveOfferers);
     const roll = Math.random();
     const passed = roll < probability;
 
     const ageHours = offerAgeMs / (60 * 60 * 1000);
+    const draftStatsArray = Array.from(playerDraftStats.entries()).map(
+      ([pid, s]) => ({ pid, ...s }),
+    );
     const entry = {
       offerId,
       offeringFid,
       ownerOfferCount7d,
+      ownerDraftCount,
       divisionOfferCount7d,
       framingHint,
       offerAgeHours: Number(ageHours.toFixed(2)),
       isFirstSighting,
+      maxEffectiveOfferers,
       probability,
       roll: Number(roll.toFixed(3)),
       passed,
+      draftStats: draftStatsArray,
       redaction: redaction.debug,
       tipPreview: redaction.tip,
     };
@@ -1538,8 +1614,9 @@ async function scanTradeOffers({ redis, dryRun }) {
     log(
       `  [offer-scan] offerId=${offerId} fid=${offeringFid} ` +
         `age=${ageHours.toFixed(1)}h frame=${framingHint} ` +
-        `owner7d=${ownerOfferCount7d} div7d=${divisionOfferCount7d} ` +
-        `p=${probability} roll=${roll.toFixed(3)} → ${passed ? 'PASS' : 'fail'}` +
+        `owner7d=${ownerOfferCount7d}(drafts=${ownerDraftCount}) div7d=${divisionOfferCount7d} ` +
+        `effOff=${maxEffectiveOfferers} ` +
+        `p=${probability.toFixed(4)} roll=${roll.toFixed(3)} → ${passed ? 'PASS' : 'fail'}` +
         (redaction.tip.escalatedPlayer
           ? ` [escalation=${redaction.tip.escalatedPlayer.tier}/${redaction.tip.escalatedPlayer.distinctOfferers}]`
           : ''),

--- a/tests/trade-builder-tip-source.test.ts
+++ b/tests/trade-builder-tip-source.test.ts
@@ -1,0 +1,347 @@
+/**
+ * Trade-Builder Drafts as a Tip Source.
+ *
+ * Saved trade-builder drafts feed Schefter's rumor mill as a *softer* shopping
+ * signal than submitted offers. This file pins the contract:
+ *
+ *   - drafts decay in 3 days (vs. 7 for submitted offers)
+ *   - each draft offerer counts as 0.4 of a real offerer (discount)
+ *   - draft contribution can elevate a player from `base` to `tightened_circle`
+ *     (n=3) but MUST NOT unlock the `named` tier (n>=4) on its own
+ *   - per-run posting probability scales exponentially with the most-shopped
+ *     player's effective offerer count, capped at 4× base
+ *   - drafts NEVER on their own create a rumor — only blend into existing
+ *     real-offer escalation/probability
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import {
+  offerPostProbability,
+  OFFER_POST_PROBABILITY,
+  OFFER_VOLUME_BOOST_FACTOR,
+  OFFER_VOLUME_BOOST_MAX,
+  tierForDistinctOfferers,
+} from '../scripts/lib/redact-trade-offer.mjs';
+import {
+  TB_DRAFT_OFFERER_WEIGHT,
+  TB_DRAFT_WINDOW_MS,
+  TB_DRAFT_PLAYER_KEY_PREFIX,
+  TB_DRAFT_OWNER_KEY_PREFIX,
+  scanDraftTrades,
+  getDraftOfferersForPlayer,
+  getOwnerDraftCount,
+} from '../scripts/lib/scan-draft-trades.mjs';
+
+function read(rel: string): string {
+  return readFileSync(path.join(process.cwd(), rel), 'utf8');
+}
+
+describe('trade-builder draft constants', () => {
+  it('decays drafts in 3 days', () => {
+    expect(TB_DRAFT_WINDOW_MS).toBe(3 * 24 * 60 * 60 * 1000);
+  });
+
+  it('weights one saved draft as 0.4 of a real offerer', () => {
+    expect(TB_DRAFT_OFFERER_WEIGHT).toBe(0.4);
+  });
+
+  it('uses dedicated Redis namespace prefixes', () => {
+    expect(TB_DRAFT_PLAYER_KEY_PREFIX).toBe('schefter:tb_drafts:player:');
+    expect(TB_DRAFT_OWNER_KEY_PREFIX).toBe('schefter:tb_drafts:owner:');
+  });
+});
+
+describe('offerPostProbability — exponential scaling on shopping volume', () => {
+  it('returns the flat base probability for a single offerer', () => {
+    expect(offerPostProbability(1)).toBeCloseTo(OFFER_POST_PROBABILITY);
+  });
+
+  it('treats missing/zero/NaN offerers as the floor (1)', () => {
+    expect(offerPostProbability()).toBeCloseTo(OFFER_POST_PROBABILITY);
+    expect(offerPostProbability(0)).toBeCloseTo(OFFER_POST_PROBABILITY);
+    expect(offerPostProbability(NaN)).toBeCloseTo(OFFER_POST_PROBABILITY);
+  });
+
+  it('scales exponentially with effective offerer count', () => {
+    expect(offerPostProbability(2)).toBeCloseTo(OFFER_POST_PROBABILITY * OFFER_VOLUME_BOOST_FACTOR);
+    expect(offerPostProbability(3)).toBeCloseTo(
+      OFFER_POST_PROBABILITY * OFFER_VOLUME_BOOST_FACTOR ** 2,
+    );
+    expect(offerPostProbability(4)).toBeCloseTo(
+      OFFER_POST_PROBABILITY * OFFER_VOLUME_BOOST_FACTOR ** 3,
+    );
+  });
+
+  it('caps the multiplier at OFFER_VOLUME_BOOST_MAX so a heavily-shopped player never auto-posts', () => {
+    const capped = OFFER_POST_PROBABILITY * OFFER_VOLUME_BOOST_MAX;
+    expect(offerPostProbability(99)).toBeCloseTo(capped);
+    // Even capped, the per-run probability must remain a roll, not a guarantee.
+    expect(offerPostProbability(99)).toBeLessThan(0.05);
+  });
+
+  it('is monotonically non-decreasing in effective offerer count', () => {
+    let last = 0;
+    for (let n = 1; n <= 20; n += 1) {
+      const p = offerPostProbability(n);
+      expect(p).toBeGreaterThanOrEqual(last);
+      last = p;
+    }
+  });
+});
+
+describe('escalation tier classifier', () => {
+  it('returns base/tightened_circle/named at the documented thresholds', () => {
+    expect(tierForDistinctOfferers(0)).toBe('base');
+    expect(tierForDistinctOfferers(1)).toBe('base');
+    expect(tierForDistinctOfferers(2)).toBe('base');
+    expect(tierForDistinctOfferers(3)).toBe('tightened_circle');
+    expect(tierForDistinctOfferers(4)).toBe('named');
+    expect(tierForDistinctOfferers(99)).toBe('named');
+  });
+});
+
+describe('rumor-scan: tier cap on draft-only contribution', () => {
+  const src = read('scripts/schefter-rumor-scan.mjs');
+
+  it('imports the draft-trades helpers + tier classifier', () => {
+    expect(src).toMatch(/from\s+['"]\.\/lib\/scan-draft-trades\.mjs['"]/);
+    expect(src).toMatch(/tierForDistinctOfferers/);
+  });
+
+  it('blends draft offerers into the per-player count using the discount weight', () => {
+    expect(src).toMatch(/realCount\s*\+\s*TB_DRAFT_OFFERER_WEIGHT\s*\*\s*draftCount/);
+  });
+
+  it('caps the effective count at tightened_circle when no real offerer reaches the named tier', () => {
+    // The cap rewrites effectiveCount = 3 (the tightened_circle threshold)
+    // when realTier !== 'named' but the blended count would otherwise unlock
+    // 'named'. This is the load-bearing privacy guard for soft signals.
+    expect(src).toMatch(/realTier\s*!==\s*['"]named['"]/);
+    expect(src).toMatch(/tierForDistinctOfferers\(effectiveCount\)\s*===\s*['"]named['"]/);
+    expect(src).toMatch(/effectiveCount\s*=\s*3\s*;/);
+  });
+
+  it('passes the most-shopped player count into the probability roll', () => {
+    expect(src).toMatch(/maxEffectiveOfferers/);
+    expect(src).toMatch(/offerPostProbability\(\s*maxEffectiveOfferers\s*\)/);
+  });
+
+  it('runs the draft scan before iterating real offers (so player history reflects drafts on first pass)', () => {
+    const scanIdx = src.indexOf('await scanDraftTrades(');
+    const offerLoopIdx = src.indexOf('for (const [offerId, { raw, offeringFid }] of offerMap)');
+    expect(scanIdx).toBeGreaterThan(-1);
+    expect(offerLoopIdx).toBeGreaterThan(-1);
+    expect(scanIdx).toBeLessThan(offerLoopIdx);
+  });
+});
+
+describe('rumor-scan: drafts never create rumors on their own', () => {
+  const src = read('scripts/schefter-rumor-scan.mjs');
+
+  it('only iterates `offerMap` (real pending trades) — drafts are never a primary key', () => {
+    // The for-loop that emits tips is keyed by offerMap, not by any draft store.
+    expect(src).toMatch(/for \(const \[offerId, \{ raw, offeringFid \}\] of offerMap\)/);
+    // We must NEVER iterate draft keys in the tip-emission loop.
+    expect(src).not.toMatch(/for\s*\([^)]*tb_drafts[^)]*\)\s*\{/);
+  });
+});
+
+// ── In-memory fake Redis ──
+// Minimal subset required by scanDraftTrades / getDraftOfferersForPlayer /
+// getOwnerDraftCount. Sorted sets are stored as Maps keyed by member with
+// numeric scores; range reads filter by score window.
+
+class FakeRedis {
+  store = new Map<string, unknown>();
+  ttls = new Map<string, number>();
+
+  async get(key: string) {
+    return this.store.has(key) ? this.store.get(key) : null;
+  }
+  async set(key: string, value: unknown) {
+    this.store.set(key, value);
+    return 'OK';
+  }
+  async zadd(key: string, { score, member }: { score: number; member: string }) {
+    let zset = this.store.get(key) as Map<string, number> | undefined;
+    if (!zset) {
+      zset = new Map();
+      this.store.set(key, zset);
+    }
+    zset.set(member, score);
+    return 1;
+  }
+  async zrange(
+    key: string,
+    min: number,
+    max: number,
+    opts: { byScore?: boolean } = {},
+  ) {
+    const zset = this.store.get(key) as Map<string, number> | undefined;
+    if (!zset) return [];
+    if (!opts.byScore) {
+      return Array.from(zset.keys());
+    }
+    return Array.from(zset.entries())
+      .filter(([, score]) => score >= min && score <= max)
+      .sort((a, b) => a[1] - b[1])
+      .map(([member]) => member);
+  }
+  async zremrangebyscore(key: string, min: number, max: number) {
+    const zset = this.store.get(key) as Map<string, number> | undefined;
+    if (!zset) return 0;
+    let removed = 0;
+    for (const [member, score] of zset) {
+      if (score >= min && score <= max) {
+        zset.delete(member);
+        removed += 1;
+      }
+    }
+    return removed;
+  }
+  async expire(key: string, seconds: number) {
+    this.ttls.set(key, seconds);
+    return 1;
+  }
+  async zcard(key: string) {
+    const zset = this.store.get(key) as Map<string, number> | undefined;
+    return zset ? zset.size : 0;
+  }
+}
+
+describe('scanDraftTrades — Redis projection of dt:{fid} into shopping signals', () => {
+  it('projects each owner-side draft player into the per-player sorted set', async () => {
+    const redis = new FakeRedis();
+    const now = Date.now();
+    redis.store.set('dt:0001', [
+      {
+        id: 'd1',
+        name: 'shop CMC',
+        createdAt: now,
+        updatedAt: now,
+        teamA: { franchiseId: '0001', playerIds: ['12345', '67890'], draftPicks: [], rookieExtensions: {} },
+        teamB: { franchiseId: '0002', playerIds: ['99999'], draftPicks: [], rookieExtensions: {} },
+      },
+    ]);
+    const teams = new Map([
+      ['0001', { division: 'East' }],
+      ['0002', { division: 'West' }],
+    ]);
+
+    const summary = await scanDraftTrades({ redis: redis as any, teams, dryRun: false });
+
+    expect(summary.ownersScanned).toBe(1);
+    expect(summary.draftsScanned).toBe(1);
+    expect(summary.playerEntries).toBe(2);
+
+    const cmcOfferers = await getDraftOfferersForPlayer({ redis: redis as any, playerId: '12345' });
+    expect(cmcOfferers.has('0001')).toBe(true);
+
+    // The asset on teamB's side ("99999") is what the owner is *requesting*,
+    // not offering — it must NOT show up in the trade-block player set.
+    const requestedFids = await getDraftOfferersForPlayer({ redis: redis as any, playerId: '99999' });
+    expect(requestedFids.size).toBe(0);
+  });
+
+  it('skips drafts older than the 3-day window', async () => {
+    const redis = new FakeRedis();
+    const now = Date.now();
+    const stale = now - TB_DRAFT_WINDOW_MS - 60_000;
+    redis.store.set('dt:0001', [
+      {
+        id: 'd1',
+        name: 'old',
+        createdAt: stale,
+        updatedAt: stale,
+        teamA: { franchiseId: '0001', playerIds: ['12345'], draftPicks: [], rookieExtensions: {} },
+        teamB: { franchiseId: '0002', playerIds: [], draftPicks: [], rookieExtensions: {} },
+      },
+    ]);
+    const teams = new Map([['0001', { division: 'East' }]]);
+
+    const summary = await scanDraftTrades({ redis: redis as any, teams, dryRun: false });
+    expect(summary.draftsScanned).toBe(0);
+    const fids = await getDraftOfferersForPlayer({ redis: redis as any, playerId: '12345' });
+    expect(fids.size).toBe(0);
+  });
+
+  it('handles the owner being on teamB instead of teamA', async () => {
+    const redis = new FakeRedis();
+    const now = Date.now();
+    redis.store.set('dt:0003', [
+      {
+        id: 'd2',
+        name: 'reverse-builder',
+        createdAt: now,
+        updatedAt: now,
+        teamA: { franchiseId: '0007', playerIds: ['XXXX'], draftPicks: [], rookieExtensions: {} },
+        teamB: { franchiseId: '0003', playerIds: ['55555'], draftPicks: [], rookieExtensions: {} },
+      },
+    ]);
+    const teams = new Map([
+      ['0003', { division: 'East' }],
+      ['0007', { division: 'West' }],
+    ]);
+
+    await scanDraftTrades({ redis: redis as any, teams, dryRun: false });
+    // Owner 0003 is on teamB, so 55555 is what they're shopping.
+    const ownerSideFids = await getDraftOfferersForPlayer({ redis: redis as any, playerId: '55555' });
+    expect(ownerSideFids.has('0003')).toBe(true);
+    // teamA's player (XXXX) is requested, not shopped — must not be tagged.
+    const otherSideFids = await getDraftOfferersForPlayer({ redis: redis as any, playerId: 'XXXX' });
+    expect(otherSideFids.size).toBe(0);
+  });
+
+  it('records owner draft volume via getOwnerDraftCount', async () => {
+    const redis = new FakeRedis();
+    const now = Date.now();
+    redis.store.set('dt:0001', [
+      {
+        id: 'd1',
+        name: 'a',
+        createdAt: now,
+        updatedAt: now,
+        teamA: { franchiseId: '0001', playerIds: ['p1'], draftPicks: [], rookieExtensions: {} },
+        teamB: { franchiseId: '0002', playerIds: [], draftPicks: [], rookieExtensions: {} },
+      },
+      {
+        id: 'd2',
+        name: 'b',
+        createdAt: now,
+        updatedAt: now,
+        teamA: { franchiseId: '0001', playerIds: ['p2'], draftPicks: [], rookieExtensions: {} },
+        teamB: { franchiseId: '0003', playerIds: [], draftPicks: [], rookieExtensions: {} },
+      },
+    ]);
+    const teams = new Map([
+      ['0001', { division: 'East' }],
+      ['0002', { division: 'East' }],
+      ['0003', { division: 'West' }],
+    ]);
+
+    await scanDraftTrades({ redis: redis as any, teams, dryRun: false });
+    const count = await getOwnerDraftCount({ redis: redis as any, franchiseId: '0001' });
+    expect(count).toBe(2);
+  });
+
+  it('does not write when dryRun=true', async () => {
+    const redis = new FakeRedis();
+    const now = Date.now();
+    redis.store.set('dt:0001', [
+      {
+        id: 'd1',
+        name: 'a',
+        createdAt: now,
+        updatedAt: now,
+        teamA: { franchiseId: '0001', playerIds: ['p1'], draftPicks: [], rookieExtensions: {} },
+        teamB: { franchiseId: '0002', playerIds: [], draftPicks: [], rookieExtensions: {} },
+      },
+    ]);
+    const teams = new Map([['0001', { division: 'East' }]]);
+
+    await scanDraftTrades({ redis: redis as any, teams, dryRun: true });
+    const fids = await getDraftOfferersForPlayer({ redis: redis as any, playerId: 'p1' });
+    expect(fids.size).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Adds trade-builder saved drafts as a softer shopping signal alongside submitted offers in the Schefter rumor scanner. Drafts are weighted at 0.4× real offers, decay in 3 days (vs. 7 for submitted offers), and can elevate players from `base` to `tightened_circle` tier but never unlock the `named` tier on their own.

## Key Changes

- **New module `scripts/lib/scan-draft-trades.mjs`**: Reads each franchise's saved draft trades from Redis (`dt:{franchiseId}`) and projects them into sorted sets keyed by player and owner. Provides three exported functions:
  - `scanDraftTrades()`: Walks all franchises, filters drafts within the 3-day window, and populates Redis with draft signals
  - `getDraftOfferersForPlayer()`: Returns distinct franchise IDs with saved drafts involving a player
  - `getOwnerDraftCount()`: Returns raw count of drafts an owner has open
  - Exports constants: `TB_DRAFT_OFFERER_WEIGHT` (0.4), `TB_DRAFT_WINDOW_MS` (3 days), Redis key prefixes

- **Updated `scripts/schefter-rumor-scan.mjs`**:
  - Calls `scanDraftTrades()` before the main offer loop (Phase 0) so draft signals are available on first pass
  - Blends draft offerers into per-player effective count: `realCount + 0.4 * draftCount`
  - Implements tier cap: when no real offerer reaches `named` tier, caps effective count at 3 (tightened_circle threshold) even if drafts would push it higher
  - Passes `maxEffectiveOfferers` to `offerPostProbability()` for exponential scaling
  - Blends owner draft volume into 7-day aggressiveness hint (volumeHint)
  - Logs draft stats per offer for transparency

- **Updated `scripts/lib/redact-trade-offer.mjs`**:
  - Modified `offerPostProbability()` to accept `effectiveOfferers` parameter and scale exponentially
  - Added `OFFER_VOLUME_BOOST_FACTOR` (1.5) and `OFFER_VOLUME_BOOST_MAX` (4) constants
  - Probability formula: `base * (1.5 ^ (effectiveOfferers - 1))` capped at `4 * base` (~3% max per run)
  - Exported `tierForDistinctOfferers()` for use in scanner's tier-cap logic

- **Comprehensive test suite `tests/trade-builder-tip-source.test.ts`**:
  - Validates all constants and their documented values
  - Tests exponential scaling behavior and monotonicity of probability function
  - Verifies tier classification thresholds
  - Confirms rumor-scan integration: draft scan runs before offer loop, drafts never create rumors on their own, tier cap is enforced
  - Includes `FakeRedis` mock for integration testing of `scanDraftTrades()`, `getDraftOfferersForPlayer()`, and `getOwnerDraftCount()`
  - Tests draft age filtering, owner-side detection (teamA vs. teamB), and dry-run mode

## Notable Implementation Details

- Drafts are **never** a primary key in the tip-emission loop — only real pending offers from `offerMap` trigger rumors. Drafts only influence tier escalation and probability scaling.
- The tier cap is enforced in the scanner where both real and draft counts are available, preventing draft-only contribution from unlocking the `named` tier (which authorizes Schefter to name the player).
- Effective offerer count is floored to an integer after blending, preserving the distinction between 1 real offer (base tier) and 1 real + 2 drafts (tightened_circle).
- Owner draft volume is separately tracked and blended into the 7-day aggressiveness hint, independent of the per-player tier cap.
- All draft Redis keys have a 7-day TTL; the 3-day window is enforced at read time via score filtering.

https://claude.ai/code/session_018stXh51Ux7sg4ErL2HbCuj