### PR TITLE
Style HottestDesksWidget as a card with updated typography

### DIFF
--- a/src/components/theleague/HottestDesksWidget.astro
+++ b/src/components/theleague/HottestDesksWidget.astro
@@ -128,8 +128,23 @@ const isEmpty = rows.length === 0;
 
 <style>
   .sf-rail-hottest {
-    /* sits in the sf-news-rail flex column; no extra card chrome —
-       the widget reads as a typographic leaderboard, not a panel. */
+    background: var(--card-bg, #ffffff);
+    border-radius: var(--card-radius, 0.5rem);
+    box-shadow: var(--card-shadow, var(--shadow-card));
+    padding: 0.875rem 1rem 0.5rem;
+  }
+
+  .sf-rail-hottest .sf-rail-section__title {
+    /* Override the rail's shared section-title chrome (uppercase eyebrow
+       with a primary-color left border). Inside a card, that left border
+       fights the card edge — promote the title to a card heading instead. */
+    padding-left: 0;
+    border-left: none;
+    text-transform: none;
+    letter-spacing: 0;
+    font-size: 0.9375rem;
+    color: var(--color-gray-900, #111827);
+    margin: 0 0 0.5rem;
   }
 
   .sf-rail-hottest__list {
@@ -150,7 +165,7 @@ const isEmpty = rows.length === 0;
     row-gap: 0.0625rem;
     align-items: center;
     padding: 0.5rem 0;
-    border-bottom: 1px solid var(--color-gray-50, #f9fafb);
+    border-bottom: 1px solid var(--color-gray-100, #f3f4f6);
   }
 
   .sf-rail-hottest__item:last-child {


### PR DESCRIPTION
## Summary
Updated the HottestDesksWidget styling to display as a card component with proper visual hierarchy and spacing, rather than as a typographic leaderboard without card chrome.

## Key Changes
- Added card styling to `.sf-rail-hottest` with background, border-radius, box-shadow, and padding using CSS variables
- Redesigned `.sf-rail-hottest .sf-rail-section__title` to function as a card heading instead of a rail section eyebrow:
  - Removed uppercase styling and left border that conflicted with card edge
  - Adjusted font size, color, letter-spacing, and margins for card context
- Updated `.sf-rail-hottest__item` border color from `--color-gray-50` to `--color-gray-100` for better contrast against the card background

## Implementation Details
The widget now uses the shared card design system (background, radius, shadow) while overriding the inherited rail section title styles to prevent visual conflicts. The darker border color ensures list item separators remain visible on the lighter card background.

https://claude.ai/code/session_0159GM82HiXMZBdwR6iYCeKo