### PR TITLE
fix(rosters): re-render table after roster move + capture insights

### DIFF
--- a/docs/claude/insights/domains/frontend.md
+++ b/docs/claude/insights/domains/frontend.md
@@ -254,3 +254,38 @@ Future franchise rebrandings just need a new history entry added to the config.
 **Evidence:** `src/pages/theleague/admin/schefter.astro` four-state pill system (`posted` / `pending` / `expired` / `no-match`). Server builds `postedGmIdToPostId` map from `feed.posts[].tipIds` (durable) and ships it down once per fetch. Client checks the durable lookup BEFORE the queue lookup.
 
 **Recommendation:** When designing status indicators, identify the durable source first. If the durable source requires a server-side join/aggregation, do it once in the API route (in a lookup table, not row-by-row from the client). Document the four states explicitly so future readers don't conflate "not in queue" with "never picked up".
+
+---
+
+## 2026-05-04 - Multi-Section Tables: Mutating Source Arrays Isn't Enough
+
+**Context:** Built a roster-move action button on `src/pages/theleague/rosters.astro`. After a successful MFL write, the local-state-update function moved the player object between `teamData.players` / `teamData.injuredReserve` / `teamData.practiceSquad` arrays and updated the row's CSS class. The user reported: "I moved a guy to practice squad but he's still on the active roster."
+
+**Insight:** The rosters page renders Active / Practice Squad / IR as visually-distinct sections built from the three bucket arrays. The DOM layout — which `<tr>` sits in which section — comes from the rendering pass that walks those arrays in order, not from the row's CSS class. Mutating the bucket arrays without re-running the render keeps the row in its original DOM position, even though the data thinks it has moved.
+
+This is the trade-block flow's blind spot: trade-block adds/removes a small badge inside an existing row, so a class flip is sufficient. Roster moves cross section boundaries, so they aren't.
+
+**Evidence:** `src/pages/theleague/rosters.astro` — `applyLocalRosterMove` (~line 8914) was correctly mutating `teamData.players` / `.practiceSquad` / `.injuredReserve` and toggling `roster-row--{tag}` classes, but the player visually stayed on the active roster until a hard reload.
+
+**Recommendation:** For any state change that re-classifies a row across multi-section table boundaries, call the page's full re-render function (`updateView()` in this codebase) after mutating the source arrays. Don't try to surgically move DOM nodes — the render function already handles section ordering, sort, contract-action overlays, cap math, and re-attaching click handlers. Any DOM-only "move the row" approach skips those side effects.
+
+Pattern:
+```js
+// 1. POST to server, await success
+// 2. Mutate the source-of-truth arrays (teamData.* buckets)
+// 3. Update any persistent UI state that survives re-render (e.g. data-attrs on the action button)
+// 4. Call updateView() to re-render from the mutated state
+```
+
+---
+
+## 2026-05-04 - `player.status` in Rosters Page Is the Bucket, Not MFL Rookie Classification
+
+**Context:** Wiring a UI gate to show "Move to Practice Squad" only for rookies. The naive read of MFL's player record uses `status === 'R'` for rookies. Tried plumbing `player.status` from the action button into the gate.
+
+**Insight:** In `src/pages/theleague/rosters.astro`, `player.status` is the BUCKET status from the rosters API — `'ROSTER'` / `'INJURED_RESERVE'` / `'TAXI_SQUAD'`. The MFL rookie classification (`'R'`) only exists on the players export, NOT on the roster export. The two endpoints share a field name with completely different meanings. A naive `player.status === 'R'` check will NEVER match.
+
+**Evidence:** rosters.astro line ~1029 sets `status: liveData.status ?? salaryPlayer.status ?? 'ROSTER'` from the live rosters data. The same `player.status` field flows through `mapPlayers()` and into the row data passed to the SSR template.
+
+**Recommendation:** For client-side rookie detection on the rosters page, use `contractInfo === 'RC' || contractInfo === 'TO'`. TheLeague's auto-stamp script (`scripts/sync-draft-pick-contracts.mjs`) writes one of those tags onto every drafted rookie within minutes of the pick, so it's a reliable proxy for "is this player a current rookie." For server-side authoritative checks, fetch the players export and check `status === 'R'` — that's MFL's own classification and the right gate for any irreversible action.
+

--- a/docs/claude/insights/domains/mfl-api.md
+++ b/docs/claude/insights/domains/mfl-api.md
@@ -893,3 +893,37 @@ Recommend migrating to `/import?TYPE=ir` with `ACTIVATED`/`DEACTIVATED` params v
 - `data/theleague/mfl-feeds/2026/transactions.json` — TAXI transactions confirmed same structure
 - `data/theleague/mfl-feeds/2026/rosters.json` — TAXI_SQUAD status players with `contractInfo: "TO"`
 - `data/theleague/mfl-feeds/2026/league.json` — `taxiSquad: "3"`, `draftPlayerPool: "Rookie"`
+
+---
+
+## 2026-05-04 - getRosters() Was Stripping Cookies on api→www49 Redirect
+
+**Context:** Building owner-mode roster-move endpoints (`/api/move-to-ir`, `/api/move-to-practice`) that preflight by calling `mflClient.getRosters()` to verify the player belongs to the user's roster before submitting the write.
+
+**Insight:** `MFLMatchupApiClient.getRosters()` in `src/utils/mfl-matchup-api.ts` used the internal `makeRequest()` helper (raw `fetch()` with `redirect: 'follow'`). Node's undici strips sensitive headers — including `Cookie` — on cross-origin redirects, and `api.myfantasyleague.com` always 302-redirects authenticated GETs to `www49.myfantasyleague.com`. The `MFL_USER_ID` cookie was silently dropped on the redirect, so the response came back as if unauthenticated.
+
+If MFL ever auth-gates the rosters export (the 2026 transactions endpoint is already auth-gated — see 2026-04-22 entry), `getRosters()` would silently return `{}`, and every roster-membership preflight check on top of it would yield a spurious "You can only move players from your own roster" 403.
+
+This is the exact same redirect-strip bug previously fixed for trade endpoints and `move-to-ir` write calls. `getRosters()` was missed because reads "looked fine" — until they didn't.
+
+**Evidence:** `src/utils/mfl-matchup-api.ts:237` (before fix). Five callers across the codebase relied on it: `move-to-ir.ts`, `move-to-practice.ts`, `trade-bait.ts`, `trades/submit.ts`, `cut-player.ts`. All were affected.
+
+**Recommendation:** Any MFL fetch carrying an auth cookie must go through `mflFetch()` from `src/utils/mfl-fetch.ts` — even for reads. Default-on rule: if you're attaching `Cookie: MFL_USER_ID=...`, you're using `mflFetch`. If you're hitting a public endpoint with no cookie, raw `fetch()` is fine. The fix path: when `mflUserId` is configured, route through `mflFetch`; otherwise fall back to the unauthenticated `makeRequest` for non-auth callers.
+
+---
+
+## 2026-05-04 - MFL `players` Export Single-Object Quirk on Single-ID Queries
+
+**Context:** Server-side rookie-status gate in `/api/move-to-practice` queries `TYPE=players&PLAYERS={id}&DETAILS=1` for one player at a time.
+
+**Insight:** When the `PLAYERS` filter narrows the response to exactly one player, MFL returns `players.player` as a SINGLE OBJECT — not a one-element array. This is the same single-vs-array shape quirk documented for `myleagues` and other filtered exports. Code that does `data.players.player.find(...)` will throw because `.find` doesn't exist on a plain object.
+
+**Evidence:** `src/pages/api/move-to-practice.ts:fetchPlayerStatus` normalizes with `Array.isArray(raw) ? raw : [raw]` before `.find`.
+
+**Recommendation:** Always normalize. Standard pattern across the codebase:
+```ts
+const raw = data?.players?.player;
+const list = Array.isArray(raw) ? raw : raw ? [raw] : [];
+```
+The triple-step (`Array.isArray ? : (raw ? [raw] : [])`) handles all three shapes: array, single object, and missing. Reuse this pattern wherever you read filtered MFL exports.
+

--- a/docs/claude/insights/features/roster-actions.md
+++ b/docs/claude/insights/features/roster-actions.md
@@ -1,0 +1,102 @@
+# Roster Action Button — Move to IR / Practice Squad
+
+Owner-mode roster moves wired into the existing player action button on `src/pages/theleague/rosters.astro`. Bidirectional (Move to IR ↔ Activate from IR; Move to Practice ↔ Promote from Practice). Rookies-only for the practice squad. Auto-taxi enhancement to the draft-pick contract-sync GitHub Action.
+
+---
+
+## 2026-05-04 - Architecture Summary
+
+**API surface:**
+- `POST /api/move-to-ir` — body `{ playerId, direction: 'to' | 'from' }`. Validates auth, roster membership, then calls `MFLMatchupApiClient.movePlayerToIR(playerId, franchiseId, direction)`.
+- `POST /api/move-to-practice` — same shape; adds two server-authoritative gates for `direction='to'`: rookie classification (`status === 'R'` from the MFL players export) and practice-squad cap (TheLeague = 3).
+
+**MFL endpoints used (canonical, owner mode):**
+- IR: `POST {host}/{year}/import?TYPE=ir` with `ACTIVATED=<id>&DEACTIVATED=` (or inverse). NOT the legacy `/freeagency&TYPE=moveToIR`.
+- Taxi: `POST {host}/{year}/import?TYPE=taxi_squad` with `PROMOTED=<id>&DEMOTED=` (or inverse).
+- Both go through `mflFetch()` (Cookie-safe across the api→www49 redirect).
+- Both share a private `runRosterMove()` helper in `src/utils/mfl-matchup-api.ts` that takes `{ type, onParam, offParam, playerId, direction }`.
+
+**UI surface:**
+- `populateCdmActionOptions()` at ~line 8404 of `rosters.astro` adds 4 conditional options to the existing action menu: Move to IR, Activate from IR, Move to Practice Squad, Promote from Practice. Owner-only gate (`config.authUser.franchiseId === currentTeam`). Practice-squad rookies retain access to "Move to IR" (an injury on practice should still be reachable from this menu).
+- `goToRosterMoveStep(target, direction)` (~line 8672) builds the in-modal confirmation step: cap-impact preview (Practice only — IR is 100% cap-counted in TheLeague), inline error region with `role="alert"`, primary CTA, focus management to the back button on open.
+- `applyLocalRosterMove()` (~line 8914) mutates `teamData.players` / `.practiceSquad` / `.injuredReserve` and calls `updateView()` to re-render the table.
+
+---
+
+## 2026-05-04 - Bidirectionality Was Free Once We Knew the API
+
+**Context:** Original spec asked whether "already on IR" should hide the option or show the inverse. We assumed inverse would double the implementation cost.
+
+**Insight:** MFL's `import?TYPE=ir` and `import?TYPE=taxi_squad` accept BOTH `ACTIVATED`/`DEACTIVATED` (or `PROMOTED`/`DEMOTED`) in the same request. The direction is implicit in which field you populate — there's no `MOVE=ACTIVATE/DEACTIVATE` parameter. So one private helper handles both directions for both endpoints — total surface is 4 directions × 2 endpoints with one server function and one client function each.
+
+**Recommendation:** When designing a roster move flow that has a clear "undo" semantic (IR ↔ active, Practice ↔ active), check MFL's API for inverse-in-same-call support before scoping out one-way only. It's almost always there, and the implementation cost is negligible.
+
+---
+
+## 2026-05-04 - Server-Authoritative Gates + Client-Side UI Gates Have Different Sources of Truth
+
+**Context:** The "Move to Practice Squad" option must only appear for rookies. The user said "MFL classifies rookies, use that."
+
+**Insight:** MFL's rookie classification is `status === 'R'` on the players export. That field is NOT exposed on the rosters export, nor on the player object passed to the SSR template on the rosters page. There's no clean way to bring it client-side without an extra fetch.
+
+We landed on a two-gate design:
+- **Client-side (UI)**: gate on `contractInfo === 'RC' || 'TO'`. TheLeague's auto-stamp script writes one of these onto every drafted rookie within minutes, so this is a reliable proxy. Used only to decide whether to render the option button.
+- **Server-side (authoritative)**: `/api/move-to-practice` fetches MFL's players export and rejects unless `status === 'R'`. This is the actual gate that matters.
+
+The gates can disagree only in one window: between when a player is drafted and when the auto-stamp script runs (≤5 min). In that window the option might be hidden when MFL would accept the move, or vice versa. Acceptable.
+
+**Recommendation:** Don't conflate "what the UI should show" with "what's allowed." The UI should be permissive enough that legitimate flows aren't blocked but tight enough that the obvious wrong cases don't even render. The server should be authoritative and reject loudly. Document the source of truth for each gate in a comment near the code.
+
+---
+
+## 2026-05-04 - Practice-Squad-Full Preflight UX Beats MFL's Error Message
+
+**Context:** TheLeague caps the practice squad at 3. Submitting a 4th promotion to MFL returns a generic XML error.
+
+**Insight:** Pre-flighting the cap on the client (`teamData.practiceSquad.length >= 3`) AND on the server (fetching the user's roster from MFL and counting `status === 'TAXI_SQUAD'`) lets us:
+1. Show + disable the CTA in the confirmation step rather than letting the user click and bounce.
+2. Render a contextual explanation ("Your practice squad is full. Demote a rookie first to free a slot.") instead of MFL's opaque error XML.
+3. Keep the cap-impact card visible for educational value ("here's what the move WOULD do").
+
+**Recommendation:** When MFL has a rule that's discoverable client-side (cap, roster size, draft player pool, etc.), preflight it and surface a friendly message. Only let MFL be the gate for things that aren't reasonably knowable client-side (timing, transient lock state, validation we don't model).
+
+---
+
+## 2026-05-04 - Auto-Taxi Policy: Fill in Pick Order, Newly-Drafted Only
+
+**Context:** The `sync-draft-pick-contracts.mjs` GitHub Action runs every 5 min during May. After it stamps RC/TO contracts on freshly-drafted picks, it now also auto-promotes them onto the practice squad until each franchise's cap is full.
+
+**Decision (B from the planning doc):** Fill in pick order — first 3 picks per franchise go to practice regardless of round. Newly-drafted picks only — never sweep already-rostered rookies, even if their franchise has open practice slots.
+
+**Why pick order (not late-rounds-first):** The simplest policy that requires zero per-pick value judgment. Late-round picks naturally end up on practice anyway in most leagues, and a 1st-round pick that owners want on active can be demoted with one click via the action button. The asymmetry of "auto-add → owner removes" is fine because the action button makes removal a 2-click operation.
+
+**Why newly-drafted only:** Predictability. Owners need to be able to reason about what the script touches. "It only acts on picks that just got their contract stamped" is a clear contract. Sweeping already-rostered rookies would surprise owners who chose to keep a 2024 rookie on active.
+
+**Evidence:** `scripts/sync-draft-pick-contracts.mjs:buildTaxiPromotions` is pure logic, exhaustively tested in `tests/sync-draft-pick-contracts.test.ts` (6 cases covering pick-order, cap limit, missing counts, custom limits, no-fresh-picks, multi-franchise determinism).
+
+---
+
+## 2026-05-04 - Dry-Run Gate Placement Matters for Multi-Step Scripts
+
+**Context:** The original `sync-draft-pick-contracts.mjs` had `if (cli.dryRun) return;` directly after printing the contract writes. After adding the auto-taxi block AFTER the contract write, dry-run mode never reached the taxi section — it returned before computing or printing the taxi promotions.
+
+**Insight:** When a script has multiple write stages (contracts THEN taxi), the dry-run gate should wrap each stage's write call individually, NOT short-circuit the whole function. Dry-run should still compute and print what WOULD happen at every stage. Otherwise users running `--dry-run` to preview a deploy can't see the full impact.
+
+**Pattern:**
+```js
+if (cli.dryRun) {
+  console.log('[script] --dry-run: not writing stage A.');
+} else {
+  await writeStageA();
+}
+// always compute + print stage B preview
+const stageBPlan = await computeStageBPlan();
+console.log(`[script] Stage B plan: ${stageBPlan.length} actions`);
+if (cli.dryRun) {
+  console.log('[script] --dry-run: not writing stage B.');
+} else {
+  await writeStageB(stageBPlan);
+}
+```
+
+**Recommendation:** For any multi-stage script, the dry-run check is per-stage, never script-wide. A `return` on dry-run is almost always a bug-in-waiting if more stages get added later.

--- a/src/pages/theleague/rosters.astro
+++ b/src/pages/theleague/rosters.astro
@@ -8952,12 +8952,11 @@ const defaultLastSeenText = formatLastSeen(defaultLastSeen);
         ufaBtn.dataset.playerDisplayTag = newDisplayTag;
       }
 
-      // Update the row class so visual styling reflects the move
-      const row = document.querySelector('tr[data-player-id="' + playerId + '"]');
-      if (row) {
-        row.classList.remove('roster-row--active', 'roster-row--practice', 'roster-row--injured');
-        row.classList.add('roster-row--' + newDisplayTag);
-      }
+      // Re-render the table from teamData. The page renders Active / Practice
+      // / IR as separate sections, so a class change on the existing <tr> is
+      // not enough — the row must move to its new section. updateView()
+      // rebuilds rows from the bucket arrays we just mutated.
+      updateView();
     };
 
     // ----------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Bug fix:** After a successful Move to IR / Practice Squad, the row's CSS class was updated but the `<tr>` stayed in its original section of the table. Result: a player moved to practice still visually appeared on the active roster until a hard reload. Calling `updateView()` after mutating `teamData.players` / `.practiceSquad` / `.injuredReserve` rebuilds the table from the freshly-mutated buckets so the row visibly moves.
- **Insights:** Captured learnings on the `getRosters()` cookie-strip-on-redirect bug, the MFL `players` filtered-export single-object quirk, the multi-section table re-render gotcha, and `player.status` being the bucket (not the rookie classification) on the rosters page. New feature-specific doc summarizes the architecture, bidirectional API discovery, two-gate UI/server design, auto-taxi policy rationale, and dry-run-gate placement pattern.

## Root cause

The rosters page renders Active / Practice Squad / IR as separate table sections built from three bucket arrays. `applyLocalRosterMove()` correctly mutated those arrays and toggled the row's class, but the DOM layout — which `<tr>` sits in which section — comes from the rendering pass walking the arrays in order, not from class names. The trade-block flow gets away with a class flip because it only adds/removes a small badge inside an existing row; roster moves cross section boundaries.

## Test plan

- [ ] Sign in as Pacific Pigskins on `/theleague/rosters`
- [ ] Click `⋮` on an active rookie → "Move to Practice Squad"
- [ ] Confirm in the modal
- [ ] Verify the row immediately moves into the Practice Squad section without a page reload
- [ ] Verify the cap subtotals at the top of the page update
- [ ] Repeat for Move to IR / Activate from IR / Promote from Practice
- [ ] Verify the action button on the moved row, when reopened, offers the inverse direction

https://claude.ai/code/session_01MTQjrvoNrbFgSErZhzGAWY

---
_Generated by [Claude Code](https://claude.ai/code/session_01MTQjrvoNrbFgSErZhzGAWY)_