### PR TITLE
fix(trade-builder): correct pick attribution + show 2.02 pick numbers

### DIFF
--- a/src/components/theleague/trade-builder/DraftPickSelector.tsx
+++ b/src/components/theleague/trade-builder/DraftPickSelector.tsx
@@ -45,10 +45,19 @@ export default function DraftPickSelector({
         originalPickFor: dp.originalPickFor,
       })
     );
-    return { ...sp, originalTeamName: detail?.originalTeamName ?? sp.originalPickFor };
+    return {
+      ...sp,
+      originalTeamName: detail?.originalTeamName ?? sp.originalPickFor,
+      pickInRound: detail?.pickInRound,
+    };
   });
 
-  const formatRound = (round: string) => {
+  // Format the round portion of a pick label.
+  // Current-year picks have a known slot → "2.02"; future picks fall back to "2nd".
+  const formatRound = (round: string, pickInRound?: number) => {
+    if (pickInRound != null) {
+      return `${round}.${String(pickInRound).padStart(2, '0')}`;
+    }
     const num = parseInt(round, 10);
     if (num === 1) return '1st';
     if (num === 2) return '2nd';
@@ -97,7 +106,7 @@ export default function DraftPickSelector({
                   className="draft-picks__badge"
                 >
                   <span>
-                    {pick.year} {formatRound(pick.round)}
+                    {pick.year} {formatRound(pick.round, pick.pickInRound)}
                     {pick.originalPickFor !== teamFranchiseId && (
                       <span className="draft-picks__via"> via {pick.originalTeamName}</span>
                     )}
@@ -129,7 +138,7 @@ export default function DraftPickSelector({
                     className="draft-picks__option"
                     onClick={() => onAdd(key)}
                   >
-                    {formatRound(dp.round)}
+                    {formatRound(dp.round, dp.pickInRound)}
                     {dp.originalPickFor !== teamFranchiseId && (
                       <span className="draft-picks__via"> (via {dp.originalTeamName})</span>
                     )}

--- a/src/components/theleague/trade-builder/TradeBuilder.tsx
+++ b/src/components/theleague/trade-builder/TradeBuilder.tsx
@@ -310,10 +310,12 @@ export default function TradeBuilder({ pageData, defaultTeamId, authUser: authUs
     [teamB, state.teamB.playerIds]
   );
 
-  // Compute trade impact
+  // Compute trade impact. We compute even when no players are involved
+  // (picks-only trades) so the confirmation modal — which is gated on these
+  // being non-null — still renders. computeTeamTradeImpact handles empty
+  // player arrays cleanly: cap deltas are zero and salaries are unchanged.
   const tradeImpactA = useMemo(() => {
-    if (!teamA || (teamAPlayers.length === 0 && teamBPlayers.length === 0))
-      return null;
+    if (!teamA) return null;
     return computeTeamTradeImpact(
       teamA,
       teamAPlayers,
@@ -323,8 +325,7 @@ export default function TradeBuilder({ pageData, defaultTeamId, authUser: authUs
   }, [teamA, teamAPlayers, teamBPlayers, state.teamA.rookieExtensions]);
 
   const tradeImpactB = useMemo(() => {
-    if (!teamB || (teamAPlayers.length === 0 && teamBPlayers.length === 0))
-      return null;
+    if (!teamB) return null;
     return computeTeamTradeImpact(
       teamB,
       teamBPlayers,

--- a/src/components/theleague/trade-builder/TradeBuilder.tsx
+++ b/src/components/theleague/trade-builder/TradeBuilder.tsx
@@ -663,6 +663,7 @@ export default function TradeBuilder({ pageData, defaultTeamId, authUser: authUs
               teamBPlayers={teamBPlayers}
               teamADraftPicks={state.teamA.draftPicks}
               teamBDraftPicks={state.teamB.draftPicks}
+              allTeams={data.teams}
               surplusMap={data.surplusMap}
               pickValueMap={data.pickValueMap}
               rankingLookup={rankingLookup}

--- a/src/components/theleague/trade-builder/TradeConfirmationModal.tsx
+++ b/src/components/theleague/trade-builder/TradeConfirmationModal.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import type {
   TradeBuilderTeam,
   TradeBuilderPlayer,
+  TradeBuilderDraftPick,
   DraftPickKey,
   RookieExtensionSim,
   TeamTradeImpact,
@@ -100,16 +101,37 @@ export default function TradeConfirmationModal({
 
   // No auto-close — user clicks "Done" or "View My Trades" after success
 
-  const formatPickLabel = (pick: DraftPickKey, teams: TradeBuilderTeam[]) => {
-    const originalTeam = teams.find(t =>
-      t.draftPicks.some(dp =>
-        dp.year === pick.year && dp.round === pick.round && dp.originalPickFor === pick.originalPickFor
-      )
-    );
-    const via = pick.originalPickFor && originalTeam
-      ? ` (via ${originalTeam.nameShort || originalTeam.abbrev})`
-      : '';
-    return `${pick.year} Rd ${pick.round}${via}`;
+  const formatPickLabel = (
+    pick: DraftPickKey,
+    teams: TradeBuilderTeam[],
+    holdingTeam: TradeBuilderTeam,
+  ) => {
+    // Find the matching pick entry on any team — its `originalTeamName` and
+    // `pickInRound` are already pre-computed by the page loader. We must NOT
+    // use the *holding* team's name as the "via" — that's whoever currently
+    // owns the pick, not the team it originated from.
+    let dpEntry: TradeBuilderDraftPick | undefined;
+    for (const t of teams) {
+      dpEntry = t.draftPicks.find(
+        dp =>
+          dp.year === pick.year &&
+          dp.round === pick.round &&
+          dp.originalPickFor === pick.originalPickFor,
+      );
+      if (dpEntry) break;
+    }
+
+    const roundLabel = dpEntry?.pickInRound != null
+      ? `${pick.round}.${String(dpEntry.pickInRound).padStart(2, '0')}`
+      : `Rd ${pick.round}`;
+
+    // Suppress "(via X)" when the holding team is the original owner —
+    // it's their own pick, redundant to display.
+    const showVia = pick.originalPickFor !== holdingTeam.franchiseId;
+    const viaName = dpEntry?.originalTeamName;
+    const via = showVia && viaName ? ` (via ${viaName})` : '';
+
+    return `${pick.year} ${roundLabel}${via}`;
   };
 
   const renderTeamSection = (
@@ -140,7 +162,7 @@ export default function TradeConfirmationModal({
         })}
         {picks.map((pick, i) => (
           <div key={`pick-${i}`} className="tcm-asset-row tcm-asset-row--pick">
-            <span className="tcm-asset-name">{formatPickLabel(pick, allTeams)}</span>
+            <span className="tcm-asset-name">{formatPickLabel(pick, allTeams, team)}</span>
             <span className="tcm-asset-pos">PICK</span>
           </div>
         ))}

--- a/src/components/theleague/trade-builder/TradeValueAnalysis.tsx
+++ b/src/components/theleague/trade-builder/TradeValueAnalysis.tsx
@@ -7,7 +7,7 @@
  */
 
 import React, { useMemo } from 'react';
-import type { TradeBuilderPlayer, PlayerSurplusData, DraftPickKey, DraftPickValueData } from '../../../types/trade-builder';
+import type { TradeBuilderPlayer, TradeBuilderTeam, PlayerSurplusData, DraftPickKey, DraftPickValueData } from '../../../types/trade-builder';
 import { formatCompactNumber } from '../../../utils/formatters';
 import type { RankingLookup } from '../../../utils/rankings-lookup';
 import { getPlayerRank, COMPOSITE_IMPORT_ID } from '../../../utils/rankings-lookup';
@@ -21,6 +21,8 @@ interface Props {
   teamBPlayers: TradeBuilderPlayer[];
   teamADraftPicks: DraftPickKey[];
   teamBDraftPicks: DraftPickKey[];
+  /** Used to resolve `pickInRound` for current-year picks. */
+  allTeams: TradeBuilderTeam[];
   surplusMap: Record<string, PlayerSurplusData>;
   pickValueMap?: Record<string, DraftPickValueData>;
   rankingLookup?: RankingLookup | null;
@@ -44,10 +46,25 @@ export default function TradeValueAnalysis({
   teamBPlayers,
   teamADraftPicks,
   teamBDraftPicks,
+  allTeams,
   surplusMap,
   pickValueMap,
   rankingLookup,
 }: Props) {
+  // Resolve a pick's pre-computed pickInRound (set only for current-year picks)
+  // by matching against any team's draftPicks list.
+  const lookupPickInRound = (pick: DraftPickKey): number | undefined => {
+    for (const t of allTeams) {
+      const dp = t.draftPicks.find(
+        d =>
+          d.year === pick.year &&
+          d.round === pick.round &&
+          d.originalPickFor === pick.originalPickFor,
+      );
+      if (dp) return dp.pickInRound;
+    }
+    return undefined;
+  };
   const analysis = useMemo(() => {
     const sumPlayerSurplus = (players: TradeBuilderPlayer[]) =>
       players.reduce((sum, p) => sum + (surplusMap[p.id]?.surplusValue ?? 0), 0);
@@ -118,11 +135,15 @@ export default function TradeValueAnalysis({
   const renderDraftPick = (pick: DraftPickKey) => {
     const val = pickValueMap?.[pickKey(pick)];
     const hasPkValue = val && val.surplusValue !== 0;
+    const pickInRound = lookupPickInRound(pick);
+    const roundLabel = pickInRound != null
+      ? `${pick.round}.${String(pickInRound).padStart(2, '0')}`
+      : `Rd ${pick.round}`;
 
     return (
       <div key={pickKey(pick)} className="tva__player">
         <span className="tva__player-name">
-          {pick.year} Rd {pick.round}
+          {pick.year} {roundLabel}
         </span>
         {hasPkValue ? (
           <span className="tva__player-value tva__player-value--positive">

--- a/src/pages/theleague/trade-builder.astro
+++ b/src/pages/theleague/trade-builder.astro
@@ -227,11 +227,13 @@ for (const pick of rawDraftResultPicks) {
   currentYearDpMap[dpKey] = dpCode;
   dpReverseMap[dpCode] = { year: leagueYearStr, round, originalPickFor };
 
+  const pickInRoundNum = parseInt(pick.pick, 10);
   const draftPick = {
     year: leagueYearStr,
     round,
     originalPickFor,
     originalTeamName,
+    ...(Number.isFinite(pickInRoundNum) ? { pickInRound: pickInRoundNum } : {}),
   };
 
   if (!currentYearPicksByFranchise.has(currentOwner)) {

--- a/src/types/trade-builder.ts
+++ b/src/types/trade-builder.ts
@@ -32,6 +32,9 @@ export interface TradeBuilderDraftPick {
   round: string;
   originalPickFor: string;
   originalTeamName: string;
+  /** 1-based pick-in-round (e.g. 2 for the 2nd pick of the round). Only set
+   *  for current-year picks where MFL has assigned the actual draft slot. */
+  pickInRound?: number;
 }
 
 /** Processed team data passed from Astro to React */


### PR DESCRIPTION
## Summary

Two follow-ups to PR #137 covering the trade-builder confirmation modal and pick rendering throughout the page:

1. **Wrong "via" team in confirmation modal.** `formatPickLabel` was looking up the team that *currently holds* a pick and using its name as the "via" attribution — so a Midwest-held pick that originated from Dead Cap Walking displayed as `via Midwest`. Fixed to read the pre-computed `originalTeamName` off the matched draft-pick entry, which is keyed by `originalPickFor`. Also suppresses the redundant `(via Pigskins)` when Pigskins itself is the team giving up its own original pick.

2. **Show real pick number for current-year picks.** Threaded `pick.pick` from MFL's `draftResults` feed through to a new `TradeBuilderDraftPick.pickInRound` field, populated only for current-year picks (where MFL has assigned the slot). All three pick-rendering sites — confirmation modal, side-panel selector (`DraftPickSelector`), and admin value-analysis widget (`TradeValueAnalysis`) — now display `2026 2.02 (via Dead Cap Walking)` style labels. Future-year picks fall back to the existing `1st/2nd/3rd` / `Rd N` ordinal label.

## Test plan

- [ ] Build a trade with a current-year pick that originated from a different team (e.g. a Midwest 2026 2nd that came from Dead Cap Walking)
- [ ] Confirm the side-panel pick badge shows `2026 2.02 via Dead Cap Walking`
- [ ] Open the confirmation modal and verify the same `2026 2.02 (via Dead Cap Walking)` label
- [ ] Build a trade involving a future-year pick (e.g. 2027 3rd) and confirm it falls back to `2027 Rd 3` (no `2.02` style — slot unknown)
- [ ] Verify own-team picks (Pigskins giving up Pigskins's own pick) no longer show the redundant `(via Pigskins)` parenthetical in the modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q6NB5zfcrE6hoXtDdfPN2J)_