### PR TITLE
update rookie draft hero "Draft Results" link to /theleague/draft-room

### DIFF
--- a/src/components/theleague/DraftHero.astro
+++ b/src/components/theleague/DraftHero.astro
@@ -58,9 +58,9 @@ const quickLinks: DraftLink[] = [
   },
   {
     label: 'Draft Results',
-    href: `${mflBase}&O=17`,
+    href: r('/theleague/draft-room'),
     icon: 'check',
-    external: true,
+    external: false,
   },
   {
     label: 'Free Agents',


### PR DESCRIPTION
Replaces the external MFL options page (O=17) with the internal draft room
page so users get our richer, in-app draft results view.