### PR TITLE
Fix mobile search icon position on Projected Free Agents page

### DIFF
--- a/src/pages/theleague/projected-free-agents.astro
+++ b/src/pages/theleague/projected-free-agents.astro
@@ -1371,6 +1371,10 @@ const r = (path: string) => resolveLeaguePath(path, hideLeaguePrefix);
     }
 
     .pfa-controls__search {
+      /* Reset desktop's `flex: 1 1 200px` — in column flex the 200px basis applies
+         to height, stretching the container so the absolute icon at top:50% lands
+         well below the input. */
+      flex: 0 0 auto;
       max-width: none;
     }
 


### PR DESCRIPTION
The search container had `flex: 1 1 200px` from the desktop layout. On mobile,
the parent flips to `flex-direction: column` and the 200px basis applies to
height instead of width, stretching the container to ~200px tall. The
absolutely-positioned magnifying glass at `top: 50%` then rendered ~100px
below the input instead of inside it.

https://claude.ai/code/session_019rQXJxV5DEejgBgvExpdzB