### PR TITLE
fix: drop rumor-mill tips referencing draft picks already made

### DIFF
--- a/scripts/lib/draft-pick-detector.mjs
+++ b/scripts/lib/draft-pick-detector.mjs
@@ -1,0 +1,83 @@
+/**
+ * Detect "round.pick" references like "1.12" in tip text and decide
+ * whether the referenced pick has already been made. Used by the rumor
+ * scanner to drop stale draft gossip — e.g. "Vitside taking TE at 1.12"
+ * tips that arrive in the queue before the pick is made but, because
+ * tips live in the queue for up to 7 days, can otherwise emit a fresh-
+ * voiced post 24h+ after Vitside actually picked.
+ *
+ * Pure function — takes the parsed draftResults payload and returns
+ * whether the tip should be dropped. Filesystem access is split into a
+ * separate helper below so the matcher stays unit-testable.
+ */
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+// Bounds for plausible draft coordinates. Picks outside these get
+// treated as measurements / years / version numbers and ignored — keeps
+// "$1.50", "10.5%", "v2.10" from accidentally matching a real pick.
+const MIN_ROUND = 1;
+const MAX_ROUND = 7;
+const MIN_SLOT = 1;
+const MAX_SLOT = 32;
+
+// Match "1.12", "2.05", etc. Word boundaries on both sides so "$1.50"
+// and "10.5%" stay clear (they hit MAX_ROUND clamp anyway).
+const PICK_REF_REGEX = /\b(\d{1,2})\.(\d{1,2})\b/g;
+
+/**
+ * @param {string} text
+ * @param {Array<{round?:string|number, pick?:string|number, player?:string}>} draftPicks
+ * @returns {boolean}
+ */
+export function tipReferencesCompletedPick(text, draftPicks) {
+  if (typeof text !== 'string' || text.length === 0) return false;
+  if (!Array.isArray(draftPicks) || draftPicks.length === 0) return false;
+
+  const filledPicks = new Set();
+  for (const p of draftPicks) {
+    const round = parseInt(String(p?.round ?? ''), 10);
+    const slot = parseInt(String(p?.pick ?? ''), 10);
+    if (!Number.isFinite(round) || !Number.isFinite(slot)) continue;
+    const playerId = typeof p?.player === 'string' ? p.player.trim() : '';
+    if (playerId.length > 0) filledPicks.add(`${round}.${slot}`);
+  }
+  if (filledPicks.size === 0) return false;
+
+  for (const match of text.matchAll(PICK_REF_REGEX)) {
+    const round = parseInt(match[1], 10);
+    const slot = parseInt(match[2], 10);
+    if (round < MIN_ROUND || round > MAX_ROUND) continue;
+    if (slot < MIN_SLOT || slot > MAX_SLOT) continue;
+    if (filledPicks.has(`${round}.${slot}`)) return true;
+  }
+
+  return false;
+}
+
+/**
+ * Read draftResults.json for the given league year. Returns the picks
+ * array (or null when the file is missing / malformed).
+ *
+ * @param {{ projectRoot: string, leagueYear: number|string }} args
+ */
+export async function loadDraftPicksForYear({ projectRoot, leagueYear }) {
+  try {
+    const file = path.join(
+      projectRoot,
+      'data',
+      'theleague',
+      'mfl-feeds',
+      String(leagueYear),
+      'draftResults.json',
+    );
+    const raw = await fs.readFile(file, 'utf8');
+    const data = JSON.parse(raw);
+    const draftPick = data?.draftResults?.draftUnit?.draftPick;
+    if (!draftPick) return null;
+    return Array.isArray(draftPick) ? draftPick : [draftPick];
+  } catch {
+    return null;
+  }
+}

--- a/scripts/schefter-rumor-scan.mjs
+++ b/scripts/schefter-rumor-scan.mjs
@@ -109,6 +109,10 @@ import {
   getTeamNameCount30d,
   recordTeamNaming,
 } from './lib/schefter-team-naming.mjs';
+import {
+  tipReferencesCompletedPick,
+  loadDraftPicksForYear,
+} from './lib/draft-pick-detector.mjs';
 
 const projectRoot = path.resolve(fileURLToPath(new URL('..', import.meta.url)));
 
@@ -2464,12 +2468,29 @@ async function main() {
 
   // Drop expired
   const now = new Date();
-  const freshTips = parsedTips.filter((t) => {
+  let freshTips = parsedTips.filter((t) => {
     const age = now.getTime() - (t.submittedAt ?? 0);
     return age <= TIP_EXPIRY_MS;
   });
   const expiredCount = parsedTips.length - freshTips.length;
   if (expiredCount > 0) log(`  Expired tips (>24h): ${expiredCount}`);
+
+  // Drop tips referencing draft picks that have already been made. Tips
+  // marinate in the queue for up to TIP_EXPIRY_MS (7d), so a "Vitside
+  // taking TE at 1.12" whisper submitted before the pick can still be
+  // sitting in the queue 24h after Vitside actually picked. Posting it
+  // then reads as a hallucination — drop the tip instead. Anchored to
+  // the league year so the matcher loads the right draftResults.json.
+  const seasonYear = getSeasonYearForTipster(now);
+  const draftPicks = await loadDraftPicksForYear({ projectRoot, leagueYear: seasonYear });
+  if (draftPicks && draftPicks.length > 0) {
+    const beforeCount = freshTips.length;
+    freshTips = freshTips.filter((t) => !tipReferencesCompletedPick(t.text ?? '', draftPicks));
+    const droppedCount = beforeCount - freshTips.length;
+    if (droppedCount > 0) {
+      log(`  Dropped tips referencing already-made picks: ${droppedCount}`);
+    }
+  }
 
   if (freshTips.length === 0) {
     log('  No fresh tips — clearing stale queue');

--- a/tests/draft-pick-detector.test.ts
+++ b/tests/draft-pick-detector.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest';
+// @ts-expect-error — sibling .mjs module, no .d.ts
+import { tipReferencesCompletedPick } from '../scripts/lib/draft-pick-detector.mjs';
+
+/**
+ * Locks in the fix for the May 2026 bug where the rumor scanner posted
+ * "Vitside taking TE at 1.12" 24h after Vitside actually made pick 1.12.
+ * Tips live in the queue for 7 days; without this matcher, draft gossip
+ * keeps cycling out as "fresh" long after the pick resolves.
+ */
+
+const PICK_1_12_MADE = [
+  { round: '01', pick: '12', player: '17502' },
+  { round: '01', pick: '13', player: '' },
+  { round: '02', pick: '01', player: '' },
+];
+
+const NO_PICKS_MADE = [
+  { round: '01', pick: '12', player: '' },
+  { round: '01', pick: '13', player: '' },
+];
+
+describe('tipReferencesCompletedPick', () => {
+  it('drops a tip naming a pick that has already been made', () => {
+    expect(
+      tipReferencesCompletedPick(
+        "Hearing Vitside is locked in on a TE at 1.12 — they won't budge.",
+        PICK_1_12_MADE,
+      ),
+    ).toBe(true);
+  });
+
+  it('keeps a tip naming a pick that has not been made yet', () => {
+    expect(
+      tipReferencesCompletedPick(
+        'Hearing Vitside is locked in on a TE at 1.12.',
+        NO_PICKS_MADE,
+      ),
+    ).toBe(false);
+  });
+
+  it('matches "Pick 1.12" verbatim (the actual bug post phrasing)', () => {
+    expect(
+      tipReferencesCompletedPick(
+        'Pick 1.12 is the pressure point; somebody is about to call.',
+        PICK_1_12_MADE,
+      ),
+    ).toBe(true);
+  });
+
+  it('keeps tips with no pick reference', () => {
+    expect(
+      tipReferencesCompletedPick(
+        'Hearing the Pigskins are exploring a trade-down scenario.',
+        PICK_1_12_MADE,
+      ),
+    ).toBe(false);
+  });
+
+  it('drops tips that mention multiple picks if any one is made', () => {
+    expect(
+      tipReferencesCompletedPick(
+        'Tracking 2.01 and 1.12 both — one of them is moving.',
+        PICK_1_12_MADE,
+      ),
+    ).toBe(true);
+  });
+
+  it('does NOT match plausible-looking false positives outside the round/slot bounds', () => {
+    // 10.5%, $1.50, v2.99, 9.99 — none of these are draft coordinates.
+    expect(tipReferencesCompletedPick('Up 10.5% on the year.', PICK_1_12_MADE)).toBe(false);
+    expect(tipReferencesCompletedPick('It cost $1.50 a share.', PICK_1_12_MADE)).toBe(false);
+    expect(tipReferencesCompletedPick('Build v2.99 shipped.', PICK_1_12_MADE)).toBe(false);
+  });
+
+  it('returns false when draftPicks is empty / missing', () => {
+    expect(tipReferencesCompletedPick('Vitside at 1.12 is going TE.', [])).toBe(false);
+    // @ts-expect-error — defensive null
+    expect(tipReferencesCompletedPick('Vitside at 1.12 is going TE.', null)).toBe(false);
+  });
+
+  it('returns false on empty/non-string text', () => {
+    expect(tipReferencesCompletedPick('', PICK_1_12_MADE)).toBe(false);
+    // @ts-expect-error — defensive non-string
+    expect(tipReferencesCompletedPick(undefined, PICK_1_12_MADE)).toBe(false);
+  });
+
+  it('handles MFL zero-padded round/pick strings', () => {
+    // MFL stores "01" / "12" — matcher should normalize both sides.
+    const padded = [{ round: '01', pick: '05', player: '17500' }];
+    expect(
+      tipReferencesCompletedPick('Word is 1.5 has already gone TE.', padded),
+    ).toBe(true);
+    expect(
+      tipReferencesCompletedPick('Word is 1.05 has already gone TE.', padded),
+    ).toBe(true);
+  });
+
+  it('does not match a pick that exists in the array but has no player yet', () => {
+    expect(
+      tipReferencesCompletedPick(
+        'Hearing 1.13 is going off the board for a WR.',
+        PICK_1_12_MADE, // 1.13 has player: ''
+      ),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
Tips live in the queue for up to 7 days, and the rumor scanner had no
awareness of MFL draft state. A "Vitside taking TE at 1.12" whisper
submitted before the pick still emitted a fresh-voiced post 24h after
Vitside had actually picked Omar Cooper Jr. — the post read as a
hallucination because the underlying event had already resolved.

Add a draft-pick reference matcher that scans tip text for "R.SS"
coordinates and drops the tip when the corresponding pick in
draftResults.json already has a player attached. Bounded to plausible
draft coordinates (rounds 1-7, slots 1-32) to avoid false positives on
percentages, prices, and version numbers.

https://claude.ai/code/session_01X34sidKfmkuKRLSyBsjsEt