### PR TITLE
fix: pass FRANCHISE_ID on practice-squad writes (UI + auto-taxi)

### DIFF
--- a/scripts/sync-draft-pick-contracts.mjs
+++ b/scripts/sync-draft-pick-contracts.mjs
@@ -400,9 +400,16 @@ async function fetchTaxiSquadCounts({ leagueId, year, cookies }) {
  * Uses serial calls (one player per request) so partial failures don't
  * block the rest — matches MFL's documented PROMOTED/DEMOTED single-id
  * behavior and keeps audit per-pick clear.
+ *
+ * `FRANCHISE_ID` is required when running with commissioner cookies
+ * (`MFL_USER_ID` + `MFL_IS_COMMISH`), which is how this script auths.
+ * Without it, MFL applies the promotion to the commissioner's own
+ * franchise (or silently no-ops), which is why prior runs produced
+ * the salary write but no taxi move. See
+ * docs/claude/insights/domains/mfl-api.md (2026-03-13 entry).
  */
-async function promoteOneToTaxi({ leagueId, year, cookies, playerId }) {
-  const url = `${MFL_WRITE_HOST}/${year}/import?TYPE=taxi_squad&L=${leagueId}`;
+async function promoteOneToTaxi({ leagueId, year, cookies, playerId, franchiseId }) {
+  const url = `${MFL_WRITE_HOST}/${year}/import?TYPE=taxi_squad&L=${leagueId}&FRANCHISE_ID=${franchiseId}`;
   const body = new URLSearchParams({ PROMOTED: playerId, DEMOTED: '' }).toString();
   const res = await mflFetch({ url, method: 'POST', cookies, body });
   const text = await res.text();
@@ -411,6 +418,13 @@ async function promoteOneToTaxi({ leagueId, year, cookies, playerId }) {
     return { success: false, error: m?.[1] || 'MFL rejected promotion' };
   }
   if (!res.ok) return { success: false, error: `HTTP ${res.status}` };
+  // MFL's import endpoint returns the import landing page (HTML) when it
+  // silently no-ops — e.g. missing required param or unauthorized op.
+  // Treat any HTML body as a failed write so silent failures surface
+  // instead of being logged as success.
+  if (text.includes('<html') || text.includes('<!DOCTYPE')) {
+    return { success: false, error: 'MFL did not process the promotion (received HTML landing page).' };
+  }
   return { success: true };
 }
 
@@ -641,7 +655,13 @@ async function main() {
       } else {
         let okCount = 0;
         for (const p of promotions) {
-          const r = await promoteOneToTaxi({ leagueId, year, cookies, playerId: p.playerId });
+          const r = await promoteOneToTaxi({
+            leagueId,
+            year,
+            cookies,
+            playerId: p.playerId,
+            franchiseId: p.franchiseId,
+          });
           if (r.success) {
             okCount++;
           } else {

--- a/src/utils/mfl-matchup-api.ts
+++ b/src/utils/mfl-matchup-api.ts
@@ -577,7 +577,7 @@ export class MFLMatchupApiClient {
    */
   async movePlayerToIR(
     playerId: string,
-    _franchiseId: string,
+    franchiseId: string,
     direction: 'to' | 'from' = 'to',
   ): Promise<{ success: boolean; error?: string }> {
     return this.runRosterMove({
@@ -585,6 +585,7 @@ export class MFLMatchupApiClient {
       onParam: 'ACTIVATED',
       offParam: 'DEACTIVATED',
       playerId,
+      franchiseId,
       direction,
     });
   }
@@ -601,7 +602,7 @@ export class MFLMatchupApiClient {
    */
   async movePlayerToTaxi(
     playerId: string,
-    _franchiseId: string,
+    franchiseId: string,
     direction: 'to' | 'from' = 'to',
   ): Promise<{ success: boolean; error?: string }> {
     return this.runRosterMove({
@@ -609,6 +610,7 @@ export class MFLMatchupApiClient {
       onParam: 'PROMOTED',
       offParam: 'DEMOTED',
       playerId,
+      franchiseId,
       direction,
     });
   }
@@ -622,6 +624,7 @@ export class MFLMatchupApiClient {
     onParam: 'ACTIVATED' | 'PROMOTED';
     offParam: 'DEACTIVATED' | 'DEMOTED';
     playerId: string;
+    franchiseId: string;
     direction: 'to' | 'from';
   }): Promise<{ success: boolean; error?: string }> {
     if (!this.config.mflUserId) {
@@ -629,15 +632,16 @@ export class MFLMatchupApiClient {
     }
 
     try {
-      // POST directly to the league host (www49) — going through api.myfantasyleague.com
-      // returns a 302 to www49, and mflFetch converts the POST → GET on redirect (the
-      // body is preserved by appending to the URL, but the method is not). MFL's import
-      // endpoint silently no-ops on GET — it serves the import landing page, returns
-      // no <error> tag, and the call falls through as success while the write never
-      // executes. Same pattern used by mfl-contract-writer.ts and sync-draft-pick-contracts.mjs.
+      // POST directly to the league host (www49) — api.myfantasyleague.com 302s
+      // here and mflFetch converts POST → GET on redirect, which silently no-ops
+      // MFL's import endpoint (it serves the landing page and returns no error).
       const writeHost = process.env.MFL_WRITE_HOST || 'https://www49.myfantasyleague.com';
       const url = `${writeHost}/${this.config.year}/import?TYPE=${opts.type}&L=${this.config.leagueId}`;
       const params = new URLSearchParams();
+      // FRANCHISE_ID in the body matches the working pattern in cut-player.ts /
+      // mfl-contract-writer.ts. Owner mode tolerates it (cookie franchise must
+      // match), and it's required if MFL flips into commissioner-mode parsing.
+      params.set('FRANCHISE_ID', opts.franchiseId);
       if (opts.direction === 'to') {
         params.set(opts.onParam, opts.playerId);
         params.set(opts.offParam, '');
@@ -645,6 +649,10 @@ export class MFLMatchupApiClient {
         params.set(opts.onParam, '');
         params.set(opts.offParam, opts.playerId);
       }
+
+      console.log(
+        `[runRosterMove] POST ${url} body=${params.toString()} userCookie=${this.config.mflUserId ? 'present' : 'MISSING'}`,
+      );
 
       const response = await mflFetch({
         url,
@@ -654,6 +662,9 @@ export class MFLMatchupApiClient {
       });
 
       const text = await response.text();
+      console.log(
+        `[runRosterMove] MFL response: ${response.status} ${response.headers.get('content-type') ?? ''} | body=${text.slice(0, 500)}`,
+      );
 
       if (text.includes('<error>') || text.includes('"error"')) {
         const errorMatch =


### PR DESCRIPTION
## Summary

Two related fixes for practice-squad writes silently no-op'ing on MFL:

- **UI flow** (`/api/move-to-practice` → `runRosterMove`): pass `FRANCHISE_ID` in the POST body, matching the working pattern in `cut-player.ts` and `mfl-contract-writer.ts`. Threaded `franchiseId` through `movePlayerToIR` / `movePlayerToTaxi` (both already received it from the route handlers but were discarding it as `_franchiseId`). Added request/response logging so future silent failures leave a diagnostic trail in Vercel function logs.
- **Auto-taxi cron** (`scripts/sync-draft-pick-contracts.mjs`): `promoteOneToTaxi` now passes `FRANCHISE_ID` per promotion (already on each entry from `buildTaxiPromotions`). Tightened the response check to flag HTML landing-page responses as failure so silent no-ops surface in the Actions log.

Why the UI looked like it worked before: the optimistic local update in `rosters.astro` flips the player into the practice bucket and sets `status = 'TAXI_SQUAD'`, then the cap calc applies the 50% multiplier — so the cap dollars look right and the row visually moves, but a refresh shows the player back on active because MFL never persisted.

Why salaries land but taxi doesn't (auto-taxi cron): `import?TYPE=salaries` is league-wide and embeds player IDs in the XML, so it doesn't need franchise context. `import?TYPE=taxi_squad` is per-franchise — without `FRANCHISE_ID`, a commissioner cookie either applies the move to the commissioner's own franchise or silently no-ops.

References:
- `docs/claude/insights/domains/mfl-api.md:421` — 2026-03-13 commissioner impersonation insight
- `docs/features/mfl-api.md:1108` — taxi_squad spec

## Test plan

- [x] `pnpm exec vitest run tests/sync-draft-pick-contracts.test.ts tests/trade-bait-security.test.ts` — 28/28 pass
- [x] `node --check scripts/sync-draft-pick-contracts.mjs` — syntax OK
- [ ] Owner clicks **Move to Practice Squad** on a rookie via the rosters page; verify it persists on MFL after refresh
- [ ] Inspect Vercel function logs for `[runRosterMove]` request/response lines on the move
- [ ] Manual `workflow_dispatch` of **Sync Draft Pick Contracts** on this branch with `dry_run=false` during a draft window; verify rookies actually land on each franchise's practice squad and the Actions log shows `Auto-taxi: N/N promotion(s) succeeded`

https://claude.ai/code/session_01GnYGBpALnipiVc1Xexporu

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnYGBpALnipiVc1Xexporu)_