### PR TITLE
fix(schefter): render trade-offer roll probability from the source-of-truth constant

### DIFF
--- a/scripts/schefter-rumor-scan.mjs
+++ b/scripts/schefter-rumor-scan.mjs
@@ -141,8 +141,10 @@ const MORNING_GREETING_DATE_KEY = 'schefter:morning_greeting:last_used_date';
 const OFFER_SEEN_KEY = 'schefter:trade_offers:seen';
 const OFFER_SEEN_TTL_SEC = 30 * 24 * 60 * 60;        // 30d
 
-// Cumulative-probability model (p=0.0075/run, 99% by ~day 6.4). Each live
-// offer gets:
+// Cumulative-probability model. The base per-run probability lives in
+// `scripts/lib/redact-trade-offer.mjs#OFFER_POST_PROBABILITY` (currently 0.05);
+// see that file for the cumulative-curve breakdown by realistic cadence.
+// Each live offer gets:
 //   - an entry in `first_seen` HASH (offerId → epoch ms of first sighting)
 //     used to compute age → framingHint ('fresh' <48h, 'lingering' ≥48h)
 //   - zero or one SADD into `posted` SET the first time its dice roll passes
@@ -2177,7 +2179,8 @@ async function scanTradeOffers({ redis, dryRun }) {
       continue;
     }
 
-    // Dice roll — base p=0.0075 per run, scaled exponentially by the most-
+    // Dice roll — base probability is OFFER_POST_PROBABILITY (see
+    // `scripts/lib/redact-trade-offer.mjs`), scaled exponentially by the most-
     // shopped player's effective distinct-offerer count (real + 0.4*draft).
     // Capped at 4× base. Cumulative curve still keeps most passes in the
     // 1–7 day window for low-volume players; serial-shopped players

--- a/src/pages/theleague/admin/schefter.astro
+++ b/src/pages/theleague/admin/schefter.astro
@@ -12,6 +12,7 @@
  */
 import TheLeagueLayout from '../../../layouts/TheLeagueLayout.astro';
 import { getAuthUser, isCommissionerOrAdmin } from '../../../utils/auth';
+import { OFFER_POST_PROBABILITY } from '../../../../scripts/lib/redact-trade-offer.mjs';
 
 export const prerender = false;
 
@@ -19,6 +20,19 @@ const user = getAuthUser(Astro.request);
 if (!user || !isCommissionerOrAdmin(user)) {
   return Astro.redirect('/theleague');
 }
+
+// Cumulative-probability copy is rendered from the same constant the scanner
+// uses, so the admin hint can never drift from the actual roll. Realistic
+// cadence is ~50 rolls/day (96 nominal cron ticks minus quiet hours and the
+// occasional GitHub Actions skip).
+const ROLLS_PER_DAY = 50;
+const cumulativeAfter = (hours: number) =>
+  1 - Math.pow(1 - OFFER_POST_PROBABILITY, (hours / 24) * ROLLS_PER_DAY);
+const fmtProb = (p: number) => p.toFixed(4).replace(/0+$/, '').replace(/\.$/, '');
+const fmtPct = (p: number) => `${Math.round(p * 100)}%`;
+const offerProbStr = fmtProb(OFFER_POST_PROBABILITY);
+const offerCum24h = fmtPct(cumulativeAfter(24));
+const offerCum48h = fmtPct(cumulativeAfter(48));
 ---
 
 <TheLeagueLayout title="Schefter Ops — Admin">
@@ -143,9 +157,10 @@ if (!user || !isCommissionerOrAdmin(user)) {
       <article class="ops-card" aria-labelledby="card-offers">
         <h3 id="card-offers" class="ops-card__title">Trade Offers Ingested</h3>
         <p class="ops-card__hint">
-          Cumulative-probability model: <code>p=0.025</code>/run (~91% by 24h, ~99% by 48h).
-          Bumped 2026-04-30 from 0.0075 — trade proposals are the league's highest-engagement
-          posts, so we report them faster. In-flight = offers still eligible to post.
+          Cumulative-probability model: <code>p={offerProbStr}</code>/run (~{offerCum24h} by 24h, ~{offerCum48h} by 48h
+          at ~{ROLLS_PER_DAY} rolls/day after quiet hours and Actions skips).
+          Value is read live from <code>OFFER_POST_PROBABILITY</code> in <code>scripts/lib/redact-trade-offer.mjs</code>,
+          so this hint never drifts from the scanner. In-flight = offers still eligible to post.
           Posted = offers the rumor mill has already announced.
           Lingering (≥48h) flips the voice to "phones aren't picking up".
         </p>

--- a/src/types/schefter-tips.ts
+++ b/src/types/schefter-tips.ts
@@ -36,8 +36,9 @@ export type TradeOfferVolumeHint = 'first_offer' | 'repeat_offer' | 'serial';
  * - `fresh`    : first_seen less than 48h ago → rumor-mill voice (phones ringing)
  * - `lingering`: first_seen 48h+ ago → "offered but phones aren't picking up"
  *
- * No guaranteed post — the per-run dice roll (p=0.0075) still gates emission.
- * Lingering offers can still fail the roll forever; that's the design.
+ * No guaranteed post — the per-run dice roll (OFFER_POST_PROBABILITY in
+ * scripts/lib/redact-trade-offer.mjs) still gates emission. Lingering offers
+ * can still fail the roll forever; that's the design.
  */
 export type TradeOfferFramingHint = 'fresh' | 'lingering';
 

--- a/src/utils/owner-trade-reports.ts
+++ b/src/utils/owner-trade-reports.ts
@@ -8,8 +8,9 @@
  * reads.
  *
  * The rumor scanner already implements the cumulative-probability leak model
- * (p=0.0075/run, codenames, vague framing). This module is just the intake
- * pipe — it never decides what gets published.
+ * (base probability in scripts/lib/redact-trade-offer.mjs#OFFER_POST_PROBABILITY,
+ * codenames, vague framing). This module is just the intake pipe — it never
+ * decides what gets published.
  *
  * Hash: `schefter:trade_offers:owner_reports`
  *   field: offerId (MFL trade_id)


### PR DESCRIPTION
The Schefter Ops admin page hardcoded p=0.025 / "~91% by 24h, ~99% by 48h"
in its hint copy, which was correct for the 2026-04-30 bump but went
stale when redact-trade-offer.mjs bumped the base to 0.05 on 2026-05-02.

The page now imports OFFER_POST_PROBABILITY from
scripts/lib/redact-trade-offer.mjs and renders both the value and the
24h/48h cumulative percentages (computed against ~50 effective rolls/day,
matching the comment in the source-of-truth file). The hint can no
longer drift from the scanner.

Also dropped the dead p=0.0075 references in three other docstrings —
schefter-rumor-scan.mjs, src/types/schefter-tips.ts, and
src/utils/owner-trade-reports.ts — pointing readers at the constant
instead of repeating a value that's already moved twice.