### PR TITLE
feat(draft-room): wire live MFL board polling + MFL pick deep-link

### DIFF
--- a/src/components/theleague/draft-room/DraftQueuePanel.tsx
+++ b/src/components/theleague/draft-room/DraftQueuePanel.tsx
@@ -39,6 +39,13 @@ interface DraftQueuePanelProps {
   onSyncToMfl: () => void;
   onSubmitPick: (playerId: string) => void;
   onToggleAutoSubmit: () => void;
+  /**
+   * Live-mode MFL "Make Pick" deep-link. When set, the queue is treated as
+   * local-only — Sync to MFL and Auto-pick toggles hide (those rely on a
+   * write endpoint we don't have yet) and the on-clock CTA links to MFL
+   * instead of POSTing the top-of-queue pick.
+   */
+  mflPickUrl?: string;
 }
 
 export function DraftQueuePanel({
@@ -55,7 +62,10 @@ export function DraftQueuePanel({
   onSyncToMfl,
   onSubmitPick,
   onToggleAutoSubmit,
+  mflPickUrl,
 }: DraftQueuePanelProps) {
+  // In live mode the queue is local-only — no MFL-side persistence yet.
+  const isLocalOnly = !!mflPickUrl;
   const sensors = useSensors(
     useSensor(PointerSensor),
     useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
@@ -101,31 +111,41 @@ export function DraftQueuePanel({
             )}
           </div>
 
-          <button
-            type="button"
-            onClick={handleSyncToMfl}
-            disabled={isSyncingQueue || queue.length === 0}
-            title="Sync queue to your MFL draft board"
-            className="dr-sync-btn"
-            data-state={syncSuccess ? 'success' : undefined}
-          >
-            {isSyncingQueue ? 'Syncing…' : syncSuccess ? '✓ Synced' : 'Sync to MFL'}
-          </button>
+          {!isLocalOnly && (
+            <button
+              type="button"
+              onClick={handleSyncToMfl}
+              disabled={isSyncingQueue || queue.length === 0}
+              title="Sync queue to your MFL draft board"
+              className="dr-sync-btn"
+              data-state={syncSuccess ? 'success' : undefined}
+            >
+              {isSyncingQueue ? 'Syncing…' : syncSuccess ? '✓ Synced' : 'Sync to MFL'}
+            </button>
+          )}
         </div>
 
-        <label className="dr-auto-submit-label" onClick={onToggleAutoSubmit}>
-          <span
-            role="switch"
-            aria-checked={autoSubmit}
-            tabIndex={0}
-            onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onToggleAutoSubmit(); } }}
-            onClick={(e) => { e.stopPropagation(); onToggleAutoSubmit(); }}
-            className="dr-auto-submit-switch"
-          >
-            <span className="dr-auto-submit-switch__thumb" />
-          </span>
-          <span className="dr-auto-submit-label__text">Auto-pick from queue</span>
-        </label>
+        {!isLocalOnly && (
+          <label className="dr-auto-submit-label" onClick={onToggleAutoSubmit}>
+            <span
+              role="switch"
+              aria-checked={autoSubmit}
+              tabIndex={0}
+              onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onToggleAutoSubmit(); } }}
+              onClick={(e) => { e.stopPropagation(); onToggleAutoSubmit(); }}
+              className="dr-auto-submit-switch"
+            >
+              <span className="dr-auto-submit-switch__thumb" />
+            </span>
+            <span className="dr-auto-submit-label__text">Auto-pick from queue</span>
+          </label>
+        )}
+
+        {isLocalOnly && (
+          <p className="dr-queue__hint">
+            Queue is saved on this device only. Make picks on MFL when you're on the clock.
+          </p>
+        )}
       </div>
 
       <div className="dr-queue__list">
@@ -159,7 +179,19 @@ export function DraftQueuePanel({
         )}
       </div>
 
-      {isUserTurn && (
+      {isUserTurn && isLocalOnly && (
+        <div className="dr-queue__cta">
+          <a
+            href={mflPickUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="dr-submit-pick-btn"
+          >
+            Pick on MFL ↗
+          </a>
+        </div>
+      )}
+      {isUserTurn && !isLocalOnly && (
         <div className="dr-queue__cta">
           {submitError && (
             <div className="dr-queue__cta-error">{submitError}</div>

--- a/src/components/theleague/draft-room/DraftRoom.tsx
+++ b/src/components/theleague/draft-room/DraftRoom.tsx
@@ -401,86 +401,34 @@ export default function DraftRoom({ pageData, userTeamId, mode = 'live', mockSes
     return () => window.removeEventListener('keydown', onKey);
   }, []);
 
-  // Auto-submit: when user is on clock + autoSubmit on + queue non-empty
+  // Auto-submit: when user is on clock + autoSubmit on + queue non-empty.
+  // Mock mode only — live drafts use the MFL deep-link instead.
   useEffect(() => {
+    if (!isMock) return;
     if (!state.autoSubmit || !isUserTurn || state.queue.length === 0 || state.isSubmittingPick || state.draftComplete) return;
 
     const draftedIds = new Set(state.picks.filter((p) => p.playerId).map((p) => p.playerId));
     const topItem = state.queue.find((i) => !draftedIds.has(i.playerId));
     if (!topItem) return;
 
-    if (isMock) {
-      // Mock mode: send pick via WebSocket
-      mockSend({ type: 'pick', franchiseId: userTeamId, playerId: topItem.playerId });
-      dispatch({ type: 'REMOVE_FROM_QUEUE', id: topItem.id });
-      return;
-    }
-
-    dispatch({ type: 'SUBMIT_PICK_START' });
-    fetch('/api/draft/submit-pick', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ playerId: topItem.playerId }),
-    })
-      .then((r) => r.json())
-      .then((result) => {
-        if (result.success) {
-          dispatch({ type: 'REMOVE_FROM_QUEUE', id: topItem.id });
-          dispatch({ type: 'SUBMIT_PICK_DONE' });
-        } else {
-          dispatch({ type: 'SET_SUBMIT_ERROR', error: result.message || 'Failed to submit pick' });
-        }
-      })
-      .catch((e) => {
-        dispatch({ type: 'SET_SUBMIT_ERROR', error: (e as Error).message });
-      });
+    mockSend({ type: 'pick', franchiseId: userTeamId, playerId: topItem.playerId });
+    dispatch({ type: 'REMOVE_FROM_QUEUE', id: topItem.id });
   }, [state.autoSubmit, isUserTurn, state.queue, state.isSubmittingPick, state.draftComplete, state.picks, isMock, mockSend, userTeamId]);
 
-  // Sync queue to MFL (no-op in mock mode — queue is local only)
+  // Sync queue to MFL — not yet implemented for live drafts (would require
+  // MFL auth + the rankings/queue write endpoint). Mock mode keeps its queue
+  // local too. Kept as a no-op so the prop wire-up stays stable; the button
+  // is hidden in live mode (see DraftQueuePanel mflPickUrl branch).
   const handleSyncToMfl = useCallback(async () => {
-    if (isMock || state.isSyncingQueue || state.queue.length === 0) return;
-    dispatch({ type: 'SYNC_QUEUE_START' });
-    try {
-      await fetch('/api/draft/queue', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ playerIds: state.queue.map((i) => i.playerId) }),
-      });
-    } catch {
-      // Fire-and-forget — no user-facing error needed
-    } finally {
-      dispatch({ type: 'SYNC_QUEUE_DONE' });
-    }
-  }, [state.queue, state.isSyncingQueue, isMock]);
+    /* no-op */
+  }, []);
 
-  // Manual pick submission
+  // Manual pick submission — only used in mock mode (live drafts deep-link
+  // to MFL via mflPickUrl since we don't yet have an auth'd write endpoint).
   const handleSubmitPick = useCallback((playerId: string) => {
+    if (!isMock) return;
     if (state.isSubmittingPick) return;
-
-    if (isMock) {
-      // Mock mode: send pick via WebSocket — server validates and broadcasts
-      // Send userTeamId (creator) so the server allows picking for any team on the clock
-      mockSend({ type: 'pick', franchiseId: userTeamId, playerId });
-      return;
-    }
-
-    dispatch({ type: 'SUBMIT_PICK_START' });
-    fetch('/api/draft/submit-pick', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ playerId }),
-    })
-      .then((r) => r.json())
-      .then((result) => {
-        if (!result.success) {
-          dispatch({ type: 'SET_SUBMIT_ERROR', error: result.message || 'Failed to submit pick' });
-        } else {
-          dispatch({ type: 'SUBMIT_PICK_DONE' });
-        }
-      })
-      .catch((e) => {
-        dispatch({ type: 'SET_SUBMIT_ERROR', error: (e as Error).message });
-      });
+    mockSend({ type: 'pick', franchiseId: userTeamId, playerId });
   }, [state.isSubmittingPick, isMock, mockSend, userTeamId]);
 
   // Callbacks
@@ -579,7 +527,16 @@ export default function DraftRoom({ pageData, userTeamId, mode = 'live', mockSes
         draftComplete={state.draftComplete}
         isUserTurn={isUserTurn}
         mockClockSeconds={isMock ? state.mockClockSeconds : undefined}
-        actions={isMock ? (
+        actions={!isMock && isUserTurn && data.mflPickUrl ? (
+          <a
+            href={data.mflPickUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="dr-mfl-pick-link"
+          >
+            Pick on MFL →
+          </a>
+        ) : isMock ? (
           <>
             <button
               type="button"
@@ -724,6 +681,7 @@ export default function DraftRoom({ pageData, userTeamId, mode = 'live', mockSes
               isUserTurn={isUserTurn}
               onSubmitPick={handleSubmitPick}
               currentPick={currentPick}
+              mflPickUrl={!isMock ? data.mflPickUrl : undefined}
             />
           </div>
 
@@ -749,6 +707,7 @@ export default function DraftRoom({ pageData, userTeamId, mode = 'live', mockSes
                   onSyncToMfl={handleSyncToMfl}
                   onSubmitPick={handleSubmitPick}
                   onToggleAutoSubmit={handleToggleAutoSubmit}
+                  mflPickUrl={!isMock ? data.mflPickUrl : undefined}
                 />
               </Suspense>
             ) : null}

--- a/src/components/theleague/draft-room/PlayerDetailModal.tsx
+++ b/src/components/theleague/draft-room/PlayerDetailModal.tsx
@@ -9,6 +9,8 @@ interface PlayerDetailModalProps {
   currentPick: DraftRoomPick | null;
   isQueued: boolean;
   isUserTurn: boolean;
+  /** When set (live drafts), the Draft button becomes an MFL deep-link. */
+  mflPickUrl?: string;
   onClose: () => void;
   onAddToQueue: (playerId: string) => void;
   onDraft: (playerId: string) => void;
@@ -41,6 +43,7 @@ export function PlayerDetailModal({
   currentPick,
   isQueued,
   isUserTurn,
+  mflPickUrl,
   onClose,
   onAddToQueue,
   onDraft,
@@ -372,7 +375,31 @@ export function PlayerDetailModal({
           >
             {isQueued ? '✓ In Queue' : '+ Add to Queue'}
           </button>
-          {isUserTurn && (
+          {isUserTurn && mflPickUrl ? (
+            <a
+              href={mflPickUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{
+                flex: 1,
+                padding: '0.625rem 0.75rem',
+                fontSize: '0.8125rem',
+                fontWeight: 800,
+                textTransform: 'uppercase',
+                letterSpacing: '0.04em',
+                border: 'none',
+                borderRadius: 'var(--radius-md, 0.5rem)',
+                background: 'var(--color-success, #16a34a)',
+                color: '#ffffff',
+                cursor: 'pointer',
+                textAlign: 'center',
+                textDecoration: 'none',
+                boxShadow: '0 2px 8px rgba(22, 163, 74, 0.3)',
+              }}
+            >
+              Pick on MFL ↗
+            </a>
+          ) : isUserTurn ? (
             <button
               type="button"
               onClick={() => onDraft(player.id)}
@@ -393,7 +420,7 @@ export function PlayerDetailModal({
             >
               Draft {player.name.split(' ')[0]}
             </button>
-          )}
+          ) : null}
         </footer>
       </div>
     </div>

--- a/src/components/theleague/draft-room/PlayerPoolPanel.tsx
+++ b/src/components/theleague/draft-room/PlayerPoolPanel.tsx
@@ -23,6 +23,12 @@ interface PlayerPoolPanelProps {
   isUserTurn?: boolean;
   onSubmitPick?: (playerId: string) => void;
   currentPick?: DraftRoomPick | null;
+  /**
+   * MFL deep-link to "Make Pick" (live mode only). When set, the per-row
+   * Draft button becomes an external anchor that opens MFL in a new tab
+   * — actual pick submission happens there. Undefined in mock mode.
+   */
+  mflPickUrl?: string;
 }
 
 function rankCompare(a: DraftRoomPlayer, b: DraftRoomPlayer): number {
@@ -65,6 +71,7 @@ export function PlayerPoolPanel({
   isUserTurn = false,
   onSubmitPick,
   currentPick = null,
+  mflPickUrl,
 }: PlayerPoolPanelProps) {
   const [detailPlayerId, setDetailPlayerId] = useState<string | null>(null);
 
@@ -190,7 +197,18 @@ export function PlayerPoolPanel({
             metaSlot={meta}
           />
         </button>
-        {isUserTurn && onSubmitPick && (
+        {isUserTurn && mflPickUrl ? (
+          <a
+            href={mflPickUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label={`Open MFL to draft ${player.name}`}
+            title="Make your pick on MFL"
+            className="dr-draft-btn"
+          >
+            MFL ↗
+          </a>
+        ) : isUserTurn && onSubmitPick ? (
           <button
             type="button"
             onClick={() => onSubmitPick(player.id)}
@@ -199,7 +217,7 @@ export function PlayerPoolPanel({
           >
             Draft
           </button>
-        )}
+        ) : null}
         <button
           type="button"
           onClick={() => !isQueued && onAddToQueue(player.id)}
@@ -355,6 +373,7 @@ export function PlayerPoolPanel({
         currentPick={currentPick}
         isQueued={detailPlayer ? queuedIds.has(detailPlayer.id) : false}
         isUserTurn={isUserTurn}
+        mflPickUrl={mflPickUrl}
         onClose={() => setDetailPlayerId(null)}
         onAddToQueue={(id) => {
           onAddToQueue(id);

--- a/src/config/nav-config.json
+++ b/src/config/nav-config.json
@@ -128,6 +128,15 @@
       "leagueOnly": "theleague",
       "links": [
         {
+          "id": "draft-room",
+          "label": "Draft Room",
+          "icon": "draft-podium",
+          "path": "/draft-room",
+          "external": false,
+          "leagueOnly": "theleague",
+          "description": "Live rookie draft board with picks, queue, and chat"
+        },
+        {
           "id": "mock-draft",
           "label": "Mock Draft",
           "icon": "podium-persona",
@@ -314,6 +323,7 @@
     "/search": "/search",
     "/news": "/news",
     "/mock-draft": "/mock-draft",
+    "/draft-room": "/draft-room",
     "/suggestions": "/suggestions",
     "/stats": "/stats",
     "/rules-chat": "/rules-chat"

--- a/src/pages/api/draft/status.ts
+++ b/src/pages/api/draft/status.ts
@@ -1,0 +1,101 @@
+/**
+ * /api/draft/status — Live draft board polling endpoint.
+ *
+ * Proxies MFL's public `draftResults` export and returns picks in the same
+ * shape `draft-room.astro` builds at SSR time so the client can swap the
+ * picks array in‑place. No auth required (draftResults is public).
+ *
+ * The DraftRoom client polls this every 12s when picks are recent and 30s
+ * otherwise (see DraftRoom.tsx). For an email draft 30s of latency is fine.
+ */
+
+import type { APIRoute } from 'astro';
+import { parseTradeFromComment } from '../../../utils/draft-utils';
+import type { DraftRoomPick, DraftStatusResponse } from '../../../types/draft-room';
+import { getCurrentLeagueYear } from '../../../utils/league-year';
+
+export const prerender = false;
+
+const DEFAULT_HOST = 'www49.myfantasyleague.com';
+const DEFAULT_LEAGUE_ID = '13522';
+
+interface RawDraftPick {
+  player?: string;
+  pick?: string;
+  franchise?: string;
+  timestamp?: string;
+  comments?: string;
+  round?: string;
+}
+
+function buildPicks(rawPicks: RawDraftPick | RawDraftPick[] | undefined): DraftRoomPick[] {
+  if (!rawPicks) return [];
+  const arr = Array.isArray(rawPicks) ? rawPicks : [rawPicks];
+
+  // Sort by (round, pickInRound) then assign sequential overallPickNumber.
+  // Rounds may have variable counts (R1=17, R2=18, R3=16) so a fixed stride
+  // would mis-number picks — match draft-room.astro's logic exactly.
+  const sorted = [...arr].sort((a, b) => {
+    const rDiff = parseInt(a.round || '1') - parseInt(b.round || '1');
+    return rDiff !== 0 ? rDiff : parseInt(a.pick || '1') - parseInt(b.pick || '1');
+  });
+
+  return sorted.map((p, idx) => {
+    const tradedFrom = parseTradeFromComment(p.comments || '');
+    return {
+      round: parseInt(p.round || '1'),
+      pickInRound: parseInt(p.pick || '1'),
+      overallPickNumber: idx + 1,
+      franchiseId: p.franchise || '',
+      playerId: p.player || '',
+      timestamp: p.timestamp || '',
+      comments: p.comments || '',
+      isTraded: !!tradedFrom,
+      originalTeamName: tradedFrom,
+    };
+  });
+}
+
+export const GET: APIRoute = async ({ url }) => {
+  const year = url.searchParams.get('year') || String(getCurrentLeagueYear());
+  const leagueId = url.searchParams.get('league') || url.searchParams.get('L') || DEFAULT_LEAGUE_ID;
+  const host = url.searchParams.get('host') || DEFAULT_HOST;
+
+  const mflUrl = `https://${host}/${year}/export?TYPE=draftResults&L=${leagueId}&JSON=1`;
+
+  try {
+    const res = await fetch(mflUrl, {
+      headers: { 'User-Agent': 'Mozilla/5.0 (compatible; FantasyLeague/1.0)' },
+      signal: AbortSignal.timeout(10_000),
+    });
+
+    if (!res.ok) {
+      return new Response(
+        JSON.stringify({ picks: [], serverTime: Date.now(), error: `MFL ${res.status}` }),
+        { status: 502, headers: { 'Content-Type': 'application/json' } },
+      );
+    }
+
+    const data = await res.json();
+    const picks = buildPicks(data?.draftResults?.draftUnit?.draftPick);
+    const body: DraftStatusResponse = { picks, serverTime: Date.now() };
+
+    return new Response(JSON.stringify(body), {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json',
+        // Don't cache at the edge — clients should always see the latest picks.
+        'Cache-Control': 'no-cache, no-store, must-revalidate',
+      },
+    });
+  } catch (err) {
+    return new Response(
+      JSON.stringify({
+        picks: [],
+        serverTime: Date.now(),
+        error: (err as Error).message || 'fetch failed',
+      }),
+      { status: 500, headers: { 'Content-Type': 'application/json' } },
+    );
+  }
+};

--- a/src/pages/theleague/draft-room.astro
+++ b/src/pages/theleague/draft-room.astro
@@ -119,6 +119,12 @@ const draftKind = leagueConfig.draft_kind === 'live' ? 'live' : 'email';
 const draftLimitHours = leagueConfig.draftLimitHours || '12:00';
 const draftTimerSusp = leagueConfig.draftTimerSusp || '03 07';
 
+// MFL "Make Pick" deep-link. baseURL rotates between www49/www48/etc per
+// MFL's load balancer; fall back to www49 if the feed lacks it.
+const leagueId = '13522';
+const mflBaseURL = (leagueConfig.baseURL as string | undefined) || 'https://www49.myfantasyleague.com';
+const mflPickUrl = `${mflBaseURL.replace(/\/$/, '')}/${leagueYearStr}/options?L=${leagueId}&O=17`;
+
 // ── Serialize page data ──
 const partyHost = import.meta.env.PUBLIC_PARTYKIT_HOST || '';
 
@@ -133,7 +139,8 @@ const pageData: DraftRoomPageData = {
   picks,
   players,
   partyHost,
-  leagueId: '13522',
+  leagueId,
+  mflPickUrl,
 };
 ---
 

--- a/src/styles/draft-room.css
+++ b/src/styles/draft-room.css
@@ -2209,3 +2209,40 @@
     display: none !important;
   }
 }
+
+/* ── MFL deep-link styling (live mode) ─────────────────────────────────── */
+
+/* Timer-banner action: opens MFL "Make Pick" page when on the clock. */
+.dr-mfl-pick-link {
+  padding: 0.375rem 0.875rem;
+  font-size: 0.75rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  border-radius: var(--radius-sm, 0.25rem);
+  background: #ffffff;
+  color: var(--color-primary, #1c497c);
+  text-decoration: none;
+  white-space: nowrap;
+  transition: background 0.15s var(--dr-easing-ease);
+}
+.dr-mfl-pick-link:hover,
+.dr-mfl-pick-link:focus-visible {
+  background: var(--color-gray-100, #f3f4f6);
+  outline: none;
+}
+
+/* Anchor variant of .dr-submit-pick-btn — strip the underline & center text. */
+a.dr-submit-pick-btn {
+  display: block;
+  text-align: center;
+  text-decoration: none;
+}
+
+/* Local-only queue hint (replaces auto-pick label in live mode). */
+.dr-queue__hint {
+  margin: 0.5rem 0 0;
+  font-size: 0.6875rem;
+  color: var(--color-gray-500, #6b7280);
+  line-height: 1.4;
+}

--- a/src/types/draft-room.ts
+++ b/src/types/draft-room.ts
@@ -99,6 +99,12 @@ export interface DraftRoomPageData {
   partyHost: string;
   /** MFL league ID — used when polling /api/draft/status */
   leagueId: string;
+  /**
+   * MFL "Make Pick" URL (host/options?L={leagueId}&O=17). Present in live mode
+   * so submit-pick UI can deep-link out to MFL where the pick is actually
+   * made. Undefined in mock mode (mock picks go through PartyKit).
+   */
+  mflPickUrl?: string;
 }
 
 /** Response from /api/draft/status */


### PR DESCRIPTION
The draft room was referencing three API endpoints that did not exist
(/api/draft/{status,submit-pick,queue}), so polling, in-app picks, and
queue sync all silently no-op'd. Tomorrow's rookie draft is an email
draft, so owners need a working live board and a fast path to MFL to
make picks — submit/queue writes can wait for proper auth wiring.

Changes:
- Add /api/draft/status — proxies MFL's public draftResults export and
  returns picks in the same shape draft-room.astro builds at SSR. The
  client polls every 12-30s; for an email draft 30s of latency is fine.
- Compute mflPickUrl in draft-room.astro from the league feed's baseURL
  (host/options?L={leagueId}&O=17) and pipe it through DraftRoom into
  PlayerPoolPanel, PlayerDetailModal, DraftQueuePanel, and the
  DraftTimerBanner action slot.
- In live mode (when mflPickUrl is set):
  - Per-player Draft button -> "MFL ↗" external anchor
  - Modal "Draft {name}" button -> "Pick on MFL ↗" anchor
  - Queue's submit CTA -> "Pick on MFL ↗" anchor
  - Timer banner shows "Pick on MFL →" pill when on the clock
  - Sync to MFL button + auto-pick toggle hidden (queue stays local)
  - Hint added: "Queue is saved on this device only"
- Mock mode keeps the WebSocket-driven submit/queue flow unchanged
  (mflPickUrl is undefined for mock).
- Strip the dead /api/draft/{submit-pick,queue} fetches from
  DraftRoom.tsx so failures stop spamming the network panel.
- Add Draft Room to the Offseason War Room nav section.