### PR TITLE
Double Schefter trade-offer post probability to 0.05

### DIFF
--- a/scripts/lib/redact-trade-offer.mjs
+++ b/scripts/lib/redact-trade-offer.mjs
@@ -254,20 +254,22 @@ export function redactTradeOffer({
 /**
  * Per-run probability for posting a trade-offer rumor.
  *
- * Base p=0.025 per 15-minute scanner run. The cron is `*\/15 * * * *` but
+ * Base p=0.05 per 15-minute scanner run. The cron is `*\/15 * * * *` but
  * GitHub Actions skips/queues cron jobs under platform load AND quiet-hours
  * (23:00–07:00 PT) hard-skip ~32 cycles/day, so the effective dice-roll
  * count is closer to 30–50 rolls/day per offer than the nominal 96. At the
  * current base:
- *   - 30 rolls/day → ~53% by 24h, ~78% by 48h
- *   - 50 rolls/day → ~72% by 24h, ~92% by 48h
- *   - 96 rolls/day → ~91% by 24h, ~99% by 48h
+ *   - 30 rolls/day → ~79% by 24h, ~95% by 48h
+ *   - 50 rolls/day → ~92% by 24h, ~99% by 48h
+ *   - 96 rolls/day → ~99% by 24h, ~99.9% by 48h
  * Trade offers usually file within a day or two while keeping a real per-run
  * dice roll — unposted offers can still fail forever; that's the design.
  *
  * History: was 0.0075 (~20%/24h at realistic cadence). Bumped to 0.025 on
  * 2026-04-30 (PR #141): trade proposals are TheLeague's highest-engagement
  * Schefter content, so we'd rather report them quickly than have them age out.
+ * Bumped again to 0.05 on 2026-05-02 — 0.025 still let some proposals age
+ * out before posting; doubling the base lands most offers within 24h.
  *
  * The 48h framing flip from "fresh" to "lingering" ("offered but phones aren't
  * picking up") is handled in scanTradeOffers, not here. The probability itself
@@ -288,7 +290,7 @@ export function redactTradeOffer({
  *
  * Exported for tests & dry-run logging.
  */
-export const OFFER_POST_PROBABILITY = 0.025;
+export const OFFER_POST_PROBABILITY = 0.05;
 export const OFFER_VOLUME_BOOST_FACTOR = 1.5;
 export const OFFER_VOLUME_BOOST_MAX = 4;
 


### PR DESCRIPTION
Base per-run dice roll was bumped from 0.0075 to 0.025 on 2026-04-30
(PR #141) because trade proposals drive the most GroupMe engagement,
but at realistic 30 rolls/day cadence ~22% of offers were still aging
past 48h without ever posting. Doubling to 0.05 lands ~79% within 24h
and ~95% within 48h while preserving the per-run randomness so owners
can't reverse-engineer Schefter's source from offer timing.

The volume-boost cap (OFFER_VOLUME_BOOST_MAX=4) keeps the post-boost
ceiling at ~20%/run for heavily-shopped players, still well under the
trade-builder-tip-source.test.ts < 0.5 guardrail.

https://claude.ai/code/session_01GLmpV2opF72yVtpEv8t7DT