### PR TITLE
fix(trade-alert): refresh bell modal after submitting a trade

### DIFF
--- a/src/components/theleague/trade-builder/TradeBuilder.tsx
+++ b/src/components/theleague/trade-builder/TradeBuilder.tsx
@@ -448,6 +448,15 @@ export default function TradeBuilder({ pageData, defaultTeamId, authUser: authUs
       const data = await res.json();
 
       if (data.success) {
+        // Invalidate the trade-alert modal's cached pending trades so the
+        // bell on other pages shows the newly-submitted offer instead of
+        // "No Pending Trades". The modal debounces API calls for 60s via
+        // sessionStorage; clearing the key + dispatching the event forces
+        // an immediate refetch the next time it polls.
+        try {
+          sessionStorage.removeItem('mfl:trade-alert-last-check');
+          document.dispatchEvent(new CustomEvent('mfl:trades-changed'));
+        } catch { /* sessionStorage / CustomEvent unavailable — non-fatal */ }
         setSubmissionStatus({ status: 'success', errorMessage: null });
       } else {
         setSubmissionStatus({

--- a/src/scripts/trade-alert.ts
+++ b/src/scripts/trade-alert.ts
@@ -1067,3 +1067,11 @@ async function tamPoll() {
 }
 
 document.addEventListener('astro:page-load', tamPoll);
+
+// Force an immediate fresh poll when a trade is submitted/accepted/rejected
+// elsewhere in the app, bypassing the 60s debounce so the bell badge and
+// modal reflect the new state without waiting for a navigation.
+document.addEventListener('mfl:trades-changed', () => {
+  try { sessionStorage.removeItem(TAM_DEBOUNCE_KEY); } catch {}
+  tamPoll();
+});


### PR DESCRIPTION
The trade-alert modal (the one that pops from the nav bell) caches pending
trades in module state and debounces the /api/trades/pending fetch for 60s
via sessionStorage. After submitting a trade and navigating away, the next
astro:page-load fired tamPoll() which short-circuited on the debounce
without ever fetching the new sent trade — so clicking the bell hit the
empty cache and rendered "No Pending Trades".

On a successful submit, clear the debounce key and dispatch
mfl:trades-changed; the trade-alert script listens for the event and
force-polls, so the bell badge and modal reflect the new state immediately.

https://claude.ai/code/session_01NWRN6zSAaMKthK8SkFNL8a