### PR TITLE
fix(draft-pick-sync): use MFL_USER_ID cookie auth instead of USERNAME/PASSWORD

### DIFF
--- a/.github/workflows/roster-sync.yml
+++ b/.github/workflows/roster-sync.yml
@@ -57,6 +57,8 @@ jobs:
           MFL_LEAGUE_ID: ${{ vars.MFL_LEAGUE_ID || '13522' }}
           MFL_LEAGUE_SLUG: theleague
           MFL_HOST: ${{ vars.MFL_HOST }}
+          MFL_USER_ID: ${{ secrets.MFL_USER_ID }}
+          MFL_IS_COMMISH: ${{ secrets.MFL_IS_COMMISH }}
           MFL_USERNAME: ${{ secrets.MFL_USERNAME }}
           MFL_PASSWORD: ${{ secrets.MFL_PASSWORD }}
           UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}

--- a/.github/workflows/sync-draft-pick-contracts.yml
+++ b/.github/workflows/sync-draft-pick-contracts.yml
@@ -62,6 +62,8 @@ jobs:
           MFL_LEAGUE_ID: ${{ vars.MFL_LEAGUE_ID || '13522' }}
           MFL_LEAGUE_SLUG: ${{ inputs.league_slug }}
           MFL_HOST: ${{ vars.MFL_HOST }}
+          MFL_USER_ID: ${{ secrets.MFL_USER_ID }}
+          MFL_IS_COMMISH: ${{ secrets.MFL_IS_COMMISH }}
           MFL_USERNAME: ${{ secrets.MFL_USERNAME }}
           MFL_PASSWORD: ${{ secrets.MFL_PASSWORD }}
           UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}

--- a/scripts/sync-draft-pick-contracts.mjs
+++ b/scripts/sync-draft-pick-contracts.mjs
@@ -32,7 +32,8 @@
  *   node scripts/sync-draft-pick-contracts.mjs --league afl --year 2026
  *
  * Env:
- *   MFL_USERNAME, MFL_PASSWORD     required for MFL writes (any league commish)
+ *   MFL_USER_ID + (optional) MFL_IS_COMMISH  preferred (cookie-based, no login)
+ *   MFL_USERNAME + MFL_PASSWORD              fallback (logs in to get cookie)
  *   MFL_LEAGUE_ID                  defaults to '13522'
  *   MFL_LEAGUE_SLUG                defaults to 'theleague'
  *   MFL_YEAR / PUBLIC_BASE_YEAR    optional explicit year override
@@ -421,17 +422,33 @@ async function main() {
   }
   const leagueId = String(leagueConfig.leagueId || process.env.MFL_LEAGUE_ID || '13522');
 
-  // Auth — required for both reading current salaries and writing
+  // Auth — prefer cookies if present (matches existing repo patterns); fall
+  // back to username/password login. Either yields the same cookie pair used
+  // by mfl-contract-writer.ts.
+  const envUserId = process.env.MFL_USER_ID;
+  const envCommish = process.env.MFL_IS_COMMISH;
   const username = process.env.MFL_USERNAME;
   const password = process.env.MFL_PASSWORD;
-  if (!username || !password) {
-    throw new Error('MFL_USERNAME and MFL_PASSWORD are required for draft pick sync.');
+
+  let mflUserId;
+  let mflIsCommish;
+  if (envUserId) {
+    mflUserId = envUserId;
+    mflIsCommish = envCommish;
+    console.log(
+      `[draft-pick-sync] Using MFL_USER_ID cookie from env${envCommish ? ' (commish cookie present)' : ''}.`,
+    );
+  } else if (username && password) {
+    ({ mflUserId, mflIsCommish } = await loginToMFL(username, password));
+    console.log(
+      `[draft-pick-sync] Logged into MFL via MFL_USERNAME/MFL_PASSWORD${mflIsCommish ? ' (commish cookie present)' : ''}.`,
+    );
+  } else {
+    throw new Error(
+      'No MFL credentials available. Set MFL_USER_ID (preferred) or MFL_USERNAME + MFL_PASSWORD.',
+    );
   }
-  const { mflUserId, mflIsCommish } = await loginToMFL(username, password);
   const cookies = { MFL_USER_ID: mflUserId, MFL_IS_COMMISH: mflIsCommish };
-  console.log(
-    `[draft-pick-sync] Logged into MFL${mflIsCommish ? ' (commish cookie present)' : ''}.`,
-  );
 
   // Fetch current MFL salaries to detect which picks still need RC stamped
   const mflSalaries = await fetchCurrentMFLSalaries({ leagueId, year, cookies });


### PR DESCRIPTION
## Summary

Follow-up to #150. The first manual run of `Sync Draft Pick Contracts` failed with:

```
[draft-pick-sync] Failed: Error: MFL_USERNAME and MFL_PASSWORD are required for draft pick sync.
```

The `MFL_USERNAME` / `MFL_PASSWORD` secrets aren't actually configured in this repo — no script that uses them is enforcing their presence (`fetch-mfl-feeds.mjs` ignores them entirely, and `update-salary-averages.mjs` silently falls back to unauthenticated). The repo's working auth pattern — used by `mfl-integration-test`, `schefter-scan`, and `schefter-rumor-scan` — is the cookie-based `MFL_USER_ID` + `MFL_IS_COMMISH` secrets, which already exist.

## Changes

- `scripts/sync-draft-pick-contracts.mjs`: prefer `MFL_USER_ID` (cookie) when present, skipping the login dance entirely. Fall back to `MFL_USERNAME`/`MFL_PASSWORD` login if the cookie isn't set.
- Both workflows (`sync-draft-pick-contracts.yml` and `roster-sync.yml`) now pass `MFL_USER_ID` + `MFL_IS_COMMISH` from secrets in addition to `MFL_USERNAME`/`MFL_PASSWORD`.

29 lines changed across 3 files.

## Test plan

- [ ] Re-run `Actions → Sync Draft Pick Contracts → Run workflow` with **Dry-run only checked**. Look for `Using MFL_USER_ID cookie from env (commish cookie present).` in the log.
- [ ] If the dry-run output looks right, re-run with **Dry-run only unchecked** to actually write to MFL. Should see `MFL write succeeded` and the players' contracts on MFL should reflect RC + slot salary + 4yr.
- [ ] Once verified, drop `--dry-run` from `.github/workflows/roster-sync.yml:62` so the cron-driven sync writes live every 5 minutes.

https://claude.ai/code/session_013iZp5KG4SkgXg5r1TBSUV6

---
_Generated by [Claude Code](https://claude.ai/code/session_013iZp5KG4SkgXg5r1TBSUV6)_