### PR TITLE
admin: list in-flight trade offers with stale/posted markers

### DIFF
--- a/scripts/schefter-rumor-scan.mjs
+++ b/scripts/schefter-rumor-scan.mjs
@@ -151,6 +151,19 @@ const OFFER_FIRST_SEEN_KEY = 'schefter:trade_offers:first_seen';
 const OFFER_POSTED_KEY = 'schefter:trade_offers:posted';
 const OFFER_STATE_TTL_SEC = 30 * 24 * 60 * 60;       // 30d on both first_seen HASH and posted SET
 
+// Permanent archive of every offer the scanner has ever ingested. Distinct
+// from `first_seen` because we want the running total to outlive the 30-day
+// TTL — the admin page's "Trade Offers Archive" card needs to show offers
+// from months/years ago, including ones that were never posted (retracted
+// before the dice roll fired). Entry is JSON-encoded {offerId, offeringFid,
+// partnerFid, willGiveUp, willReceive, comments, mflTimestamp, firstSeenMs}.
+const OFFER_ARCHIVE_KEY = 'schefter:trade_offers:archive';
+// Per-offer roll counter: hincrby on every offer-scan iteration that gets to
+// the dice roll (i.e., offers still eligible — not already-posted, not
+// legacy-burned). Tells the commish how many GitHub Actions runs had a chance
+// to leak the rumor before MFL dropped the offer.
+const OFFER_ROLLS_KEY = 'schefter:trade_offers:rolls';
+
 const OFFER_LINGERING_THRESHOLD_MS = 48 * 60 * 60 * 1000;   // 48h → framing flip
 
 const OFFER_OWNER_KEY_PREFIX = 'schefter:trade_offers:owner:';
@@ -1926,6 +1939,27 @@ async function scanTradeOffers({ redis, dryRun }) {
       } catch (err) {
         warn(`  [offer-scan] hset(first_seen) failed: ${err.message}`);
       }
+
+      // Permanent archive — one entry per offer ever seen. No TTL: this is
+      // the running history feed for the admin "Trade Offers Archive" card.
+      // We only write on first sighting so a returning offer keeps its
+      // original metadata (raw can shift if MFL re-orders fields).
+      try {
+        const partnerFid = String(raw.offeredto || raw.franchise2 || '').padStart(4, '0');
+        const archiveEntry = JSON.stringify({
+          offerId,
+          offeringFid,
+          partnerFid,
+          willGiveUp: raw.will_give_up || raw.franchise1_gave_up || '',
+          willReceive: raw.will_receive || raw.franchise2_gave_up || '',
+          comments: raw.comments || '',
+          mflTimestamp: Number(raw.timestamp || 0) || null,
+          firstSeenMs: nowMs,
+        });
+        await redis.hset(OFFER_ARCHIVE_KEY, { [offerId]: archiveEntry });
+      } catch (err) {
+        warn(`  [offer-scan] hset(archive) failed: ${err.message}`);
+      }
     }
 
     // Sorted-set bookkeeping: owner + division + per-player.
@@ -2111,6 +2145,19 @@ async function scanTradeOffers({ redis, dryRun }) {
           ? ` [escalation=${redaction.tip.escalatedPlayer.tier}/${redaction.tip.escalatedPlayer.distinctOfferers}]`
           : ''),
     );
+
+    // Roll counter — increment regardless of pass/fail so the admin can see
+    // how many chances each offer had to leak before MFL dropped it.
+    // Detection-only runs still count: the dice was rolled, the chance was
+    // real, even if we suppressed the post. Dry-run does NOT increment —
+    // it didn't actually mutate anything.
+    if (!dryRun) {
+      try {
+        await redis.hincrby(OFFER_ROLLS_KEY, offerId, 1);
+      } catch (err) {
+        warn(`  [offer-scan] hincrby(rolls) failed: ${err.message}`);
+      }
+    }
 
     if (!passed) continue;
 

--- a/src/pages/api/admin/schefter-stats.ts
+++ b/src/pages/api/admin/schefter-stats.ts
@@ -43,6 +43,7 @@ type RedisClient = {
   get: <T = unknown>(key: string) => Promise<T | null>;
   lrange: <T = string>(key: string, start: number, stop: number) => Promise<T[]>;
   zrange: <T = string>(key: string, min: number, max: number, opts?: { rev?: boolean }) => Promise<T[]>;
+  smembers: <T = string>(key: string) => Promise<T[]>;
 };
 
 // Imported from the scanner's shared lib so the admin preview matches the
@@ -295,6 +296,7 @@ async function readRedisStats(redis: RedisClient) {
     tradeOffersInFlight,
     tradeOffersPosted,
     tradeOffersFirstSeenMap,
+    tradeOffersPostedMembers,
     ownerReportsMap,
     pendingTipsRaw,
     recentGroupMeRaw,
@@ -312,6 +314,7 @@ async function readRedisStats(redis: RedisClient) {
     redis.hlen(OFFER_FIRST_SEEN_KEY).catch(() => 0),
     redis.scard(OFFER_POSTED_KEY).catch(() => 0),
     redis.hgetall<Record<string, string>>(OFFER_FIRST_SEEN_KEY).catch(() => null),
+    redis.smembers<string>(OFFER_POSTED_KEY).catch(() => [] as string[]),
     redis.hgetall<Record<string, unknown>>(OFFER_OWNER_REPORTS_KEY).catch(() => null),
     // Pull the actual queue contents (not just LLEN) so the admin page can
     // render a "what's next to post" list. Cap at 50 — the queue rarely
@@ -421,21 +424,44 @@ async function readRedisStats(redis: RedisClient) {
     console.warn('[admin/schefter-stats] processed archive read failed:', err);
   }
 
-  // Bucket in-flight offers by fresh vs lingering (≥48h since first_seen)
+  // Bucket in-flight offers by fresh vs lingering (≥48h since first_seen).
+  // Also build a per-offer list so the admin can SEE which offerIds are
+  // tracked. Without the list, a stat like "5 in-flight, 9.8d oldest age"
+  // is impossible to reconcile against the live MFL pendingTrades feed —
+  // the commish can't tell which ones are stale (no longer open in MFL).
   const now = Date.now();
   let offersFresh = 0;
   let offersLingering = 0;
   let oldestOfferAgeMs: number | null = null;
+  const postedSet = new Set(Array.isArray(tradeOffersPostedMembers) ? tradeOffersPostedMembers.map(String) : []);
+  const tradeOffersInFlightList: Array<{
+    offerId: string;
+    firstSeenMs: number;
+    ageMs: number;
+    lingering: boolean;
+    posted: boolean;
+  }> = [];
   if (tradeOffersFirstSeenMap && typeof tradeOffersFirstSeenMap === 'object') {
-    for (const v of Object.values(tradeOffersFirstSeenMap)) {
+    for (const [offerId, v] of Object.entries(tradeOffersFirstSeenMap)) {
       const ts = Number(v);
       if (!Number.isFinite(ts) || ts <= 0) continue;
       const age = now - ts;
-      if (age >= OFFER_LINGERING_THRESHOLD_MS) offersLingering += 1;
+      const lingering = age >= OFFER_LINGERING_THRESHOLD_MS;
+      if (lingering) offersLingering += 1;
       else offersFresh += 1;
       if (oldestOfferAgeMs === null || age > oldestOfferAgeMs) oldestOfferAgeMs = age;
+      tradeOffersInFlightList.push({
+        offerId,
+        firstSeenMs: ts,
+        ageMs: age,
+        lingering,
+        posted: postedSet.has(offerId),
+      });
     }
   }
+  // Oldest first — that's what the commish wants to see (stalest entries
+  // are the ones most likely to be stale-and-stuck).
+  tradeOffersInFlightList.sort((a, b) => b.ageMs - a.ageMs);
 
   // Owner-sourced reports: count unique offerIds and find the most recent report
   let ownerReportsCount = 0;
@@ -474,6 +500,7 @@ async function readRedisStats(redis: RedisClient) {
     tradeOffersFresh: offersFresh,
     tradeOffersLingering: offersLingering,
     tradeOffersOldestAgeMs: oldestOfferAgeMs,
+    tradeOffersInFlightList,
     ownerReportsCount,
     ownerReportsLastSeenTs,
     ownerReportsDistinctReporters,

--- a/src/pages/api/admin/schefter-stats.ts
+++ b/src/pages/api/admin/schefter-stats.ts
@@ -13,6 +13,10 @@
 import type { APIRoute } from 'astro';
 import { getAuthUser, isCommissionerOrAdmin } from '../../../utils/auth';
 import feedData from '../../../data/theleague/schefter-feed.json';
+import leagueConfig from '../../../data/theleague.config.json';
+import { parseAssets } from '../../../utils/trade-asset-parsing';
+import { getPlayerMap } from '../../../utils/player-map';
+import { getCurrentLeagueYear } from '../../../utils/league-year';
 
 export const prerender = false;
 
@@ -32,6 +36,8 @@ const OFFER_SEEN_KEY = 'schefter:trade_offers:seen';
 const OFFER_FIRST_SEEN_KEY = 'schefter:trade_offers:first_seen';
 const OFFER_POSTED_KEY = 'schefter:trade_offers:posted';
 const OFFER_OWNER_REPORTS_KEY = 'schefter:trade_offers:owner_reports';
+const OFFER_ARCHIVE_KEY = 'schefter:trade_offers:archive';
+const OFFER_ROLLS_KEY = 'schefter:trade_offers:rolls';
 const OFFER_LINGERING_THRESHOLD_MS = 48 * 60 * 60 * 1000;
 
 type RedisClient = {
@@ -95,6 +101,86 @@ function coerce(raw: unknown): number | null {
 
 function safeParse(s: string): unknown {
   try { return JSON.parse(s); } catch { return null; }
+}
+
+// Module-level team lookup (franchiseId → {name, abbrev, nameShort}). Same
+// shape the live trades endpoint exposes — we're rendering the same kind
+// of card, just for offers MFL no longer lists.
+const teamLookup = new Map<string, { name: string; abbrev: string; nameShort: string }>();
+for (const team of (leagueConfig as { teams?: Array<{ franchiseId: string; name?: string; abbrev?: string; nameShort?: string }> }).teams ?? []) {
+  if (team.franchiseId) {
+    teamLookup.set(team.franchiseId, {
+      name: team.name || '',
+      abbrev: team.abbrev || '',
+      nameShort: team.nameShort || '',
+    });
+  }
+}
+
+type ResolvedArchiveAsset = { type: 'player' | 'pick' | 'bbid'; label: string; position?: string };
+
+/**
+ * Resolve a raw MFL asset string into human-readable labels for the admin
+ * archive view. Mirrors the live-trades endpoint's resolver but trimmed:
+ * we only need the label + position, not full ESPN/headshot wiring.
+ */
+function resolveArchiveAssets(
+  assetString: string,
+  playerMap: Map<string, { name: string; position: string; team: string }>,
+): ResolvedArchiveAsset[] {
+  const { playerIds, draftPicks, blindBid } = parseAssets(assetString);
+  const resolved: ResolvedArchiveAsset[] = [];
+  for (const id of playerIds) {
+    const p = playerMap.get(id);
+    if (p) resolved.push({ type: 'player', label: p.name, position: p.position });
+    else resolved.push({ type: 'player', label: `Unknown Player (${id})` });
+  }
+  for (const code of draftPicks) {
+    if (code.startsWith('FP_')) {
+      const parts = code.split('_');
+      const franchise = parts[1];
+      const yr = parts[2];
+      const round = parts[3];
+      const team = teamLookup.get(franchise);
+      const via = team ? ` (via ${team.abbrev || team.nameShort})` : '';
+      resolved.push({ type: 'pick', label: `${yr} Rd ${round}${via}` });
+    } else if (code.startsWith('DP_')) {
+      const round = parseInt(code.split('_')[1], 10) + 1;
+      resolved.push({ type: 'pick', label: `Current Rd ${round}` });
+    }
+  }
+  if (blindBid !== null) {
+    const formatted = blindBid >= 1_000_000
+      ? `$${(blindBid / 1_000_000).toFixed(1)}M`
+      : `$${Math.round(blindBid / 1_000).toLocaleString()}K`;
+    resolved.push({ type: 'bbid', label: `${formatted} BBID` });
+  }
+  return resolved;
+}
+
+/**
+ * Build offerId → {postId, postTimestamp} index from the static feed JSON.
+ * Trade-offer rumors carry tip ids of the form `to_<offerId>` (set by
+ * `scripts/lib/redact-trade-offer.mjs`) — when the scanner promotes a tip
+ * to a published post the original tipId rides through into `post.tipIds`.
+ */
+function buildOfferToPostIndex(): Map<string, { postId: string; postTimestamp: string }> {
+  const index = new Map<string, { postId: string; postTimestamp: string }>();
+  const posts = (feedData as { posts?: Array<{ id?: unknown; timestamp?: unknown; tipIds?: unknown }> }).posts ?? [];
+  for (const post of posts) {
+    if (!post || typeof post !== 'object') continue;
+    const tipIds = Array.isArray(post.tipIds) ? post.tipIds : [];
+    for (const raw of tipIds) {
+      if (typeof raw !== 'string' || !raw.startsWith('to_')) continue;
+      const offerId = raw.slice(3);
+      if (!offerId || index.has(offerId)) continue;
+      index.set(offerId, {
+        postId: typeof post.id === 'string' ? post.id : '',
+        postTimestamp: typeof post.timestamp === 'string' ? post.timestamp : '',
+      });
+    }
+  }
+  return index;
 }
 
 function json(data: unknown, status = 200): Response {
@@ -297,6 +383,8 @@ async function readRedisStats(redis: RedisClient) {
     tradeOffersPosted,
     tradeOffersFirstSeenMap,
     tradeOffersPostedMembers,
+    tradeOffersArchiveMap,
+    tradeOffersRollsMap,
     ownerReportsMap,
     pendingTipsRaw,
     recentGroupMeRaw,
@@ -315,6 +403,8 @@ async function readRedisStats(redis: RedisClient) {
     redis.scard(OFFER_POSTED_KEY).catch(() => 0),
     redis.hgetall<Record<string, string>>(OFFER_FIRST_SEEN_KEY).catch(() => null),
     redis.smembers<string>(OFFER_POSTED_KEY).catch(() => [] as string[]),
+    redis.hgetall<Record<string, string>>(OFFER_ARCHIVE_KEY).catch(() => null),
+    redis.hgetall<Record<string, string>>(OFFER_ROLLS_KEY).catch(() => null),
     redis.hgetall<Record<string, unknown>>(OFFER_OWNER_REPORTS_KEY).catch(() => null),
     // Pull the actual queue contents (not just LLEN) so the admin page can
     // render a "what's next to post" list. Cap at 50 — the queue rarely
@@ -463,6 +553,132 @@ async function readRedisStats(redis: RedisClient) {
   // are the ones most likely to be stale-and-stuck).
   tradeOffersInFlightList.sort((a, b) => b.ageMs - a.ageMs);
 
+  // Trade Offers Archive — running history of every offer ever ingested.
+  // Joins three Redis hashes + the static feed JSON:
+  //   archive[offerId] → metadata (owners + raw asset strings + first-seen)
+  //   rolls[offerId]   → counter of dice-roll opportunities while in-flight
+  //   posted SET       → which offerIds have been promoted to a Schefter post
+  //   feed.posts       → the actual post (id + timestamp) when one exists
+  // Entries that exist only in `first_seen` (not yet migrated to archive,
+  // i.e. captured before this commit landed) get a placeholder record so
+  // the running total stays honest — they're shown with offerId only.
+  const offerToPostIndex = buildOfferToPostIndex();
+  const playerMap = (() => {
+    try {
+      const identityMap = getPlayerMap(getCurrentLeagueYear());
+      const m = new Map<string, { name: string; position: string; team: string }>();
+      for (const [id, identity] of identityMap) {
+        m.set(id, { name: identity.name, position: identity.position, team: identity.nflTeam });
+      }
+      return m;
+    } catch (err) {
+      console.warn('[admin/schefter-stats] player map load failed:', err);
+      return new Map<string, { name: string; position: string; team: string }>();
+    }
+  })();
+
+  type ArchiveAssets = { willGiveUp: ResolvedArchiveAsset[]; willReceive: ResolvedArchiveAsset[] };
+  type ArchiveEntry = {
+    offerId: string;
+    offeringFid: string;
+    offeringName: string;
+    partnerFid: string;
+    partnerName: string;
+    firstSeenMs: number;
+    rollCount: number;
+    posted: boolean;
+    postId: string | null;
+    postTimestamp: string | null;
+    legacyBackfill: boolean;
+    assets: ArchiveAssets;
+    comments: string;
+  };
+
+  const tradeOffersArchive: ArchiveEntry[] = [];
+  const archiveSeen = new Set<string>();
+  const rollsLookup = new Map<string, number>();
+  if (tradeOffersRollsMap && typeof tradeOffersRollsMap === 'object') {
+    for (const [k, v] of Object.entries(tradeOffersRollsMap)) {
+      const n = Number(v);
+      if (Number.isFinite(n)) rollsLookup.set(k, n);
+    }
+  }
+
+  function teamName(fid: string): string {
+    if (!fid) return '';
+    return teamLookup.get(fid)?.name || `Team ${fid}`;
+  }
+
+  if (tradeOffersArchiveMap && typeof tradeOffersArchiveMap === 'object') {
+    for (const [offerId, raw] of Object.entries(tradeOffersArchiveMap)) {
+      const parsed = typeof raw === 'string' ? safeParse(raw) : raw;
+      if (!parsed || typeof parsed !== 'object') continue;
+      const m = parsed as {
+        offeringFid?: unknown;
+        partnerFid?: unknown;
+        willGiveUp?: unknown;
+        willReceive?: unknown;
+        comments?: unknown;
+        firstSeenMs?: unknown;
+      };
+      const offeringFid = String(m.offeringFid ?? '');
+      const partnerFid = String(m.partnerFid ?? '');
+      const firstSeenMs = Number(m.firstSeenMs ?? 0) || 0;
+      const link = offerToPostIndex.get(offerId);
+      tradeOffersArchive.push({
+        offerId,
+        offeringFid,
+        offeringName: teamName(offeringFid),
+        partnerFid,
+        partnerName: teamName(partnerFid),
+        firstSeenMs,
+        rollCount: rollsLookup.get(offerId) ?? 0,
+        posted: postedSet.has(offerId),
+        postId: link?.postId || null,
+        postTimestamp: link?.postTimestamp || null,
+        legacyBackfill: false,
+        assets: {
+          willGiveUp: resolveArchiveAssets(typeof m.willGiveUp === 'string' ? m.willGiveUp : '', playerMap),
+          willReceive: resolveArchiveAssets(typeof m.willReceive === 'string' ? m.willReceive : '', playerMap),
+        },
+        comments: typeof m.comments === 'string' ? m.comments : '',
+      });
+      archiveSeen.add(offerId);
+    }
+  }
+
+  // Backfill: any offerId that exists in first_seen but doesn't have an
+  // archive entry yet (captured before this commit landed) gets a stub so
+  // it still shows up in the running total. Owners + assets are unknown
+  // for these; the UI labels them as legacy entries.
+  if (tradeOffersFirstSeenMap && typeof tradeOffersFirstSeenMap === 'object') {
+    for (const [offerId, ts] of Object.entries(tradeOffersFirstSeenMap)) {
+      if (archiveSeen.has(offerId)) continue;
+      const firstSeenMs = Number(ts);
+      if (!Number.isFinite(firstSeenMs) || firstSeenMs <= 0) continue;
+      const link = offerToPostIndex.get(offerId);
+      tradeOffersArchive.push({
+        offerId,
+        offeringFid: '',
+        offeringName: '',
+        partnerFid: '',
+        partnerName: '',
+        firstSeenMs,
+        rollCount: rollsLookup.get(offerId) ?? 0,
+        posted: postedSet.has(offerId),
+        postId: link?.postId || null,
+        postTimestamp: link?.postTimestamp || null,
+        legacyBackfill: true,
+        assets: { willGiveUp: [], willReceive: [] },
+        comments: '',
+      });
+    }
+  }
+
+  // Newest first — running history reads naturally with the latest at top.
+  tradeOffersArchive.sort((a, b) => b.firstSeenMs - a.firstSeenMs);
+  const tradeOffersArchiveTotal = tradeOffersArchive.length;
+
   // Owner-sourced reports: count unique offerIds and find the most recent report
   let ownerReportsCount = 0;
   let ownerReportsLastSeenTs: number | null = null;
@@ -501,6 +717,8 @@ async function readRedisStats(redis: RedisClient) {
     tradeOffersLingering: offersLingering,
     tradeOffersOldestAgeMs: oldestOfferAgeMs,
     tradeOffersInFlightList,
+    tradeOffersArchive,
+    tradeOffersArchiveTotal,
     ownerReportsCount,
     ownerReportsLastSeenTs,
     ownerReportsDistinctReporters,

--- a/src/pages/theleague/admin/schefter.astro
+++ b/src/pages/theleague/admin/schefter.astro
@@ -158,6 +158,14 @@ if (!user || !isCommissionerOrAdmin(user)) {
           <div><dt>Legacy one-shot burned</dt><dd data-k="redis.tradeOffersSeen">—</dd></div>
           <div><dt>Pending-trade watermark size</dt><dd data-k="feed.pendingTradeWatermarkSize">—</dd></div>
         </dl>
+        <h4 class="ops-subhead">In-flight offer IDs (oldest first)</h4>
+        <p class="ops-card__hint ops-card__hint--tight">
+          Each row is an entry in <code>schefter:trade_offers:first_seen</code>.
+          A <strong>stale</strong> pill means MFL no longer lists the offer as open —
+          the scanner is holding bookkeeping for an offer that's been retracted or
+          accepted. <strong>Posted</strong> entries already shipped a rumor-mill post.
+        </p>
+        <div id="ops-offers-inflight-body" class="ops-offers-inflight">Loading…</div>
       </article>
       </div>
     </section>
@@ -378,6 +386,66 @@ if (!user || !isCommissionerOrAdmin(user)) {
     return path.split('.').reduce<any>((acc, k) => (acc == null ? acc : acc[k]), obj);
   }
 
+  // Shared between the stats endpoint render and the live-MFL render. The
+  // commish needs to see both the in-flight offer list (from Redis) AND
+  // which of those IDs MFL still considers open (from the pendingTrades
+  // fetch). Either source landing repaints the list.
+  type InFlightOffer = { offerId: string; firstSeenMs: number; ageMs: number; lingering: boolean; posted: boolean };
+  const offerState: { inFlight: InFlightOffer[] | null; liveIds: Set<string> | null } = {
+    inFlight: null,
+    liveIds: null,
+  };
+
+  function fmtAge(ms: number): string {
+    if (!Number.isFinite(ms) || ms < 0) return '—';
+    const hours = ms / (60 * 60 * 1000);
+    if (hours < 1) return `${Math.max(1, Math.round(ms / 60000))}m`;
+    if (hours < 48) return `${hours.toFixed(1)}h`;
+    return `${(hours / 24).toFixed(1)}d`;
+  }
+
+  function paintOffersInFlight() {
+    const body = document.getElementById('ops-offers-inflight-body');
+    if (!body) return;
+    const list = offerState.inFlight;
+    if (!list) {
+      body.textContent = 'Loading…';
+      return;
+    }
+    if (!list.length) {
+      body.innerHTML = '<p class="ops-empty">No offers in <code>schefter:trade_offers:first_seen</code>. The hash is empty (or the 30d TTL elapsed).</p>';
+      return;
+    }
+    const liveIds = offerState.liveIds; // null = MFL fetch hasn't completed yet
+    body.innerHTML = list
+      .map((o) => {
+        const ageLabel = fmtAge(o.ageMs);
+        const whenLabel = o.firstSeenMs ? `${new Date(o.firstSeenMs).toLocaleString()} (${fmtRel(o.firstSeenMs)})` : '—';
+        const pills: string[] = [];
+        pills.push(o.lingering
+          ? '<span class="ops-pill ops-pill--warn">lingering</span>'
+          : '<span class="ops-pill ops-pill--ok">fresh</span>');
+        if (o.posted) {
+          pills.push('<span class="ops-pill ops-pill--info">posted</span>');
+        }
+        if (liveIds) {
+          pills.push(liveIds.has(o.offerId)
+            ? '<span class="ops-pill ops-pill--ok">in MFL</span>'
+            : '<span class="ops-pill ops-pill--bad">stale</span>');
+        }
+        return `
+          <article class="ops-offer">
+            <header class="ops-offer__head">
+              <code class="ops-offer__id">${escapeHtml(o.offerId)}</code>
+              ${pills.join(' ')}
+              <span class="ops-offer__age">age ${ageLabel}</span>
+            </header>
+            <p class="ops-offer__meta">first seen ${whenLabel}</p>
+          </article>`;
+      })
+      .join('');
+  }
+
   function render(data: any) {
     const updated = document.getElementById('ops-updated');
     if (updated) updated.textContent = `Updated ${new Date(data.generatedAt).toLocaleTimeString()}`;
@@ -513,6 +581,11 @@ if (!user || !isCommissionerOrAdmin(user)) {
       }
       el.textContent = v === null || v === undefined ? '—' : String(v);
     });
+
+    offerState.inFlight = Array.isArray(data.redis?.tradeOffersInFlightList)
+      ? data.redis.tradeOffersInFlightList
+      : [];
+    paintOffersInFlight();
 
     const pill = (state: 'ok' | 'bad' | 'warn', label: string) =>
       `<span class="ops-pill ops-pill--${state}">${label}</span>`;
@@ -845,6 +918,9 @@ if (!user || !isCommissionerOrAdmin(user)) {
       const total = mine.length + others.length;
       const all = [...mine, ...others].sort((a: any, b: any) => (b.timestamp || 0) - (a.timestamp || 0));
 
+      offerState.liveIds = new Set(all.map((t: any) => String(t.tradeId || '')).filter(Boolean));
+      paintOffersInFlight();
+
       summary.innerHTML = `<span class="ops-pill ops-pill--${total > 0 ? 'ok' : 'warn'}">${total} open</span>`;
 
       if (!total) {
@@ -885,6 +961,10 @@ if (!user || !isCommissionerOrAdmin(user)) {
 
       body.innerHTML = rows;
     } catch (err) {
+      // Don't repaint with a stale liveIds set — clear it so the in-flight
+      // list drops the in-MFL/stale pills until a successful fetch lands.
+      offerState.liveIds = null;
+      paintOffersInFlight();
       summary.innerHTML = `<span class="ops-pill ops-pill--bad">err</span>`;
       body.innerHTML = `<p class="ops-empty">Could not load trade proposals: ${escapeHtml((err as Error).message)}. Are you logged in to MFL?</p>`;
     }
@@ -1141,6 +1221,27 @@ if (!user || !isCommissionerOrAdmin(user)) {
 
   .ops-card__badge { font-size: 0.7rem; margin-left: 0.5rem; vertical-align: middle; font-weight: 500; }
   .ops-empty { font-size: 0.85rem; color: var(--color-text-muted, #64748b); margin: 0.5rem 0 0; padding: 0.5rem 0; }
+
+  .ops-subhead {
+    margin: 0.9rem 0 0.25rem; font-size: 0.78rem; font-weight: 700;
+    text-transform: uppercase; letter-spacing: 0.04em;
+    color: var(--color-text-muted, #475569);
+  }
+  .ops-card__hint--tight { margin: 0.1rem 0 0.5rem; font-size: 0.78rem; }
+
+  .ops-offers-inflight { display: flex; flex-direction: column; gap: 0.4rem; }
+  .ops-offer {
+    border: 1px solid var(--color-border, #e2e8f0); border-radius: 8px;
+    padding: 0.4rem 0.6rem; background: var(--color-surface-alt, #f8fafc);
+  }
+  .ops-offer__head {
+    display: flex; flex-wrap: wrap; gap: 0.4rem 0.6rem; align-items: baseline;
+    font-size: 0.85rem;
+  }
+  .ops-offer__id { font-size: 0.78rem; background: white; padding: 0.05rem 0.35rem; border-radius: 3px; }
+  .ops-offer__age { font-size: 0.72rem; color: var(--color-text-muted, #64748b); margin-left: auto; }
+  .ops-offer__meta { margin: 0.2rem 0 0; font-size: 0.72rem; color: var(--color-text-muted, #64748b); }
+  @media (max-width: 560px) { .ops-offer__age { margin-left: 0; flex-basis: 100%; } }
 
   .ops-live-trades { display: flex; flex-direction: column; gap: 0.75rem; }
   .ops-trade {

--- a/src/pages/theleague/admin/schefter.astro
+++ b/src/pages/theleague/admin/schefter.astro
@@ -218,6 +218,32 @@ if (!user || !isCommissionerOrAdmin(user)) {
       </div>
     </section>
 
+    <section class="ops-cluster" aria-labelledby="cluster-archive">
+      <h2 class="ops-cluster__title" id="cluster-archive">
+        Trade Offers Archive
+        <span class="ops-cluster__sub">Running total of every offer the scanner has ever ingested.</span>
+      </h2>
+      <div class="ops-grid">
+      <article class="ops-card ops-card--wide" aria-labelledby="card-archive">
+        <h3 id="card-archive" class="ops-card__title">
+          Captured Trades
+          <span id="ops-archive-summary" class="ops-card__badge">—</span>
+        </h3>
+        <p class="ops-card__hint">
+          Every trade offer the rumor-mill scanner has caught. Stored permanently
+          in <code>schefter:trade_offers:archive</code>. Each row shows the
+          owners involved; expand the accordion for the assets exchanged.
+          The roll counter (<code>schefter:trade_offers:rolls</code>) tells you
+          how many GitHub Actions runs had a chance to leak the rumor — every
+          15 minutes the scanner rolls a die against <code>p</code> while the
+          offer is in-flight. If a post shipped, the link drops you on the
+          news feed where Schefter announced it (same content as GroupMe).
+        </p>
+        <div id="ops-archive-body" class="ops-archive">Loading…</div>
+      </article>
+      </div>
+    </section>
+
     <section class="ops-cluster" aria-labelledby="cluster-stats">
       <h2 class="ops-cluster__title" id="cluster-stats">
         Activity &amp; Stats
@@ -396,12 +422,124 @@ if (!user || !isCommissionerOrAdmin(user)) {
     liveIds: null,
   };
 
+  // Archive of every offer ever captured. Same liveIds Set powers the
+  // "still in MFL" pill — separate state object keeps render concerns
+  // isolated from the in-flight diagnostic list above.
+  type ArchiveAsset = { type: string; label: string; position?: string };
+  type ArchiveEntry = {
+    offerId: string;
+    offeringFid: string;
+    offeringName: string;
+    partnerFid: string;
+    partnerName: string;
+    firstSeenMs: number;
+    rollCount: number;
+    posted: boolean;
+    postId: string | null;
+    postTimestamp: string | null;
+    legacyBackfill: boolean;
+    assets: { willGiveUp: ArchiveAsset[]; willReceive: ArchiveAsset[] };
+    comments: string;
+  };
+  const archiveState: { entries: ArchiveEntry[] | null; total: number } = {
+    entries: null,
+    total: 0,
+  };
+
   function fmtAge(ms: number): string {
     if (!Number.isFinite(ms) || ms < 0) return '—';
     const hours = ms / (60 * 60 * 1000);
     if (hours < 1) return `${Math.max(1, Math.round(ms / 60000))}m`;
     if (hours < 48) return `${hours.toFixed(1)}h`;
     return `${(hours / 24).toFixed(1)}d`;
+  }
+
+  function paintArchive() {
+    const body = document.getElementById('ops-archive-body');
+    const summary = document.getElementById('ops-archive-summary');
+    if (!body) return;
+    const list = archiveState.entries;
+    if (!list) {
+      if (summary) summary.textContent = '…';
+      body.textContent = 'Loading…';
+      return;
+    }
+    const total = archiveState.total ?? list.length;
+    if (summary) {
+      summary.innerHTML = total > 0
+        ? `<span class="ops-pill ops-pill--ok">${total} captured</span>`
+        : `<span class="ops-pill ops-pill--warn">none yet</span>`;
+    }
+    if (!list.length) {
+      body.innerHTML = '<p class="ops-empty">No trades captured yet. Once the scanner ingests its first offer (every 15 min), this fills in.</p>';
+      return;
+    }
+    const liveIds = offerState.liveIds; // null → MFL fetch hasn't completed yet
+
+    const renderAssetList = (items: ArchiveAsset[]) => {
+      if (!Array.isArray(items) || !items.length) return '<em class="ops-archive__empty">—</em>';
+      return items.map((a) => {
+        const label = escapeHtml(a?.label || 'Unknown');
+        const pos = a?.position ? ` <span class="ops-asset__pos">${escapeHtml(a.position)}</span>` : '';
+        return `<li>${label}${pos}</li>`;
+      }).join('');
+    };
+
+    body.innerHTML = list.map((e) => {
+      const ownersLabel = e.legacyBackfill
+        ? `<span class="ops-archive__legacy">owners not recorded</span>`
+        : `<strong>${escapeHtml(e.offeringName || `Team ${e.offeringFid}` || '?')}</strong>
+           → <strong>${escapeHtml(e.partnerName || `Team ${e.partnerFid}` || '?')}</strong>`;
+      const seen = e.firstSeenMs ? `${new Date(e.firstSeenMs).toLocaleString()} (${fmtRel(e.firstSeenMs)})` : '—';
+      const rollLabel = `${e.rollCount} roll${e.rollCount === 1 ? '' : 's'}`;
+      const pills: string[] = [];
+      if (e.posted) {
+        if (e.postId) {
+          const safePid = encodeURIComponent(e.postId);
+          pills.push(`<a class="ops-pill ops-pill--info ops-pill--link" href="/theleague/news#post-${safePid}" title="View Schefter's post">posted</a>`);
+        } else {
+          pills.push('<span class="ops-pill ops-pill--info">posted</span>');
+        }
+      }
+      if (liveIds) {
+        pills.push(liveIds.has(e.offerId)
+          ? '<span class="ops-pill ops-pill--ok">in MFL</span>'
+          : (e.posted
+              ? '<span class="ops-pill ops-pill--mute">closed</span>'
+              : '<span class="ops-pill ops-pill--warn">stale</span>'));
+      }
+      if (e.legacyBackfill) {
+        pills.push('<span class="ops-pill ops-pill--mute" title="Captured before the archive was wired up — owners and assets unknown">legacy</span>');
+      }
+      const detailsBody = e.legacyBackfill
+        ? `<p class="ops-archive__note">Captured before the archive was wired up — owners and assets aren't recorded for this entry.</p>`
+        : `
+          <div class="ops-trade__body">
+            <div class="ops-trade__side">
+              <h4>${escapeHtml(e.offeringName || `Team ${e.offeringFid}` || '?')} gives</h4>
+              <ul class="ops-asset-list">${renderAssetList(e.assets?.willGiveUp || [])}</ul>
+            </div>
+            <div class="ops-trade__side">
+              <h4>${escapeHtml(e.partnerName || `Team ${e.partnerFid}` || '?')} gives</h4>
+              <ul class="ops-asset-list">${renderAssetList(e.assets?.willReceive || [])}</ul>
+            </div>
+          </div>
+          ${e.comments ? `<p class="ops-trade__comments">"${escapeHtml(e.comments)}"</p>` : ''}
+        `;
+      const offerIdRow = `<p class="ops-archive__meta">offer <code>${escapeHtml(e.offerId)}</code> · first seen ${seen}</p>`;
+      return `
+        <details class="ops-archive__row">
+          <summary class="ops-archive__summary">
+            <span class="ops-archive__owners">${ownersLabel}</span>
+            <span class="ops-archive__pills">${pills.join(' ')}</span>
+            <span class="ops-archive__rolls" title="GitHub Actions runs that had a chance to leak this rumor">${rollLabel}</span>
+          </summary>
+          <div class="ops-archive__details">
+            ${offerIdRow}
+            ${detailsBody}
+          </div>
+        </details>`;
+    }).join('');
   }
 
   function paintOffersInFlight() {
@@ -586,6 +724,14 @@ if (!user || !isCommissionerOrAdmin(user)) {
       ? data.redis.tradeOffersInFlightList
       : [];
     paintOffersInFlight();
+
+    archiveState.entries = Array.isArray(data.redis?.tradeOffersArchive)
+      ? data.redis.tradeOffersArchive
+      : [];
+    archiveState.total = typeof data.redis?.tradeOffersArchiveTotal === 'number'
+      ? data.redis.tradeOffersArchiveTotal
+      : archiveState.entries.length;
+    paintArchive();
 
     const pill = (state: 'ok' | 'bad' | 'warn', label: string) =>
       `<span class="ops-pill ops-pill--${state}">${label}</span>`;
@@ -920,6 +1066,7 @@ if (!user || !isCommissionerOrAdmin(user)) {
 
       offerState.liveIds = new Set(all.map((t: any) => String(t.tradeId || '')).filter(Boolean));
       paintOffersInFlight();
+      paintArchive();
 
       summary.innerHTML = `<span class="ops-pill ops-pill--${total > 0 ? 'ok' : 'warn'}">${total} open</span>`;
 
@@ -965,6 +1112,7 @@ if (!user || !isCommissionerOrAdmin(user)) {
       // list drops the in-MFL/stale pills until a successful fetch lands.
       offerState.liveIds = null;
       paintOffersInFlight();
+      paintArchive();
       summary.innerHTML = `<span class="ops-pill ops-pill--bad">err</span>`;
       body.innerHTML = `<p class="ops-empty">Could not load trade proposals: ${escapeHtml((err as Error).message)}. Are you logged in to MFL?</p>`;
     }
@@ -1242,6 +1390,42 @@ if (!user || !isCommissionerOrAdmin(user)) {
   .ops-offer__age { font-size: 0.72rem; color: var(--color-text-muted, #64748b); margin-left: auto; }
   .ops-offer__meta { margin: 0.2rem 0 0; font-size: 0.72rem; color: var(--color-text-muted, #64748b); }
   @media (max-width: 560px) { .ops-offer__age { margin-left: 0; flex-basis: 100%; } }
+
+  .ops-archive { display: flex; flex-direction: column; gap: 0.4rem; }
+  .ops-archive__row {
+    border: 1px solid var(--color-border, #e2e8f0); border-radius: 8px;
+    background: var(--color-surface-alt, #f8fafc);
+  }
+  .ops-archive__row[open] { background: white; }
+  .ops-archive__summary {
+    display: flex; flex-wrap: wrap; gap: 0.4rem 0.75rem; align-items: baseline;
+    padding: 0.55rem 0.75rem; cursor: pointer; font-size: 0.9rem;
+    list-style: none;
+  }
+  .ops-archive__summary::-webkit-details-marker { display: none; }
+  .ops-archive__summary::before {
+    content: '▸'; display: inline-block; width: 0.8rem;
+    color: var(--color-text-muted, #64748b); transition: transform 0.15s ease;
+  }
+  .ops-archive__row[open] .ops-archive__summary::before { transform: rotate(90deg); }
+  .ops-archive__owners { flex: 1 1 auto; min-width: 0; }
+  .ops-archive__pills { display: inline-flex; flex-wrap: wrap; gap: 0.25rem; }
+  .ops-archive__rolls {
+    font-size: 0.72rem; color: var(--color-text-muted, #64748b);
+    font-variant-numeric: tabular-nums;
+  }
+  .ops-archive__legacy { color: var(--color-text-muted, #64748b); font-style: italic; }
+  .ops-archive__details { padding: 0 0.75rem 0.7rem; border-top: 1px solid var(--color-border, #e2e8f0); }
+  .ops-archive__meta {
+    margin: 0.5rem 0 0.4rem; font-size: 0.72rem;
+    color: var(--color-text-muted, #64748b);
+  }
+  .ops-archive__meta code { background: var(--color-surface-alt, #f1f5f9); padding: 0.05rem 0.3rem; border-radius: 3px; }
+  .ops-archive__note { margin: 0.5rem 0 0; font-size: 0.78rem; color: var(--color-text-muted, #64748b); font-style: italic; }
+  .ops-archive__empty { color: var(--color-text-muted, #94a3b8); }
+  @media (max-width: 560px) {
+    .ops-archive__rolls { flex-basis: 100%; }
+  }
 
   .ops-live-trades { display: flex; flex-direction: column; gap: 0.75rem; }
   .ops-trade {


### PR DESCRIPTION
The "Trade Offers Ingested" card on /theleague/admin/schefter showed only
counters (5 in-flight) with no way to reconcile against the live MFL
pendingTrades feed (1 open). When the scanner's first_seen hash holds
offerIds that MFL no longer lists as open, the commish couldn't tell
which entries were stale-and-stuck.

Render each entry from schefter:trade_offers:first_seen with its age,
fresh/lingering pill, posted pill, and an in-MFL/stale pill cross-
referenced against the live tradeIds returned by /api/trades/pending.