### PR TITLE
chore(draft-pick-sync): May-only cron + drop redundant feeds refresh

### DIFF
--- a/.github/workflows/roster-sync.yml
+++ b/.github/workflows/roster-sync.yml
@@ -52,23 +52,9 @@ jobs:
           MFL_LEAGUE_SLUG: theleague
         run: node ./scripts/update-salary-averages.mjs
 
-      - name: Sync draft-pick contracts (theleague)
-        env:
-          MFL_LEAGUE_ID: ${{ vars.MFL_LEAGUE_ID || '13522' }}
-          MFL_LEAGUE_SLUG: theleague
-          MFL_HOST: ${{ vars.MFL_HOST }}
-          MFL_USER_ID: ${{ secrets.MFL_USER_ID }}
-          MFL_IS_COMMISH: ${{ secrets.MFL_IS_COMMISH }}
-          MFL_USERNAME: ${{ secrets.MFL_USERNAME }}
-          MFL_PASSWORD: ${{ secrets.MFL_PASSWORD }}
-          UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
-          UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
-          KV_REST_API_URL: ${{ secrets.KV_REST_API_URL }}
-          KV_REST_API_TOKEN: ${{ secrets.KV_REST_API_TOKEN }}
-        # Running with --dry-run while we verify the first batch. Drop the
-        # flag to enable live MFL writes (RC + slot salary + 4yr default
-        # for newly drafted players who don't yet have RC stamped).
-        run: node ./scripts/sync-draft-pick-contracts.mjs --dry-run
+      # Note: draft-pick contract sync runs in its own workflow
+      # (sync-draft-pick-contracts.yml), May-only cron, since the rookie
+      # draft is the only window that needs it.
 
       - name: Fetch live NFL odds
         run: node ./scripts/fetch-live-odds.mjs

--- a/.github/workflows/sync-draft-pick-contracts.yml
+++ b/.github/workflows/sync-draft-pick-contracts.yml
@@ -1,16 +1,22 @@
 name: Sync Draft Pick Contracts
 
-# Manually-triggered workflow for testing/running scripts/sync-draft-pick-contracts.mjs
-# in isolation (so its output isn't buried inside the roster-sync log).
+# Stamps RC + slot-based rookie salary + 4yr default on newly-drafted
+# players directly to MFL. Idempotent — re-runs skip players who already
+# have RC stamped.
 #
-# Usage:
+# Schedule: every 5 min during May only (the rookie draft window in
+# TheLeague). Outside May the workflow does not fire at all. Update the
+# month component in the cron expression if the draft schedule shifts.
+#
+# Manual triggering (workflow_dispatch) is available year-round for
+# testing or off-cycle runs:
 #   GitHub UI → Actions → Sync Draft Pick Contracts → Run workflow
-#   - Branch: pick the branch you want to test from
 #   - dry_run: leave checked to PRINT the would-be writes without
-#              touching MFL. Uncheck to actually write RC + slot salary
-#              + 4yr default to MFL for any unstamped draft picks.
+#              touching MFL. Uncheck to actually write.
 
 on:
+  schedule:
+    - cron: "*/5 * * 5 *"   # every 5 min, May only (UTC)
   workflow_dispatch:
     inputs:
       dry_run:
@@ -23,7 +29,7 @@ on:
         default: 'theleague'
 
 concurrency:
-  group: sync-draft-pick-contracts-${{ inputs.league_slug }}
+  group: sync-draft-pick-contracts-${{ inputs.league_slug || 'theleague' }}
   cancel-in-progress: false
 
 jobs:
@@ -47,20 +53,17 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Refresh MFL feeds (so draftResults.json is current)
-        env:
-          MFL_LEAGUE_ID: ${{ vars.MFL_LEAGUE_ID || '13522' }}
-          MFL_LEAGUE_SLUG: ${{ inputs.league_slug }}
-          MFL_HOST: ${{ vars.MFL_HOST }}
-          MFL_USERNAME: ${{ secrets.MFL_USERNAME }}
-          MFL_PASSWORD: ${{ secrets.MFL_PASSWORD }}
-          MFL_API_KEY: ${{ secrets.MFL_API_KEY }}
-        run: node ./scripts/fetch-mfl-feeds.mjs --force
+      # Note: we intentionally do NOT call fetch-mfl-feeds.mjs here. That
+      # script loops 17 weeks of weeklyResults with a 1.2s delay = ~20s
+      # of wasted work. The roster-sync workflow already commits a fresh
+      # draftResults.json every 5 min; we just read what's checked in
+      # (worst case 5 min stale, fine since this workflow runs at the
+      # same cadence).
 
       - name: Sync draft-pick contracts
         env:
           MFL_LEAGUE_ID: ${{ vars.MFL_LEAGUE_ID || '13522' }}
-          MFL_LEAGUE_SLUG: ${{ inputs.league_slug }}
+          MFL_LEAGUE_SLUG: ${{ inputs.league_slug || 'theleague' }}
           MFL_HOST: ${{ vars.MFL_HOST }}
           MFL_USER_ID: ${{ secrets.MFL_USER_ID }}
           MFL_IS_COMMISH: ${{ secrets.MFL_IS_COMMISH }}
@@ -71,6 +74,8 @@ jobs:
           KV_REST_API_URL: ${{ secrets.KV_REST_API_URL }}
           KV_REST_API_TOKEN: ${{ secrets.KV_REST_API_TOKEN }}
         run: |
+          # Scheduled runs have no inputs, so inputs.dry_run is empty.
+          # Treat anything other than the literal string "true" as live.
           if [ "${{ inputs.dry_run }}" = "true" ]; then
             echo "::notice::Running in DRY-RUN mode (no MFL writes)"
             node ./scripts/sync-draft-pick-contracts.mjs --dry-run


### PR DESCRIPTION
## Summary

Follow-up to #150/#152. The draft-pick contract sync was running every 5 minutes year-round inside `roster-sync.yml`, but the rookie draft only happens for a couple weeks each year — so ~9000 of those runs per month were pure overhead.

This PR moves the sync into its own dedicated workflow with a **May-only cron** (`*/5 * * 5 *`). Outside May, the workflow doesn't fire at all. The workflow remains manually triggerable year-round via `workflow_dispatch` for testing or off-cycle runs.

## Changes

- **New schedule** on `sync-draft-pick-contracts.yml`: `*/5 * * 5 *` (every 5 min, May only, UTC). Update the month component if the draft schedule shifts.
- **Removed** the `Sync draft-pick contracts` step from `roster-sync.yml` — handled by the dedicated workflow now.
- **Removed** the slow `Refresh MFL feeds` step from `sync-draft-pick-contracts.yml`. That step looped 17 weeks of `weeklyResults` with a 1.2s polite delay (~20s of wasted work). The roster-sync workflow already commits a fresh `draftResults.json` every 5 min, so the script just reads what's checked in (worst case 5 min stale, fine since this workflow polls at the same cadence).
- Defaulted `inputs.league_slug` and `inputs.dry_run` so scheduled runs (which have no `inputs`) still work.

## Test plan

- [ ] Verify the new workflow appears in the Actions tab and shows the May-only schedule.
- [ ] Manually trigger via `workflow_dispatch` with **Dry-run only checked** — should print the would-be writes and exit. (Already verified pre-merge that the auth path works.)
- [ ] Once May arrives, confirm the cron fires every 5 min and the live write step succeeds (the dry-run input is empty for scheduled runs, so the script runs in live mode).
- [ ] Verify nothing in `roster-sync.yml` broke after removing the step.

https://claude.ai/code/session_013iZp5KG4SkgXg5r1TBSUV6

---
_Generated by [Claude Code](https://claude.ai/code/session_013iZp5KG4SkgXg5r1TBSUV6)_