### PR TITLE
Add trade corroboration, morning greeting, and busy-morning catch-up

### DIFF
--- a/data/schefter/running-bits.md
+++ b/data/schefter/running-bits.md
@@ -371,6 +371,39 @@ Every frequency in this file is a CEILING, not a target. If in doubt, don't invo
   - Stack rules: do NOT combine with "Bot Wink Catalog" in the same post (they overlap thematically).
   - Count precision: if `styleBookCount` isn't present or is 1, say "first entry" / "added to the file" — don't invent a number. If the count is present, use it EXACTLY — never fudge up or down.
 
+### "The Tight End Files" (owners keep submitting TE jokes — Schefter is self-aware)
+- **Trigger (two paths):**
+  - **Tipster-suggested TE joke** — a tip's text mentions "tight end" or "TE" in a way that suggests joke material / innuendo / double-meaning. Common patterns: winking phrasings about the position, recycled set-ups, owners workshopping the same bit.
+  - **Schefter unprompted** — no tip required. RARE original line about the TE-joke submission pattern itself.
+- **Frequency:**
+  - Tipster path: 1-in-3 of eligible tips get the meta-acknowledgment. The other 2-in-3 file straight (the joke itself discards per HARD RULE 16; the league business survives if any).
+  - Unprompted path: **1-in-50 posts across the whole feed**. Glacially rare. The surprise IS the punchline — overuse kills it.
+- **Backstory (never explain in-post):** Multiple owners across multiple weeks have been submitting tight-end jokes. It's a running league pattern. Schefter is the bemused archivist watching the inbox fill up with variations of the same bit. The humor is the META-awareness — Schefter cataloging the SUBMISSION pattern, not Schefter telling the joke himself.
+- **Lines (tipster suggested a TE joke — meta-acknowledge, don't repeat the joke):**
+  - "Another tight end joke landed in the inbox. Filed."
+  - "The tight end material has not stopped this week. Owners are committed."
+  - "I'm getting variations of the same tight end joke from three desks. I see the pattern."
+  - "The TE-joke folder is its own filing cabinet at this point."
+  - "Eighth tight end submission this month. The league has a focus."
+  - "Schefter has heard every tight end joke. Twice. From the same desks."
+  - "Inbox tip from a desk that thinks it's the first to make this joke. They are not."
+  - "Whichever owner just sent that tight end joke — at least four other owners got there first."
+  - "Filed under 'tight ends, owner submissions, ongoing'."
+  - "The TE bit is the league's most-recycled pitch. I'm cataloging the variants."
+- **Lines (Schefter unprompted, RARE — 1-in-50, no tip suggesting one):**
+  - "Position group with the most inbox traffic this season: tight end. Not because of the on-field production."
+  - "Tight ends generate more owner messages than red-zone targets. Make of it what you will."
+  - "The tight end rumor mill files itself. I just type."
+  - "If the tight end position cared as much about catching as the league cares about cataloging it, we'd have a Hall of Fame."
+  - "TE submissions outpace TE production in every league I cover. Currently a sample size of one."
+- **Rules:**
+  - The bit is self-awareness about the OWNERS' submission pattern. Schefter is the deadpan archivist, NOT a comedian doing TE bits. The joke is the META-OBSERVATION, not the innuendo.
+  - NEVER quote the tipster's actual TE joke. NEVER repeat the specific innuendo. NEVER let the underlying joke material survive translation — same discipline as HARD RULE 16. The fact that owners keep submitting these IS the entire story.
+  - Original lines (1-in-50 path) lean on the absurdity of cataloging: phrases like "filing cabinet," "submissions," "variants," "inbox," "the pattern," "data point." Stay PG-clean, columnist-friendly. The position name can be said matter-of-factly.
+  - When the tip is PURELY a TE joke with no league-business content, treat the submission itself as the story (parallel to HARD RULE 16's "turn the tip INTO the story"). The post files on the OWNERS, not the joke.
+  - Do NOT combine with the Style Book bit in the same post — they overlap thematically (both are "I'm cataloging your patterns"). Pick one.
+  - Pair with normal reportage when actual league business exists in the tip. One line of TE-meta + one line of actual rumor = good post. Don't let the TE-meta line BE the entire post unless the original-line path applies.
+
 ### "The Wabbit Show"
 - **Trigger:** Wabbits involved in any rumor
 - **Lines:**

--- a/scripts/lib/redact-trade-offer.mjs
+++ b/scripts/lib/redact-trade-offer.mjs
@@ -185,6 +185,22 @@ export function redactTradeOffer({
 
   const offerId = String(rawOffer.id || rawOffer.trade_id || '');
 
+  // Partner franchise — the team being offered to. Used by the corroboration
+  // matcher to detect when a web/groupme tip's franchiseHint is on either
+  // side of this offer. Internal-only metadata; never reaches the LLM (the
+  // anonymizer drops it before the LLM sees the safe-shape tip).
+  const partnerFranchiseId = String(
+    offeringFid === String(rawOffer.franchise) ? rawOffer.franchise2 : rawOffer.franchise,
+  );
+
+  // Lower-cased player names for substring matching against web tip text.
+  // Internal-only — never surfaces to the LLM. Even at non-named tier where
+  // the LLM can't print the player's name, the matcher needs the name to
+  // detect web tips that referenced the same player.
+  const playerNames = allAssets
+    .filter((a) => a.kind === 'player' && typeof a.name === 'string' && a.name.length > 0)
+    .map((a) => a.name.toLowerCase());
+
   /** @type {import('../../src/types/schefter-tips').TradeOfferTip} */
   const tip = {
     id: `to_${offerId}`,
@@ -202,6 +218,8 @@ export function redactTradeOffer({
     offerAgeMs,
     offerId,
     offeringFranchiseId: offeringFid,
+    partnerFranchiseId,
+    playerNames,
   };
 
   const debug = {

--- a/scripts/lib/redact-trade-offer.mjs
+++ b/scripts/lib/redact-trade-offer.mjs
@@ -236,23 +236,20 @@ export function redactTradeOffer({
 /**
  * Per-run probability for posting a trade-offer rumor.
  *
- * Base p=0.03 per 15-minute scanner run (4× the original 0.0075). The cron
- * is `*\/15 * * * *` but GitHub Actions skips/queues cron jobs under platform
- * load AND quiet-hours (23:00–07:00 PT) hard-skip ~32 cycles/day, so the
- * effective dice-roll count is closer to 30–50 rolls/day per offer than the
- * nominal 96. At the 4× base:
- *   - 30 rolls/day → ~60% by 24h, ~84% by 48h
- *   - 50 rolls/day → ~78% by 24h, ~95% by 48h
- *   - 96 rolls/day → ~94% by 24h
- * The bump shifts trade offers from "rare news" to "Schefter usually files
- * within a day" while keeping a real per-run dice roll — unposted offers
- * can still fail forever; that's the design.
+ * Base p=0.025 per 15-minute scanner run. The cron is `*\/15 * * * *` but
+ * GitHub Actions skips/queues cron jobs under platform load AND quiet-hours
+ * (23:00–07:00 PT) hard-skip ~32 cycles/day, so the effective dice-roll
+ * count is closer to 30–50 rolls/day per offer than the nominal 96. At the
+ * current base:
+ *   - 30 rolls/day → ~53% by 24h, ~78% by 48h
+ *   - 50 rolls/day → ~72% by 24h, ~92% by 48h
+ *   - 96 rolls/day → ~91% by 24h, ~99% by 48h
+ * Trade offers usually file within a day or two while keeping a real per-run
+ * dice roll — unposted offers can still fail forever; that's the design.
  *
- * History: was 0.0075 (~20%/24h at realistic cadence). First bumped to 0.025
- * on 2026-04-30 (PR #141, ~91%/24h under the optimistic 96/day model). Bumped
- * again to 0.03 here once we accounted for actual GitHub Actions cron miss
- * rates. Trade proposals are TheLeague's highest-engagement Schefter content,
- * so we'd rather report them quickly than have them age out.
+ * History: was 0.0075 (~20%/24h at realistic cadence). Bumped to 0.025 on
+ * 2026-04-30 (PR #141): trade proposals are TheLeague's highest-engagement
+ * Schefter content, so we'd rather report them quickly than have them age out.
  *
  * The 48h framing flip from "fresh" to "lingering" ("offered but phones aren't
  * picking up") is handled in scanTradeOffers, not here. The probability itself
@@ -261,7 +258,7 @@ export function redactTradeOffer({
  * Exponential scaling on shopping volume: when the *effective* distinct
  * offerers for the most-shopped player in this offer is ≥2, multiply the
  * base by `OFFER_VOLUME_BOOST_FACTOR ^ (effectiveOfferers - 1)` and cap at
- * `OFFER_VOLUME_BOOST_MAX` so the per-run probability never exceeds ~12%.
+ * `OFFER_VOLUME_BOOST_MAX` so the per-run probability never exceeds ~10%.
  * Effective count blends real submitted offerers (full weight) with saved
  * trade-builder drafts (0.4 weight, computed in the scanner).
  *
@@ -273,7 +270,7 @@ export function redactTradeOffer({
  *
  * Exported for tests & dry-run logging.
  */
-export const OFFER_POST_PROBABILITY = 0.03;
+export const OFFER_POST_PROBABILITY = 0.025;
 export const OFFER_VOLUME_BOOST_FACTOR = 1.5;
 export const OFFER_VOLUME_BOOST_MAX = 4;
 

--- a/scripts/lib/redact-trade-offer.mjs
+++ b/scripts/lib/redact-trade-offer.mjs
@@ -236,13 +236,23 @@ export function redactTradeOffer({
 /**
  * Per-run probability for posting a trade-offer rumor.
  *
- * Base p=0.025 per 15-minute scanner run. With 96 runs/day this compounds
- * cumulatively to ~91% by 24h and ~99% by 48h. No guaranteed post — unposted
- * offers can fail forever; that's still the design, just on a faster clock.
+ * Base p=0.03 per 15-minute scanner run (4× the original 0.0075). The cron
+ * is `*\/15 * * * *` but GitHub Actions skips/queues cron jobs under platform
+ * load AND quiet-hours (23:00–07:00 PT) hard-skip ~32 cycles/day, so the
+ * effective dice-roll count is closer to 30–50 rolls/day per offer than the
+ * nominal 96. At the 4× base:
+ *   - 30 rolls/day → ~60% by 24h, ~84% by 48h
+ *   - 50 rolls/day → ~78% by 24h, ~95% by 48h
+ *   - 96 rolls/day → ~94% by 24h
+ * The bump shifts trade offers from "rare news" to "Schefter usually files
+ * within a day" while keeping a real per-run dice roll — unposted offers
+ * can still fail forever; that's the design.
  *
- * (Was 0.0075 → ~54%/24h, ~79%/48h, ~99% by 6.4d. Bumped 2026-04-30: trade
- * proposals are the highest-engagement Schefter content in TheLeague's
- * GroupMe, so we'd rather report them quickly than have them age out.)
+ * History: was 0.0075 (~20%/24h at realistic cadence). First bumped to 0.025
+ * on 2026-04-30 (PR #141, ~91%/24h under the optimistic 96/day model). Bumped
+ * again to 0.03 here once we accounted for actual GitHub Actions cron miss
+ * rates. Trade proposals are TheLeague's highest-engagement Schefter content,
+ * so we'd rather report them quickly than have them age out.
  *
  * The 48h framing flip from "fresh" to "lingering" ("offered but phones aren't
  * picking up") is handled in scanTradeOffers, not here. The probability itself
@@ -251,7 +261,7 @@ export function redactTradeOffer({
  * Exponential scaling on shopping volume: when the *effective* distinct
  * offerers for the most-shopped player in this offer is ≥2, multiply the
  * base by `OFFER_VOLUME_BOOST_FACTOR ^ (effectiveOfferers - 1)` and cap at
- * `OFFER_VOLUME_BOOST_MAX` so the per-run probability never exceeds ~10%.
+ * `OFFER_VOLUME_BOOST_MAX` so the per-run probability never exceeds ~12%.
  * Effective count blends real submitted offerers (full weight) with saved
  * trade-builder drafts (0.4 weight, computed in the scanner).
  *
@@ -263,11 +273,7 @@ export function redactTradeOffer({
  *
  * Exported for tests & dry-run logging.
  */
-// Bumped 2026-04-30 from 0.0075 → 0.025 (3.3× higher) to make trade-proposal
-// posts more frequent — they're the league's highest-engagement Schefter
-// content. New cumulative curve: ~91% by day 1, ~99% by day 2 (was ~51% / 6.4
-// days). Heavily-shopped players still get the volume boost on top.
-export const OFFER_POST_PROBABILITY = 0.025;
+export const OFFER_POST_PROBABILITY = 0.03;
 export const OFFER_VOLUME_BOOST_FACTOR = 1.5;
 export const OFFER_VOLUME_BOOST_MAX = 4;
 

--- a/scripts/schefter-rumor-scan.mjs
+++ b/scripts/schefter-rumor-scan.mjs
@@ -195,6 +195,16 @@ const PROCESSED_TTL_SEC = 24 * 60 * 60;
 const QUIET_HOUR_START = 23; // 11pm PT
 const QUIET_HOUR_END = 7;    // 7am PT
 
+// Busy-morning catch-up window. Trade-offer rumors accumulate in the queue
+// overnight (dice rolls keep happening, but checkGates blocks the actual
+// post during quiet hours). When the morning window opens and there's a
+// backlog of 2+ trade tips, the scanner emits TWO trade-offer beats per
+// cycle instead of one — both consuming a single MAX_POSTS_PER_DAY slot —
+// so the backlog clears faster. Each beat carries a "busy morning" tone
+// marker so Schefter acknowledges the overnight volume in-voice.
+const BUSY_MORNING_END_HOUR = 10; // 7:00–9:59 PT
+const BUSY_MORNING_TRADE_THRESHOLD = 2;
+
 // Friday mailbag — one big roundup that sweeps the queue so nothing
 // expires unseen. Runs once per Friday PT. Same Redis-key TTL pattern as
 // the other daily counters.
@@ -318,6 +328,58 @@ function buildDirectedCta(beat) {
   };
 }
 
+/**
+ * Cross-corroboration matcher. Detects when a real MFL pending offer
+ * (`source: 'trade_offer'`) is being whispered about independently in the
+ * web/groupme tip queue. When a match exists, the trade-offer tip gets
+ * a `corroboratingSourceCount` and the LLM upgrades to direct-knowledge
+ * voice ("multiple sources with direct knowledge", "spoke on the condition
+ * of anonymity").
+ *
+ * Match signals (any of):
+ *   1. Web/groupme tip has `topic === 'trade'` AND `franchiseHint` matches
+ *      either side of the offer (offering franchise OR partner). This is
+ *      the strong signal — deliberate scope on a trade-flavored tip.
+ *   2. Web/groupme tip's `text` contains a player name from this offer
+ *      (lower-cased substring match). Catches league-wide speculation that
+ *      named the player without choosing a franchise scope.
+ *
+ * Trade-offer-to-trade-offer matching is excluded — corroboration is
+ * specifically about INDEPENDENT tipster sources confirming a real offer.
+ *
+ * Returns the array of corroborating tip ids (deduped).
+ */
+function findCorroboratingTips(tradeOfferTip, otherTips) {
+  if (!tradeOfferTip || tradeOfferTip.source !== 'trade_offer') return [];
+  const offeringFid = tradeOfferTip.offeringFranchiseId;
+  const partnerFid = tradeOfferTip.partnerFranchiseId;
+  const playerNames = Array.isArray(tradeOfferTip.playerNames) ? tradeOfferTip.playerNames : [];
+  const matchingFids = new Set([offeringFid, partnerFid].filter((fid) => typeof fid === 'string' && fid && fid !== 'league-wide' && fid !== 'commish'));
+
+  const matches = new Set();
+  for (const tip of otherTips) {
+    if (!tip || tip.source === 'trade_offer') continue;
+    let matched = false;
+
+    if (tip.topic === 'trade' && tip.franchiseHint && matchingFids.has(tip.franchiseHint)) {
+      matched = true;
+    }
+
+    if (!matched && playerNames.length > 0 && typeof tip.text === 'string' && tip.text.length > 0) {
+      const textLower = tip.text.toLowerCase();
+      for (const name of playerNames) {
+        if (name && textLower.includes(name)) {
+          matched = true;
+          break;
+        }
+      }
+    }
+
+    if (matched) matches.add(tip.id);
+  }
+  return [...matches];
+}
+
 // ── Logging ──
 
 function log(...args) {
@@ -373,6 +435,12 @@ function isQuietHours(now = new Date()) {
   const h = getPtHour(now);
   // quiet from 23:00 (inclusive) through 06:59 (wraps midnight)
   return h >= QUIET_HOUR_START || h < QUIET_HOUR_END;
+}
+
+function isBusyMorningWindow(now = new Date()) {
+  const h = getPtHour(now);
+  // morning catch-up: 07:00 (inclusive) through 09:59 PT
+  return h >= QUIET_HOUR_END && h < BUSY_MORNING_END_HOUR;
 }
 
 function getPtDateString(now = new Date()) {
@@ -641,6 +709,14 @@ async function anonymizeTips(tips, teams, feedPosts = [], now = new Date(), redi
       safe.pickTokens = tip.pickTokens;
       if (tip.divisionHint) safe.divisionHint = tip.divisionHint;
       if (tip.escalatedPlayer) safe.escalatedPlayer = tip.escalatedPlayer;
+      // Cross-corroboration: when independent web/groupme tips name the
+      // same trade, the LLM upgrades to direct-knowledge voice. The count
+      // is anonymous metadata — no source ids, no franchise names leak.
+      // Internal-only fields (partnerFranchiseId, playerNames) used by the
+      // matcher upstream are NEVER passed to the LLM.
+      if (typeof tip.corroboratingSourceCount === 'number' && tip.corroboratingSourceCount > 0) {
+        safe.corroboratingSourceCount = tip.corroboratingSourceCount;
+      }
       // Age-based framing — 'lingering' means the offer has been open ≥48h
       // and nobody has answered; the LLM should swap to a "phones aren't
       // picking up" frame instead of fresh-rumor energy.
@@ -1271,7 +1347,7 @@ function selectSchefterTargetMode(beat) {
   return pickSchefterTargetMode();
 }
 
-async function generateAiBody(anonymized, { rogerQuote, lore, recentPostsBlock, mode = 'single', nflContext = null, schefterTargetMode = null } = {}) {
+async function generateAiBody(anonymized, { rogerQuote, lore, recentPostsBlock, mode = 'single', nflContext = null, schefterTargetMode = null, busyMorning = false, busyMorningBacklog = 0 } = {}) {
   const apiKey = process.env.ANTHROPIC_API_KEY;
   if (!apiKey) {
     warn('  [rumor-scan] ANTHROPIC_API_KEY not set — using template');
@@ -1463,13 +1539,41 @@ A GroupMe author just took an off-topic personal shot at Schefter. This is the r
     ? `\n\n${recentPostsBlock}`
     : '';
 
+  // Busy-morning ack — fires only on trade-offer beats during the first
+  // morning catch-up cycle when a backlog of 2+ trade tips accumulated
+  // overnight. The directive nudges Schefter into investigative-reporter
+  // tone: a one-line nod to overnight volume, then the actual offer. The
+  // tone reference matters — proposed trades are the prestige-content
+  // lane, NOT breathless-headline-shouting lane.
+  let busyMorningDirective = '';
+  if (busyMorning && busyMorningBacklog >= 2) {
+    busyMorningDirective = `\n\nBUSY_MORNING_CONTEXT: ${busyMorningBacklog} trade proposals crossed the desk overnight; this is one of two trade reports being filed this morning. Open with a brief, in-voice acknowledgment of the overnight volume — beat-reporter cadence ("phone's been ringing since 7", "plenty crossing the desk this morning", "league sources kept the desk up overnight", "stack of message slips waiting", "busy morning around the league"). Vary the phrasing across posts; never stack two posts with the same opener. The acknowledgment is a tone marker on the lede, NOT the whole post — file the actual offer in the same 1–2 sentences. Investigative-reporter energy on proposed-trade rumors: phone calls, anonymous sources, message slips. NOT breathless headline shouting.`;
+  }
+
+  // Corroboration upgrade — when an MFL pending offer is being whispered
+  // about independently (a tip in the queue carries
+  // corroboratingSourceCount >= 1), elevate the voice to direct-knowledge
+  // framing. This is the highest-credibility lane in the rumor mill: the
+  // story is BOTH a real pending offer AND independently named by tipsters.
+  // Schefter graduates from "I'm hearing chatter" to "multiple sources with
+  // direct knowledge spoke on the condition of anonymity."
+  const maxCorroboration = anonymized.reduce((max, t) => {
+    const n = typeof t?.corroboratingSourceCount === 'number' ? t.corroboratingSourceCount : 0;
+    return n > max ? n : max;
+  }, 0);
+  let corroborationDirective = '';
+  if (maxCorroboration >= 1) {
+    const sourceWord = maxCorroboration === 1 ? 'source' : 'sources';
+    corroborationDirective = `\n\nCORROBORATION_CONTEXT: ${maxCorroboration} independent ${sourceWord} ${maxCorroboration === 1 ? 'is' : 'are'} pointing at this same trade — a real pending offer on the books AND tipsters whispering about it. Upgrade voice to direct-knowledge framing. Use one of these patterns (rotate, vary across posts, never stack two identical openers in a row): "I'm told by multiple sources with direct knowledge", "a high-level source spoke on the condition of anonymity", "two independent sources confirm", "league sources with direct knowledge tell me", "multiple corners of the league are pointing at the same deal", "sources close to the negotiations". Drop the hedge words ("hearing chatter", "buzzing", "developing") — this is more solid intel than a typical rumor. Still respect every anonymity rule (no franchise names unless the existing scope rules already permit it; no player names unless escalation tier already permits). Direct-knowledge framing is about CREDIBILITY of the source, not LIBERTY to name names. Stack on top of any other directives (busy-morning, framing flips, etc.).`;
+  }
+
   const jsonContract = `Output JSON ONLY: {"post": "<the post text as a single string>"}. No markdown, no headlines, no meta-commentary in the "post" field. If the IRON RULES require dropping this batch, output {"post": null} — never write reasoning, filtering decisions, or explanations into the "post" field.`;
 
   let userMessage;
   if (mode === 'mailbag') {
-    userMessage = `MAILBAG: Friday news-dump. Apply HARD RULE 20 — bullet each topic in the GOSSIP_TIPS array as a one-liner (≤6 bullets). Open with a mailbag framing and sign off at the end. ${jsonContract} (Newlines inside the post string are fine for bullets.)${rogerDirective}${schefterModeDirective}${recentBlock}\n\nGOSSIP_TIPS:\n${JSON.stringify(anonymized, null, 2)}`;
+    userMessage = `MAILBAG: Friday news-dump. Apply HARD RULE 20 — bullet each topic in the GOSSIP_TIPS array as a one-liner (≤6 bullets). Open with a mailbag framing and sign off at the end. ${jsonContract} (Newlines inside the post string are fine for bullets.)${rogerDirective}${schefterModeDirective}${busyMorningDirective}${corroborationDirective}${recentBlock}\n\nGOSSIP_TIPS:\n${JSON.stringify(anonymized, null, 2)}`;
   } else {
-    userMessage = `Synthesize these tips into ONE rumor-mill post (1–2 sentences, one topic). ${jsonContract}${rogerDirective}${schefterModeDirective}${recentBlock}\n\nTIPS:\n${JSON.stringify(anonymized, null, 2)}`;
+    userMessage = `Synthesize these tips into ONE rumor-mill post (1–2 sentences, one topic). ${jsonContract}${rogerDirective}${schefterModeDirective}${busyMorningDirective}${corroborationDirective}${recentBlock}\n\nTIPS:\n${JSON.stringify(anonymized, null, 2)}`;
   }
 
   if (DRY_RUN) {
@@ -2254,6 +2358,14 @@ async function main() {
   let postKind; // 'trade' | 'gossip' | 'mailbag'
   let batch;
   let secondaryBatch = null;
+  // Busy-morning catch-up: when the morning window opens with 2+ trade
+  // tips waiting, the scanner ships TWO trade-offer beats this cycle
+  // (each its own post; both consume one MAX_POSTS_PER_DAY slot). The
+  // flag below is also passed into the LLM so Schefter acknowledges the
+  // overnight volume in-voice (rule: investigative-reporter energy, not
+  // breathless headline shouting).
+  let busyMorning = false;
+  let busyMorningBacklog = 0;
 
   if (mailbagBatch) {
     postKind = 'mailbag';
@@ -2277,10 +2389,10 @@ async function main() {
     // independent feed post in the SAME scan cycle. Both posts count as
     // one slot against the daily + gossip caps, but each has its own
     // post id so reactions, comments, and whisper-back threads stay
-    // separate. Trade-rumor posts never carry a secondary — they stay
-    // strictly single-topic.
+    // separate. Trade-rumor posts get the same two-post pattern under the
+    // busy-morning catch-up rule below — see BUSY_MORNING_END_HOUR.
     //
-    // The secondary only fires under real backlog pressure
+    // The gossip secondary only fires under real backlog pressure
     // (>= SECONDARY_GOSSIP_POST_PRESSURE gossip tips queued). Below that
     // threshold we ship a single post and let the secondary bucket wait
     // its turn — the two-post double is a pile-up catch-up mechanism,
@@ -2294,6 +2406,27 @@ async function main() {
         log(`  Holding ${secondaryBucket.key} for next cycle — gossip queue depth ${gossipQueueDepth} < ${SECONDARY_GOSSIP_POST_PRESSURE} (no pile-up pressure)`);
       }
     }
+
+    // Busy-morning trade catch-up: the trade bucket key is `trade:offer`
+    // (all trade-offer tips share one bucket — see schefter-bucket-logic
+    // .mjs), so pickPrimaryBucket only ever returns one trade bucket.
+    // To ship 2 trade-offer posts in this cycle, we split the trade
+    // bucket's tips: oldest tip → primary beat, next-oldest → secondary
+    // beat. Each becomes its own post with its own anonymization pass.
+    if (
+      postKind === 'trade' &&
+      primaryBucket.tips.length >= BUSY_MORNING_TRADE_THRESHOLD &&
+      isBusyMorningWindow(now)
+    ) {
+      busyMorning = true;
+      busyMorningBacklog = primaryBucket.tips.length;
+      const sortedTips = [...primaryBucket.tips].sort(
+        (a, b) => (a.submittedAt ?? 0) - (b.submittedAt ?? 0),
+      );
+      batch = sortedTips.slice(0, 1);
+      secondaryBatch = sortedTips.slice(1, 2);
+      log(`  [busy-morning] Trade backlog ${busyMorningBacklog} — splitting into 2 beats (one slot)`);
+    }
   }
 
   const batchIds = new Set([
@@ -2302,6 +2435,26 @@ async function main() {
   ]);
   const unusedTips = freshTips.filter((t) => !batchIds.has(t.id));
   log(`  Processing batch of ${batch.length}${secondaryBatch ? ` + ${secondaryBatch.length} secondary` : ''} (holding ${unusedTips.length} for next cycle)`);
+
+  // Cross-corroboration. For each trade-offer tip about to ship, check
+  // whether the rest of the queue contains independent web/groupme tips
+  // pointing at the same offer (matching franchise scope on a trade-topic
+  // tip, or a player-name substring match in the text). The resulting
+  // count flows through anonymization to the LLM, which upgrades to
+  // direct-knowledge voice. Mutates the tip objects in place — the
+  // anonymizer reads the count off the tip and surfaces it to the LLM.
+  const corroborationCandidates = freshTips; // include batch + leftovers
+  for (const tipBatch of [batch, secondaryBatch].filter(Boolean)) {
+    for (const tip of tipBatch) {
+      if (tip.source !== 'trade_offer') continue;
+      const others = corroborationCandidates.filter((t) => t.id !== tip.id);
+      const matches = findCorroboratingTips(tip, others);
+      if (matches.length > 0) {
+        tip.corroboratingSourceCount = matches.length;
+        log(`  [corroboration] ${tip.id} matched ${matches.length} independent tip(s): ${matches.join(', ')}`);
+      }
+    }
+  }
 
   // Anonymize — load the feed early so whisper-back tips can pull parent
   // headline snippets into their scope.
@@ -2351,15 +2504,17 @@ async function main() {
   // Build the list of "beats" — one per independent feed post we'll ship
   // this cycle. Most post kinds produce exactly one beat; a two-topic
   // gossip cycle produces TWO beats (independent post IDs, independent
-  // reactions/threads) even though they share the same cap slot.
+  // reactions/threads) even though they share the same cap slot. Trade
+  // beats also produce two posts in busy-morning catch-up mode — see
+  // BUSY_MORNING_END_HOUR / BUSY_MORNING_TRADE_THRESHOLD above.
   const beats = [
     { batch, anonymized, kind: postKind },
   ];
-  if (secondaryBatch && postKind === 'gossip') {
+  if (secondaryBatch && (postKind === 'gossip' || (postKind === 'trade' && busyMorning))) {
     beats.push({
       batch: secondaryBatch,
       anonymized: secondaryAnonymized,
-      kind: 'gossip',
+      kind: postKind,
     });
   }
   log(`  Producing ${beats.length} post(s) this cycle`);
@@ -2384,6 +2539,8 @@ async function main() {
       mode: aiMode,
       nflContext,
       schefterTargetMode: schefterModes[i],
+      busyMorning: busyMorning && beat.kind === 'trade',
+      busyMorningBacklog: busyMorning ? busyMorningBacklog : 0,
     })),
   );
 

--- a/scripts/schefter-rumor-scan.mjs
+++ b/scripts/schefter-rumor-scan.mjs
@@ -223,27 +223,59 @@ function buildTradeBuilderPath(franchiseId) {
 }
 
 /**
- * Resolve the CTA for a post based on its primary bucket. Trade-bait
- * posts targeted at a single franchise swap the default tip-page CTA
- * for a Trade Builder deep-link; everything else uses the tip page.
- * Returns all three rendering targets (feed link, feed label, GroupMe
- * URL suffix) so the post builder + groupMeTextFor stay in sync.
+ * A tip is "trade-flavored" if it's about trades in any way — actual MFL
+ * pending offers, owner-listed trade bait, or web/groupme speculation with
+ * topic === 'trade'. All three send readers to the Trade Builder so the
+ * natural next click is to build a counter-offer, not to whisper back.
+ *
+ * Whisper-back tips (`repliesToPostId`) are excluded — the user explicitly
+ * chose to reply to a non-trade rumor; we honor that lane.
+ */
+function isTradeFlavoredTip(tip) {
+  if (!tip) return false;
+  if (tip.source === 'trade_offer' || tip.source === 'trade_bait') return true;
+  if (tip.repliesToPostId) return false;
+  return tip.topic === 'trade';
+}
+
+/**
+ * Bare Trade Builder path used when a trade-flavored rumor doesn't resolve
+ * to a single franchise (league-wide speculation, or a multi-franchise
+ * cluster). Owners land on the empty builder and pick from there.
+ */
+const TRADE_BUILDER_PATH = '/theleague/trade-builder';
+
+/**
+ * Resolve the CTA for a post based on its primary bucket.
+ *
+ * Trade-flavored beats (any tip with source 'trade_offer'/'trade_bait' or
+ * topic 'trade') route to the Trade Builder — single-franchise scope
+ * pre-loads via `?b=<fid>`, multi-franchise or league-wide drops to the
+ * bare builder. Everything else (commish beef, roster gripes, predictions,
+ * other) keeps the tip-page CTA so readers can whisper a follow-up.
+ *
+ * Returns the feed link, feed label, GroupMe prefix, and absolute GroupMe
+ * URL so the post builder + groupMeTextFor stay in sync.
  */
 function resolveCta(primaryBucket) {
   const tips = primaryBucket?.tips ?? [];
-  const allTradeBait = tips.length > 0 && tips.every((t) => t.source === 'trade_bait');
-  if (allTradeBait) {
-    const franchiseIds = new Set(tips.map((t) => t.franchiseHint).filter(Boolean));
-    if (franchiseIds.size === 1) {
-      const [fid] = franchiseIds;
-      const path = buildTradeBuilderPath(fid);
-      return {
-        link: path,
-        linkLabel: TRADE_BUILDER_LINK_LABEL,
-        groupMePrefix: TRADE_BUILDER_GROUPME_PREFIX,
-        groupMeUrl: `${PUBLIC_BASE_URL}${path}`,
-      };
-    }
+  const tradeFlavored = tips.length > 0 && tips.some(isTradeFlavoredTip);
+  if (tradeFlavored) {
+    const franchiseIds = new Set(
+      tips
+        .filter(isTradeFlavoredTip)
+        .map((t) => t.franchiseHint)
+        .filter((fid) => typeof fid === 'string' && fid !== 'league-wide' && fid !== 'commish'),
+    );
+    const path = franchiseIds.size === 1
+      ? buildTradeBuilderPath([...franchiseIds][0])
+      : TRADE_BUILDER_PATH;
+    return {
+      link: path,
+      linkLabel: TRADE_BUILDER_LINK_LABEL,
+      groupMePrefix: TRADE_BUILDER_GROUPME_PREFIX,
+      groupMeUrl: `${PUBLIC_BASE_URL}${path}`,
+    };
   }
   return {
     link: TIP_PAGE_PATH,
@@ -260,13 +292,20 @@ function resolveCta(primaryBucket) {
  * the tip form. Per HARD RULE 4b: this turns one-sided sniping into a thread,
  * which is the engagement-multiplier feature.
  *
+ * Skipped for trade-flavored beats — those route to the Trade Builder via
+ * resolveCta, and a directed tip-form link would override that. Owners who
+ * want to whisper back on a trade rumor can still tap the regular tip page.
+ *
  * Returns null when the beat doesn't qualify (no franchise-explicit-pick
- * scope, or the resolving tip has no franchiseHint).
+ * scope, the resolving tip has no franchiseHint, or any tip in the batch
+ * is trade-flavored).
  */
 function buildDirectedCta(beat) {
   const safe = beat?.anonymized?.[0];
   if (safe?.scope?.kind !== 'franchise-explicit-pick') return null;
-  const tip = beat?.batch?.find((t) => typeof t?.franchiseHint === 'string' && t.franchiseHint.length > 0);
+  const batch = beat?.batch ?? [];
+  if (batch.some(isTradeFlavoredTip)) return null;
+  const tip = batch.find((t) => typeof t?.franchiseHint === 'string' && t.franchiseHint.length > 0);
   const franchiseId = tip?.franchiseHint;
   if (!franchiseId) return null;
   const franchiseShort = safe.scope.franchise || `Team ${franchiseId}`;

--- a/scripts/schefter-rumor-scan.mjs
+++ b/scripts/schefter-rumor-scan.mjs
@@ -132,6 +132,7 @@ const FIRST_TIP_TS_KEY = 'schefter:tips:first_tip_ts';
 const TIPS_QUEUE_KEY = 'schefter:tips:queue';
 const TIPS_PROCESSED_KEY = 'schefter:tips:processed';
 const ROGER_LAST_RIFF_DATE_KEY = 'schefter:ask_roger:last_riff_date';
+const MORNING_GREETING_DATE_KEY = 'schefter:morning_greeting:last_used_date';
 
 // ── Phase 6: Trade-Offer Rumor Redis keys ──
 // Legacy key (pre-cumulative-probability model). Still read for dedup against
@@ -204,6 +205,14 @@ const QUIET_HOUR_END = 7;    // 7am PT
 // marker so Schefter acknowledges the overnight volume in-voice.
 const BUSY_MORNING_END_HOUR = 10; // 7:00–9:59 PT
 const BUSY_MORNING_TRADE_THRESHOLD = 2;
+
+// Morning-greeting window. The first post of the day (any kind, any tier)
+// in this window gets a "good morning, league" cold-open from the classic-
+// news / SportsCenter playbook. Once-per-PT-day — subsequent morning posts
+// go out greeting-less so we don't spam openers. Slightly wider than the
+// busy-morning window so a post that lands at 10:30 (just after the
+// catch-up window closes) still gets the greeting.
+const MORNING_GREETING_END_HOUR = 11; // 7:00–10:59 PT
 
 // Friday mailbag — one big roundup that sweeps the queue so nothing
 // expires unseen. Runs once per Friday PT. Same Redis-key TTL pattern as
@@ -441,6 +450,12 @@ function isBusyMorningWindow(now = new Date()) {
   const h = getPtHour(now);
   // morning catch-up: 07:00 (inclusive) through 09:59 PT
   return h >= QUIET_HOUR_END && h < BUSY_MORNING_END_HOUR;
+}
+
+function isMorningGreetingWindow(now = new Date()) {
+  const h = getPtHour(now);
+  // morning greeting: 07:00 (inclusive) through 10:59 PT
+  return h >= QUIET_HOUR_END && h < MORNING_GREETING_END_HOUR;
 }
 
 function getPtDateString(now = new Date()) {
@@ -1347,7 +1362,7 @@ function selectSchefterTargetMode(beat) {
   return pickSchefterTargetMode();
 }
 
-async function generateAiBody(anonymized, { rogerQuote, lore, recentPostsBlock, mode = 'single', nflContext = null, schefterTargetMode = null, busyMorning = false, busyMorningBacklog = 0 } = {}) {
+async function generateAiBody(anonymized, { rogerQuote, lore, recentPostsBlock, mode = 'single', nflContext = null, schefterTargetMode = null, busyMorning = false, busyMorningBacklog = 0, morningGreeting = false } = {}) {
   const apiKey = process.env.ANTHROPIC_API_KEY;
   if (!apiKey) {
     warn('  [rumor-scan] ANTHROPIC_API_KEY not set — using template');
@@ -1550,6 +1565,40 @@ A GroupMe author just took an off-topic personal shot at Schefter. This is the r
     busyMorningDirective = `\n\nBUSY_MORNING_CONTEXT: ${busyMorningBacklog} trade proposals crossed the desk overnight; this is one of two trade reports being filed this morning. Open with a brief, in-voice acknowledgment of the overnight volume — beat-reporter cadence ("phone's been ringing since 7", "plenty crossing the desk this morning", "league sources kept the desk up overnight", "stack of message slips waiting", "busy morning around the league"). Vary the phrasing across posts; never stack two posts with the same opener. The acknowledgment is a tone marker on the lede, NOT the whole post — file the actual offer in the same 1–2 sentences. Investigative-reporter energy on proposed-trade rumors: phone calls, anonymous sources, message slips. NOT breathless headline shouting.`;
   }
 
+  // Morning greeting — once-per-day cold-open from the classic-news /
+  // SportsCenter playbook when the first post of the morning lands in
+  // the 07:00–10:59 PT window. The directive lists rotating phrasings so
+  // each morning sounds different. Stacks naturally with BUSY_MORNING_CONTEXT:
+  // if both fire, the LLM is instructed to merge them into ONE opener
+  // (e.g. "Morning, league. Phone's been ringing since 7.") instead of
+  // double-stacking two separate ledes.
+  let morningGreetingDirective = '';
+  if (morningGreeting) {
+    morningGreetingDirective = `\n\nMORNING_GREETING_CONTEXT: this is the first Schefter post of the day (PT). Cold-open with a brief, in-voice "good morning" line in the classic-news / sports-columnist tradition. Pick ONE pattern from the playbook (rotate across days; never reuse the same opener two days in a row):
+
+Beat-reporter / column openers:
+  - "Morning, league."
+  - "Top of the morning."
+  - "Pour yourself a cup."
+  - "First cup says it all."
+  - "Coffee's hot, so's the chatter."
+  - "Wake up to this."
+  - "Morning brief, league."
+
+Bryant Gumbel / Today Show:
+  - "Up and at 'em."
+  - "Bright and early."
+
+SportsCenter / SVP:
+  - "Welcome to your morning."
+  - "Set your coffee down."
+
+Howard Cosell echo (USE ONLY when the post names a single specific franchise — i.e. "franchise-multi-source" or "franchise-explicit-pick" or "trade-bait" scope):
+  - "Good morning to everyone except the [Franchise]."
+
+The greeting is a SHORT (2–6 words) cold-open BEFORE the actual post body — a tone marker, not the whole post. Keep total length 1–2 sentences. If BUSY_MORNING_CONTEXT also fires, MERGE the two — one combined opener (e.g. "Morning, league. Phone's been ringing since 7.") — never two separate ledes. NEVER use the Cosell pattern with anonymous / division / league-wide / commish scope (it requires naming a franchise; doing so on an anonymous-scope post leaks identity).`;
+  }
+
   // Corroboration upgrade — when an MFL pending offer is being whispered
   // about independently (a tip in the queue carries
   // corroboratingSourceCount >= 1), elevate the voice to direct-knowledge
@@ -1571,9 +1620,9 @@ A GroupMe author just took an off-topic personal shot at Schefter. This is the r
 
   let userMessage;
   if (mode === 'mailbag') {
-    userMessage = `MAILBAG: Friday news-dump. Apply HARD RULE 20 — bullet each topic in the GOSSIP_TIPS array as a one-liner (≤6 bullets). Open with a mailbag framing and sign off at the end. ${jsonContract} (Newlines inside the post string are fine for bullets.)${rogerDirective}${schefterModeDirective}${busyMorningDirective}${corroborationDirective}${recentBlock}\n\nGOSSIP_TIPS:\n${JSON.stringify(anonymized, null, 2)}`;
+    userMessage = `MAILBAG: Friday news-dump. Apply HARD RULE 20 — bullet each topic in the GOSSIP_TIPS array as a one-liner (≤6 bullets). Open with a mailbag framing and sign off at the end. ${jsonContract} (Newlines inside the post string are fine for bullets.)${rogerDirective}${schefterModeDirective}${morningGreetingDirective}${busyMorningDirective}${corroborationDirective}${recentBlock}\n\nGOSSIP_TIPS:\n${JSON.stringify(anonymized, null, 2)}`;
   } else {
-    userMessage = `Synthesize these tips into ONE rumor-mill post (1–2 sentences, one topic). ${jsonContract}${rogerDirective}${schefterModeDirective}${busyMorningDirective}${corroborationDirective}${recentBlock}\n\nTIPS:\n${JSON.stringify(anonymized, null, 2)}`;
+    userMessage = `Synthesize these tips into ONE rumor-mill post (1–2 sentences, one topic). ${jsonContract}${rogerDirective}${schefterModeDirective}${morningGreetingDirective}${busyMorningDirective}${corroborationDirective}${recentBlock}\n\nTIPS:\n${JSON.stringify(anonymized, null, 2)}`;
   }
 
   if (DRY_RUN) {
@@ -2501,6 +2550,21 @@ async function main() {
     log(`  [roger-riff] Dice roll failed — no riff this cycle`);
   }
 
+  // Morning greeting — once per PT day, when the first post lands in the
+  // 07:00–10:59 PT window, the LLM gets a directive to cold-open with a
+  // classic-news / sports-column "good morning" line. The Redis key is
+  // stamped only on successful post commit (alongside last_post_ts and
+  // ROGER_LAST_RIFF_DATE_KEY) so a failed cycle doesn't burn the slot.
+  let morningGreeting = false;
+  let lastMorningGreetingDate = null;
+  if (isMorningGreetingWindow(now)) {
+    try {
+      lastMorningGreetingDate = await redis.get(MORNING_GREETING_DATE_KEY);
+    } catch { /* tolerate */ }
+    morningGreeting = lastMorningGreetingDate !== todayPt;
+    log(`  [morning-greeting] window open, todayPT=${todayPt}, lastUsed=${lastMorningGreetingDate ?? '(none)'} → ${morningGreeting ? 'will fire on primary beat' : 'already greeted today'}`);
+  }
+
   // Build the list of "beats" — one per independent feed post we'll ship
   // this cycle. Most post kinds produce exactly one beat; a two-topic
   // gossip cycle produces TWO beats (independent post IDs, independent
@@ -2529,7 +2593,8 @@ async function main() {
   const schefterModes = beats.map((beat) => selectSchefterTargetMode(beat));
 
   // Generate bodies in parallel. Only the primary beat gets the Roger
-  // riff — the riff is a once-per-day cameo that shouldn't double up.
+  // riff and the morning greeting — both are once-per-day cameos that
+  // shouldn't double up across beats in the same cycle.
   const aiMode = postKind === 'mailbag' ? 'mailbag' : 'single';
   const aiBodies = await Promise.all(
     beats.map((beat, i) => generateAiBody(beat.anonymized, {
@@ -2541,6 +2606,7 @@ async function main() {
       schefterTargetMode: schefterModes[i],
       busyMorning: busyMorning && beat.kind === 'trade',
       busyMorningBacklog: busyMorning ? busyMorningBacklog : 0,
+      morningGreeting: i === 0 && morningGreeting,
     })),
   );
 
@@ -2804,7 +2870,14 @@ async function main() {
       await redis.set(ROGER_LAST_RIFF_DATE_KEY, todayPt, { ex: 48 * 60 * 60 });
     }
 
-    log(`  Redis updated: posts_today=${newCount}, queue drained, processed archived${hadRogerRiff ? ', roger riff date stamped' : ''}`);
+    // Morning greeting date stamp — only set when we actually fired the
+    // greeting on this cycle, so a failed post doesn't burn the slot. 48h
+    // TTL mirrors the Roger pattern so clock skew can't strand the key.
+    if (morningGreeting) {
+      await redis.set(MORNING_GREETING_DATE_KEY, todayPt, { ex: 48 * 60 * 60 });
+    }
+
+    log(`  Redis updated: posts_today=${newCount}, queue drained, processed archived${hadRogerRiff ? ', roger riff date stamped' : ''}${morningGreeting ? ', morning greeting stamped' : ''}`);
   } catch (err) {
     warn(`  Redis post-write update failed: ${err.message}`);
   }

--- a/scripts/schefter-rumor-scan.mjs
+++ b/scripts/schefter-rumor-scan.mjs
@@ -1593,6 +1593,14 @@ SportsCenter / SVP:
   - "Welcome to your morning."
   - "Set your coffee down."
 
+Adam Schefter signature (his real voice — sourcing tic + morning context):
+  - "Just got off the phone, league."
+  - "Sources up early."
+  - "Per my sources, morning brief."
+  - "I'm told the league's already moving."
+  - "League sources checking in."
+  - "BREAKING: morning brief."
+
 Howard Cosell echo (USE ONLY when the post names a single specific franchise — i.e. "franchise-multi-source" or "franchise-explicit-pick" or "trade-bait" scope):
   - "Good morning to everyone except the [Franchise]."
 

--- a/src/pages/api/schefter/cooker-status.ts
+++ b/src/pages/api/schefter/cooker-status.ts
@@ -13,8 +13,25 @@
  *     postsToday: number,
  *     dailyCap: number,
  *     dailyCapHit: boolean,
- *     marinateWindowMs: number
+ *     marinateWindowMs: number,
+ *     heat: 'quiet' | 'simmer' | 'rolling' | 'boil' | 'overflow',
+ *     backloggedHint: boolean
  *   }
+ *
+ * `heat` is the soft popularity signal — a tier derived from queueDepth that
+ * the tip page renders as a badge so owners can see Schefter heating up
+ * without exposing exact counts as the only signal. Thresholds align with
+ * the scanner's own pressure points so the public copy stays in sync with
+ * the scanner's internal escalation:
+ *   - 0           quiet     — empty queue
+ *   - 1–3         simmer    — normal trickle
+ *   - 4–5         rolling   — secondary-gossip-post pressure (SECONDARY_GOSSIP_POST_PRESSURE)
+ *   - 6–9         boil      — gossip cap auto-bumps to 2/day (GOSSIP_BOOST_QUEUE_DEPTH)
+ *   - 10+         overflow  — exceeds MAX_TIPS_PER_BATCH; leftovers will roll to next cycle
+ *
+ * `backloggedHint` is true when heat ∈ {boil, overflow} — the tip page uses
+ * it to append a "your tip may marinate longer than usual" note so owners
+ * self-throttle without us hard-rejecting on submit.
  *
  * No identity signal — returns counts only. Queue contents are NEVER returned.
  */
@@ -32,6 +49,24 @@ const RUMOR_POSTS_TODAY_KEY = 'schefter:rumor:posts_today';
 const MARINATE_WINDOW_MS = 60 * 60 * 1000;
 const DAILY_CAP = 3;
 
+// Heat tier thresholds — kept in sync with the scanner's escalation in
+// scripts/schefter-rumor-scan.mjs. Both endpoints read the same Redis list,
+// so when scanner-side constants change these MUST move with them.
+export const HEAT_SIMMER_MIN = 1;     // 1-3 tips
+export const HEAT_ROLLING_MIN = 4;    // SECONDARY_GOSSIP_POST_PRESSURE
+export const HEAT_BOIL_MIN = 6;       // GOSSIP_BOOST_QUEUE_DEPTH
+export const HEAT_OVERFLOW_MIN = 10;  // MAX_TIPS_PER_BATCH
+
+export type Heat = 'quiet' | 'simmer' | 'rolling' | 'boil' | 'overflow';
+
+export function classifyHeat(queueDepth: number): Heat {
+  if (queueDepth >= HEAT_OVERFLOW_MIN) return 'overflow';
+  if (queueDepth >= HEAT_BOIL_MIN) return 'boil';
+  if (queueDepth >= HEAT_ROLLING_MIN) return 'rolling';
+  if (queueDepth >= HEAT_SIMMER_MIN) return 'simmer';
+  return 'quiet';
+}
+
 // In-process cache. The client polls /api/schefter/cooker-status every 60s
 // per open tab; under any concurrency at all we rack up Redis commands fast
 // (3 per request: LLEN + 2× GET). Cooker state changes slowly enough that a
@@ -47,6 +82,8 @@ type CookerSnapshot = {
   dailyCap: number;
   dailyCapHit: boolean;
   marinateWindowMs: number;
+  heat: Heat;
+  backloggedHint: boolean;
 };
 let _cache: { data: CookerSnapshot; expiresAt: number } | null = null;
 
@@ -115,6 +152,8 @@ export const GET: APIRoute = async () => {
       dailyCap: DAILY_CAP,
       dailyCapHit: false,
       marinateWindowMs: MARINATE_WINDOW_MS,
+      heat: 'quiet',
+      backloggedHint: false,
     };
     // Cache the zero state too — prevents a hot-path of Redis-missing
     // requests from re-running the import every poll.
@@ -143,6 +182,8 @@ export const GET: APIRoute = async () => {
   const dailyCapHit = postsToday >= DAILY_CAP;
   const nextEarliestPostAt =
     marinateStartedAt !== null ? marinateStartedAt + MARINATE_WINDOW_MS : null;
+  const heat = classifyHeat(queueDepth);
+  const backloggedHint = heat === 'boil' || heat === 'overflow';
 
   const snapshot: CookerSnapshot = {
     queueDepth,
@@ -152,6 +193,8 @@ export const GET: APIRoute = async () => {
     dailyCap: DAILY_CAP,
     dailyCapHit,
     marinateWindowMs: MARINATE_WINDOW_MS,
+    heat,
+    backloggedHint,
   };
   _cache = { data: snapshot, expiresAt: now + CACHE_TTL_MS };
   return json(snapshot);

--- a/src/pages/theleague/schefter/tip.astro
+++ b/src/pages/theleague/schefter/tip.astro
@@ -385,7 +385,15 @@ const preselectTeam = (() => {
           <h2 class="section-header__title" id="cooker-title">Schefter's kitchen</h2>
           <p class="section-header__sub" data-cooker-sub>Checking on the pot…</p>
         </div>
+        <div class="tip-rail-cooker__heat" data-cooker-heat hidden>
+          <span class="tip-rail-cooker__heat-dot" aria-hidden="true"></span>
+          <span class="tip-rail-cooker__heat-label" data-cooker-heat-label></span>
+        </div>
         <p class="tip-rail-cooker__body" data-cooker-body>Loading…</p>
+        <p class="tip-rail-cooker__hint" data-cooker-hint hidden>
+          Schefter's slammed — tips coming in faster than he can file. Yours
+          may marinate longer than usual before it surfaces.
+        </p>
       </section>
 
       <section class="tip-rail-card tip-rail-hot" aria-labelledby="hot-title" data-hot-topics>
@@ -882,6 +890,73 @@ const preselectTeam = (() => {
     font-variant-numeric: tabular-nums;
   }
 
+  /* Heat badge — soft popularity signal. Color escalates with queue depth.
+     The dot pulses on boil/overflow as a passive "we hear you" indicator. */
+  .tip-rail-cooker__heat {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    padding: 0.1875rem 0.625rem;
+    border-radius: 999px;
+    font-size: 0.6875rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    align-self: flex-start;
+    background: var(--color-gray-50, #f9fafb);
+    color: var(--color-gray-600, #4b5563);
+    border: 1px solid var(--color-gray-100, #f3f4f6);
+  }
+  .tip-rail-cooker__heat-dot {
+    width: 0.4375rem;
+    height: 0.4375rem;
+    border-radius: 50%;
+    background: currentColor;
+    flex-shrink: 0;
+  }
+  .tip-rail-cooker[data-heat="quiet"] .tip-rail-cooker__heat {
+    color: var(--color-gray-500, #6b7280);
+  }
+  .tip-rail-cooker[data-heat="simmer"] .tip-rail-cooker__heat {
+    color: #047857;
+    background: color-mix(in srgb, #047857 8%, transparent);
+    border-color: color-mix(in srgb, #047857 20%, transparent);
+  }
+  .tip-rail-cooker[data-heat="rolling"] .tip-rail-cooker__heat {
+    color: #b45309;
+    background: color-mix(in srgb, #b45309 10%, transparent);
+    border-color: color-mix(in srgb, #b45309 24%, transparent);
+  }
+  .tip-rail-cooker[data-heat="boil"] .tip-rail-cooker__heat,
+  .tip-rail-cooker[data-heat="overflow"] .tip-rail-cooker__heat {
+    color: var(--color-error-dark, #b91c1c);
+    background: color-mix(in srgb, var(--color-error-dark, #b91c1c) 10%, transparent);
+    border-color: color-mix(in srgb, var(--color-error-dark, #b91c1c) 28%, transparent);
+  }
+  .tip-rail-cooker[data-heat="boil"] .tip-rail-cooker__heat-dot,
+  .tip-rail-cooker[data-heat="overflow"] .tip-rail-cooker__heat-dot {
+    animation: cooker-heat-pulse 1.6s ease-in-out infinite;
+  }
+  @keyframes cooker-heat-pulse {
+    0%, 100% { opacity: 1; transform: scale(1); }
+    50% { opacity: 0.5; transform: scale(0.7); }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .tip-rail-cooker__heat-dot { animation: none; }
+  }
+  .tip-rail-cooker__hint {
+    margin: 0;
+    font-size: 0.75rem;
+    line-height: 1.4;
+    font-style: italic;
+    color: var(--color-gray-600, #4b5563);
+    border-left: 2px solid color-mix(in srgb, var(--color-error-dark, #b91c1c) 35%, transparent);
+    padding-left: 0.5rem;
+  }
+  @media (prefers-color-scheme: dark) {
+    .tip-rail-cooker__hint { color: var(--color-gray-300, #d1d5db); }
+  }
+
   .tip-rail-hot__chips {
     display: flex;
     flex-wrap: wrap;
@@ -1367,6 +1442,36 @@ const preselectTeam = (() => {
   const cookerRoot = document.querySelector('[data-cooker-status]') as HTMLElement | null;
   const cookerBody = document.querySelector('[data-cooker-body]') as HTMLElement | null;
   const cookerSub = document.querySelector('[data-cooker-sub]') as HTMLElement | null;
+  const cookerHeat = document.querySelector('[data-cooker-heat]') as HTMLElement | null;
+  const cookerHeatLabel = document.querySelector('[data-cooker-heat-label]') as HTMLElement | null;
+  const cookerHint = document.querySelector('[data-cooker-hint]') as HTMLElement | null;
+
+  type Heat = 'quiet' | 'simmer' | 'rolling' | 'boil' | 'overflow';
+  // Soft popularity signal — labels escalate with queue depth so owners can
+  // see Schefter heating up. Tracks the server's heat thresholds in
+  // src/pages/api/schefter/cooker-status.ts.
+  const HEAT_LABELS: Record<Heat, string> = {
+    quiet: 'Quiet',
+    simmer: 'Simmer',
+    rolling: 'Rolling',
+    boil: 'On the boil',
+    overflow: 'Slammed',
+  };
+  function classifyHeatFallback(queueDepth: number): Heat {
+    if (queueDepth >= 10) return 'overflow';
+    if (queueDepth >= 6) return 'boil';
+    if (queueDepth >= 4) return 'rolling';
+    if (queueDepth >= 1) return 'simmer';
+    return 'quiet';
+  }
+  function applyHeat(heat: Heat, backloggedHint: boolean) {
+    if (cookerRoot) cookerRoot.setAttribute('data-heat', heat);
+    if (cookerHeat && cookerHeatLabel) {
+      cookerHeatLabel.textContent = HEAT_LABELS[heat];
+      cookerHeat.hidden = false;
+    }
+    if (cookerHint) cookerHint.hidden = !backloggedHint;
+  }
 
   function formatCountdown(ms: number): string {
     if (ms <= 0) return 'any minute now';
@@ -1393,6 +1498,13 @@ const preselectTeam = (() => {
       const postsToday = Number(data?.postsToday ?? 0);
       const dailyCap = Number(data?.dailyCap ?? 3);
       const dailyCapHit = data?.dailyCapHit === true || postsToday >= dailyCap;
+      // Heat tier — server classifies, but we fall back to the same thresholds
+      // if an old client hits a freshly-deployed server (or vice versa).
+      const heat: Heat = (typeof data?.heat === 'string' && (data.heat as Heat) in HEAT_LABELS)
+        ? (data.heat as Heat)
+        : classifyHeatFallback(queueDepth);
+      const backloggedHint = data?.backloggedHint === true;
+      applyHeat(heat, backloggedHint);
 
       if (dailyCapHit) {
         cookerRoot.setAttribute('data-state', 'capped');

--- a/tests/schefter-busy-morning.test.ts
+++ b/tests/schefter-busy-morning.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Busy-morning catch-up for trade-offer rumors.
+ *
+ * When the morning window opens (07:00–09:59 PT) with 2+ trade-offer tips
+ * waiting in the queue, the rumor-mill scanner ships TWO trade-offer beats
+ * in a single cycle (each its own post; both share one MAX_POSTS_PER_DAY
+ * slot) AND passes a "busy morning" tone directive to the LLM so Schefter
+ * acknowledges the overnight volume in-voice.
+ *
+ * The user's #1 goal is "get him to break real trade proposals," and the
+ * morning catch-up is what clears the overnight backlog faster than the
+ * default one-trade-per-cycle cadence.
+ *
+ * These tests pin the source-level behavior since the scanner is a long
+ * stateful runner — we validate the constants, the gating predicates, and
+ * the prompt construction via grep-asserted source guards plus a focused
+ * harness reimplementing the morning-window check.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+function read(rel: string): string {
+  return readFileSync(path.join(process.cwd(), rel), 'utf8');
+}
+
+const SCANNER_SRC = read('scripts/schefter-rumor-scan.mjs');
+
+describe('busy-morning constants', () => {
+  it('declares BUSY_MORNING_END_HOUR = 10 (07:00–09:59 PT window)', () => {
+    expect(SCANNER_SRC).toMatch(/const\s+BUSY_MORNING_END_HOUR\s*=\s*10/);
+  });
+
+  it('declares BUSY_MORNING_TRADE_THRESHOLD = 2', () => {
+    expect(SCANNER_SRC).toMatch(/const\s+BUSY_MORNING_TRADE_THRESHOLD\s*=\s*2/);
+  });
+
+  it('window starts at QUIET_HOUR_END so it opens the moment quiet hours close', () => {
+    // The predicate is `h >= QUIET_HOUR_END && h < BUSY_MORNING_END_HOUR`.
+    expect(SCANNER_SRC).toMatch(/h\s*>=\s*QUIET_HOUR_END\s*&&\s*h\s*<\s*BUSY_MORNING_END_HOUR/);
+  });
+});
+
+describe('isBusyMorningWindow predicate', () => {
+  // Reimplement the predicate to validate the boundary behavior. The real
+  // predicate uses Intl.DateTimeFormat for tz handling; here we test the
+  // pure logic against documented hour boundaries.
+  function isBusyMorningWindow(ptHour: number): boolean {
+    const QUIET_HOUR_END = 7;
+    const BUSY_MORNING_END_HOUR = 10;
+    return ptHour >= QUIET_HOUR_END && ptHour < BUSY_MORNING_END_HOUR;
+  }
+
+  it('rejects pre-7am (still quiet hours)', () => {
+    expect(isBusyMorningWindow(0)).toBe(false);
+    expect(isBusyMorningWindow(5)).toBe(false);
+    expect(isBusyMorningWindow(6)).toBe(false);
+  });
+
+  it('accepts the 07:00–09:59 window', () => {
+    expect(isBusyMorningWindow(7)).toBe(true);
+    expect(isBusyMorningWindow(8)).toBe(true);
+    expect(isBusyMorningWindow(9)).toBe(true);
+  });
+
+  it('rejects 10:00 onward (catch-up window closed)', () => {
+    expect(isBusyMorningWindow(10)).toBe(false);
+    expect(isBusyMorningWindow(12)).toBe(false);
+    expect(isBusyMorningWindow(20)).toBe(false);
+  });
+});
+
+describe('busy-morning split logic', () => {
+  it('triggers only when postKind === "trade"', () => {
+    // The block sits inside `if (postKind === 'trade' && ...)` — never
+    // splits gossip or mailbag buckets.
+    expect(SCANNER_SRC).toMatch(
+      /postKind === 'trade' &&\s*\n?\s*primaryBucket\.tips\.length >= BUSY_MORNING_TRADE_THRESHOLD/,
+    );
+  });
+
+  it('requires the morning window AND backlog threshold simultaneously', () => {
+    // Both conditions are AND'd together — neither alone is sufficient.
+    expect(SCANNER_SRC).toMatch(
+      /BUSY_MORNING_TRADE_THRESHOLD &&\s*\n?\s*isBusyMorningWindow\(now\)/,
+    );
+  });
+
+  it('sorts tips by submittedAt so oldest backlog goes first', () => {
+    expect(SCANNER_SRC).toMatch(
+      /sortedTips\s*=\s*\[\.\.\.primaryBucket\.tips\]\.sort\(/,
+    );
+    expect(SCANNER_SRC).toMatch(/a\.submittedAt\s*\?\?\s*0/);
+  });
+
+  it('takes exactly the first two tips (one per beat, never more)', () => {
+    expect(SCANNER_SRC).toMatch(/sortedTips\.slice\(0,\s*1\)/);
+    expect(SCANNER_SRC).toMatch(/sortedTips\.slice\(1,\s*2\)/);
+  });
+});
+
+describe('beat-building permits the secondary trade beat', () => {
+  it('allows secondary when postKind === "trade" AND busyMorning is set', () => {
+    // The condition: `postKind === 'gossip' || (postKind === 'trade' && busyMorning)`
+    // ensures normal trade cycles still emit a single beat.
+    expect(SCANNER_SRC).toMatch(
+      /postKind === 'gossip' \|\| \(postKind === 'trade' && busyMorning\)/,
+    );
+  });
+
+  it('uses postKind for the secondary beat kind (not hardcoded "gossip")', () => {
+    // After the change, the secondary beat inherits postKind so trade
+    // beats stay tagged as trade through downstream handling.
+    const beatPush = SCANNER_SRC.match(
+      /beats\.push\(\{[\s\S]*?secondaryBatch[\s\S]*?\}\)/,
+    )?.[0] ?? '';
+    expect(beatPush).toMatch(/kind:\s*postKind/);
+    expect(beatPush).not.toMatch(/kind:\s*['"]gossip['"]/);
+  });
+});
+
+describe('busy-morning directive in the LLM prompt', () => {
+  it('generateAiBody accepts busyMorning + busyMorningBacklog options', () => {
+    expect(SCANNER_SRC).toMatch(
+      /async function generateAiBody\([^)]*busyMorning\s*=\s*false[^)]*busyMorningBacklog\s*=\s*0/,
+    );
+  });
+
+  it('passes busyMorning per-beat (only when beat.kind === "trade")', () => {
+    // Directive doesn't apply to non-trade beats even if the cycle is busy.
+    expect(SCANNER_SRC).toMatch(/busyMorning:\s*busyMorning && beat\.kind === 'trade'/);
+  });
+
+  it('builds a BUSY_MORNING_CONTEXT directive when both conditions hold', () => {
+    expect(SCANNER_SRC).toMatch(/busyMorningDirective\s*=/);
+    expect(SCANNER_SRC).toMatch(/BUSY_MORNING_CONTEXT:/);
+    expect(SCANNER_SRC).toMatch(/trade proposals crossed the desk overnight/);
+  });
+
+  it('uses investigative-reporter framing (phone calls, message slips) NOT breathless shouting', () => {
+    expect(SCANNER_SRC).toMatch(/phone's been ringing/);
+    expect(SCANNER_SRC).toMatch(/league sources kept the desk up overnight/);
+    expect(SCANNER_SRC).toMatch(/NOT breathless headline shouting/);
+  });
+
+  it('splices the directive into both single and mailbag userMessage paths', () => {
+    // Both code paths must include busyMorningDirective in the template,
+    // otherwise the LLM never sees it.
+    const occurrences = SCANNER_SRC.match(/\$\{busyMorningDirective\}/g) ?? [];
+    expect(occurrences.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('only fires when busyMorningBacklog >= 2 (matches the trade-bucket threshold)', () => {
+    expect(SCANNER_SRC).toMatch(/busyMorning && busyMorningBacklog >= 2/);
+  });
+});
+
+describe('cap accounting — busy-morning posts share one slot', () => {
+  it('uses one MAX_POSTS_PER_DAY slot for the whole cycle (matches gossip secondary pattern)', () => {
+    // The cap-increment line increments by 1 regardless of beat count.
+    // We grep for the existing comment pattern that documents this.
+    expect(SCANNER_SRC).toMatch(/even with \$\{builtPosts\.length\} posts — counts as one cap slot/);
+  });
+});

--- a/tests/schefter-cooker-heat.test.ts
+++ b/tests/schefter-cooker-heat.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Heat-tier tests for the cooker-status endpoint.
+ *
+ * The heat tier is the soft popularity signal exposed to the tip page so
+ * owners can see Schefter heating up as the queue fills. The thresholds are
+ * deliberately aligned with the scanner's escalation points in
+ * scripts/schefter-rumor-scan.mjs — when the scanner constants move, the
+ * heat thresholds MUST move with them or the public copy will diverge from
+ * what the scanner is actually doing.
+ *
+ * These tests pin the boundaries and the alignment.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import {
+  classifyHeat,
+  HEAT_SIMMER_MIN,
+  HEAT_ROLLING_MIN,
+  HEAT_BOIL_MIN,
+  HEAT_OVERFLOW_MIN,
+} from '../src/pages/api/schefter/cooker-status';
+
+function read(rel: string): string {
+  return readFileSync(path.join(process.cwd(), rel), 'utf8');
+}
+
+describe('classifyHeat — boundary behavior', () => {
+  it('returns quiet for an empty queue', () => {
+    expect(classifyHeat(0)).toBe('quiet');
+  });
+
+  it('treats small trickle (1-3) as simmer', () => {
+    expect(classifyHeat(1)).toBe('simmer');
+    expect(classifyHeat(2)).toBe('simmer');
+    expect(classifyHeat(3)).toBe('simmer');
+  });
+
+  it('flips to rolling at the secondary-gossip-post pressure threshold', () => {
+    expect(classifyHeat(HEAT_ROLLING_MIN - 1)).toBe('simmer');
+    expect(classifyHeat(HEAT_ROLLING_MIN)).toBe('rolling');
+    expect(classifyHeat(5)).toBe('rolling');
+  });
+
+  it('flips to boil at the gossip-boost queue depth', () => {
+    expect(classifyHeat(HEAT_BOIL_MIN - 1)).toBe('rolling');
+    expect(classifyHeat(HEAT_BOIL_MIN)).toBe('boil');
+    expect(classifyHeat(9)).toBe('boil');
+  });
+
+  it('flips to overflow once the batch limit is exceeded', () => {
+    expect(classifyHeat(HEAT_OVERFLOW_MIN - 1)).toBe('boil');
+    expect(classifyHeat(HEAT_OVERFLOW_MIN)).toBe('overflow');
+    expect(classifyHeat(50)).toBe('overflow');
+  });
+});
+
+describe('heat thresholds align with scanner constants', () => {
+  // The scanner's pressure points are the source of truth for what counts
+  // as "busy". If these constants ever drift from cooker-status, the public
+  // popularity signal stops matching what the scanner is actually doing.
+  const scannerSrc = read('scripts/schefter-rumor-scan.mjs');
+
+  function readNumericConst(name: string): number {
+    const match = scannerSrc.match(new RegExp(`const\\s+${name}\\s*=\\s*(\\d+)`));
+    if (!match) throw new Error(`Could not find ${name} in schefter-rumor-scan.mjs`);
+    return Number(match[1]);
+  }
+
+  it('HEAT_ROLLING_MIN matches SECONDARY_GOSSIP_POST_PRESSURE', () => {
+    expect(HEAT_ROLLING_MIN).toBe(readNumericConst('SECONDARY_GOSSIP_POST_PRESSURE'));
+  });
+
+  it('HEAT_BOIL_MIN matches GOSSIP_BOOST_QUEUE_DEPTH', () => {
+    expect(HEAT_BOIL_MIN).toBe(readNumericConst('GOSSIP_BOOST_QUEUE_DEPTH'));
+  });
+
+  it('HEAT_OVERFLOW_MIN matches MAX_TIPS_PER_BATCH', () => {
+    expect(HEAT_OVERFLOW_MIN).toBe(readNumericConst('MAX_TIPS_PER_BATCH'));
+  });
+
+  it('thresholds increase strictly monotonically', () => {
+    expect(HEAT_SIMMER_MIN).toBeLessThan(HEAT_ROLLING_MIN);
+    expect(HEAT_ROLLING_MIN).toBeLessThan(HEAT_BOIL_MIN);
+    expect(HEAT_BOIL_MIN).toBeLessThan(HEAT_OVERFLOW_MIN);
+  });
+});
+
+describe('cooker-status response shape includes heat fields', () => {
+  const src = read('src/pages/api/schefter/cooker-status.ts');
+
+  it('declares heat on the snapshot type', () => {
+    expect(src).toMatch(/heat:\s*Heat/);
+  });
+
+  it('declares backloggedHint on the snapshot type', () => {
+    expect(src).toMatch(/backloggedHint:\s*boolean/);
+  });
+
+  it('only sets backloggedHint when heat is boil or overflow', () => {
+    // Spot-check the live fn — the JSON write path uses these values.
+    // We don't have a live Redis here, so cover the boundaries directly.
+    expect(classifyHeat(HEAT_BOIL_MIN - 1)).not.toMatch(/boil|overflow/);
+    expect(classifyHeat(HEAT_BOIL_MIN)).toMatch(/boil|overflow/);
+    expect(classifyHeat(HEAT_OVERFLOW_MIN)).toMatch(/boil|overflow/);
+  });
+});

--- a/tests/schefter-morning-greeting.test.ts
+++ b/tests/schefter-morning-greeting.test.ts
@@ -141,6 +141,18 @@ describe('MORNING_GREETING_CONTEXT directive in the LLM prompt', () => {
     expect(SCANNER_SRC).toMatch(/Set your coffee down\./);
   });
 
+  it('lists Adam Schefter signature cold-opens (real voice tics)', () => {
+    // Schefter's actual sourcing tics adapted for morning context — keeps
+    // the bot's voice anchored to the real reporter on top of the broader
+    // news-broadcasting tradition above. See conversation history for
+    // the rationale behind including this register.
+    expect(SCANNER_SRC).toMatch(/Just got off the phone, league\./);
+    expect(SCANNER_SRC).toMatch(/Sources up early\./);
+    expect(SCANNER_SRC).toMatch(/Per my sources, morning brief\./);
+    expect(SCANNER_SRC).toMatch(/I'm told the league's already moving\./);
+    expect(SCANNER_SRC).toMatch(/BREAKING: morning brief\./);
+  });
+
   it('includes the Howard Cosell echo gated to single-franchise scopes', () => {
     expect(SCANNER_SRC).toMatch(
       /Good morning to everyone except the \[Franchise\]/,

--- a/tests/schefter-morning-greeting.test.ts
+++ b/tests/schefter-morning-greeting.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Morning greeting — once-per-PT-day cold-open from the classic-news /
+ * sports-columnist playbook on the first Schefter post of the morning.
+ *
+ * Window:    07:00–10:59 PT (slightly wider than the busy-morning catch-up
+ *            window so a 10:30am post still lands a greeting).
+ * Frequency: once per PT day. Stamped in Redis under MORNING_GREETING_DATE_KEY
+ *            after the post commits — failed cycles don't burn the slot.
+ * Scope:     primary beat only. Secondary beats in the same cycle (busy-
+ *            morning trade catch-up) skip the greeting so we don't double
+ *            up two cold-opens in one cycle.
+ *
+ * Voice library (per the user's "classic news / sports references" ask):
+ * - Beat-reporter: "Morning, league.", "Top of the morning.", "Pour yourself a cup."
+ * - Bryant Gumbel / Today: "Up and at 'em.", "Bright and early."
+ * - SportsCenter / SVP: "Welcome to your morning."
+ * - Howard Cosell echo: "Good morning to everyone except the [Franchise]."
+ *   (gated to scopes that already permit naming a single franchise)
+ *
+ * The directive is instructed to MERGE with BUSY_MORNING_CONTEXT when both
+ * fire, producing one combined opener instead of two stacked ledes.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+function read(rel: string): string {
+  return readFileSync(path.join(process.cwd(), rel), 'utf8');
+}
+
+const SCANNER_SRC = read('scripts/schefter-rumor-scan.mjs');
+
+describe('morning-greeting constants + Redis key', () => {
+  it('declares MORNING_GREETING_END_HOUR = 11 (07:00–10:59 PT window)', () => {
+    expect(SCANNER_SRC).toMatch(/const\s+MORNING_GREETING_END_HOUR\s*=\s*11/);
+  });
+
+  it('declares the Redis date key under the schefter:morning_greeting namespace', () => {
+    expect(SCANNER_SRC).toMatch(
+      /MORNING_GREETING_DATE_KEY\s*=\s*['"]schefter:morning_greeting:last_used_date['"]/,
+    );
+  });
+});
+
+describe('isMorningGreetingWindow predicate', () => {
+  function isMorningGreetingWindow(ptHour: number): boolean {
+    const QUIET_HOUR_END = 7;
+    const MORNING_GREETING_END_HOUR = 11;
+    return ptHour >= QUIET_HOUR_END && ptHour < MORNING_GREETING_END_HOUR;
+  }
+
+  it('rejects pre-7am quiet hours', () => {
+    expect(isMorningGreetingWindow(0)).toBe(false);
+    expect(isMorningGreetingWindow(5)).toBe(false);
+    expect(isMorningGreetingWindow(6)).toBe(false);
+  });
+
+  it('accepts the full 07:00–10:59 window', () => {
+    expect(isMorningGreetingWindow(7)).toBe(true);
+    expect(isMorningGreetingWindow(8)).toBe(true);
+    expect(isMorningGreetingWindow(9)).toBe(true);
+    expect(isMorningGreetingWindow(10)).toBe(true);
+  });
+
+  it('rejects 11:00 onward (greeting window closed)', () => {
+    expect(isMorningGreetingWindow(11)).toBe(false);
+    expect(isMorningGreetingWindow(15)).toBe(false);
+    expect(isMorningGreetingWindow(22)).toBe(false);
+  });
+
+  it('extends past the busy-morning window so a 10:30am post still gets greeted', () => {
+    // BUSY_MORNING_END_HOUR is 10; greeting window goes to 11 so the 10:00–10:59
+    // hour is greeting-eligible but not busy-morning-eligible.
+    function isBusyMorningWindow(ptHour: number): boolean {
+      return ptHour >= 7 && ptHour < 10;
+    }
+    expect(isMorningGreetingWindow(10)).toBe(true);
+    expect(isBusyMorningWindow(10)).toBe(false);
+  });
+});
+
+describe('once-per-day Redis gate', () => {
+  it('reads lastMorningGreetingDate from MORNING_GREETING_DATE_KEY', () => {
+    expect(SCANNER_SRC).toMatch(/redis\.get\(MORNING_GREETING_DATE_KEY\)/);
+  });
+
+  it('flips morningGreeting=true only when stored date !== todayPt', () => {
+    expect(SCANNER_SRC).toMatch(/morningGreeting\s*=\s*lastMorningGreetingDate\s*!==\s*todayPt/);
+  });
+
+  it('only checks Redis when the window is open (avoids unnecessary calls)', () => {
+    expect(SCANNER_SRC).toMatch(/if \(isMorningGreetingWindow\(now\)\)/);
+  });
+
+  it('stamps the date in Redis only after a successful post commit', () => {
+    // The set call lives inside the same try/catch as last_post_ts and the
+    // Roger riff stamp — failed cycles don't write.
+    expect(SCANNER_SRC).toMatch(
+      /if \(morningGreeting\) \{\s*\n?\s*await redis\.set\(MORNING_GREETING_DATE_KEY,\s*todayPt,\s*\{\s*ex:\s*48\s*\*\s*60\s*\*\s*60\s*\}\s*\)/,
+    );
+  });
+
+  it('uses 48h TTL to mirror the Roger riff pattern (clock-skew tolerant)', () => {
+    expect(SCANNER_SRC).toMatch(
+      /MORNING_GREETING_DATE_KEY[\s\S]{0,80}48\s*\*\s*60\s*\*\s*60/,
+    );
+  });
+});
+
+describe('greeting fires only on the primary beat', () => {
+  it('passes morningGreeting only when i === 0', () => {
+    expect(SCANNER_SRC).toMatch(/morningGreeting:\s*i === 0 && morningGreeting/);
+  });
+});
+
+describe('MORNING_GREETING_CONTEXT directive in the LLM prompt', () => {
+  it('generateAiBody accepts a morningGreeting option', () => {
+    expect(SCANNER_SRC).toMatch(
+      /async function generateAiBody\([^)]*morningGreeting\s*=\s*false[^)]*\)/,
+    );
+  });
+
+  it('builds a MORNING_GREETING_CONTEXT directive when the flag is set', () => {
+    expect(SCANNER_SRC).toMatch(/morningGreetingDirective\s*=/);
+    expect(SCANNER_SRC).toMatch(/MORNING_GREETING_CONTEXT:/);
+  });
+
+  it('lists beat-reporter / column openers (Morning league, Top of the morning, Pour yourself a cup)', () => {
+    expect(SCANNER_SRC).toMatch(/Morning, league\./);
+    expect(SCANNER_SRC).toMatch(/Top of the morning\./);
+    expect(SCANNER_SRC).toMatch(/Pour yourself a cup\./);
+  });
+
+  it('lists the Bryant Gumbel / Today Show patterns', () => {
+    expect(SCANNER_SRC).toMatch(/Up and at 'em\./);
+    expect(SCANNER_SRC).toMatch(/Bright and early\./);
+  });
+
+  it('lists the SportsCenter / SVP cold-opens', () => {
+    expect(SCANNER_SRC).toMatch(/Welcome to your morning\./);
+    expect(SCANNER_SRC).toMatch(/Set your coffee down\./);
+  });
+
+  it('includes the Howard Cosell echo gated to single-franchise scopes', () => {
+    expect(SCANNER_SRC).toMatch(
+      /Good morning to everyone except the \[Franchise\]/,
+    );
+    expect(SCANNER_SRC).toMatch(/franchise-multi-source/);
+    expect(SCANNER_SRC).toMatch(/franchise-explicit-pick/);
+    expect(SCANNER_SRC).toMatch(/trade-bait/);
+  });
+
+  it('forbids the Cosell pattern on anonymous scopes (privacy guard)', () => {
+    expect(SCANNER_SRC).toMatch(/NEVER use the Cosell pattern with anonymous/);
+  });
+
+  it('instructs the LLM to MERGE with BUSY_MORNING_CONTEXT (one combined opener)', () => {
+    expect(SCANNER_SRC).toMatch(/If BUSY_MORNING_CONTEXT also fires, MERGE the two/);
+    expect(SCANNER_SRC).toMatch(/never two separate ledes/);
+  });
+
+  it('caps the greeting at a tone marker, not the whole post', () => {
+    expect(SCANNER_SRC).toMatch(/SHORT \(2–6 words\)/);
+    expect(SCANNER_SRC).toMatch(/total length 1–2 sentences/);
+  });
+
+  it('splices the directive into both single and mailbag userMessage paths', () => {
+    const occurrences = SCANNER_SRC.match(/\$\{morningGreetingDirective\}/g) ?? [];
+    expect(occurrences.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('places greeting BEFORE busy-morning + corroboration directives in the prompt order', () => {
+    // Order matters: greeting opens the message, busy-morning + corroboration
+    // qualify the body. The single-mode userMessage template must list
+    // morningGreetingDirective before busyMorningDirective and corroborationDirective.
+    const userMessageTemplate = SCANNER_SRC.match(
+      /Synthesize these tips into ONE rumor-mill post[\s\S]*?TIPS:/,
+    )?.[0] ?? '';
+    const greetIdx = userMessageTemplate.indexOf('morningGreetingDirective');
+    const busyIdx = userMessageTemplate.indexOf('busyMorningDirective');
+    const corrIdx = userMessageTemplate.indexOf('corroborationDirective');
+    expect(greetIdx).toBeGreaterThan(-1);
+    expect(busyIdx).toBeGreaterThan(-1);
+    expect(corrIdx).toBeGreaterThan(-1);
+    expect(greetIdx).toBeLessThan(busyIdx);
+    expect(greetIdx).toBeLessThan(corrIdx);
+  });
+});

--- a/tests/schefter-tight-end-files.test.ts
+++ b/tests/schefter-tight-end-files.test.ts
@@ -1,0 +1,98 @@
+/**
+ * "The Tight End Files" — running-bit meta-awareness for owner-submitted
+ * tight-end jokes.
+ *
+ * Multiple owners across multiple weeks have been submitting variations of
+ * the same tight-end joke. Schefter's response is meta-awareness — he files
+ * on the SUBMISSION pattern itself rather than retelling the joke. The bit
+ * also has a glacially-rare "Schefter unprompted" path (1-in-50) where he
+ * makes an original line about the cataloging absurdity itself.
+ *
+ * These tests pin the running-bit lore so future edits can't quietly drop
+ * the trigger conditions, frequency caps, or anti-leak rules. The lore is
+ * loaded into the system prompt by `loadLore` (scripts/lib/schefter-lore.mjs),
+ * so changes to running-bits.md are read at runtime — no scanner restart
+ * required, but the prompt cache (`_cache` closure in loadLore) lives for
+ * the lifetime of the Node process.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+function read(rel: string): string {
+  return readFileSync(path.join(process.cwd(), rel), 'utf8');
+}
+
+const RUNNING_BITS = read('data/schefter/running-bits.md');
+
+describe('"The Tight End Files" running-bit lore', () => {
+  it('section exists with the expected header', () => {
+    expect(RUNNING_BITS).toMatch(/### "The Tight End Files"/);
+  });
+
+  it('declares two trigger paths (tipster-suggested + Schefter unprompted)', () => {
+    expect(RUNNING_BITS).toMatch(/Tipster-suggested TE joke/);
+    expect(RUNNING_BITS).toMatch(/Schefter unprompted/);
+  });
+
+  it('caps frequency at 1-in-3 of eligible tipster-suggested posts', () => {
+    expect(RUNNING_BITS).toMatch(/Tipster path:\s*1-in-3/);
+  });
+
+  it('caps the unprompted path at 1-in-50 (glacially rare)', () => {
+    expect(RUNNING_BITS).toMatch(/Unprompted path[\s\S]{0,80}1-in-50/);
+  });
+
+  it('lists meta-acknowledgment lines that reference the SUBMISSION pattern, not the joke itself', () => {
+    expect(RUNNING_BITS).toMatch(/Another tight end joke landed in the inbox\. Filed\./);
+    expect(RUNNING_BITS).toMatch(/three desks/);
+    expect(RUNNING_BITS).toMatch(/filing cabinet/);
+    expect(RUNNING_BITS).toMatch(/Eighth tight end submission this month/);
+  });
+
+  it('lists original (Schefter-unprompted) lines about the cataloging absurdity', () => {
+    expect(RUNNING_BITS).toMatch(/Position group with the most inbox traffic/);
+    expect(RUNNING_BITS).toMatch(/tight end rumor mill files itself/);
+  });
+
+  it('forbids quoting the tipster joke verbatim', () => {
+    expect(RUNNING_BITS).toMatch(/NEVER quote the tipster's actual TE joke/);
+    expect(RUNNING_BITS).toMatch(/NEVER repeat the specific innuendo/);
+  });
+
+  it('mirrors HARD RULE 16 — submission becomes the story when tip has no league business', () => {
+    expect(RUNNING_BITS).toMatch(/turn the tip INTO the story/);
+  });
+
+  it('forbids stacking with the Style Book bit (thematic overlap)', () => {
+    expect(RUNNING_BITS).toMatch(/Do NOT combine with the Style Book bit/);
+  });
+
+  it('keeps Schefter PG / columnist-clean (the meta-observation IS the joke, not the innuendo)', () => {
+    expect(RUNNING_BITS).toMatch(/Stay PG-clean, columnist-friendly/);
+  });
+
+  it('places the bit before "The Wabbit Show" entry (last running bit before catalog sections)', () => {
+    const teIdx = RUNNING_BITS.indexOf('### "The Tight End Files"');
+    const wabbitIdx = RUNNING_BITS.indexOf('### "The Wabbit Show"');
+    expect(teIdx).toBeGreaterThan(-1);
+    expect(wabbitIdx).toBeGreaterThan(-1);
+    expect(teIdx).toBeLessThan(wabbitIdx);
+  });
+});
+
+describe('lore loader picks up the new bit', () => {
+  // The scanner imports loadLore from scripts/lib/schefter-lore.mjs, which
+  // reads running-bits.md and assembles the system-prompt suffix. Verify
+  // the loader still references the running-bits file so the new section
+  // gets pulled in automatically.
+  const loaderSrc = read('scripts/lib/schefter-lore.mjs');
+
+  it('loadLore reads running-bits.md', () => {
+    expect(loaderSrc).toMatch(/running-bits\.md/);
+  });
+
+  it('appends bits content under the "## RUNNING BITS" header', () => {
+    expect(loaderSrc).toMatch(/##\s*RUNNING BITS/);
+  });
+});

--- a/tests/schefter-trade-corroboration.test.ts
+++ b/tests/schefter-trade-corroboration.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Cross-corroboration: real MFL pending offer × independent tipster sources.
+ *
+ * When a trade-offer tip (source: 'trade_offer') is being whispered about
+ * independently in the rest of the queue (web/groupme tips that match the
+ * same franchise scope or mention a player name from the offer), the LLM
+ * upgrades to direct-knowledge voice — "multiple sources with direct
+ * knowledge", "spoke on the condition of anonymity" — instead of the
+ * default "I'm hearing chatter" hedge.
+ *
+ * The matcher (`findCorroboratingTips`) is the source-of-truth predicate
+ * for this elevation. These tests pin its behavior and the downstream
+ * plumbing (anonymizer surface, LLM directive insertion).
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+function read(rel: string): string {
+  return readFileSync(path.join(process.cwd(), rel), 'utf8');
+}
+
+const SCANNER_SRC = read('scripts/schefter-rumor-scan.mjs');
+const REDACT_SRC = read('scripts/lib/redact-trade-offer.mjs');
+
+describe('redactTradeOffer — corroboration metadata', () => {
+  it('exposes partnerFranchiseId on the redacted tip', () => {
+    expect(REDACT_SRC).toMatch(/partnerFranchiseId/);
+    expect(REDACT_SRC).toMatch(
+      /offeringFid === String\(rawOffer\.franchise\)\s*\?\s*rawOffer\.franchise2\s*:\s*rawOffer\.franchise/,
+    );
+  });
+
+  it('exposes lower-cased playerNames for substring matching', () => {
+    expect(REDACT_SRC).toMatch(/playerNames\s*=\s*allAssets/);
+    expect(REDACT_SRC).toMatch(/a\.name\.toLowerCase\(\)/);
+  });
+
+  it('keeps internal-only metadata fields out of the LLM-visible tip', () => {
+    // The anonymizer's trade_offer branch must NOT assign partnerFranchiseId
+    // or playerNames onto `safe` — those are matcher-only metadata.
+    // (Comments inside the branch may reference them as guidance; what we
+    // care about is that no `safe.<field> =` assignment exists.)
+    const branch = SCANNER_SRC.match(
+      /if \(tip\.source === 'trade_offer'\) \{[\s\S]*?return safe;\s*\}/,
+    )?.[0] ?? '';
+    expect(branch).not.toMatch(/safe\.partnerFranchiseId\s*=/);
+    expect(branch).not.toMatch(/safe\.playerNames\s*=/);
+  });
+});
+
+describe('findCorroboratingTips — match logic', () => {
+  // Reimplement the predicate to validate behavior. The real function
+  // lives at module scope in the scanner mjs and is grep-asserted below.
+  function findCorroboratingTips(
+    tradeOfferTip: { source?: string; offeringFranchiseId?: string; partnerFranchiseId?: string; playerNames?: string[] } | null,
+    otherTips: Array<{ id?: string; source?: string; topic?: string; franchiseHint?: string; text?: string }>,
+  ): string[] {
+    if (!tradeOfferTip || tradeOfferTip.source !== 'trade_offer') return [];
+    const offeringFid = tradeOfferTip.offeringFranchiseId;
+    const partnerFid = tradeOfferTip.partnerFranchiseId;
+    const playerNames = Array.isArray(tradeOfferTip.playerNames) ? tradeOfferTip.playerNames : [];
+    const matchingFids = new Set(
+      [offeringFid, partnerFid].filter(
+        (fid): fid is string => typeof fid === 'string' && fid.length > 0 && fid !== 'league-wide' && fid !== 'commish',
+      ),
+    );
+    const matches = new Set<string>();
+    for (const tip of otherTips) {
+      if (!tip || tip.source === 'trade_offer') continue;
+      let matched = false;
+      if (tip.topic === 'trade' && tip.franchiseHint && matchingFids.has(tip.franchiseHint)) {
+        matched = true;
+      }
+      if (!matched && playerNames.length > 0 && typeof tip.text === 'string' && tip.text.length > 0) {
+        const textLower = tip.text.toLowerCase();
+        for (const name of playerNames) {
+          if (name && textLower.includes(name)) {
+            matched = true;
+            break;
+          }
+        }
+      }
+      if (matched && tip.id) matches.add(tip.id);
+    }
+    return [...matches];
+  }
+
+  const baseOffer = {
+    source: 'trade_offer' as const,
+    offeringFranchiseId: '0003',
+    partnerFranchiseId: '0007',
+    playerNames: ["ja'marr chase", 'breece hall'],
+  };
+
+  it('matches a web trade-topic tip pointing at the offering franchise', () => {
+    const matches = findCorroboratingTips(baseOffer, [
+      { id: 't1', source: 'web', topic: 'trade', franchiseHint: '0003', text: 'shopping their 1st' },
+    ]);
+    expect(matches).toEqual(['t1']);
+  });
+
+  it('matches a web trade-topic tip pointing at the partner franchise', () => {
+    const matches = findCorroboratingTips(baseOffer, [
+      { id: 't2', source: 'web', topic: 'trade', franchiseHint: '0007', text: 'looking for a WR' },
+    ]);
+    expect(matches).toEqual(['t2']);
+  });
+
+  it('does NOT match a non-trade-topic tip on the same franchise', () => {
+    const matches = findCorroboratingTips(baseOffer, [
+      { id: 't3', source: 'web', topic: 'roster', franchiseHint: '0003', text: 'roster looks weak' },
+    ]);
+    expect(matches).toEqual([]);
+  });
+
+  it('matches a player-name substring even with different scope', () => {
+    const matches = findCorroboratingTips(baseOffer, [
+      { id: 't4', source: 'web', topic: 'trade', franchiseHint: 'league-wide', text: "Hearing JA'MARR CHASE is on the move" },
+    ]);
+    expect(matches).toEqual(['t4']);
+  });
+
+  it('matches a GroupMe tip the same way (source-agnostic)', () => {
+    const matches = findCorroboratingTips(baseOffer, [
+      { id: 't5', source: 'groupme', text: 'Breece Hall to Magicians? saw it last night' },
+    ]);
+    expect(matches).toEqual(['t5']);
+  });
+
+  it('excludes other trade_offer tips from the match pool', () => {
+    const matches = findCorroboratingTips(baseOffer, [
+      { id: 'to_other', source: 'trade_offer' },
+    ]);
+    expect(matches).toEqual([]);
+  });
+
+  it('excludes league-wide and commish hints from franchise matching', () => {
+    const matches = findCorroboratingTips(baseOffer, [
+      { id: 't6', source: 'web', topic: 'trade', franchiseHint: 'league-wide', text: 'something is brewing' },
+      { id: 't7', source: 'web', topic: 'trade', franchiseHint: 'commish', text: 'the commish' },
+    ]);
+    expect(matches).toEqual([]);
+  });
+
+  it('returns empty when the offer has no franchise scope and no player names', () => {
+    const matches = findCorroboratingTips({ source: 'trade_offer' }, [
+      { id: 't8', source: 'web', topic: 'trade', franchiseHint: '0003' },
+    ]);
+    expect(matches).toEqual([]);
+  });
+
+  it('dedupes when one tip matches via multiple signals', () => {
+    const matches = findCorroboratingTips(baseOffer, [
+      // Hits BOTH franchise (offering) and player-name (Chase) — should
+      // surface once.
+      { id: 't9', source: 'web', topic: 'trade', franchiseHint: '0003', text: "ja'marr chase rumors" },
+    ]);
+    expect(matches).toEqual(['t9']);
+  });
+
+  it('returns an empty array for null/undefined trade tip', () => {
+    expect(findCorroboratingTips(null, [{ id: 't', source: 'web' }])).toEqual([]);
+  });
+
+  it('returns an empty array for non-trade-offer source', () => {
+    expect(findCorroboratingTips({ source: 'web' as never } as never, [{ id: 't', source: 'web' }])).toEqual([]);
+  });
+});
+
+describe('scanner integration — corroboration plumbing', () => {
+  it('declares findCorroboratingTips at module scope', () => {
+    expect(SCANNER_SRC).toMatch(/function findCorroboratingTips\(tradeOfferTip,\s*otherTips\)/);
+  });
+
+  it('mutates trade-offer tips with corroboratingSourceCount in the main loop', () => {
+    expect(SCANNER_SRC).toMatch(/tip\.corroboratingSourceCount\s*=\s*matches\.length/);
+  });
+
+  it('considers BOTH primary and secondary batches for corroboration', () => {
+    expect(SCANNER_SRC).toMatch(/\[batch,\s*secondaryBatch\]\.filter\(Boolean\)/);
+  });
+
+  it('passes corroboratingSourceCount into the anonymized safe tip', () => {
+    expect(SCANNER_SRC).toMatch(/safe\.corroboratingSourceCount\s*=\s*tip\.corroboratingSourceCount/);
+  });
+
+  it('only surfaces the count when > 0 (no zero-leak in the anonymizer output)', () => {
+    expect(SCANNER_SRC).toMatch(/tip\.corroboratingSourceCount\s*>\s*0/);
+  });
+});
+
+describe('CORROBORATION_CONTEXT directive in the LLM prompt', () => {
+  it('reads max corroboration count across the anonymized batch', () => {
+    expect(SCANNER_SRC).toMatch(/maxCorroboration\s*=\s*anonymized\.reduce/);
+  });
+
+  it('only fires when at least one source corroborates', () => {
+    expect(SCANNER_SRC).toMatch(/maxCorroboration\s*>=\s*1/);
+  });
+
+  it('includes the user-requested direct-knowledge phrasings', () => {
+    expect(SCANNER_SRC).toMatch(/multiple sources with direct knowledge/);
+    expect(SCANNER_SRC).toMatch(/spoke on the condition of anonymity/);
+    expect(SCANNER_SRC).toMatch(/league sources with direct knowledge/);
+  });
+
+  it('instructs the LLM to drop hedge words in the corroborated lane', () => {
+    expect(SCANNER_SRC).toMatch(/Drop the hedge words/);
+  });
+
+  it('preserves anonymity rules (no name liberty, just credibility upgrade)', () => {
+    expect(SCANNER_SRC).toMatch(/CREDIBILITY of the source, not LIBERTY to name names/);
+  });
+
+  it('splices the directive into both single and mailbag userMessage paths', () => {
+    const occurrences = SCANNER_SRC.match(/\$\{corroborationDirective\}/g) ?? [];
+    expect(occurrences.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('singular vs plural source word is grammatically correct', () => {
+    // sourceWord = matches === 1 ? 'source' : 'sources'
+    expect(SCANNER_SRC).toMatch(/maxCorroboration === 1\s*\?\s*'source'\s*:\s*'sources'/);
+  });
+});

--- a/tests/schefter-trade-cta.test.ts
+++ b/tests/schefter-trade-cta.test.ts
@@ -1,0 +1,196 @@
+/**
+ * CTA routing for the Schefter rumor mill.
+ *
+ * Trade-flavored beats (any tip with source 'trade_offer'/'trade_bait' or
+ * topic === 'trade') route to the Trade Builder so the natural next click
+ * is to build a counter-offer. Single-franchise scope pre-loads via
+ * `?b=<fid>`; multi-franchise or league-wide drops to the bare builder.
+ * Non-trade beats (commish beef, roster gripes, predictions, other) keep
+ * the tip-page CTA so readers can whisper a follow-up.
+ *
+ * The directed-CTA override ("Geeks desk — your move →") points at the
+ * tip form and would clobber a Trade Builder link if applied to a trade
+ * beat, so it must skip trade-flavored beats entirely.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+function read(rel: string): string {
+  return readFileSync(path.join(process.cwd(), rel), 'utf8');
+}
+
+const SCANNER_SRC = read('scripts/schefter-rumor-scan.mjs');
+
+describe('isTradeFlavoredTip — classification', () => {
+  // The function lives inside the scanner mjs and isn't exported; we
+  // validate via source-level guards that the predicate covers the
+  // documented cases. Behavioral tests of CTA routing live below and
+  // exercise the predicate end-to-end.
+
+  it('declares an isTradeFlavoredTip helper', () => {
+    expect(SCANNER_SRC).toMatch(/function isTradeFlavoredTip\(tip\)/);
+  });
+
+  it('matches trade_offer source', () => {
+    expect(SCANNER_SRC).toMatch(/tip\.source === 'trade_offer'/);
+  });
+
+  it('matches trade_bait source', () => {
+    expect(SCANNER_SRC).toMatch(/tip\.source === 'trade_bait'/);
+  });
+
+  it('matches topic === "trade" web/groupme tips', () => {
+    expect(SCANNER_SRC).toMatch(/tip\.topic === 'trade'/);
+  });
+
+  it('excludes whisper-back tips so explicit replies stay in their lane', () => {
+    // The function returns false when repliesToPostId is set — the body
+    // contains both checks in the documented order.
+    const fn = SCANNER_SRC.match(
+      /function isTradeFlavoredTip\(tip\) \{[\s\S]*?\n\}/,
+    )?.[0] ?? '';
+    expect(fn).toMatch(/tip\.repliesToPostId/);
+    expect(fn).toMatch(/return false/);
+  });
+});
+
+describe('resolveCta — trade-flavored beats route to the Trade Builder', () => {
+  // Pull resolveCta out of the scanner via dynamic import. The scanner
+  // doesn't run at import time (top-level runs via require.main === module
+  // pattern or similar guard), but importing for function refs is safe.
+  // We instead validate via grep-asserted source-level behavior + execute
+  // via a focused harness below.
+
+  it('imports the Trade Builder constants used by the CTA path', () => {
+    expect(SCANNER_SRC).toMatch(/TRADE_BUILDER_LINK_LABEL = 'Open in Trade Builder/);
+    expect(SCANNER_SRC).toMatch(/TRADE_BUILDER_GROUPME_PREFIX = 'Counter on the block/);
+    expect(SCANNER_SRC).toMatch(/const TRADE_BUILDER_PATH = '\/theleague\/trade-builder'/);
+  });
+
+  it('routes single-franchise trade beats through buildTradeBuilderPath(fid)', () => {
+    // Pinned: when exactly one franchise is named across trade-flavored
+    // tips, we deep-link with ?b=<fid>.
+    expect(SCANNER_SRC).toMatch(
+      /franchiseIds\.size === 1\s*\?\s*buildTradeBuilderPath\(/,
+    );
+  });
+
+  it('drops league-wide / multi-franchise trade beats to the bare builder', () => {
+    expect(SCANNER_SRC).toMatch(/:\s*TRADE_BUILDER_PATH\b/);
+  });
+
+  it('league-wide and commish hints do not count toward franchise scope', () => {
+    expect(SCANNER_SRC).toMatch(/fid !== 'league-wide' && fid !== 'commish'/);
+  });
+});
+
+describe('buildDirectedCta — skips trade beats', () => {
+  it('bails out when any tip in the batch is trade-flavored', () => {
+    const fn = SCANNER_SRC.match(
+      /function buildDirectedCta\(beat\) \{[\s\S]*?\n\}/,
+    )?.[0] ?? '';
+    expect(fn).toMatch(/batch\.some\(isTradeFlavoredTip\)/);
+    expect(fn).toMatch(/return null/);
+  });
+});
+
+describe('CTA routing — execution via a focused harness', () => {
+  // resolveCta is a pure function over { tips }. Re-implement the routing
+  // by importing the scanner module dynamically. Node ESM doesn't expose
+  // top-level non-exported fns, so we redeclare the predicate + path
+  // helper here and assert behavioral equivalence with the source.
+  //
+  // The intent is to lock in the BEHAVIOR even though the function isn't
+  // exported — if scanner-side logic drifts from this harness, the
+  // grep-asserted tests above will fail first.
+
+  function isTradeFlavoredTip(tip: { source?: string; topic?: string; repliesToPostId?: string } | null) {
+    if (!tip) return false;
+    if (tip.source === 'trade_offer' || tip.source === 'trade_bait') return true;
+    if (tip.repliesToPostId) return false;
+    return tip.topic === 'trade';
+  }
+
+  function resolveCta(bucket: { tips?: Array<{ source?: string; topic?: string; franchiseHint?: string; repliesToPostId?: string }> }) {
+    const tips = bucket?.tips ?? [];
+    const tradeFlavored = tips.length > 0 && tips.some(isTradeFlavoredTip);
+    if (tradeFlavored) {
+      const franchiseIds = new Set(
+        tips
+          .filter(isTradeFlavoredTip)
+          .map((t) => t.franchiseHint)
+          .filter((fid): fid is string => typeof fid === 'string' && fid !== 'league-wide' && fid !== 'commish'),
+      );
+      const path = franchiseIds.size === 1
+        ? `/theleague/trade-builder?b=${encodeURIComponent([...franchiseIds][0])}`
+        : '/theleague/trade-builder';
+      return { link: path, kind: 'trade_builder' as const };
+    }
+    return { link: '/schefter/tip', kind: 'tip_page' as const };
+  }
+
+  it('trade_offer with one franchise → /theleague/trade-builder?b=<fid>', () => {
+    const cta = resolveCta({ tips: [{ source: 'trade_offer', franchiseHint: '0003' }] });
+    expect(cta).toEqual({ link: '/theleague/trade-builder?b=0003', kind: 'trade_builder' });
+  });
+
+  it('trade_bait single franchise → builder pre-loaded', () => {
+    const cta = resolveCta({ tips: [{ source: 'trade_bait', franchiseHint: '0007' }] });
+    expect(cta).toEqual({ link: '/theleague/trade-builder?b=0007', kind: 'trade_builder' });
+  });
+
+  it('web tip with topic=trade and one franchise → builder pre-loaded', () => {
+    const cta = resolveCta({ tips: [{ topic: 'trade', franchiseHint: '0001' }] });
+    expect(cta).toEqual({ link: '/theleague/trade-builder?b=0001', kind: 'trade_builder' });
+  });
+
+  it('league-wide trade speculation → bare builder (no ?b=)', () => {
+    const cta = resolveCta({ tips: [{ topic: 'trade', franchiseHint: 'league-wide' }] });
+    expect(cta).toEqual({ link: '/theleague/trade-builder', kind: 'trade_builder' });
+  });
+
+  it('multi-franchise trade rumor → bare builder', () => {
+    const cta = resolveCta({
+      tips: [
+        { source: 'trade_offer', franchiseHint: '0003' },
+        { source: 'trade_offer', franchiseHint: '0007' },
+      ],
+    });
+    expect(cta).toEqual({ link: '/theleague/trade-builder', kind: 'trade_builder' });
+  });
+
+  it('mixed trade + non-trade bucket still routes to builder (any trade tip wins)', () => {
+    const cta = resolveCta({
+      tips: [
+        { topic: 'trade', franchiseHint: '0003' },
+        { topic: 'roster', franchiseHint: '0003' },
+      ],
+    });
+    expect(cta).toEqual({ link: '/theleague/trade-builder?b=0003', kind: 'trade_builder' });
+  });
+
+  it('commish beef stays on the tip page', () => {
+    const cta = resolveCta({ tips: [{ topic: 'commish', franchiseHint: 'commish' }] });
+    expect(cta).toEqual({ link: '/schefter/tip', kind: 'tip_page' });
+  });
+
+  it('roster gripe stays on the tip page', () => {
+    const cta = resolveCta({ tips: [{ topic: 'roster', franchiseHint: '0005' }] });
+    expect(cta).toEqual({ link: '/schefter/tip', kind: 'tip_page' });
+  });
+
+  it('whisper-back to a non-trade rumor stays on the tip page even with topic=trade', () => {
+    // A user replying to a roster-gripe rumor explicitly chose that thread —
+    // we honor their lane and don't redirect to the trade builder.
+    const cta = resolveCta({
+      tips: [{ topic: 'trade', franchiseHint: '0003', repliesToPostId: 'sf_rumor_x' }],
+    });
+    expect(cta).toEqual({ link: '/schefter/tip', kind: 'tip_page' });
+  });
+
+  it('empty bucket falls back to tip page', () => {
+    expect(resolveCta({})).toEqual({ link: '/schefter/tip', kind: 'tip_page' });
+    expect(resolveCta({ tips: [] })).toEqual({ link: '/schefter/tip', kind: 'tip_page' });
+  });
+});


### PR DESCRIPTION
## Summary

This PR adds three interconnected features to the Schefter rumor mill scanner to improve trade-offer coverage and morning-window responsiveness:

1. **Cross-corroboration matching** — Real MFL pending offers (`source: 'trade_offer'`) are elevated to direct-knowledge voice when independent web/groupme tips mention the same trade or player names, signaling multiple sources with direct knowledge.

2. **Morning greeting window** — The first post of any kind between 7:00–10:59 PT gets a classic-news cold-open ("Morning, league", "Welcome to your morning", etc.) once per PT day, stamped in Redis to prevent spam.

3. **Busy-morning catch-up** — When the morning window opens (7:00–9:59 PT) with 2+ trade tips queued overnight, the scanner emits TWO trade beats in a single cycle (sharing one MAX_POSTS_PER_DAY slot) with a "busy morning" tone directive so Schefter acknowledges the overnight volume.

## Key Changes

**Scanner (`scripts/schefter-rumor-scan.mjs`)**
- Added `MORNING_GREETING_DATE_KEY` Redis key and `MORNING_GREETING_END_HOUR = 11` constant
- Added `BUSY_MORNING_END_HOUR = 10` and `BUSY_MORNING_TRADE_THRESHOLD = 2` constants
- Implemented `isTradeFlavoredTip()` predicate to classify tips as trade-related (source `trade_offer`/`trade_bait` or topic `trade`, excluding whisper-back replies)
- Implemented `findCorroboratingTips()` matcher that detects when web/groupme tips reference the same trade via franchise scope or player-name substring matching
- Refactored `resolveCta()` to route all trade-flavored beats to Trade Builder (single-franchise pre-loads with `?b=<fid>`, multi-franchise drops to bare builder)
- Updated `buildDirectedCta()` to skip trade-flavored beats so tip-form CTAs don't override Trade Builder routing
- Added `isBusyMorningWindow()` and `isMorningGreetingWindow()` predicates
- Integrated busy-morning split logic: when conditions align, sorts tips by age and emits two trade beats with `busyMorning` and `busyMorningBacklog` flags
- Integrated morning-greeting gate: checks Redis once per window, stamps date only after successful post commit
- Updated `anonymizeTips()` to surface `corroboratingSourceCount` to the LLM (internal metadata like `partnerFranchiseId` and `playerNames` stay hidden)
- Extended `generateAiBody()` signature to accept `morningGreeting`, `busyMorning`, and `busyMorningBacklog` options; builds corresponding LLM directives

**Trade-offer redaction (`scripts/lib/redact-trade-offer.mjs`)**
- Added `partnerFranchiseId` field (the team being offered to) for corroboration matching
- Added `playerNames` array (lower-cased for substring matching) for corroboration matching
- Both fields are internal-only metadata, never passed to the LLM

**Cooker-status endpoint (`src/pages/api/schefter/cooker-status.ts`)**
- Added `heat` tier classification (quiet/simmer/rolling/boil/overflow) derived from queue depth
- Added `backloggedHint` boolean flag (true when heat ∈ {boil, overflow})
- Heat thresholds align with scanner pressure points: SECONDARY_GOSSIP_POST_PRESSURE, GOSSIP_BOOST_QUEUE_DEPTH, MAX_TIPS_PER_BATCH

**Tip page UI (`src/pages/theleague/schefter/tip.astro`)**
- Added heat badge with color escalation and pulse animation on boil/overflow
- Added "marinating longer than usual" hint text that displays when backlog is high
- Styled heat states: quiet (gray), simmer (green), rolling (amber), boil/overflow (red with pulse)

**

https://claude.ai/code/session_01AshBz3WLjBMtHi73nNsBJM