### PR TITLE
fix: resolve trade originator from owner-view pendingTrades

### DIFF
--- a/src/utils/owner-trade-reports.ts
+++ b/src/utils/owner-trade-reports.ts
@@ -18,6 +18,8 @@
  * 30-day TTL matches OFFER_STATE_TTL_SEC in scripts/schefter-rumor-scan.mjs.
  */
 
+import leagueConfig from '../data/theleague.config.json';
+
 const HASH_KEY = 'schefter:trade_offers:owner_reports';
 const TTL_SECONDS = 30 * 24 * 60 * 60;
 
@@ -64,6 +66,44 @@ function offerIdOf(raw: Record<string, unknown>): string | null {
   return s.length > 0 ? s : null;
 }
 
+const teamNameToFid = new Map<string, string>();
+for (const team of (leagueConfig as { teams?: Array<{ name?: string; franchiseId?: string }> }).teams ?? []) {
+  if (team?.name && team?.franchiseId) {
+    teamNameToFid.set(String(team.name).toLowerCase(), String(team.franchiseId));
+  }
+}
+
+/**
+ * MFL's owner-view `pendingTrades` payload omits the `franchise` (originator)
+ * field — it only carries `offeredto` (the partner) plus a `description` like
+ * "Pacific Pigskins proposed a trade to ...". Mirror the resolver in
+ * `src/pages/api/trades/pending.ts#resolveProposer` so the rumor scanner's
+ * downstream `String(raw.franchise || '').padStart(4, '0')` doesn't collapse
+ * to `'0000'` and surface as "Team 0000" in the admin archive.
+ */
+export function resolveOriginatorFid(
+  raw: Record<string, unknown>,
+  reportingFranchiseId: string,
+): string {
+  const reporterPadded = String(reportingFranchiseId).padStart(4, '0');
+  const existing = String(raw.franchise ?? '').trim();
+  if (existing) return existing.padStart(4, '0');
+
+  const partner = String(raw.offeredto ?? raw.franchise2 ?? '').trim().padStart(4, '0');
+  // Owner view: `offeredto` is always the counter-party. If the reporter is
+  // not the partner, the reporter authored the offer.
+  if (partner && partner !== reporterPadded) return reporterPadded;
+
+  // Reporter is the recipient — pull the proposer's name from the description.
+  const desc = String(raw.description ?? '');
+  const match = desc.match(/^(.+?)\s+proposed a trade to\s/i);
+  if (match) {
+    const fid = teamNameToFid.get(match[1].trim().toLowerCase());
+    if (fid) return fid.padStart(4, '0');
+  }
+  return '';
+}
+
 /**
  * MFL returns different field names for owner-view vs commish-view
  * `pendingTrades`. The rumor scanner expects commish-view shape
@@ -79,22 +119,27 @@ function normalizeRaw(
   raw: Record<string, unknown>,
   reportingFranchiseId: string,
 ): Record<string, unknown> {
+  // Even commish-shaped rows can be missing `franchise` if MFL changes the
+  // field set; populate it unconditionally so downstream never sees `'0000'`.
+  const originator = resolveOriginatorFid(raw, reportingFranchiseId);
+
   if (raw.franchise1_gave_up !== undefined || raw.franchise2_gave_up !== undefined) {
-    return raw;
+    return originator && !raw.franchise ? { ...raw, franchise: originator } : raw;
   }
 
   const willGiveUp = raw.will_give_up;
   const willReceive = raw.will_receive;
   if (willGiveUp === undefined && willReceive === undefined) return raw;
 
-  const originator = String(raw.franchise ?? '').padStart(4, '0');
-  const ownerIsOriginator = originator === reportingFranchiseId.padStart(4, '0');
+  const reporterPadded = String(reportingFranchiseId).padStart(4, '0');
+  const ownerIsOriginator = originator === reporterPadded;
 
   const f1 = ownerIsOriginator ? willGiveUp : willReceive;
   const f2 = ownerIsOriginator ? willReceive : willGiveUp;
 
   return {
     ...raw,
+    franchise: originator || (raw.franchise as string | undefined) || '',
     franchise1_gave_up: f1 ?? '',
     franchise2_gave_up: f2 ?? '',
     franchise2: raw.franchise2 ?? raw.offeredto ?? '',

--- a/tests/owner-trade-reports.test.ts
+++ b/tests/owner-trade-reports.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Owner trade-report normalization.
+ *
+ * MFL's owner-view `pendingTrades` payload omits the `franchise` (originator)
+ * field. The rumor scanner reads `raw.franchise` and pads to 4 digits; if
+ * we don't infer the originator before we hand the row off, the scanner
+ * stamps the offer with `'0000'` and the admin archive surfaces it as
+ * "Team 0000 → <real partner>". Pin the resolver so that bug can't come
+ * back.
+ */
+import { describe, it, expect } from 'vitest';
+import { resolveOriginatorFid } from '../src/utils/owner-trade-reports';
+
+describe('resolveOriginatorFid (owner-view pendingTrades)', () => {
+  it('uses raw.franchise when present', () => {
+    const raw = { franchise: '0007', offeredto: '0001' };
+    expect(resolveOriginatorFid(raw, '0001')).toBe('0007');
+  });
+
+  it('zero-pads a present-but-short franchise id', () => {
+    const raw = { franchise: '7', offeredto: '0001' };
+    expect(resolveOriginatorFid(raw, '0001')).toBe('0007');
+  });
+
+  it('returns the reporter id when the reporter is the originator (offeredto != reporter)', () => {
+    // Reporter (0001) sent the offer to 0003. MFL omits `franchise` in owner view.
+    const raw = { offeredto: '0003', will_give_up: 'A', will_receive: 'B' };
+    expect(resolveOriginatorFid(raw, '0001')).toBe('0001');
+  });
+
+  it('parses the description when the reporter is the recipient', () => {
+    // Reporter (0001) is the recipient; description names the proposer.
+    const raw = {
+      offeredto: '0001',
+      description: 'Maverick proposed a trade to Pacific Pigskins',
+    };
+    // Maverick is franchiseId 0003 in theleague.config.json.
+    expect(resolveOriginatorFid(raw, '0001')).toBe('0003');
+  });
+
+  it('falls back to empty string when description name does not match a team', () => {
+    const raw = {
+      offeredto: '0001',
+      description: 'Phantom Squad proposed a trade to Pacific Pigskins',
+    };
+    expect(resolveOriginatorFid(raw, '0001')).toBe('');
+  });
+
+  it('does NOT collapse to 0000 when raw.franchise is empty', () => {
+    // The historical bug: scanner reads '' and pads to '0000'. The resolver
+    // must produce a real fid (or empty) so `'0000'` never leaks downstream.
+    const raw = { offeredto: '0003', will_give_up: 'A', will_receive: 'B' };
+    expect(resolveOriginatorFid(raw, '0001')).not.toBe('0000');
+  });
+
+  it('handles short reporter id by padding before comparison', () => {
+    const raw = { offeredto: '0003' };
+    expect(resolveOriginatorFid(raw, '1')).toBe('0001');
+  });
+});


### PR DESCRIPTION
The admin trade-offers archive was rendering "Team 0000 → <real partner>"
because MFL's owner-view `pendingTrades` payload omits the `franchise`
(originator) field, and `reportOwnerTrades()` wrote the raw row to Redis
unchanged. The rumor scanner then read `String(raw.franchise || '').padStart(4, '0')`
and stamped `'0000'` as the offering franchise. Mirror the description-
parsing resolver from `pages/api/trades/pending.ts#resolveProposer` so
`normalizeRaw()` populates `franchise` before persistence — and use the
resolved id (instead of the missing-franchise default) when assigning
`franchise1_gave_up` / `franchise2_gave_up`, which were silently swapped
when the owner was the originator.

https://claude.ai/code/session_017Ee1FNR4HSjZ6FrdmHTQTe