### PR TITLE
fix: point Draft a Player CTA at MFL options page

### DIFF
--- a/src/components/theleague/DraftHero.astro
+++ b/src/components/theleague/DraftHero.astro
@@ -121,7 +121,7 @@ const rulesLink = r('/theleague/rules#draft-rules');
       </div>
 
       <a
-        href={`https://${mflHost}/${leagueYear}/select_franchise?L=${leagueId}&O=52`}
+        href={`${mflBase}&O=52`}
         class="draft-hero__cta"
         target="_blank"
         rel="noopener noreferrer"


### PR DESCRIPTION
The CTA was using select_franchise?O=52, which gates the draft action
behind franchise selection. Use the existing options?L=…&O=52 URL so the
button lands directly on the make-pick screen.