### PR TITLE
fix(contracts): allow 1st-round TO rookies to declare initial contract length

### DIFF
--- a/src/utils/contract-eligibility.ts
+++ b/src/utils/contract-eligibility.ts
@@ -273,8 +273,14 @@ export function getPlayerEligibility(
     }
   }
 
-  // 2. Check for rookie override (RC player before August cutdown)
-  if (isRC && isMFLRookie(playerInfo, currentYear)) {
+  // 2. Check for rookie override (RC or TO player before August cutdown)
+  // Rookies drafted in our league this year — including 1st-rounders who carry
+  // the TO (Team Option) tag — can adjust their initial contract length until
+  // the 3rd Sunday in August. RC picks may declare 1-3 years; 1st-round TO
+  // picks are signed to a 4-year rookie deal with a 5th-year option, so they
+  // may declare 1-4 years.
+  const isFirstRoundRookieTag = contractInfo === 'TO';
+  if ((isRC || isFirstRoundRookieTag) && isMFLRookie(playerInfo, currentYear)) {
     const cutdownDate = getAugustCutdownDate(now.getFullYear());
     if (now < cutdownDate && window.windowType === 'offseason') {
       return {
@@ -283,7 +289,7 @@ export function getPlayerEligibility(
         declarationType: 'rookie-override',
         deadlineTimestamp: Math.floor(cutdownDate.getTime() / 1000),
         isExpired: false,
-        yearOptions: [1, 2, 3],
+        yearOptions: isFirstRoundRookieTag ? [1, 2, 3, 4] : [1, 2, 3],
       };
     }
   }

--- a/tests/contract-eligibility.test.ts
+++ b/tests/contract-eligibility.test.ts
@@ -410,6 +410,41 @@ describe('getPlayerEligibility', () => {
       // Without MFL rookie status, RC player gets rookie-extension instead of override
       expect(result.declarationType).not.toBe('rookie-override');
     });
+
+    it('marks 1st-round TO rookie as eligible for override with 1-4 year options', () => {
+      // 1st-round 2026 pick: contractInfo is "TO", default 4-year rookie deal.
+      // Even at currentYears=1 (which would normally fail the team-option check)
+      // the just-drafted rookie must remain adjustable until August.
+      const roster = makeRosterPlayer({ contractYear: '1', contractInfo: 'TO' });
+      const playerInfo = makePlayerInfo({ status: 'R', draft_year: String(currentYear) });
+
+      const result = getPlayerEligibility('14867', '0009', roster, [], playerInfo, currentYear, now);
+      expect(result.eligible).toBe(true);
+      expect(result.declarationType).toBe('rookie-override');
+      expect(result.yearOptions).toEqual([1, 2, 3, 4]);
+    });
+
+    it('marks TO rookie as override when default 4-year contract is set', () => {
+      const roster = makeRosterPlayer({ contractYear: '4', contractInfo: 'TO' });
+      const playerInfo = makePlayerInfo({ status: 'R', draft_year: String(currentYear) });
+
+      const result = getPlayerEligibility('14867', '0009', roster, [], playerInfo, currentYear, now);
+      expect(result.eligible).toBe(true);
+      expect(result.declarationType).toBe('rookie-override');
+      expect(result.declarationType).not.toBe('team-option');
+      expect(result.yearOptions).toEqual([1, 2, 3, 4]);
+    });
+
+    it('does not mark TO veteran (non-rookie) for override', () => {
+      // Existing TO player whose rookie window has closed — should still flow
+      // into team-option for the Year 4 decision, not rookie-override.
+      const roster = makeRosterPlayer({ contractYear: '2', contractInfo: 'TO' });
+      const playerInfo = makePlayerInfo({ status: 'A', draft_year: '2024' });
+
+      const result = getPlayerEligibility('14867', '0009', roster, [], playerInfo, currentYear, now);
+      expect(result.declarationType).not.toBe('rookie-override');
+      expect(result.declarationType).toBe('team-option');
+    });
   });
 
   describe('franchise-tag eligibility', () => {


### PR DESCRIPTION
A 1st-round 2026+ pick is tagged TO (Team Option) per league rule, and the
rookie-override path was gated on isRC — so just-drafted 1st-rounders fell
through to either ineligible (currentYears<2) or the wrong team-option flow.
Extend rookie-override to cover TO+isMFLRookie players with [1,2,3,4]
year options, matching the 4-year rookie contract structure (the 5th-year
option remains a separate decision routed through team-option later).