### PR TITLE
fix: stamp 1st-round picks with TO tag for 2026+ rookie drafts

### DIFF
--- a/scripts/sync-draft-pick-contracts.mjs
+++ b/scripts/sync-draft-pick-contracts.mjs
@@ -4,22 +4,28 @@
  *
  * After each MFL feed fetch, scan draftResults.json for newly-completed
  * picks and write the league's standard rookie contract directly to MFL:
- *   contractInfo = "RC"
- *   contractYear = "4"      (default RC length; owners reduce to 1-3 via the
- *                            existing rookie-override flow before the August
- *                            cutdown)
+ *   contractInfo = "RC" for rounds 2-3, and rounds 1 in years before 2026
+ *   contractInfo = "TO" for round 1 picks in 2026 and later (5th-year team
+ *                       option flag — required for the rosters page to offer
+ *                       the team-option action when the player has 1 year left)
+ *   contractYear = "4"  (default RC length; owners reduce to 1-3 via the
+ *                        existing rookie-override flow before the August
+ *                        cutdown)
  *   salary       = slot-based rookie salary by round/pick/position
  *
  * Why direct write instead of pending-declaration model:
  *   MFL does NOT auto-apply RC on drafted players. Without this script
- *   stamping RC, the rosters-page rookie-override button never appears
- *   (eligibility check requires contractInfo === 'RC'). By writing RC + the
- *   slot salary up front, owners can self-serve their year choice 1-3 from
- *   the rosters page until the August cutdown. The commissioner is no
- *   longer the critical-path step.
+ *   stamping a contractInfo, the rosters-page rookie-override button never
+ *   appears (eligibility check requires contractInfo === 'RC' or 'TO'). By
+ *   writing the right tag + the slot salary up front, owners can self-serve
+ *   their year choice 1-3 from the rosters page until the August cutdown.
+ *   The commissioner is no longer the critical-path step.
  *
  * Idempotency: queries current MFL salaries first and skips any drafted
- * player who already has contractInfo === 'RC'. Safe to run on every
+ * player whose contractInfo already matches what we'd write. A 1st-round
+ * pick that was previously stamped 'RC' (before this script knew about TO)
+ * gets re-stamped as 'TO' on the next run — preserving any reduced
+ * contractYear from the rookie-override flow. Safe to run on every
  * roster-sync tick (every 5 min).
  *
  * Audit trail: also writes an `applied` ContractDeclaration record into
@@ -57,17 +63,30 @@ const MFL_WRITE_HOST = process.env.MFL_WRITE_HOST || 'https://www49.myfantasylea
 // ── Pure logic (testable) ──────────────────────────────────────────────
 
 /**
+ * Returns the contractInfo tag that a freshly-drafted pick of the given
+ * round/year should carry. 1st-round picks from 2026 onward get 'TO' (5th-
+ * year team option); everything else gets 'RC'. Per league constitution
+ * (FIRST-ROUND TEAM OPTION section).
+ */
+export function getExpectedRookieContractInfo(round, year) {
+  const yr = parseInt(year, 10);
+  if (round === 1 && Number.isFinite(yr) && yr >= 2026) return 'TO';
+  return 'RC';
+}
+
+/**
  * Build the list of MFL contract writes that should happen for the given
- * draft results, skipping any pick that already has contractInfo='RC' on
- * MFL.
+ * draft results, skipping any pick whose current MFL contractInfo already
+ * matches the expected value for its round/year.
  *
  * @param {object} args
  * @param {object} args.draftResults  Parsed draftResults.json
  * @param {Map<string, {position: string, name: string}>} args.playerIndex
  * @param {Map<string, {salary: string, contractYear: string, contractInfo: string}>} args.mflSalaries
  *   Player ID → current MFL contract state
+ * @param {string|number} args.year  Draft year (e.g. '2026')
  */
-export function buildDraftPickWrites({ draftResults, playerIndex, mflSalaries }) {
+export function buildDraftPickWrites({ draftResults, playerIndex, mflSalaries, year }) {
   const draftPicks = draftResults?.draftResults?.draftUnit?.draftPick ?? [];
   const writes = [];
 
@@ -79,13 +98,26 @@ export function buildDraftPickWrites({ draftResults, playerIndex, mflSalaries })
     const franchiseId = String(pick.franchise ?? '').trim();
     if (!franchiseId) continue;
 
-    // Skip if this player already has RC stamped on MFL
-    const current = mflSalaries.get(playerId);
-    if (current?.contractInfo === 'RC') continue;
-
     const round = parseInt(pick.round, 10);
     const pickInRound = parseInt(pick.pick, 10);
     if (!Number.isFinite(round) || !Number.isFinite(pickInRound)) continue;
+
+    const expectedContractInfo = getExpectedRookieContractInfo(round, year);
+
+    // Skip if MFL already has the expected tag — intent-aware so a 1st-rounder
+    // previously stamped 'RC' gets re-stamped to 'TO' on the next run.
+    const current = mflSalaries.get(playerId);
+    if (current?.contractInfo === expectedContractInfo) continue;
+
+    // Preserve the existing contractYear when re-stamping a player who was
+    // already given a rookie tag (their year may have been reduced via the
+    // rookie-override flow). Otherwise default to the standard 4-year RC.
+    const wasAlreadyStamped = current?.contractInfo === 'RC' || current?.contractInfo === 'TO';
+    const existingYear = wasAlreadyStamped ? parseInt(current?.contractYear ?? '', 10) : NaN;
+    const contractYear =
+      Number.isFinite(existingYear) && existingYear >= 1 && existingYear <= 5
+        ? String(existingYear)
+        : String(RC_DEFAULT_YEARS);
 
     const overallPick = overallPickFromRoundPick(round, pickInRound);
     const player = playerIndex.get(playerId);
@@ -102,8 +134,8 @@ export function buildDraftPickWrites({ draftResults, playerIndex, mflSalaries })
       pickInRound,
       position,
       salary,
-      contractYear: String(RC_DEFAULT_YEARS),
-      contractInfo: 'RC',
+      contractYear,
+      contractInfo: expectedContractInfo,
       acquisitionTimestamp: Number.isFinite(tsSec) ? tsSec : undefined,
     });
   }
@@ -350,9 +382,9 @@ function buildAuditDeclaration({ write, leagueId, franchiseNameMap }) {
     currentYears: 0,
     currentSalary: 0,
     currentContractInfo: '',
-    requestedYears: RC_DEFAULT_YEARS,
+    requestedYears: parseInt(write.contractYear, 10) || RC_DEFAULT_YEARS,
     requestedSalary: write.salary,
-    requestedContractInfo: 'RC',
+    requestedContractInfo: write.contractInfo,
     status: 'applied',
     submittedBy: 'Draft Auto-Sync',
     submittedAt,
@@ -453,14 +485,14 @@ async function main() {
   // Fetch current MFL salaries to detect which picks still need RC stamped
   const mflSalaries = await fetchCurrentMFLSalaries({ leagueId, year, cookies });
 
-  const writes = buildDraftPickWrites({ draftResults, playerIndex, mflSalaries });
+  const writes = buildDraftPickWrites({ draftResults, playerIndex, mflSalaries, year });
 
   if (writes.length === 0) {
-    console.log('[draft-pick-sync] All drafted players already have RC stamped. Nothing to do.');
+    console.log('[draft-pick-sync] All drafted players already have the expected contractInfo stamped. Nothing to do.');
     return;
   }
 
-  console.log(`[draft-pick-sync] ${writes.length} draft pick(s) need RC + slot salary stamped:`);
+  console.log(`[draft-pick-sync] ${writes.length} draft pick(s) need contract stamped:`);
   for (const w of writes) {
     console.log(
       `  ${(franchiseNameMap.get(w.franchiseId) ?? w.franchiseId).padEnd(14)} ` +

--- a/tests/sync-draft-pick-contracts.test.ts
+++ b/tests/sync-draft-pick-contracts.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect } from 'vitest';
 // @ts-expect-error - .mjs without types
-import { buildDraftPickWrites } from '../scripts/sync-draft-pick-contracts.mjs';
+import {
+  buildDraftPickWrites,
+  getExpectedRookieContractInfo,
+} from '../scripts/sync-draft-pick-contracts.mjs';
 // @ts-expect-error - .mjs without types
 import { getRookieSlotSalary } from '../scripts/lib/rookie-salary-slots.mjs';
 
@@ -22,8 +25,32 @@ const playerIndex = new Map<string, { position: string; name: string }>([
   ['19999', { position: 'TE', name: 'Round 3 TE' }],
 ]);
 
+describe('getExpectedRookieContractInfo', () => {
+  it('returns TO for 1st-round picks in 2026 and later', () => {
+    expect(getExpectedRookieContractInfo(1, '2026')).toBe('TO');
+    expect(getExpectedRookieContractInfo(1, '2027')).toBe('TO');
+    expect(getExpectedRookieContractInfo(1, 2030)).toBe('TO');
+  });
+
+  it('returns RC for 1st-round picks before 2026', () => {
+    expect(getExpectedRookieContractInfo(1, '2025')).toBe('RC');
+    expect(getExpectedRookieContractInfo(1, '2024')).toBe('RC');
+  });
+
+  it('returns RC for rounds 2 and 3 regardless of year', () => {
+    expect(getExpectedRookieContractInfo(2, '2026')).toBe('RC');
+    expect(getExpectedRookieContractInfo(3, '2026')).toBe('RC');
+    expect(getExpectedRookieContractInfo(2, '2030')).toBe('RC');
+  });
+
+  it('falls back to RC when year is missing or invalid', () => {
+    expect(getExpectedRookieContractInfo(1, undefined)).toBe('RC');
+    expect(getExpectedRookieContractInfo(1, 'not-a-year')).toBe('RC');
+  });
+});
+
 describe('buildDraftPickWrites', () => {
-  it('emits a write per completed pick that does not already have RC on MFL', () => {
+  it('emits a write per completed pick that does not already have the expected tag on MFL', () => {
     const draftResults = makeDraftResults([
       { round: '01', pick: '01', player: '17472', franchise: '0007', timestamp: '1777756190' },
       { round: '01', pick: '02', player: '17543', franchise: '0004', timestamp: '1777756190' },
@@ -31,7 +58,7 @@ describe('buildDraftPickWrites', () => {
     ]);
     const mflSalaries = new Map();
 
-    const writes = buildDraftPickWrites({ draftResults, playerIndex, mflSalaries });
+    const writes = buildDraftPickWrites({ draftResults, playerIndex, mflSalaries, year: '2025' });
 
     expect(writes).toHaveLength(2);
 
@@ -58,12 +85,12 @@ describe('buildDraftPickWrites', () => {
     ]);
     const mflSalaries = new Map();
 
-    const writes = buildDraftPickWrites({ draftResults, playerIndex, mflSalaries });
+    const writes = buildDraftPickWrites({ draftResults, playerIndex, mflSalaries, year: '2025' });
 
     expect(writes).toHaveLength(0);
   });
 
-  it('is idempotent — skips picks where MFL already has contractInfo=RC', () => {
+  it('is idempotent — skips picks where MFL already has the expected contractInfo', () => {
     const draftResults = makeDraftResults([
       { round: '01', pick: '01', player: '17472', franchise: '0007', timestamp: '1777756190' },
       { round: '01', pick: '02', player: '17543', franchise: '0004', timestamp: '1777756190' },
@@ -76,13 +103,13 @@ describe('buildDraftPickWrites', () => {
       contractInfo: 'RC',
     });
 
-    const writes = buildDraftPickWrites({ draftResults, playerIndex, mflSalaries });
+    const writes = buildDraftPickWrites({ draftResults, playerIndex, mflSalaries, year: '2025' });
 
     expect(writes).toHaveLength(1);
     expect(writes[0].playerId).toBe('17543');
   });
 
-  it('still writes when MFL has the player on roster but without RC', () => {
+  it('still writes when MFL has the player on roster but without a tag', () => {
     // Drafted players initially appear with empty contractInfo; we should
     // write RC + slot salary in that case.
     const draftResults = makeDraftResults([
@@ -96,10 +123,11 @@ describe('buildDraftPickWrites', () => {
       contractInfo: '',
     });
 
-    const writes = buildDraftPickWrites({ draftResults, playerIndex, mflSalaries });
+    const writes = buildDraftPickWrites({ draftResults, playerIndex, mflSalaries, year: '2025' });
 
     expect(writes).toHaveLength(1);
     expect(writes[0].contractInfo).toBe('RC');
+    // Default to 4-year RC since player wasn't previously stamped as RC/TO
     expect(writes[0].contractYear).toBe('4');
     expect(writes[0].salary).toBe(3_000_000);
   });
@@ -110,7 +138,7 @@ describe('buildDraftPickWrites', () => {
     ]);
     const mflSalaries = new Map();
 
-    const writes = buildDraftPickWrites({ draftResults, playerIndex, mflSalaries });
+    const writes = buildDraftPickWrites({ draftResults, playerIndex, mflSalaries, year: '2025' });
 
     expect(writes).toHaveLength(1);
     expect(writes[0].playerName).toBe('Player 99999');
@@ -124,7 +152,7 @@ describe('buildDraftPickWrites', () => {
     ]);
     const mflSalaries = new Map();
 
-    const writes = buildDraftPickWrites({ draftResults, playerIndex, mflSalaries });
+    const writes = buildDraftPickWrites({ draftResults, playerIndex, mflSalaries, year: '2025' });
 
     expect(writes).toHaveLength(1);
     // TE round 3 flat rate
@@ -133,5 +161,76 @@ describe('buildDraftPickWrites', () => {
 
   it('round 2 pick 1 maps to overall pick 18 in the salary table', () => {
     expect(getRookieSlotSalary(2, 18, 'WR')).toBe(700_000);
+  });
+
+  it('stamps 1st-round picks as TO for 2026+ drafts', () => {
+    const draftResults = makeDraftResults([
+      { round: '01', pick: '01', player: '17472', franchise: '0007', timestamp: '1777756190' },
+      { round: '02', pick: '01', player: '18001', franchise: '0001', timestamp: '1777756190' },
+    ]);
+    const mflSalaries = new Map();
+
+    const writes = buildDraftPickWrites({ draftResults, playerIndex, mflSalaries, year: '2026' });
+
+    expect(writes).toHaveLength(2);
+    expect(writes[0].contractInfo).toBe('TO');
+    expect(writes[0].contractYear).toBe('4');
+    // Round 2 pick is still RC
+    expect(writes[1].contractInfo).toBe('RC');
+  });
+
+  it('re-stamps an existing RC 1st-rounder to TO in 2026, preserving contractYear', () => {
+    // Owner already reduced this 1st-rounder from 4yr → 2yr via the rookie-
+    // override flow before we knew about the TO tag. The next sync should
+    // flip RC → TO without resetting their contractYear back to 4.
+    const draftResults = makeDraftResults([
+      { round: '01', pick: '01', player: '17472', franchise: '0007', timestamp: '1777756190' },
+    ]);
+
+    const mflSalaries = new Map();
+    mflSalaries.set('17472', {
+      salary: '3000000.00',
+      contractYear: '2',
+      contractInfo: 'RC',
+    });
+
+    const writes = buildDraftPickWrites({ draftResults, playerIndex, mflSalaries, year: '2026' });
+
+    expect(writes).toHaveLength(1);
+    expect(writes[0].contractInfo).toBe('TO');
+    // Preserved from existing MFL state, not reset to default 4
+    expect(writes[0].contractYear).toBe('2');
+  });
+
+  it('skips a 1st-rounder already stamped TO in 2026', () => {
+    const draftResults = makeDraftResults([
+      { round: '01', pick: '01', player: '17472', franchise: '0007', timestamp: '1777756190' },
+    ]);
+
+    const mflSalaries = new Map();
+    mflSalaries.set('17472', {
+      salary: '3000000.00',
+      contractYear: '4',
+      contractInfo: 'TO',
+    });
+
+    const writes = buildDraftPickWrites({ draftResults, playerIndex, mflSalaries, year: '2026' });
+
+    expect(writes).toHaveLength(0);
+  });
+
+  it('does NOT re-stamp 2nd/3rd round picks already stamped RC in 2026', () => {
+    const draftResults = makeDraftResults([
+      { round: '02', pick: '01', player: '18001', franchise: '0001', timestamp: '1777756190' },
+      { round: '03', pick: '05', player: '19999', franchise: '0001', timestamp: '1777756190' },
+    ]);
+
+    const mflSalaries = new Map();
+    mflSalaries.set('18001', { salary: '700000.00', contractYear: '4', contractInfo: 'RC' });
+    mflSalaries.set('19999', { salary: '450000.00', contractYear: '4', contractInfo: 'RC' });
+
+    const writes = buildDraftPickWrites({ draftResults, playerIndex, mflSalaries, year: '2026' });
+
+    expect(writes).toHaveLength(0);
   });
 });


### PR DESCRIPTION
Per the constitution, 1st-round picks from 2026 onward carry a 5th-year
team option, flagged in MFL via contractInfo='TO' (vs. 'RC' for other
rookie deals). The rosters page uses this flag to offer the team-option
action and to exclude TO players from franchise tag / vet extension.

The auto-sync script was hardcoding 'RC' for every drafted pick, which
silently locked all 2026+ 1st-rounders out of their team-option year.

Changes:
- Round-aware tagging: getExpectedRookieContractInfo(round, year) returns
  'TO' for round 1 in 2026+, 'RC' otherwise.
- Intent-aware idempotency: skip only when MFL's current contractInfo
  already matches the expected value, so existing 1st-rounders stamped
  'RC' get re-stamped to 'TO' on the next sync tick.
- Preserve contractYear when re-stamping a player who was already given
  RC/TO (keeps any rookie-override year reduction intact); default to 4
  for fresh stamps.
- 9 new test cases cover the year/round matrix plus the re-stamp path.