### PR TITLE
fix(roster): make practice-squad / IR moves persist on MFL

### DIFF
--- a/.github/workflows/sync-draft-pick-contracts.yml
+++ b/.github/workflows/sync-draft-pick-contracts.yml
@@ -1,10 +1,16 @@
 name: Sync Draft Pick Contracts
 
 # Stamps RC + slot-based rookie salary + 4yr default on newly-drafted
-# players directly to MFL, and auto-promotes those fresh picks onto the
-# practice squad in pick order until each franchise's taxi cap is full.
-# Idempotent — re-runs skip players who already have RC stamped, and
-# franchises already at the practice-squad cap produce no promotions.
+# players directly to MFL. Idempotent — re-runs skip players who already
+# have the expected contractInfo stamped.
+#
+# Practice-squad placement is NOT handled here: MFL blocks commissioner
+# impersonation when the league has `lockout: "Yes"` (TheLeague keeps it
+# on year-round), so a script-driven auto-taxi step always fails with
+# `"Can not impersonate another franchise when LOCKOUT is on."` Owners
+# move their own picks to the practice squad via the rosters page UI
+# (POST /api/move-to-practice), which uses each owner's session cookie
+# and doesn't impersonate.
 #
 # Schedule: every 5 min during May only (the rookie draft window in
 # TheLeague). Outside May the workflow does not fire at all. Update the
@@ -14,8 +20,7 @@ name: Sync Draft Pick Contracts
 # testing or off-cycle runs:
 #   GitHub UI → Actions → Sync Draft Pick Contracts → Run workflow
 #   - dry_run: leave checked to PRINT the would-be writes without
-#              touching MFL (covers both contracts and auto-taxi).
-#              Uncheck to actually write.
+#              touching MFL. Uncheck to actually write.
 
 on:
   schedule:

--- a/scripts/sync-draft-pick-contracts.mjs
+++ b/scripts/sync-draft-pick-contracts.mjs
@@ -28,10 +28,14 @@
  * contractYear from the rookie-override flow. Safe to run on every
  * roster-sync tick (every 5 min).
  *
- * Auto-taxi: after the contract write succeeds, freshly-drafted picks
- * are promoted onto each franchise's practice squad in pick order until
- * the taxi cap is filled. Only fresh picks from this run are considered
- * — already-rostered rookies are never swept. See buildTaxiPromotions.
+ * Auto-taxi note: an earlier version of this script also promoted fresh
+ * picks onto each franchise's practice squad. MFL blocks commissioner
+ * impersonation when `lockout: "Yes"` is set (TheLeague keeps it on
+ * year-round per the constitution), so the auto-taxi step would always
+ * fail with `"Can not impersonate another franchise when LOCKOUT is on."`
+ * Practice-squad placement now happens via the per-owner UI flow at
+ * /api/move-to-practice instead, where each owner moves their own picks
+ * without commissioner impersonation.
  *
  * Audit trail: also writes an `applied` ContractDeclaration record into
  * storage (Upstash Redis or local JSON) so the change shows up in the
@@ -146,61 +150,6 @@ export function buildDraftPickWrites({ draftResults, playerIndex, mflSalaries, y
   }
 
   return writes;
-}
-
-/**
- * Pure-logic builder for auto-taxi promotions.
- *
- * Given the draft-pick writes from this run plus current per-franchise
- * practice-squad counts, returns the list of newly-drafted picks that
- * should be promoted onto the taxi squad — strictly limited to fresh
- * picks in this tick, filling each franchise's open slots in PICK
- * ORDER (lowest overall pick first).
- *
- * Non-rookie pools (already-rostered players) are NEVER swept. The
- * promotion list is bounded by `(taxiLimit - currentCount)` per
- * franchise. Idempotent: a pick whose franchise is already at the
- * limit produces no entry.
- *
- * @param {object} args
- * @param {Array<{playerId: string, playerName: string, franchiseId: string, round: number, pickInRound: number}>} args.writes
- *   The draft-pick writes for this run (already filtered to fresh picks).
- * @param {Map<string, number>} args.taxiCounts
- *   Map of franchiseId → current practice-squad size (count of TAXI_SQUAD players).
- * @param {number} [args.taxiLimit=3]  Per-franchise practice-squad cap.
- */
-export function buildTaxiPromotions({ writes, taxiCounts, taxiLimit = 3 }) {
-  const byFranchise = new Map();
-  for (const w of writes) {
-    if (!byFranchise.has(w.franchiseId)) byFranchise.set(w.franchiseId, []);
-    byFranchise.get(w.franchiseId).push(w);
-  }
-
-  const promotions = [];
-  for (const [franchiseId, picks] of byFranchise) {
-    const current = taxiCounts.get(franchiseId) ?? 0;
-    const slots = Math.max(0, taxiLimit - current);
-    if (slots === 0) continue;
-
-    // Sort ascending by overall pick (round, then pickInRound) so earlier
-    // picks fill open slots first — Policy B from the design discussion.
-    const sorted = [...picks].sort((a, b) => {
-      if (a.round !== b.round) return a.round - b.round;
-      return a.pickInRound - b.pickInRound;
-    });
-
-    for (const pick of sorted.slice(0, slots)) {
-      promotions.push({
-        playerId: pick.playerId,
-        playerName: pick.playerName,
-        franchiseId: pick.franchiseId,
-        round: pick.round,
-        pickInRound: pick.pickInRound,
-      });
-    }
-  }
-
-  return promotions;
 }
 
 // ── MFL auth + fetch (mirrors src/utils/mfl-login.ts + mfl-fetch.ts) ──
@@ -371,61 +320,6 @@ async function writeContractsToMFL({ leagueId, year, cookies, writes }) {
     }
   }
   return { success: false, attempts: delays.length + 1, error: lastError };
-}
-
-// ── Auto-taxi (practice-squad) promotion ───────────────────────────────
-
-/**
- * Fetch per-franchise practice-squad counts from MFL.
- * Returns a Map<franchiseId, count> — number of players currently in
- * the TAXI_SQUAD bucket per franchise. Missing franchises map to 0.
- */
-async function fetchTaxiSquadCounts({ leagueId, year, cookies }) {
-  const url = `${MFL_READ_HOST}/${year}/export?TYPE=rosters&L=${leagueId}&JSON=1`;
-  const res = await mflFetch({ url, cookies });
-  if (!res.ok) throw new Error(`MFL rosters fetch failed: ${res.status}`);
-  const data = await res.json();
-  const raw = data?.rosters?.franchise;
-  const list = Array.isArray(raw) ? raw : raw ? [raw] : [];
-  const counts = new Map();
-  for (const fr of list) {
-    const players = Array.isArray(fr.player) ? fr.player : fr.player ? [fr.player] : [];
-    counts.set(String(fr.id), players.filter((p) => p.status === 'TAXI_SQUAD').length);
-  }
-  return counts;
-}
-
-/**
- * POST a single taxi_squad promotion to MFL. Returns { success, error? }.
- * Uses serial calls (one player per request) so partial failures don't
- * block the rest — matches MFL's documented PROMOTED/DEMOTED single-id
- * behavior and keeps audit per-pick clear.
- *
- * `FRANCHISE_ID` is required when running with commissioner cookies
- * (`MFL_USER_ID` + `MFL_IS_COMMISH`), which is how this script auths.
- * Without it, MFL applies the promotion to the commissioner's own
- * franchise (or silently no-ops), which is why prior runs produced
- * the salary write but no taxi move. See
- * docs/claude/insights/domains/mfl-api.md (2026-03-13 entry).
- */
-async function promoteOneToTaxi({ leagueId, year, cookies, playerId, franchiseId }) {
-  const url = `${MFL_WRITE_HOST}/${year}/import?TYPE=taxi_squad&L=${leagueId}&FRANCHISE_ID=${franchiseId}`;
-  const body = new URLSearchParams({ PROMOTED: playerId, DEMOTED: '' }).toString();
-  const res = await mflFetch({ url, method: 'POST', cookies, body });
-  const text = await res.text();
-  if (text.includes('<error>')) {
-    const m = text.match(/<error[^>]*>(.*?)<\/error>/s);
-    return { success: false, error: m?.[1] || 'MFL rejected promotion' };
-  }
-  if (!res.ok) return { success: false, error: `HTTP ${res.status}` };
-  // MFL's import endpoint returns the import landing page (HTML) when it
-  // silently no-ops — e.g. missing required param or unauthorized op.
-  // Treat any HTML body as a failed write so silent failures surface
-  // instead of being logged as success.
-  if (text.includes('<html') || text.includes('<!DOCTYPE')) {
-    return { success: false, error: 'MFL did not process the promotion (received HTML landing page).' };
-  }
-  return { success: true };
 }
 
 // ── Audit-trail declaration storage (best-effort) ──────────────────────
@@ -634,45 +528,6 @@ async function main() {
     } catch (err) {
       console.warn(`[draft-pick-sync] Audit-trail write failed (MFL write already succeeded): ${err.message}`);
     }
-  }
-
-  // Auto-taxi: promote freshly-drafted picks onto the practice squad in
-  // pick order, up to each franchise's open slots. Newly-drafted only —
-  // existing rookies are never swept. See buildTaxiPromotions for policy.
-  try {
-    const taxiCounts = await fetchTaxiSquadCounts({ leagueId, year, cookies });
-    const promotions = buildTaxiPromotions({ writes, taxiCounts });
-    if (promotions.length === 0) {
-      console.log('[draft-pick-sync] No auto-taxi promotions (all rosters at practice-squad cap or no fresh picks).');
-    } else {
-      console.log(`[draft-pick-sync] Auto-taxi: promoting ${promotions.length} rookie(s) to practice squad:`);
-      for (const p of promotions) {
-        const fname = (franchiseNameMap.get(p.franchiseId) ?? p.franchiseId).padEnd(14);
-        console.log(`  ${fname} R${p.round}.${String(p.pickInRound).padStart(2, '0')} ${p.playerName}`);
-      }
-      if (cli.dryRun) {
-        console.log('[draft-pick-sync] --dry-run: not writing taxi promotions to MFL.');
-      } else {
-        let okCount = 0;
-        for (const p of promotions) {
-          const r = await promoteOneToTaxi({
-            leagueId,
-            year,
-            cookies,
-            playerId: p.playerId,
-            franchiseId: p.franchiseId,
-          });
-          if (r.success) {
-            okCount++;
-          } else {
-            console.warn(`[draft-pick-sync] Auto-taxi failed for ${p.playerName} (${p.playerId}): ${r.error}`);
-          }
-        }
-        console.log(`[draft-pick-sync] Auto-taxi: ${okCount}/${promotions.length} promotion(s) succeeded.`);
-      }
-    }
-  } catch (err) {
-    console.warn(`[draft-pick-sync] Auto-taxi step failed (contract writes already succeeded): ${err.message}`);
   }
 }
 

--- a/src/utils/mfl-matchup-api.ts
+++ b/src/utils/mfl-matchup-api.ts
@@ -632,16 +632,16 @@ export class MFLMatchupApiClient {
     }
 
     try {
-      // POST directly to the league host (www49) — api.myfantasyleague.com 302s
-      // here and mflFetch converts POST → GET on redirect, which silently no-ops
-      // MFL's import endpoint (it serves the landing page and returns no error).
-      const writeHost = process.env.MFL_WRITE_HOST || 'https://www49.myfantasyleague.com';
-      const url = `${writeHost}/${this.config.year}/import?TYPE=${opts.type}&L=${this.config.leagueId}`;
-      const params = new URLSearchParams();
-      // FRANCHISE_ID in the body matches the working pattern in cut-player.ts /
-      // mfl-contract-writer.ts. Owner mode tolerates it (cookie franchise must
-      // match), and it's required if MFL flips into commissioner-mode parsing.
-      params.set('FRANCHISE_ID', opts.franchiseId);
+      // Mirrors the proven owner-mode write pattern in src/pages/api/cut-player.ts:
+      // POST to api.myfantasyleague.com (mflFetch handles the cross-origin
+      // redirect to www49 and re-attaches the cookie), put every parameter in
+      // the body, owner cookie only — never send MFL_IS_COMMISH.
+      const url = `https://api.myfantasyleague.com/${this.config.year}/import`;
+      const params = new URLSearchParams({
+        TYPE: opts.type,
+        L: this.config.leagueId,
+        FRANCHISE_ID: opts.franchiseId,
+      });
       if (opts.direction === 'to') {
         params.set(opts.onParam, opts.playerId);
         params.set(opts.offParam, '');
@@ -651,7 +651,7 @@ export class MFLMatchupApiClient {
       }
 
       console.log(
-        `[runRosterMove] POST ${url} body=${params.toString()} userCookie=${this.config.mflUserId ? 'present' : 'MISSING'}`,
+        `[runRosterMove] POST ${url} (type=${opts.type}, franchise=${opts.franchiseId}, ${opts.direction === 'to' ? opts.onParam : opts.offParam}=${opts.playerId})`,
       );
 
       const response = await mflFetch({

--- a/tests/sync-draft-pick-contracts.test.ts
+++ b/tests/sync-draft-pick-contracts.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect } from 'vitest';
 // @ts-expect-error - .mjs without types
 import {
   buildDraftPickWrites,
-  buildTaxiPromotions,
   getExpectedRookieContractInfo,
 } from '../scripts/sync-draft-pick-contracts.mjs';
 // @ts-expect-error - .mjs without types
@@ -233,117 +232,5 @@ describe('buildDraftPickWrites', () => {
     const writes = buildDraftPickWrites({ draftResults, playerIndex, mflSalaries, year: '2026' });
 
     expect(writes).toHaveLength(0);
-  });
-});
-
-describe('buildTaxiPromotions', () => {
-  type Write = {
-    playerId: string;
-    playerName: string;
-    franchiseId: string;
-    round: number;
-    pickInRound: number;
-  };
-
-  const makeWrite = (
-    playerId: string,
-    franchiseId: string,
-    round: number,
-    pickInRound: number,
-  ): Write => ({
-    playerId,
-    playerName: `Player ${playerId}`,
-    franchiseId,
-    round,
-    pickInRound,
-  });
-
-  it('promotes fresh picks in pick order, filling each franchise to the cap', () => {
-    const writes: Write[] = [
-      // Franchise 0001 — 4 picks, 0/3 used → fills first 3 in pick order
-      makeWrite('1001', '0001', 1, 5),
-      makeWrite('1002', '0001', 4, 16),
-      makeWrite('1003', '0001', 2, 8),
-      makeWrite('1004', '0001', 3, 12),
-      // Franchise 0002 — 1 pick, 2/3 used → fills 1 remaining slot
-      makeWrite('2001', '0002', 4, 14),
-    ];
-    const taxiCounts = new Map<string, number>([
-      ['0001', 0],
-      ['0002', 2],
-    ]);
-
-    const result = buildTaxiPromotions({ writes, taxiCounts });
-
-    const ids = result.map((p) => p.playerId).sort();
-    // 0001 picks sorted by (round,pick): R1.5=1001, R2.8=1003, R3.12=1004, R4.16=1002
-    // → first 3 fill the empty practice squad; R4.16 (1002) gets excluded.
-    // 0002: R4.14=2001 fills the only open slot.
-    expect(ids).toEqual(['1001', '1003', '1004', '2001'].sort());
-    expect(result.find((p) => p.playerId === '1002')).toBeUndefined();
-  });
-
-  it('emits no promotions for franchises already at the cap', () => {
-    const writes: Write[] = [makeWrite('1001', '0001', 2, 5), makeWrite('1002', '0001', 3, 9)];
-    const taxiCounts = new Map<string, number>([['0001', 3]]);
-
-    const result = buildTaxiPromotions({ writes, taxiCounts });
-
-    expect(result).toEqual([]);
-  });
-
-  it('treats missing taxi counts as zero (assumes empty practice squad)', () => {
-    const writes: Write[] = [makeWrite('1001', '0001', 4, 10)];
-    const taxiCounts = new Map<string, number>(); // franchise 0001 absent
-
-    const result = buildTaxiPromotions({ writes, taxiCounts });
-
-    expect(result).toHaveLength(1);
-    expect(result[0].playerId).toBe('1001');
-  });
-
-  it('respects a custom taxiLimit when the league cap differs', () => {
-    const writes: Write[] = [
-      makeWrite('1001', '0001', 1, 1),
-      makeWrite('1002', '0001', 2, 1),
-      makeWrite('1003', '0001', 3, 1),
-    ];
-    const taxiCounts = new Map<string, number>([['0001', 0]]);
-
-    const result = buildTaxiPromotions({ writes, taxiCounts, taxiLimit: 1 });
-
-    expect(result).toHaveLength(1);
-    expect(result[0].playerId).toBe('1001'); // earliest pick wins
-  });
-
-  it('does not sweep franchises that have no fresh picks in this run', () => {
-    const writes: Write[] = [makeWrite('1001', '0001', 4, 10)];
-    const taxiCounts = new Map<string, number>([
-      ['0001', 0],
-      ['0002', 0], // 0/3 but no fresh picks for 0002
-    ]);
-
-    const result = buildTaxiPromotions({ writes, taxiCounts });
-
-    expect(result).toHaveLength(1);
-    expect(result.every((p) => p.franchiseId === '0001')).toBe(true);
-  });
-
-  it('orders multi-franchise output deterministically via per-franchise pick order', () => {
-    const writes: Write[] = [
-      makeWrite('A2', '0001', 2, 5),
-      makeWrite('A1', '0001', 1, 5),
-      makeWrite('B2', '0002', 3, 7),
-      makeWrite('B1', '0002', 1, 7),
-    ];
-    const taxiCounts = new Map<string, number>([['0001', 0], ['0002', 0]]);
-
-    const result = buildTaxiPromotions({ writes, taxiCounts });
-
-    // Each franchise's promotions should be in ascending round/pick order.
-    const f1 = result.filter((p) => p.franchiseId === '0001').map((p) => p.playerId);
-    const f2 = result.filter((p) => p.franchiseId === '0002').map((p) => p.playerId);
-    expect(f1).toEqual(['A1', 'A2']);
-    expect(f2).toEqual(['B1', 'B2']);
   });
 });


### PR DESCRIPTION
Follow-up to #171. That PR landed the `FRANCHISE_ID` fix + diagnostic logging, but kept POSTing directly to `www49` — the UI **Move to Practice Squad** action was still silently no-op'ing (player flips into the practice bucket optimistically, then a refresh shows them back on active roster).

## What changed

1. **Rewrote `runRosterMove`** (`src/utils/mfl-matchup-api.ts`) to mirror the proven owner-mode write pattern in `src/pages/api/cut-player.ts`:
   - POST to `api.myfantasyleague.com/{year}/import` — `mflFetch` handles the cross-origin redirect to `www49` and re-attaches the cookie
   - Every parameter in the body: `TYPE`, `L`, `FRANCHISE_ID`, plus the `PROMOTED`/`DEMOTED` or `ACTIVATED`/`DEACTIVATED` pair
   - Owner cookie only — never sends `MFL_IS_COMMISH`, never impersonates
   - Diagnostic `[runRosterMove]` request/response logging retained

   The previous "POST direct to www49" approach was treating a symptom — cut-player goes through the redirect every day and works.

2. **Removed the auto-taxi step from the cron** (`scripts/sync-draft-pick-contracts.mjs`):
   - `buildTaxiPromotions` (pure-logic builder + 6 unit tests)
   - `fetchTaxiSquadCounts` (read helper)
   - `promoteOneToTaxi` (write helper)
   - the auto-taxi block in `main()`
   - workflow YAML comments mentioning auto-taxi

   When the cron last ran with the diagnostic logging from #171, it surfaced the real blocker: `"Can not impersonate another franchise when LOCKOUT is on."` TheLeague keeps `lockout: "Yes"` set year-round per the constitution, so commissioner-mode taxi promotions can never work for any non-commissioner franchise. Practice-squad placement now happens entirely through the per-owner UI flow.

## Test plan

- [x] `pnpm exec vitest run tests/sync-draft-pick-contracts.test.ts tests/trade-bait-security.test.ts` — 22/22 pass
- [x] `node --check scripts/sync-draft-pick-contracts.mjs` — syntax OK
- [ ] Owner clicks **Move to Practice Squad** on a rookie via the rosters page on the preview deploy → verify it persists on MFL after a refresh
- [ ] If anything goes wrong, paste the `[runRosterMove]` request/response lines from Vercel function logs

## References

- `src/pages/api/cut-player.ts` — proven owner-mode write reference
- `docs/claude/insights/domains/mfl-api.md` (2026-03-13 entry) — commissioner impersonation + lockout interaction

https://claude.ai/code/session_01GnYGBpALnipiVc1Xexporu

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnYGBpALnipiVc1Xexporu)_