### PR TITLE
feat: auto-create contract declarations for newly-drafted players

### DIFF
--- a/.github/workflows/roster-sync.yml
+++ b/.github/workflows/roster-sync.yml
@@ -56,11 +56,17 @@ jobs:
         env:
           MFL_LEAGUE_ID: ${{ vars.MFL_LEAGUE_ID || '13522' }}
           MFL_LEAGUE_SLUG: theleague
+          MFL_HOST: ${{ vars.MFL_HOST }}
+          MFL_USERNAME: ${{ secrets.MFL_USERNAME }}
+          MFL_PASSWORD: ${{ secrets.MFL_PASSWORD }}
           UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
           UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
           KV_REST_API_URL: ${{ secrets.KV_REST_API_URL }}
           KV_REST_API_TOKEN: ${{ secrets.KV_REST_API_TOKEN }}
-        run: node ./scripts/sync-draft-pick-contracts.mjs
+        # Running with --dry-run while we verify the first batch. Drop the
+        # flag to enable live MFL writes (RC + slot salary + 4yr default
+        # for newly drafted players who don't yet have RC stamped).
+        run: node ./scripts/sync-draft-pick-contracts.mjs --dry-run
 
       - name: Fetch live NFL odds
         run: node ./scripts/fetch-live-odds.mjs

--- a/.github/workflows/roster-sync.yml
+++ b/.github/workflows/roster-sync.yml
@@ -52,6 +52,16 @@ jobs:
           MFL_LEAGUE_SLUG: theleague
         run: node ./scripts/update-salary-averages.mjs
 
+      - name: Sync draft-pick contracts (theleague)
+        env:
+          MFL_LEAGUE_ID: ${{ vars.MFL_LEAGUE_ID || '13522' }}
+          MFL_LEAGUE_SLUG: theleague
+          UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
+          UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
+          KV_REST_API_URL: ${{ secrets.KV_REST_API_URL }}
+          KV_REST_API_TOKEN: ${{ secrets.KV_REST_API_TOKEN }}
+        run: node ./scripts/sync-draft-pick-contracts.mjs
+
       - name: Fetch live NFL odds
         run: node ./scripts/fetch-live-odds.mjs
 

--- a/.github/workflows/sync-draft-pick-contracts.yml
+++ b/.github/workflows/sync-draft-pick-contracts.yml
@@ -1,0 +1,78 @@
+name: Sync Draft Pick Contracts
+
+# Manually-triggered workflow for testing/running scripts/sync-draft-pick-contracts.mjs
+# in isolation (so its output isn't buried inside the roster-sync log).
+#
+# Usage:
+#   GitHub UI → Actions → Sync Draft Pick Contracts → Run workflow
+#   - Branch: pick the branch you want to test from
+#   - dry_run: leave checked to PRINT the would-be writes without
+#              touching MFL. Uncheck to actually write RC + slot salary
+#              + 4yr default to MFL for any unstamped draft picks.
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry-run only (print, do not write to MFL)'
+        type: boolean
+        default: true
+      league_slug:
+        description: 'League slug (matches data/<slug>/mfl-feeds/)'
+        type: string
+        default: 'theleague'
+
+concurrency:
+  group: sync-draft-pick-contracts-${{ inputs.league_slug }}
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v5
+        with:
+          version: 10.24.0
+
+      - name: Use Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Refresh MFL feeds (so draftResults.json is current)
+        env:
+          MFL_LEAGUE_ID: ${{ vars.MFL_LEAGUE_ID || '13522' }}
+          MFL_LEAGUE_SLUG: ${{ inputs.league_slug }}
+          MFL_HOST: ${{ vars.MFL_HOST }}
+          MFL_USERNAME: ${{ secrets.MFL_USERNAME }}
+          MFL_PASSWORD: ${{ secrets.MFL_PASSWORD }}
+          MFL_API_KEY: ${{ secrets.MFL_API_KEY }}
+        run: node ./scripts/fetch-mfl-feeds.mjs --force
+
+      - name: Sync draft-pick contracts
+        env:
+          MFL_LEAGUE_ID: ${{ vars.MFL_LEAGUE_ID || '13522' }}
+          MFL_LEAGUE_SLUG: ${{ inputs.league_slug }}
+          MFL_HOST: ${{ vars.MFL_HOST }}
+          MFL_USERNAME: ${{ secrets.MFL_USERNAME }}
+          MFL_PASSWORD: ${{ secrets.MFL_PASSWORD }}
+          UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
+          UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
+          KV_REST_API_URL: ${{ secrets.KV_REST_API_URL }}
+          KV_REST_API_TOKEN: ${{ secrets.KV_REST_API_TOKEN }}
+        run: |
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            echo "::notice::Running in DRY-RUN mode (no MFL writes)"
+            node ./scripts/sync-draft-pick-contracts.mjs --dry-run
+          else
+            echo "::warning::LIVE MFL WRITE MODE — will stamp RC + slot salary on unstamped draft picks"
+            node ./scripts/sync-draft-pick-contracts.mjs
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,10 @@ pnpm-debug.log*
 data/salary-history-archive/
 data/*/salary-history/
 
+# Contract declarations: local-dev-only filesystem fallback. Production reads
+# from Upstash Redis. See src/utils/contract-storage.ts.
+data/*/contract-declarations.json
+
 # Salary history - only keep summary-week-*.json files
 src/data/salary-history/**/raw-*.json
 src/data/salary-history/**/summary-2*.json

--- a/scripts/lib/rookie-salary-slots.mjs
+++ b/scripts/lib/rookie-salary-slots.mjs
@@ -1,0 +1,88 @@
+/**
+ * Rookie slot salary table — single source of truth.
+ *
+ * Imported by:
+ *   - src/utils/draft-pick-cap-impact.ts (re-exports as ROOKIE_SALARIES_2026)
+ *   - scripts/sync-draft-pick-contracts.mjs (auto-create draft pick contracts)
+ *
+ * Pick numbers in this table are OVERALL pick numbers (round 1: 1-17,
+ * round 2: 18-35). Round 3+ uses ROUND_3_FLAT_RATE.
+ */
+
+export const ROOKIE_SALARIES_2026 = {
+  // Round 1
+  1: {
+    1: { QB: 3000000, RB: 3400000, WR: 3500000, TE: 2500000, PK: 575000, DEF: 575000 },
+    2: { QB: 2650000, RB: 3100000, WR: 3200000, TE: 2100000, PK: 525000, DEF: 525000 },
+    3: { QB: 2300000, RB: 2600000, WR: 2900000, TE: 1800000, PK: 500000, DEF: 500000 },
+    4: { QB: 1900000, RB: 2200000, WR: 2600000, TE: 1500000, PK: 450000, DEF: 450000 },
+    5: { QB: 1600000, RB: 1800000, WR: 2300000, TE: 1250000, PK: 450000, DEF: 450000 },
+    6: { QB: 1300000, RB: 1600000, WR: 2000000, TE: 1100000, PK: 450000, DEF: 450000 },
+    7: { QB: 1100000, RB: 1400000, WR: 1850000, TE: 950000, PK: 450000, DEF: 450000 },
+    8: { QB: 1000000, RB: 1200000, WR: 1675000, TE: 850000, PK: 450000, DEF: 450000 },
+    9: { QB: 925000, RB: 1100000, WR: 1550000, TE: 775000, PK: 450000, DEF: 450000 },
+    10: { QB: 875000, RB: 1000000, WR: 1400000, TE: 775000, PK: 450000, DEF: 450000 },
+    11: { QB: 825000, RB: 900000, WR: 1350000, TE: 700000, PK: 450000, DEF: 450000 },
+    12: { QB: 800000, RB: 850000, WR: 1225000, TE: 675000, PK: 450000, DEF: 450000 },
+    13: { QB: 750000, RB: 800000, WR: 1150000, TE: 650000, PK: 450000, DEF: 450000 },
+    14: { QB: 700000, RB: 750000, WR: 1075000, TE: 650000, PK: 450000, DEF: 450000 },
+    15: { QB: 675000, RB: 725000, WR: 1000000, TE: 625000, PK: 450000, DEF: 450000 },
+    16: { QB: 650000, RB: 700000, WR: 900000, TE: 625000, PK: 450000, DEF: 450000 },
+    // Toilet Bowl Pick (Round 1, Pick 17)
+    17: { QB: 625000, RB: 650000, WR: 800000, TE: 600000, PK: 450000, DEF: 450000 },
+  },
+  // Round 2
+  2: {
+    18: { QB: 575000, RB: 600000, WR: 700000, TE: 600000, PK: 425000, DEF: 425000 },
+    19: { QB: 525000, RB: 575000, WR: 650000, TE: 550000, PK: 425000, DEF: 425000 },
+    20: { QB: 525000, RB: 550000, WR: 625000, TE: 550000, PK: 425000, DEF: 425000 },
+    21: { QB: 500000, RB: 525000, WR: 600000, TE: 525000, PK: 425000, DEF: 425000 },
+    22: { QB: 475000, RB: 500000, WR: 575000, TE: 525000, PK: 425000, DEF: 425000 },
+    23: { QB: 475000, RB: 500000, WR: 575000, TE: 500000, PK: 425000, DEF: 425000 },
+    24: { QB: 475000, RB: 475000, WR: 550000, TE: 475000, PK: 425000, DEF: 425000 },
+    25: { QB: 475000, RB: 475000, WR: 550000, TE: 475000, PK: 425000, DEF: 425000 },
+    26: { QB: 475000, RB: 475000, WR: 525000, TE: 475000, PK: 425000, DEF: 425000 },
+    27: { QB: 475000, RB: 475000, WR: 525000, TE: 475000, PK: 425000, DEF: 425000 },
+    28: { QB: 475000, RB: 475000, WR: 525000, TE: 475000, PK: 425000, DEF: 425000 },
+    29: { QB: 475000, RB: 475000, WR: 525000, TE: 475000, PK: 425000, DEF: 425000 },
+    30: { QB: 475000, RB: 475000, WR: 525000, TE: 475000, PK: 425000, DEF: 425000 },
+    31: { QB: 475000, RB: 475000, WR: 525000, TE: 475000, PK: 425000, DEF: 425000 },
+    32: { QB: 475000, RB: 475000, WR: 525000, TE: 475000, PK: 425000, DEF: 425000 },
+    33: { QB: 475000, RB: 475000, WR: 500000, TE: 475000, PK: 425000, DEF: 425000 },
+    // Toilet Bowl Picks (Round 2, Pick 17 & 18)
+    34: { QB: 475000, RB: 475000, WR: 500000, TE: 475000, PK: 425000, DEF: 425000 },
+    35: { QB: 475000, RB: 475000, WR: 500000, TE: 475000, PK: 425000, DEF: 425000 },
+  },
+};
+
+export const ROUND_3_FLAT_RATE = {
+  QB: 450000, RB: 450000, WR: 475000, TE: 450000, PK: 425000, DEF: 425000,
+};
+
+const SUPPORTED_POSITIONS = new Set(['QB', 'RB', 'WR', 'TE', 'PK', 'DEF']);
+
+/**
+ * Convert (round, pickInRound) to overall pick number used by the salary table.
+ * Round 1 picks 1-17 → overall 1-17. Round 2 picks 1-18 → overall 18-35.
+ * Round 3+ doesn't matter; flat rate applies regardless of overall pick.
+ */
+export function overallPickFromRoundPick(round, pickInRound) {
+  if (round === 1) return pickInRound;
+  if (round === 2) return 17 + pickInRound;
+  return pickInRound;
+}
+
+/**
+ * Look up the slot-based rookie salary for a given (round, overallPick, position).
+ * Falls back to round-3 flat rate when out-of-table.
+ */
+export function getRookieSlotSalary(round, overallPick, position) {
+  const pos = String(position || '').toUpperCase();
+  const basePos = SUPPORTED_POSITIONS.has(pos) ? pos : 'WR';
+
+  if (round === 1 || round === 2) {
+    const row = ROOKIE_SALARIES_2026[round]?.[overallPick];
+    if (row) return row[basePos] ?? row.WR ?? 425000;
+  }
+  return ROUND_3_FLAT_RATE[basePos] ?? 425000;
+}

--- a/scripts/sync-draft-pick-contracts.mjs
+++ b/scripts/sync-draft-pick-contracts.mjs
@@ -2,28 +2,41 @@
 /**
  * Sync Draft Pick Contracts
  *
- * After each MFL feed fetch, scan draftResults.json for newly-completed picks
- * and create a pending `rookie-override` contract declaration for each one.
- * The slot-based rookie salary is auto-populated from
- * scripts/lib/rookie-salary-slots.mjs so the owner only has to choose
- * contract years (1-3, vs the default 4yr RC) on the contracts page.
+ * After each MFL feed fetch, scan draftResults.json for newly-completed
+ * picks and write the league's standard rookie contract directly to MFL:
+ *   contractInfo = "RC"
+ *   contractYear = "4"      (default RC length; owners reduce to 1-3 via the
+ *                            existing rookie-override flow before the August
+ *                            cutdown)
+ *   salary       = slot-based rookie salary by round/pick/position
  *
- * Idempotent: skips picks that already have a declaration for that
- * player+franchise.
+ * Why direct write instead of pending-declaration model:
+ *   MFL does NOT auto-apply RC on drafted players. Without this script
+ *   stamping RC, the rosters-page rookie-override button never appears
+ *   (eligibility check requires contractInfo === 'RC'). By writing RC + the
+ *   slot salary up front, owners can self-serve their year choice 1-3 from
+ *   the rosters page until the August cutdown. The commissioner is no
+ *   longer the critical-path step.
  *
- * Storage:
- *   - Upstash Redis when UPSTASH_REDIS_REST_URL/TOKEN (or KV_*) are set
- *   - Filesystem fallback at data/<league>/contract-declarations.json
- *     (mirrors the runtime behavior of src/utils/contract-storage.ts)
+ * Idempotency: queries current MFL salaries first and skips any drafted
+ * player who already has contractInfo === 'RC'. Safe to run on every
+ * roster-sync tick (every 5 min).
+ *
+ * Audit trail: also writes an `applied` ContractDeclaration record into
+ * storage (Upstash Redis or local JSON) so the change shows up in the
+ * Applied Contracts section on /theleague/contracts/manage.
  *
  * Usage:
- *   node scripts/sync-draft-pick-contracts.mjs              # theleague, latest year
+ *   node scripts/sync-draft-pick-contracts.mjs              # write to MFL
+ *   node scripts/sync-draft-pick-contracts.mjs --dry-run    # just print
  *   node scripts/sync-draft-pick-contracts.mjs --league afl --year 2026
  *
  * Env:
- *   MFL_LEAGUE_SLUG              defaults to 'theleague'
- *   MFL_YEAR / PUBLIC_BASE_YEAR  optional explicit year
- *   UPSTASH_REDIS_REST_URL/TOKEN OR KV_REST_API_URL/TOKEN — production storage
+ *   MFL_USERNAME, MFL_PASSWORD     required for MFL writes (any league commish)
+ *   MFL_LEAGUE_ID                  defaults to '13522'
+ *   MFL_LEAGUE_SLUG                defaults to 'theleague'
+ *   MFL_YEAR / PUBLIC_BASE_YEAR    optional explicit year override
+ *   UPSTASH_REDIS_REST_URL/TOKEN   audit trail in production
  */
 
 import { promises as fs } from 'node:fs';
@@ -36,37 +49,26 @@ import {
 
 const projectRoot = path.resolve(fileURLToPath(new URL('..', import.meta.url)));
 const REDIS_KEY = 'contract-declarations';
+const RC_DEFAULT_YEARS = 4;
+const MFL_READ_HOST = process.env.MFL_HOST || 'https://api.myfantasyleague.com';
+const MFL_WRITE_HOST = process.env.MFL_WRITE_HOST || 'https://www49.myfantasyleague.com';
 
 // ── Pure logic (testable) ──────────────────────────────────────────────
 
 /**
- * Build the set of contract declarations that should exist for the given
- * draft results. Returns ONLY new declarations (skips ones already in
- * `existingDeclarations` by playerId+franchiseId).
+ * Build the list of MFL contract writes that should happen for the given
+ * draft results, skipping any pick that already has contractInfo='RC' on
+ * MFL.
  *
  * @param {object} args
- * @param {object} args.draftResults  The parsed draftResults.json content
+ * @param {object} args.draftResults  Parsed draftResults.json
  * @param {Map<string, {position: string, name: string}>} args.playerIndex
- * @param {Map<string, string>} args.franchiseNameMap  franchiseId → display name
- * @param {string} args.leagueId
- * @param {Array<{playerId: string, franchiseId: string}>} args.existingDeclarations
- * @param {() => string} [args.idGenerator]  For deterministic test output
- * @param {() => Date} [args.now]  Override "now" for tests
+ * @param {Map<string, {salary: string, contractYear: string, contractInfo: string}>} args.mflSalaries
+ *   Player ID → current MFL contract state
  */
-export function buildDraftPickDeclarations({
-  draftResults,
-  playerIndex,
-  franchiseNameMap,
-  leagueId,
-  existingDeclarations,
-  idGenerator = generateId,
-  now = () => new Date(),
-}) {
+export function buildDraftPickWrites({ draftResults, playerIndex, mflSalaries }) {
   const draftPicks = draftResults?.draftResults?.draftUnit?.draftPick ?? [];
-  const existing = new Set(
-    existingDeclarations.map((d) => `${d.franchiseId}:${d.playerId}`),
-  );
-  const created = [];
+  const writes = [];
 
   for (const pick of draftPicks) {
     const playerId = String(pick.player ?? '').trim();
@@ -76,8 +78,9 @@ export function buildDraftPickDeclarations({
     const franchiseId = String(pick.franchise ?? '').trim();
     if (!franchiseId) continue;
 
-    const key = `${franchiseId}:${playerId}`;
-    if (existing.has(key)) continue;
+    // Skip if this player already has RC stamped on MFL
+    const current = mflSalaries.get(playerId);
+    if (current?.contractInfo === 'RC') continue;
 
     const round = parseInt(pick.round, 10);
     const pickInRound = parseInt(pick.pick, 10);
@@ -88,42 +91,196 @@ export function buildDraftPickDeclarations({
     const position = player?.position ?? 'WR';
     const playerName = player?.name ?? `Player ${playerId}`;
     const salary = getRookieSlotSalary(round, overallPick, position);
-
     const tsSec = parseInt(ts, 10);
-    const submittedAt = Number.isFinite(tsSec)
-      ? new Date(tsSec * 1000).toISOString()
-      : now().toISOString();
 
-    created.push({
-      id: idGenerator(),
-      type: 'rookie-override',
+    writes.push({
       playerId,
       playerName,
       franchiseId,
-      franchiseName: franchiseNameMap.get(franchiseId) ?? `Team ${franchiseId}`,
-      leagueId,
-      currentYears: 4,
-      currentSalary: salary,
-      currentContractInfo: 'RC',
-      requestedYears: 4,
-      requestedSalary: salary,
-      requestedContractInfo: 'RC',
-      status: 'pending',
-      submittedBy: 'Draft Auto-Sync',
-      submittedAt,
-      mflSynced: false,
+      round,
+      pickInRound,
+      position,
+      salary,
+      contractYear: String(RC_DEFAULT_YEARS),
+      contractInfo: 'RC',
       acquisitionTimestamp: Number.isFinite(tsSec) ? tsSec : undefined,
     });
   }
 
-  return created;
+  return writes;
 }
 
-function generateId() {
-  return `DECL_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+// ── MFL auth + fetch (mirrors src/utils/mfl-login.ts + mfl-fetch.ts) ──
+
+/**
+ * Manual-redirect fetch that re-attaches the Cookie header on every hop.
+ * Required because Node.js undici strips Cookie on cross-origin 302s, and
+ * MFL's api.* host always redirects to www49.* for authenticated calls.
+ */
+async function mflFetch({ url, method = 'GET', cookies, body, timeoutMs = 10_000 }) {
+  let currentUrl = url;
+  let currentMethod = method;
+  let currentBody = body;
+  const cookieHeader = Object.entries(cookies)
+    .filter(([, v]) => v)
+    .map(([k, v]) => `${k}=${v}`)
+    .join('; ');
+
+  for (let hop = 0; hop <= 3; hop++) {
+    const headers = { Cookie: cookieHeader };
+    if (currentMethod === 'POST' && currentBody) {
+      headers['Content-Type'] = 'application/x-www-form-urlencoded';
+    }
+    const res = await fetch(currentUrl, {
+      method: currentMethod,
+      headers,
+      body: currentMethod === 'POST' ? currentBody : undefined,
+      redirect: 'manual',
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (res.status < 300 || res.status >= 400) return res;
+    const location = res.headers.get('location');
+    if (!location) return res;
+    currentUrl = location.startsWith('http')
+      ? location
+      : new URL(location, currentUrl).href;
+    if (res.status === 302 || res.status === 303) {
+      if (currentMethod === 'POST' && currentBody) {
+        const sep = currentUrl.includes('?') ? '&' : '?';
+        currentUrl = `${currentUrl}${sep}${currentBody}`;
+      }
+      currentMethod = 'GET';
+      currentBody = undefined;
+    }
+  }
+  throw new Error(`mflFetch exceeded redirect limit for ${url}`);
 }
 
-// ── Storage layer ──────────────────────────────────────────────────────
+/**
+ * Log into MFL with username/password and return MFL_USER_ID + (optional)
+ * MFL_IS_COMMISH cookies. Mirrors src/utils/mfl-login.ts but stripped to
+ * just the cookie acquisition (no franchise-resolution step).
+ */
+async function loginToMFL(username, password) {
+  const year = new Date().getFullYear();
+  const loginUrl = `https://api.myfantasyleague.com/${year}/login`;
+  const params = new URLSearchParams({ USERNAME: username, PASSWORD: password, XML: '1' });
+
+  const allSetCookies = [];
+  let url = loginUrl;
+  let method = 'POST';
+  let body = params.toString();
+  let finalText = '';
+
+  for (let hop = 0; hop <= 3; hop++) {
+    const headers = method === 'POST' ? { 'Content-Type': 'application/x-www-form-urlencoded' } : {};
+    const res = await fetch(url, {
+      method,
+      headers,
+      body: method === 'POST' ? body : undefined,
+      redirect: 'manual',
+      signal: AbortSignal.timeout(8000),
+    });
+    const hopCookies = res.headers.getSetCookie?.() ?? [];
+    allSetCookies.push(...hopCookies);
+    if (res.status >= 300 && res.status < 400) {
+      const location = res.headers.get('location');
+      if (!location) {
+        finalText = await res.text();
+        break;
+      }
+      url = location.startsWith('http') ? location : new URL(location, url).href;
+      if (res.status === 302 || res.status === 303) {
+        if (method === 'POST' && body) {
+          const sep = url.includes('?') ? '&' : '?';
+          url = `${url}${sep}${body}`;
+        }
+        method = 'GET';
+        body = undefined;
+      }
+      continue;
+    }
+    finalText = await res.text();
+    break;
+  }
+
+  // Fall back to GET-with-params if POST returned empty
+  if (!finalText.trim()) {
+    const fallbackUrl = `${loginUrl}?${params.toString()}`;
+    const res = await fetch(fallbackUrl, { redirect: 'follow', signal: AbortSignal.timeout(8000) });
+    finalText = await res.text();
+    const hopCookies = res.headers.getSetCookie?.() ?? [];
+    allSetCookies.push(...hopCookies);
+  }
+
+  const errorMatch = finalText.match(/<error[^>]*>(.*?)<\/error>/s);
+  if (errorMatch) throw new Error(`MFL login failed: ${errorMatch[1].trim()}`);
+
+  const cookieMatch = finalText.match(/MFL_USER_ID="([^"]+)"/);
+  if (!cookieMatch) throw new Error(`MFL login: no MFL_USER_ID in response: ${finalText.slice(0, 200)}`);
+
+  let commishCookie;
+  for (const cookieStr of allSetCookies) {
+    const m = cookieStr.match(/MFL_IS_COMMISH=([^;]+)/);
+    if (m) {
+      commishCookie = m[1];
+      break;
+    }
+  }
+
+  return { mflUserId: cookieMatch[1], mflIsCommish: commishCookie };
+}
+
+async function fetchCurrentMFLSalaries({ leagueId, year, cookies }) {
+  const url = `${MFL_READ_HOST}/${year}/export?TYPE=salaries&L=${leagueId}&JSON=1`;
+  const res = await mflFetch({ url, cookies });
+  if (!res.ok) throw new Error(`MFL salaries fetch failed: ${res.status}`);
+  const data = await res.json();
+  const players = data?.salaries?.leagueUnit?.player ?? [];
+  const map = new Map();
+  for (const p of players) {
+    map.set(String(p.id), {
+      salary: p.salary,
+      contractYear: p.contractYear,
+      contractInfo: p.contractInfo,
+    });
+  }
+  return map;
+}
+
+async function writeContractsToMFL({ leagueId, year, cookies, writes }) {
+  const url = `${MFL_WRITE_HOST}/${year}/import?TYPE=salaries&L=${leagueId}&APPEND=1`;
+  const playerXml = writes
+    .map(
+      (w) =>
+        `<player id="${w.playerId}" salary="${w.salary}" contractYear="${w.contractYear}" contractInfo="${w.contractInfo}" />`,
+    )
+    .join('');
+  const xml = `<salaries><leagueUnit unit="LEAGUE">${playerXml}</leagueUnit></salaries>`;
+  const body = new URLSearchParams({ DATA: xml }).toString();
+
+  const delays = [500, 1500];
+  let lastError = '';
+  for (let attempt = 0; attempt <= delays.length; attempt++) {
+    const res = await mflFetch({ url, method: 'POST', cookies, body });
+    if (res.ok) {
+      const text = await res.text();
+      if (text.toLowerCase().includes('error')) {
+        lastError = `MFL error response: ${text.slice(0, 200)}`;
+      } else {
+        return { success: true, attempts: attempt + 1, response: text.slice(0, 200) };
+      }
+    } else {
+      lastError = `HTTP ${res.status}`;
+    }
+    if (attempt < delays.length) {
+      await new Promise((r) => setTimeout(r, delays[attempt]));
+    }
+  }
+  return { success: false, attempts: delays.length + 1, error: lastError };
+}
+
+// ── Audit-trail declaration storage (best-effort) ──────────────────────
 
 function getRedisConfig() {
   const url =
@@ -138,93 +295,82 @@ function getRedisConfig() {
   return { url, token };
 }
 
-async function readDeclarationsFromRedis(redis) {
-  const res = await fetch(`${redis.url}/hgetall/${encodeURIComponent(REDIS_KEY)}`, {
-    headers: { Authorization: `Bearer ${redis.token}` },
-  });
-  if (!res.ok) {
-    throw new Error(`Redis hgetall failed: ${res.status} ${await res.text()}`);
-  }
-  const json = await res.json();
-  const result = json?.result;
-  if (!result) return [];
+async function writeAuditDeclarations(declarations, leagueSlug) {
+  if (declarations.length === 0) return;
 
-  // Upstash REST returns an object {field: value, ...} for hgetall
-  if (typeof result === 'object' && !Array.isArray(result)) {
-    return Object.values(result).map(parseRedisValue).filter(Boolean);
-  }
-
-  // Legacy flat-array form: [field, value, field, value, ...]
-  if (Array.isArray(result)) {
-    const out = [];
-    for (let i = 1; i < result.length; i += 2) {
-      const parsed = parseRedisValue(result[i]);
-      if (parsed) out.push(parsed);
+  const redis = getRedisConfig();
+  if (redis) {
+    const body = [REDIS_KEY];
+    for (const d of declarations) body.push(d.id, JSON.stringify(d));
+    const res = await fetch(`${redis.url}/hset`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${redis.token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      console.warn(`[draft-pick-sync] audit write to Redis failed: ${res.status} ${await res.text()}`);
     }
-    return out;
+    return;
   }
 
-  return [];
-}
-
-function parseRedisValue(v) {
-  if (v == null) return null;
-  if (typeof v === 'object') return v;
+  // Local dev fallback
+  const filePath = path.join(projectRoot, 'data', leagueSlug, 'contract-declarations.json');
+  let existing = { version: '1.0', lastUpdated: '', declarations: [] };
   try {
-    return JSON.parse(v);
-  } catch {
-    return null;
-  }
-}
-
-async function writeDeclarationsToRedis(redis, declarations) {
-  // Upstash supports HSET with multiple field/value pairs in one call.
-  // Build args: [REDIS_KEY, field1, value1, field2, value2, ...]
-  const body = [REDIS_KEY];
-  for (const d of declarations) {
-    body.push(d.id, JSON.stringify(d));
-  }
-  const res = await fetch(`${redis.url}/hset`, {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${redis.token}`,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify(body),
-  });
-  if (!res.ok) {
-    throw new Error(`Redis hset failed: ${res.status} ${await res.text()}`);
-  }
-}
-
-async function readDeclarationsFromFile(filePath) {
-  try {
-    const raw = await fs.readFile(filePath, 'utf-8');
-    const parsed = JSON.parse(raw);
-    return parsed.declarations ?? [];
+    existing = JSON.parse(await fs.readFile(filePath, 'utf-8'));
   } catch (err) {
-    if (err.code === 'ENOENT') return [];
-    throw err;
+    if (err.code !== 'ENOENT') throw err;
   }
-}
-
-async function writeDeclarationsToFile(filePath, declarations) {
+  existing.lastUpdated = new Date().toISOString();
+  existing.declarations = [...declarations, ...(existing.declarations ?? [])];
   await fs.mkdir(path.dirname(filePath), { recursive: true });
-  const file = {
-    version: '1.0',
-    lastUpdated: new Date().toISOString(),
-    declarations,
-  };
-  await fs.writeFile(filePath, JSON.stringify(file, null, 2), 'utf-8');
+  await fs.writeFile(filePath, JSON.stringify(existing, null, 2), 'utf-8');
 }
 
-// ── CLI entry point ────────────────────────────────────────────────────
+function generateDeclarationId() {
+  return `DECL_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function buildAuditDeclaration({ write, leagueId, franchiseNameMap }) {
+  const submittedAt = write.acquisitionTimestamp
+    ? new Date(write.acquisitionTimestamp * 1000).toISOString()
+    : new Date().toISOString();
+  return {
+    id: generateDeclarationId(),
+    type: 'rookie-override',
+    playerId: write.playerId,
+    playerName: write.playerName,
+    franchiseId: write.franchiseId,
+    franchiseName: franchiseNameMap.get(write.franchiseId) ?? `Team ${write.franchiseId}`,
+    leagueId,
+    currentYears: 0,
+    currentSalary: 0,
+    currentContractInfo: '',
+    requestedYears: RC_DEFAULT_YEARS,
+    requestedSalary: write.salary,
+    requestedContractInfo: 'RC',
+    status: 'applied',
+    submittedBy: 'Draft Auto-Sync',
+    submittedAt,
+    reviewedBy: 'Draft Auto-Sync',
+    reviewedAt: new Date().toISOString(),
+    mflSynced: true,
+    mflSyncedAt: new Date().toISOString(),
+    acquisitionTimestamp: write.acquisitionTimestamp,
+  };
+}
+
+// ── CLI ────────────────────────────────────────────────────────────────
 
 function parseArgs(argv) {
-  const args = { league: undefined, year: undefined };
+  const args = { league: undefined, year: undefined, dryRun: false };
   for (let i = 0; i < argv.length; i++) {
     if (argv[i] === '--league') args.league = argv[++i];
     else if (argv[i] === '--year') args.year = argv[++i];
+    else if (argv[i] === '--dry-run') args.dryRun = true;
   }
   return args;
 }
@@ -235,9 +381,6 @@ function getCurrentDraftYear() {
     process.env.PUBLIC_BASE_YEAR ||
     process.env.MFL_SEASON;
   if (env) return parseInt(env, 10);
-  // The draft happens in the spring of the current calendar year for that
-  // year's season. Default to the current calendar year — the script also
-  // tolerates a missing draftResults.json by exiting cleanly.
   return new Date().getFullYear();
 }
 
@@ -249,14 +392,8 @@ async function main() {
   const feedsDir = path.join(projectRoot, 'data', leagueSlug, 'mfl-feeds', year);
   const draftResultsPath = path.join(feedsDir, 'draftResults.json');
   const playersPath = path.join(feedsDir, 'players.json');
-  const leagueConfigPath = path.join(
-    projectRoot,
-    'src',
-    'data',
-    `${leagueSlug}.config.json`,
-  );
+  const leagueConfigPath = path.join(projectRoot, 'src', 'data', `${leagueSlug}.config.json`);
 
-  // Bail cleanly if no draft data yet
   let draftResults;
   try {
     draftResults = JSON.parse(await fs.readFile(draftResultsPath, 'utf-8'));
@@ -282,54 +419,61 @@ async function main() {
       team.nameShort || team.nameMedium || team.name || `Team ${team.franchiseId}`,
     );
   }
-  const leagueId = String(
-    leagueConfig.leagueId || process.env.MFL_LEAGUE_ID || '13522',
-  );
+  const leagueId = String(leagueConfig.leagueId || process.env.MFL_LEAGUE_ID || '13522');
 
-  // Read existing declarations (Redis preferred, file fallback)
-  const redis = getRedisConfig();
-  const filePath = path.join(
-    projectRoot,
-    'data',
-    leagueSlug,
-    'contract-declarations.json',
-  );
-
-  let existingDeclarations;
-  if (redis) {
-    existingDeclarations = await readDeclarationsFromRedis(redis);
-  } else {
-    existingDeclarations = await readDeclarationsFromFile(filePath);
+  // Auth — required for both reading current salaries and writing
+  const username = process.env.MFL_USERNAME;
+  const password = process.env.MFL_PASSWORD;
+  if (!username || !password) {
+    throw new Error('MFL_USERNAME and MFL_PASSWORD are required for draft pick sync.');
   }
+  const { mflUserId, mflIsCommish } = await loginToMFL(username, password);
+  const cookies = { MFL_USER_ID: mflUserId, MFL_IS_COMMISH: mflIsCommish };
+  console.log(
+    `[draft-pick-sync] Logged into MFL${mflIsCommish ? ' (commish cookie present)' : ''}.`,
+  );
 
-  const newDeclarations = buildDraftPickDeclarations({
-    draftResults,
-    playerIndex,
-    franchiseNameMap,
-    leagueId,
-    existingDeclarations,
-  });
+  // Fetch current MFL salaries to detect which picks still need RC stamped
+  const mflSalaries = await fetchCurrentMFLSalaries({ leagueId, year, cookies });
 
-  if (newDeclarations.length === 0) {
-    console.log('[draft-pick-sync] No new draft picks to process.');
+  const writes = buildDraftPickWrites({ draftResults, playerIndex, mflSalaries });
+
+  if (writes.length === 0) {
+    console.log('[draft-pick-sync] All drafted players already have RC stamped. Nothing to do.');
     return;
   }
 
-  if (redis) {
-    await writeDeclarationsToRedis(redis, newDeclarations);
-  } else {
-    const merged = [...newDeclarations, ...existingDeclarations];
-    await writeDeclarationsToFile(filePath, merged);
+  console.log(`[draft-pick-sync] ${writes.length} draft pick(s) need RC + slot salary stamped:`);
+  for (const w of writes) {
+    console.log(
+      `  ${(franchiseNameMap.get(w.franchiseId) ?? w.franchiseId).padEnd(14)} ` +
+        `R${w.round}.${String(w.pickInRound).padStart(2, '0')} ${w.position.padEnd(3)} ` +
+        `${w.playerName.padEnd(28)} → $${w.salary.toLocaleString()} / ${w.contractYear}yr / ${w.contractInfo}`,
+    );
   }
 
-  console.log(`[draft-pick-sync] Created ${newDeclarations.length} new rookie-override declaration(s):`);
-  for (const d of newDeclarations) {
-    const fmtSalary = `$${d.currentSalary.toLocaleString()}`;
-    console.log(`  ${d.franchiseName.padEnd(14)} → ${d.playerName} (${fmtSalary})`);
+  if (cli.dryRun) {
+    console.log('[draft-pick-sync] --dry-run: not writing to MFL.');
+    return;
+  }
+
+  const result = await writeContractsToMFL({ leagueId, year, cookies, writes });
+  if (!result.success) {
+    throw new Error(`MFL write failed after ${result.attempts} attempt(s): ${result.error}`);
+  }
+  console.log(`[draft-pick-sync] MFL write succeeded (attempt ${result.attempts}).`);
+
+  const auditDeclarations = writes.map((w) =>
+    buildAuditDeclaration({ write: w, leagueId, franchiseNameMap }),
+  );
+  try {
+    await writeAuditDeclarations(auditDeclarations, leagueSlug);
+    console.log(`[draft-pick-sync] Recorded ${auditDeclarations.length} audit-trail declaration(s).`);
+  } catch (err) {
+    console.warn(`[draft-pick-sync] Audit-trail write failed (MFL write already succeeded): ${err.message}`);
   }
 }
 
-// Run only when invoked directly (not when imported by tests)
 if (import.meta.url === `file://${process.argv[1]}`) {
   main().catch((err) => {
     console.error('[draft-pick-sync] Failed:', err);

--- a/scripts/sync-draft-pick-contracts.mjs
+++ b/scripts/sync-draft-pick-contracts.mjs
@@ -1,0 +1,338 @@
+#!/usr/bin/env node
+/**
+ * Sync Draft Pick Contracts
+ *
+ * After each MFL feed fetch, scan draftResults.json for newly-completed picks
+ * and create a pending `rookie-override` contract declaration for each one.
+ * The slot-based rookie salary is auto-populated from
+ * scripts/lib/rookie-salary-slots.mjs so the owner only has to choose
+ * contract years (1-3, vs the default 4yr RC) on the contracts page.
+ *
+ * Idempotent: skips picks that already have a declaration for that
+ * player+franchise.
+ *
+ * Storage:
+ *   - Upstash Redis when UPSTASH_REDIS_REST_URL/TOKEN (or KV_*) are set
+ *   - Filesystem fallback at data/<league>/contract-declarations.json
+ *     (mirrors the runtime behavior of src/utils/contract-storage.ts)
+ *
+ * Usage:
+ *   node scripts/sync-draft-pick-contracts.mjs              # theleague, latest year
+ *   node scripts/sync-draft-pick-contracts.mjs --league afl --year 2026
+ *
+ * Env:
+ *   MFL_LEAGUE_SLUG              defaults to 'theleague'
+ *   MFL_YEAR / PUBLIC_BASE_YEAR  optional explicit year
+ *   UPSTASH_REDIS_REST_URL/TOKEN OR KV_REST_API_URL/TOKEN — production storage
+ */
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  getRookieSlotSalary,
+  overallPickFromRoundPick,
+} from './lib/rookie-salary-slots.mjs';
+
+const projectRoot = path.resolve(fileURLToPath(new URL('..', import.meta.url)));
+const REDIS_KEY = 'contract-declarations';
+
+// ── Pure logic (testable) ──────────────────────────────────────────────
+
+/**
+ * Build the set of contract declarations that should exist for the given
+ * draft results. Returns ONLY new declarations (skips ones already in
+ * `existingDeclarations` by playerId+franchiseId).
+ *
+ * @param {object} args
+ * @param {object} args.draftResults  The parsed draftResults.json content
+ * @param {Map<string, {position: string, name: string}>} args.playerIndex
+ * @param {Map<string, string>} args.franchiseNameMap  franchiseId → display name
+ * @param {string} args.leagueId
+ * @param {Array<{playerId: string, franchiseId: string}>} args.existingDeclarations
+ * @param {() => string} [args.idGenerator]  For deterministic test output
+ * @param {() => Date} [args.now]  Override "now" for tests
+ */
+export function buildDraftPickDeclarations({
+  draftResults,
+  playerIndex,
+  franchiseNameMap,
+  leagueId,
+  existingDeclarations,
+  idGenerator = generateId,
+  now = () => new Date(),
+}) {
+  const draftPicks = draftResults?.draftResults?.draftUnit?.draftPick ?? [];
+  const existing = new Set(
+    existingDeclarations.map((d) => `${d.franchiseId}:${d.playerId}`),
+  );
+  const created = [];
+
+  for (const pick of draftPicks) {
+    const playerId = String(pick.player ?? '').trim();
+    const ts = String(pick.timestamp ?? '').trim();
+    if (!playerId || !ts) continue; // not yet drafted
+
+    const franchiseId = String(pick.franchise ?? '').trim();
+    if (!franchiseId) continue;
+
+    const key = `${franchiseId}:${playerId}`;
+    if (existing.has(key)) continue;
+
+    const round = parseInt(pick.round, 10);
+    const pickInRound = parseInt(pick.pick, 10);
+    if (!Number.isFinite(round) || !Number.isFinite(pickInRound)) continue;
+
+    const overallPick = overallPickFromRoundPick(round, pickInRound);
+    const player = playerIndex.get(playerId);
+    const position = player?.position ?? 'WR';
+    const playerName = player?.name ?? `Player ${playerId}`;
+    const salary = getRookieSlotSalary(round, overallPick, position);
+
+    const tsSec = parseInt(ts, 10);
+    const submittedAt = Number.isFinite(tsSec)
+      ? new Date(tsSec * 1000).toISOString()
+      : now().toISOString();
+
+    created.push({
+      id: idGenerator(),
+      type: 'rookie-override',
+      playerId,
+      playerName,
+      franchiseId,
+      franchiseName: franchiseNameMap.get(franchiseId) ?? `Team ${franchiseId}`,
+      leagueId,
+      currentYears: 4,
+      currentSalary: salary,
+      currentContractInfo: 'RC',
+      requestedYears: 4,
+      requestedSalary: salary,
+      requestedContractInfo: 'RC',
+      status: 'pending',
+      submittedBy: 'Draft Auto-Sync',
+      submittedAt,
+      mflSynced: false,
+      acquisitionTimestamp: Number.isFinite(tsSec) ? tsSec : undefined,
+    });
+  }
+
+  return created;
+}
+
+function generateId() {
+  return `DECL_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+// ── Storage layer ──────────────────────────────────────────────────────
+
+function getRedisConfig() {
+  const url =
+    process.env.UPSTASH_REDIS_REST_URL ||
+    process.env.KV_REST_API_URL ||
+    process.env.STORAGE_REST_API_URL;
+  const token =
+    process.env.UPSTASH_REDIS_REST_TOKEN ||
+    process.env.KV_REST_API_TOKEN ||
+    process.env.STORAGE_REST_API_TOKEN;
+  if (!url || !token) return null;
+  return { url, token };
+}
+
+async function readDeclarationsFromRedis(redis) {
+  const res = await fetch(`${redis.url}/hgetall/${encodeURIComponent(REDIS_KEY)}`, {
+    headers: { Authorization: `Bearer ${redis.token}` },
+  });
+  if (!res.ok) {
+    throw new Error(`Redis hgetall failed: ${res.status} ${await res.text()}`);
+  }
+  const json = await res.json();
+  const result = json?.result;
+  if (!result) return [];
+
+  // Upstash REST returns an object {field: value, ...} for hgetall
+  if (typeof result === 'object' && !Array.isArray(result)) {
+    return Object.values(result).map(parseRedisValue).filter(Boolean);
+  }
+
+  // Legacy flat-array form: [field, value, field, value, ...]
+  if (Array.isArray(result)) {
+    const out = [];
+    for (let i = 1; i < result.length; i += 2) {
+      const parsed = parseRedisValue(result[i]);
+      if (parsed) out.push(parsed);
+    }
+    return out;
+  }
+
+  return [];
+}
+
+function parseRedisValue(v) {
+  if (v == null) return null;
+  if (typeof v === 'object') return v;
+  try {
+    return JSON.parse(v);
+  } catch {
+    return null;
+  }
+}
+
+async function writeDeclarationsToRedis(redis, declarations) {
+  // Upstash supports HSET with multiple field/value pairs in one call.
+  // Build args: [REDIS_KEY, field1, value1, field2, value2, ...]
+  const body = [REDIS_KEY];
+  for (const d of declarations) {
+    body.push(d.id, JSON.stringify(d));
+  }
+  const res = await fetch(`${redis.url}/hset`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${redis.token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    throw new Error(`Redis hset failed: ${res.status} ${await res.text()}`);
+  }
+}
+
+async function readDeclarationsFromFile(filePath) {
+  try {
+    const raw = await fs.readFile(filePath, 'utf-8');
+    const parsed = JSON.parse(raw);
+    return parsed.declarations ?? [];
+  } catch (err) {
+    if (err.code === 'ENOENT') return [];
+    throw err;
+  }
+}
+
+async function writeDeclarationsToFile(filePath, declarations) {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  const file = {
+    version: '1.0',
+    lastUpdated: new Date().toISOString(),
+    declarations,
+  };
+  await fs.writeFile(filePath, JSON.stringify(file, null, 2), 'utf-8');
+}
+
+// ── CLI entry point ────────────────────────────────────────────────────
+
+function parseArgs(argv) {
+  const args = { league: undefined, year: undefined };
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--league') args.league = argv[++i];
+    else if (argv[i] === '--year') args.year = argv[++i];
+  }
+  return args;
+}
+
+function getCurrentDraftYear() {
+  const env =
+    process.env.MFL_YEAR ||
+    process.env.PUBLIC_BASE_YEAR ||
+    process.env.MFL_SEASON;
+  if (env) return parseInt(env, 10);
+  // The draft happens in the spring of the current calendar year for that
+  // year's season. Default to the current calendar year — the script also
+  // tolerates a missing draftResults.json by exiting cleanly.
+  return new Date().getFullYear();
+}
+
+async function main() {
+  const cli = parseArgs(process.argv.slice(2));
+  const leagueSlug = cli.league || process.env.MFL_LEAGUE_SLUG || 'theleague';
+  const year = cli.year || String(getCurrentDraftYear());
+
+  const feedsDir = path.join(projectRoot, 'data', leagueSlug, 'mfl-feeds', year);
+  const draftResultsPath = path.join(feedsDir, 'draftResults.json');
+  const playersPath = path.join(feedsDir, 'players.json');
+  const leagueConfigPath = path.join(
+    projectRoot,
+    'src',
+    'data',
+    `${leagueSlug}.config.json`,
+  );
+
+  // Bail cleanly if no draft data yet
+  let draftResults;
+  try {
+    draftResults = JSON.parse(await fs.readFile(draftResultsPath, 'utf-8'));
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      console.log(`[draft-pick-sync] No draftResults.json at ${draftResultsPath}; nothing to do.`);
+      return;
+    }
+    throw err;
+  }
+
+  const playersRaw = JSON.parse(await fs.readFile(playersPath, 'utf-8'));
+  const playerIndex = new Map();
+  for (const p of playersRaw?.players?.player ?? []) {
+    playerIndex.set(String(p.id), { position: p.position, name: p.name });
+  }
+
+  const leagueConfig = JSON.parse(await fs.readFile(leagueConfigPath, 'utf-8'));
+  const franchiseNameMap = new Map();
+  for (const team of leagueConfig.teams ?? []) {
+    franchiseNameMap.set(
+      team.franchiseId,
+      team.nameShort || team.nameMedium || team.name || `Team ${team.franchiseId}`,
+    );
+  }
+  const leagueId = String(
+    leagueConfig.leagueId || process.env.MFL_LEAGUE_ID || '13522',
+  );
+
+  // Read existing declarations (Redis preferred, file fallback)
+  const redis = getRedisConfig();
+  const filePath = path.join(
+    projectRoot,
+    'data',
+    leagueSlug,
+    'contract-declarations.json',
+  );
+
+  let existingDeclarations;
+  if (redis) {
+    existingDeclarations = await readDeclarationsFromRedis(redis);
+  } else {
+    existingDeclarations = await readDeclarationsFromFile(filePath);
+  }
+
+  const newDeclarations = buildDraftPickDeclarations({
+    draftResults,
+    playerIndex,
+    franchiseNameMap,
+    leagueId,
+    existingDeclarations,
+  });
+
+  if (newDeclarations.length === 0) {
+    console.log('[draft-pick-sync] No new draft picks to process.');
+    return;
+  }
+
+  if (redis) {
+    await writeDeclarationsToRedis(redis, newDeclarations);
+  } else {
+    const merged = [...newDeclarations, ...existingDeclarations];
+    await writeDeclarationsToFile(filePath, merged);
+  }
+
+  console.log(`[draft-pick-sync] Created ${newDeclarations.length} new rookie-override declaration(s):`);
+  for (const d of newDeclarations) {
+    const fmtSalary = `$${d.currentSalary.toLocaleString()}`;
+    console.log(`  ${d.franchiseName.padEnd(14)} → ${d.playerName} (${fmtSalary})`);
+  }
+}
+
+// Run only when invoked directly (not when imported by tests)
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((err) => {
+    console.error('[draft-pick-sync] Failed:', err);
+    process.exit(1);
+  });
+}

--- a/src/utils/draft-pick-cap-impact.ts
+++ b/src/utils/draft-pick-cap-impact.ts
@@ -1,56 +1,17 @@
 import type { TeamCapSituation } from '../types/auction-predictor';
+import {
+  ROOKIE_SALARIES_2026 as SHARED_ROOKIE_SALARIES_2026,
+  ROUND_3_FLAT_RATE as SHARED_ROUND_3_FLAT_RATE,
+} from '../../scripts/lib/rookie-salary-slots.mjs';
 
-// 2026 Rookie Slot Salaries (from rules.astro)
-// Note: These values escalate by 10% annually after the rookie year
-export const ROOKIE_SALARIES_2026: Record<number, Record<number, Record<string, number>>> = {
-  // Round 1
-  1: {
-    1: { QB: 3000000, RB: 3400000, WR: 3500000, TE: 2500000, PK: 575000, DEF: 575000 },
-    2: { QB: 2650000, RB: 3100000, WR: 3200000, TE: 2100000, PK: 525000, DEF: 525000 },
-    3: { QB: 2300000, RB: 2600000, WR: 2900000, TE: 1800000, PK: 500000, DEF: 500000 },
-    4: { QB: 1900000, RB: 2200000, WR: 2600000, TE: 1500000, PK: 450000, DEF: 450000 },
-    5: { QB: 1600000, RB: 1800000, WR: 2300000, TE: 1250000, PK: 450000, DEF: 450000 },
-    6: { QB: 1300000, RB: 1600000, WR: 2000000, TE: 1100000, PK: 450000, DEF: 450000 },
-    7: { QB: 1100000, RB: 1400000, WR: 1850000, TE: 950000, PK: 450000, DEF: 450000 },
-    8: { QB: 1000000, RB: 1200000, WR: 1675000, TE: 850000, PK: 450000, DEF: 450000 },
-    9: { QB: 925000, RB: 1100000, WR: 1550000, TE: 775000, PK: 450000, DEF: 450000 },
-    10: { QB: 875000, RB: 1000000, WR: 1400000, TE: 775000, PK: 450000, DEF: 450000 },
-    11: { QB: 825000, RB: 900000, WR: 1350000, TE: 700000, PK: 450000, DEF: 450000 },
-    12: { QB: 800000, RB: 850000, WR: 1225000, TE: 675000, PK: 450000, DEF: 450000 },
-    13: { QB: 750000, RB: 800000, WR: 1150000, TE: 650000, PK: 450000, DEF: 450000 },
-    14: { QB: 700000, RB: 750000, WR: 1075000, TE: 650000, PK: 450000, DEF: 450000 },
-    15: { QB: 675000, RB: 725000, WR: 1000000, TE: 625000, PK: 450000, DEF: 450000 },
-    16: { QB: 650000, RB: 700000, WR: 900000, TE: 625000, PK: 450000, DEF: 450000 },
-    // Toilet Bowl Pick (Round 1, Pick 17)
-    17: { QB: 625000, RB: 650000, WR: 800000, TE: 600000, PK: 450000, DEF: 450000 },
-  },
-  // Round 2
-  2: {
-    18: { QB: 575000, RB: 600000, WR: 700000, TE: 600000, PK: 425000, DEF: 425000 },
-    19: { QB: 525000, RB: 575000, WR: 650000, TE: 550000, PK: 425000, DEF: 425000 },
-    20: { QB: 525000, RB: 550000, WR: 625000, TE: 550000, PK: 425000, DEF: 425000 },
-    21: { QB: 500000, RB: 525000, WR: 600000, TE: 525000, PK: 425000, DEF: 425000 },
-    22: { QB: 475000, RB: 500000, WR: 575000, TE: 525000, PK: 425000, DEF: 425000 },
-    23: { QB: 475000, RB: 500000, WR: 575000, TE: 500000, PK: 425000, DEF: 425000 },
-    24: { QB: 475000, RB: 475000, WR: 550000, TE: 475000, PK: 425000, DEF: 425000 },
-    25: { QB: 475000, RB: 475000, WR: 550000, TE: 475000, PK: 425000, DEF: 425000 },
-    26: { QB: 475000, RB: 475000, WR: 525000, TE: 475000, PK: 425000, DEF: 425000 },
-    27: { QB: 475000, RB: 475000, WR: 525000, TE: 475000, PK: 425000, DEF: 425000 },
-    28: { QB: 475000, RB: 475000, WR: 525000, TE: 475000, PK: 425000, DEF: 425000 },
-    29: { QB: 475000, RB: 475000, WR: 525000, TE: 475000, PK: 425000, DEF: 425000 },
-    30: { QB: 475000, RB: 475000, WR: 525000, TE: 475000, PK: 425000, DEF: 425000 },
-    31: { QB: 475000, RB: 475000, WR: 525000, TE: 475000, PK: 425000, DEF: 425000 },
-    32: { QB: 475000, RB: 475000, WR: 525000, TE: 475000, PK: 425000, DEF: 425000 },
-    33: { QB: 475000, RB: 475000, WR: 500000, TE: 475000, PK: 425000, DEF: 425000 },
-    // Toilet Bowl Picks (Round 2, Pick 17 & 18)
-    34: { QB: 475000, RB: 475000, WR: 500000, TE: 475000, PK: 425000, DEF: 425000 },
-    35: { QB: 475000, RB: 475000, WR: 500000, TE: 475000, PK: 425000, DEF: 425000 },
-  }
-};
+// 2026 Rookie Slot Salaries — single source of truth lives in
+// scripts/lib/rookie-salary-slots.mjs so it can be imported by both TS
+// and .mjs scripts. Re-exported here for existing callers.
+// Note: These values escalate by 10% annually after the rookie year.
+export const ROOKIE_SALARIES_2026: Record<number, Record<number, Record<string, number>>> =
+  SHARED_ROOKIE_SALARIES_2026;
 
-const ROUND_3_FLAT_RATE = {
-  QB: 450000, RB: 450000, WR: 475000, TE: 450000, PK: 425000, DEF: 425000
-};
+const ROUND_3_FLAT_RATE = SHARED_ROUND_3_FLAT_RATE;
 
 export interface DraftPick {
   round: number;

--- a/tests/sync-draft-pick-contracts.test.ts
+++ b/tests/sync-draft-pick-contracts.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 // @ts-expect-error - .mjs without types
-import { buildDraftPickDeclarations } from '../scripts/sync-draft-pick-contracts.mjs';
+import { buildDraftPickWrites } from '../scripts/sync-draft-pick-contracts.mjs';
 // @ts-expect-error - .mjs without types
 import { getRookieSlotSalary } from '../scripts/lib/rookie-salary-slots.mjs';
 
@@ -22,56 +22,32 @@ const playerIndex = new Map<string, { position: string; name: string }>([
   ['19999', { position: 'TE', name: 'Round 3 TE' }],
 ]);
 
-const franchiseNameMap = new Map<string, string>([
-  ['0001', 'Pigskins'],
-  ['0007', 'Magicians'],
-  ['0004', 'Mafia'],
-]);
-
-let nextId = 1;
-const idGenerator = () => `DECL_TEST_${nextId++}`;
-
-describe('buildDraftPickDeclarations', () => {
-  it('creates a rookie-override declaration for each completed pick', () => {
-    nextId = 1;
+describe('buildDraftPickWrites', () => {
+  it('emits a write per completed pick that does not already have RC on MFL', () => {
     const draftResults = makeDraftResults([
-      { round: '01', pick: '01', player: '17472', franchise: '0007', timestamp: '1777756190', comments: '' },
-      { round: '01', pick: '02', player: '17543', franchise: '0004', timestamp: '1777756190', comments: '' },
-      { round: '01', pick: '03', player: '', franchise: '0001', timestamp: '', comments: '' },
+      { round: '01', pick: '01', player: '17472', franchise: '0007', timestamp: '1777756190' },
+      { round: '01', pick: '02', player: '17543', franchise: '0004', timestamp: '1777756190' },
+      { round: '01', pick: '03', player: '', franchise: '0001', timestamp: '' },
     ]);
+    const mflSalaries = new Map();
 
-    const result = buildDraftPickDeclarations({
-      draftResults,
-      playerIndex,
-      franchiseNameMap,
-      leagueId: '13522',
-      existingDeclarations: [],
-      idGenerator,
-    });
+    const writes = buildDraftPickWrites({ draftResults, playerIndex, mflSalaries });
 
-    expect(result).toHaveLength(2);
+    expect(writes).toHaveLength(2);
 
-    const [first, second] = result;
-    expect(first.type).toBe('rookie-override');
-    expect(first.status).toBe('pending');
+    const [first, second] = writes;
     expect(first.playerId).toBe('17472');
     expect(first.franchiseId).toBe('0007');
-    expect(first.franchiseName).toBe('Magicians');
-    expect(first.playerName).toBe('Cam Ward');
-    expect(first.currentYears).toBe(4);
-    expect(first.requestedYears).toBe(4);
-    expect(first.currentContractInfo).toBe('RC');
-    expect(first.submittedBy).toBe('Draft Auto-Sync');
-    expect(first.acquisitionTimestamp).toBe(1777756190);
-    expect(first.id).toBe('DECL_TEST_1');
+    expect(first.position).toBe('QB');
     // Pick 1 overall, QB → $3,000,000
-    expect(first.currentSalary).toBe(3_000_000);
-    expect(first.requestedSalary).toBe(3_000_000);
+    expect(first.salary).toBe(3_000_000);
+    expect(first.contractYear).toBe('4');
+    expect(first.contractInfo).toBe('RC');
+    expect(first.acquisitionTimestamp).toBe(1777756190);
 
     expect(second.playerId).toBe('17543');
-    expect(second.franchiseName).toBe('Mafia');
     // Pick 2 overall, WR → $3,200,000
-    expect(second.currentSalary).toBe(3_200_000);
+    expect(second.salary).toBe(3_200_000);
   });
 
   it('skips picks that have no player or no timestamp', () => {
@@ -80,84 +56,82 @@ describe('buildDraftPickDeclarations', () => {
       { round: '01', pick: '02', player: '17472', franchise: '0007', timestamp: '' },
       { round: '01', pick: '03', player: '', franchise: '0004', timestamp: '1777756190' },
     ]);
+    const mflSalaries = new Map();
 
-    const result = buildDraftPickDeclarations({
-      draftResults,
-      playerIndex,
-      franchiseNameMap,
-      leagueId: '13522',
-      existingDeclarations: [],
-      idGenerator,
-    });
+    const writes = buildDraftPickWrites({ draftResults, playerIndex, mflSalaries });
 
-    expect(result).toHaveLength(0);
+    expect(writes).toHaveLength(0);
   });
 
-  it('is idempotent — skips picks already in existingDeclarations', () => {
+  it('is idempotent — skips picks where MFL already has contractInfo=RC', () => {
     const draftResults = makeDraftResults([
       { round: '01', pick: '01', player: '17472', franchise: '0007', timestamp: '1777756190' },
       { round: '01', pick: '02', player: '17543', franchise: '0004', timestamp: '1777756190' },
     ]);
 
-    const existingDeclarations = [
-      { playerId: '17472', franchiseId: '0007' },
-    ];
-
-    const result = buildDraftPickDeclarations({
-      draftResults,
-      playerIndex,
-      franchiseNameMap,
-      leagueId: '13522',
-      existingDeclarations,
-      idGenerator,
+    const mflSalaries = new Map();
+    mflSalaries.set('17472', {
+      salary: '3000000.00',
+      contractYear: '4',
+      contractInfo: 'RC',
     });
 
-    expect(result).toHaveLength(1);
-    expect(result[0].playerId).toBe('17543');
+    const writes = buildDraftPickWrites({ draftResults, playerIndex, mflSalaries });
+
+    expect(writes).toHaveLength(1);
+    expect(writes[0].playerId).toBe('17543');
   });
 
-  it('falls back to a generic name when player is unknown', () => {
+  it('still writes when MFL has the player on roster but without RC', () => {
+    // Drafted players initially appear with empty contractInfo; we should
+    // write RC + slot salary in that case.
+    const draftResults = makeDraftResults([
+      { round: '01', pick: '01', player: '17472', franchise: '0007', timestamp: '1777756190' },
+    ]);
+
+    const mflSalaries = new Map();
+    mflSalaries.set('17472', {
+      salary: '0.00',
+      contractYear: '1',
+      contractInfo: '',
+    });
+
+    const writes = buildDraftPickWrites({ draftResults, playerIndex, mflSalaries });
+
+    expect(writes).toHaveLength(1);
+    expect(writes[0].contractInfo).toBe('RC');
+    expect(writes[0].contractYear).toBe('4');
+    expect(writes[0].salary).toBe(3_000_000);
+  });
+
+  it('falls back to a generic name and WR slot when player is unknown', () => {
     const draftResults = makeDraftResults([
       { round: '02', pick: '01', player: '99999', franchise: '0001', timestamp: '1777756190' },
     ]);
+    const mflSalaries = new Map();
 
-    const result = buildDraftPickDeclarations({
-      draftResults,
-      playerIndex,
-      franchiseNameMap,
-      leagueId: '13522',
-      existingDeclarations: [],
-      idGenerator,
-    });
+    const writes = buildDraftPickWrites({ draftResults, playerIndex, mflSalaries });
 
-    expect(result).toHaveLength(1);
-    expect(result[0].playerName).toBe('Player 99999');
-    // Unknown position → defaults to WR slot for round 2 pick 1 (overall 18) → $700K
-    expect(result[0].currentSalary).toBe(700_000);
+    expect(writes).toHaveLength(1);
+    expect(writes[0].playerName).toBe('Player 99999');
+    // Round 2 pick 1 (overall 18) WR slot → $700K
+    expect(writes[0].salary).toBe(700_000);
   });
 
   it('uses round-3 flat rate for picks beyond round 2', () => {
     const draftResults = makeDraftResults([
       { round: '03', pick: '05', player: '19999', franchise: '0001', timestamp: '1777756190' },
     ]);
+    const mflSalaries = new Map();
 
-    const result = buildDraftPickDeclarations({
-      draftResults,
-      playerIndex,
-      franchiseNameMap,
-      leagueId: '13522',
-      existingDeclarations: [],
-      idGenerator,
-    });
+    const writes = buildDraftPickWrites({ draftResults, playerIndex, mflSalaries });
 
-    expect(result).toHaveLength(1);
+    expect(writes).toHaveLength(1);
     // TE round 3 flat rate
-    expect(result[0].currentSalary).toBe(450_000);
+    expect(writes[0].salary).toBe(450_000);
   });
 
   it('round 2 pick 1 maps to overall pick 18 in the salary table', () => {
-    // Sanity check: ensures the (round, pickInRound) → overall conversion
-    // matches what the table expects.
     expect(getRookieSlotSalary(2, 18, 'WR')).toBe(700_000);
   });
 });

--- a/tests/sync-draft-pick-contracts.test.ts
+++ b/tests/sync-draft-pick-contracts.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from 'vitest';
+// @ts-expect-error - .mjs without types
+import { buildDraftPickDeclarations } from '../scripts/sync-draft-pick-contracts.mjs';
+// @ts-expect-error - .mjs without types
+import { getRookieSlotSalary } from '../scripts/lib/rookie-salary-slots.mjs';
+
+function makeDraftResults(picks: Array<Record<string, string>>) {
+  return {
+    encoding: 'utf-8',
+    draftResults: {
+      draftUnit: {
+        draftPick: picks,
+      },
+    },
+  };
+}
+
+const playerIndex = new Map<string, { position: string; name: string }>([
+  ['17472', { position: 'QB', name: 'Cam Ward' }],
+  ['17543', { position: 'WR', name: 'Travis Hunter' }],
+  ['18001', { position: 'RB', name: 'Round 2 RB' }],
+  ['19999', { position: 'TE', name: 'Round 3 TE' }],
+]);
+
+const franchiseNameMap = new Map<string, string>([
+  ['0001', 'Pigskins'],
+  ['0007', 'Magicians'],
+  ['0004', 'Mafia'],
+]);
+
+let nextId = 1;
+const idGenerator = () => `DECL_TEST_${nextId++}`;
+
+describe('buildDraftPickDeclarations', () => {
+  it('creates a rookie-override declaration for each completed pick', () => {
+    nextId = 1;
+    const draftResults = makeDraftResults([
+      { round: '01', pick: '01', player: '17472', franchise: '0007', timestamp: '1777756190', comments: '' },
+      { round: '01', pick: '02', player: '17543', franchise: '0004', timestamp: '1777756190', comments: '' },
+      { round: '01', pick: '03', player: '', franchise: '0001', timestamp: '', comments: '' },
+    ]);
+
+    const result = buildDraftPickDeclarations({
+      draftResults,
+      playerIndex,
+      franchiseNameMap,
+      leagueId: '13522',
+      existingDeclarations: [],
+      idGenerator,
+    });
+
+    expect(result).toHaveLength(2);
+
+    const [first, second] = result;
+    expect(first.type).toBe('rookie-override');
+    expect(first.status).toBe('pending');
+    expect(first.playerId).toBe('17472');
+    expect(first.franchiseId).toBe('0007');
+    expect(first.franchiseName).toBe('Magicians');
+    expect(first.playerName).toBe('Cam Ward');
+    expect(first.currentYears).toBe(4);
+    expect(first.requestedYears).toBe(4);
+    expect(first.currentContractInfo).toBe('RC');
+    expect(first.submittedBy).toBe('Draft Auto-Sync');
+    expect(first.acquisitionTimestamp).toBe(1777756190);
+    expect(first.id).toBe('DECL_TEST_1');
+    // Pick 1 overall, QB → $3,000,000
+    expect(first.currentSalary).toBe(3_000_000);
+    expect(first.requestedSalary).toBe(3_000_000);
+
+    expect(second.playerId).toBe('17543');
+    expect(second.franchiseName).toBe('Mafia');
+    // Pick 2 overall, WR → $3,200,000
+    expect(second.currentSalary).toBe(3_200_000);
+  });
+
+  it('skips picks that have no player or no timestamp', () => {
+    const draftResults = makeDraftResults([
+      { round: '01', pick: '01', player: '', franchise: '0001', timestamp: '' },
+      { round: '01', pick: '02', player: '17472', franchise: '0007', timestamp: '' },
+      { round: '01', pick: '03', player: '', franchise: '0004', timestamp: '1777756190' },
+    ]);
+
+    const result = buildDraftPickDeclarations({
+      draftResults,
+      playerIndex,
+      franchiseNameMap,
+      leagueId: '13522',
+      existingDeclarations: [],
+      idGenerator,
+    });
+
+    expect(result).toHaveLength(0);
+  });
+
+  it('is idempotent — skips picks already in existingDeclarations', () => {
+    const draftResults = makeDraftResults([
+      { round: '01', pick: '01', player: '17472', franchise: '0007', timestamp: '1777756190' },
+      { round: '01', pick: '02', player: '17543', franchise: '0004', timestamp: '1777756190' },
+    ]);
+
+    const existingDeclarations = [
+      { playerId: '17472', franchiseId: '0007' },
+    ];
+
+    const result = buildDraftPickDeclarations({
+      draftResults,
+      playerIndex,
+      franchiseNameMap,
+      leagueId: '13522',
+      existingDeclarations,
+      idGenerator,
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].playerId).toBe('17543');
+  });
+
+  it('falls back to a generic name when player is unknown', () => {
+    const draftResults = makeDraftResults([
+      { round: '02', pick: '01', player: '99999', franchise: '0001', timestamp: '1777756190' },
+    ]);
+
+    const result = buildDraftPickDeclarations({
+      draftResults,
+      playerIndex,
+      franchiseNameMap,
+      leagueId: '13522',
+      existingDeclarations: [],
+      idGenerator,
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].playerName).toBe('Player 99999');
+    // Unknown position → defaults to WR slot for round 2 pick 1 (overall 18) → $700K
+    expect(result[0].currentSalary).toBe(700_000);
+  });
+
+  it('uses round-3 flat rate for picks beyond round 2', () => {
+    const draftResults = makeDraftResults([
+      { round: '03', pick: '05', player: '19999', franchise: '0001', timestamp: '1777756190' },
+    ]);
+
+    const result = buildDraftPickDeclarations({
+      draftResults,
+      playerIndex,
+      franchiseNameMap,
+      leagueId: '13522',
+      existingDeclarations: [],
+      idGenerator,
+    });
+
+    expect(result).toHaveLength(1);
+    // TE round 3 flat rate
+    expect(result[0].currentSalary).toBe(450_000);
+  });
+
+  it('round 2 pick 1 maps to overall pick 18 in the salary table', () => {
+    // Sanity check: ensures the (round, pickInRound) → overall conversion
+    // matches what the table expects.
+    expect(getRookieSlotSalary(2, 18, 'WR')).toBe(700_000);
+  });
+});


### PR DESCRIPTION
Adds scripts/sync-draft-pick-contracts.mjs which scans draftResults.json
after each MFL feed fetch and creates a pending rookie-override contract
declaration for each completed pick, with the slot-based rookie salary
auto-populated from ROOKIE_SALARIES_2026. Owners then only need to
choose contract years (1-3 vs the default 4yr RC) on the contracts page.

The salary table moved to scripts/lib/rookie-salary-slots.mjs so both TS
code and the .mjs sync script share a single source of truth.

The script is idempotent (skips picks already declared) and runs in the
roster-sync workflow every 5 minutes, writing to Upstash Redis in
production and the gitignored data/<league>/contract-declarations.json
file in local dev.