### PR TITLE
fix(trade-builder): submit button no-op for picks-only trades

### DIFF
--- a/src/components/theleague/trade-builder/TradeBuilder.tsx
+++ b/src/components/theleague/trade-builder/TradeBuilder.tsx
@@ -310,10 +310,12 @@ export default function TradeBuilder({ pageData, defaultTeamId, authUser: authUs
     [teamB, state.teamB.playerIds]
   );
 
-  // Compute trade impact
+  // Compute trade impact. We compute even when no players are involved
+  // (picks-only trades) so the confirmation modal — which is gated on these
+  // being non-null — still renders. computeTeamTradeImpact handles empty
+  // player arrays cleanly: cap deltas are zero and salaries are unchanged.
   const tradeImpactA = useMemo(() => {
-    if (!teamA || (teamAPlayers.length === 0 && teamBPlayers.length === 0))
-      return null;
+    if (!teamA) return null;
     return computeTeamTradeImpact(
       teamA,
       teamAPlayers,
@@ -323,8 +325,7 @@ export default function TradeBuilder({ pageData, defaultTeamId, authUser: authUs
   }, [teamA, teamAPlayers, teamBPlayers, state.teamA.rookieExtensions]);
 
   const tradeImpactB = useMemo(() => {
-    if (!teamB || (teamAPlayers.length === 0 && teamBPlayers.length === 0))
-      return null;
+    if (!teamB) return null;
     return computeTeamTradeImpact(
       teamB,
       teamBPlayers,


### PR DESCRIPTION
The Submit button is rendered when `hasValidTrade` is true (each side has
≥1 player OR ≥1 draft pick), but the confirmation modal was gated on
`tradeImpactA && tradeImpactB`, both of which short-circuited to null
when neither team had any players selected. A picks-only trade therefore
showed the Submit button but did nothing on click — Save Draft (which has
no impact-render gating) still worked, hence the asymmetric symptom.

`computeTeamTradeImpact` handles empty player arrays correctly (zero cap
delta, zero salary change), so drop the early return.