### PR TITLE
Filter mock draft rookie pool to draftable positions only

### DIFF
--- a/src/pages/api/mock-draft/create.ts
+++ b/src/pages/api/mock-draft/create.ts
@@ -20,6 +20,7 @@ import {
   resolveMflId,
   formatMflName,
 } from '../../../utils/player-name-matching';
+import { isDraftablePosition } from '../../../utils/build-draft-players';
 
 const ALL_RANKING_SOURCES: MockRankingSource[] = [
   'mfl-rookie',
@@ -173,8 +174,16 @@ export const POST: APIRoute = async ({ request }) => {
     const allPlayers: any[] = allPlayersRaw
       ? (Array.isArray(allPlayersRaw) ? allPlayersRaw : [allPlayersRaw])
       : [];
+    // Filter to draftable offensive rookies. Without the position gate, the
+    // pool includes IDPs (DE/DT/LB/CB/S) that show up in MFL's rookie ADP and
+    // get auto-picked by AI teams — but the client's player map (built via
+    // build-draft-players → DRAFTABLE_POSITIONS) excludes them, so those
+    // slots render blank ("—") on the board even though the server thinks
+    // the pick was made.
     const rookiePool = allPlayers.filter(
-      (p: any) => p.status === 'R' || p.draft_year === leagueYearStr,
+      (p: any) =>
+        (p.status === 'R' || p.draft_year === leagueYearStr) &&
+        isDraftablePosition(p.position || ''),
     );
     const rookieIdSet = new Set(rookiePool.map((p: any) => p.id));
 

--- a/src/utils/build-draft-players.ts
+++ b/src/utils/build-draft-players.ts
@@ -35,7 +35,7 @@ interface BuildDraftPlayersOptions {
   viewerFranchiseId?: string;
 }
 
-const DRAFTABLE = new Set(['QB', 'RB', 'WR', 'TE', 'PK', 'DEF']);
+export const DRAFTABLE_POSITIONS = new Set(['QB', 'RB', 'WR', 'TE', 'PK', 'DEF']);
 
 function normPos(pos: string): string {
   if (!pos) return '';
@@ -44,6 +44,12 @@ function normPos(pos: string): string {
   if (upper === 'PK' || upper === 'K') return 'PK';
   return upper;
 }
+
+export function isDraftablePosition(pos: string): boolean {
+  return DRAFTABLE_POSITIONS.has(normPos(pos));
+}
+
+const DRAFTABLE = DRAFTABLE_POSITIONS;
 
 function formatName(mflName: string): string {
   if (!mflName) return '';


### PR DESCRIPTION
## Summary
Fixed a bug where defensive players (DE/DT/LB/CB/S) from MFL's rookie ADP were being auto-picked in mock drafts but rendering as blank slots on the board, since the client only recognizes offensive positions as draftable.

## Changes
- Exported `DRAFTABLE_POSITIONS` constant and created `isDraftablePosition()` helper function in `build-draft-players.ts` to make position validation reusable
- Updated the mock draft rookie pool filter in `create.ts` to exclude non-draftable positions using the new helper function
- Added explanatory comment documenting why the position gate is necessary to prevent the server/client mismatch

## Details
The issue occurred because:
1. The server's rookie pool included all players with status 'R' or matching the league year, including IDPs
2. AI teams would auto-pick these defensive players during mock draft generation
3. The client's player map (built from `DRAFTABLE_POSITIONS`) only includes offensive positions (QB, RB, WR, TE, PK, DEF)
4. This caused picked IDP slots to render as "—" on the board even though the server recorded the pick

The fix ensures the server's rookie pool matches the client's draftable position set, preventing this rendering mismatch.

https://claude.ai/code/session_012gtprfZFyjBWr7Et78HyeP