### PR TITLE
feat: franchise history Phase 1 wrap-up — blowouts, championships, scrollable tables

### DIFF
--- a/data/theleague/championship-history.json
+++ b/data/theleague/championship-history.json
@@ -1,0 +1,24 @@
+{
+  "$comment": "Hand-curated league championship history. Used by compute-franchise-history.mjs to fill in the years where MFL's playoff-brackets export returns metadata only (no franchise winners). Each entry maps a year to the franchise IDs that finished 1st and 2nd. Names are recorded as they were AT THAT TIME — to find the franchise ID, cross-reference data/theleague/mfl-feeds/<year>/league.json.",
+  "championships": [
+    { "year": 2007, "champion": "0015", "runnerUp": "0007", "championName": "Dark Magicians of Chaos", "runnerUpName": "Acer FC Edge" },
+    { "year": 2008, "champion": "0015", "runnerUp": "0008", "championName": "Dark Magicians of Chaos", "runnerUpName": "Bring the Pain" },
+    { "year": 2009, "champion": "0004", "runnerUp": "0006", "championName": "Las Vegas Elite", "runnerUpName": "LBer-DeCleaters" },
+    { "year": 2010, "champion": "0007", "runnerUp": "0006", "championName": "Fire Ready Aim", "runnerUpName": "LBer-DeCleaters" },
+    { "year": 2011, "champion": "0013", "runnerUp": "0007", "championName": "Sabertooths", "runnerUpName": "Fire Ready Aim" },
+    { "year": 2012, "champion": "0014", "runnerUp": "0012", "championName": "Devil Dogs", "runnerUpName": "Vitside Mafia" },
+    { "year": 2013, "champion": "0014", "runnerUp": "0003", "championName": "Devil Dogs", "runnerUpName": "Poker in the Rear" },
+    { "year": 2014, "champion": "0008", "runnerUp": "0001", "championName": "Bring the Pain", "runnerUpName": "Pacific Pigskins" },
+    { "year": 2015, "champion": "0011", "runnerUp": "0005", "championName": "Amish Rakefighters", "runnerUpName": "The Executioners" },
+    { "year": 2016, "champion": "0006", "runnerUp": "0015", "championName": "LBer-DeCleaters", "runnerUpName": "Dark Magicians of Chaos" },
+    { "year": 2017, "champion": "0007", "runnerUp": "0013", "championName": "Fire Ready Aim", "runnerUpName": "Gridiron Geeks" },
+    { "year": 2018, "champion": "0011", "runnerUp": "0004", "championName": "Under Siege", "runnerUpName": "The Art of War" },
+    { "year": 2019, "champion": "0008", "runnerUp": "0011", "championName": "Bring the Pain", "runnerUpName": "Midwestside Connection" },
+    { "year": 2020, "champion": "0008", "runnerUp": "0016", "championName": "Bring the Pain", "runnerUpName": "Running Down The Dream" },
+    { "year": 2021, "champion": "0011", "runnerUp": "0008", "championName": "Midwestside Connection", "runnerUpName": "Bring the Pain" },
+    { "year": 2022, "champion": "0012", "runnerUp": "0015", "championName": "Vitside Mafia", "runnerUpName": "Dark Magicians of Chaos" },
+    { "year": 2023, "champion": "0007", "runnerUp": "0002", "championName": "Fire Ready Aim", "runnerUpName": "Da Dangsters" },
+    { "year": 2024, "champion": "0009", "runnerUp": "0002", "championName": "Wascawy Wabbits", "runnerUpName": "Da Dangsters" },
+    { "year": 2025, "champion": "0010", "runnerUp": "0015", "championName": "Computer Jocks", "runnerUpName": "Dark Magicians of Chaos" }
+  ]
+}

--- a/data/theleague/derived/franchise-history.json
+++ b/data/theleague/derived/franchise-history.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-07T18:59:12.598Z",
+  "generatedAt": "2026-05-07T19:09:10.563Z",
   "yearsCovered": [
     2007,
     2008,
@@ -25,8 +25,8 @@
   "yearSummaries": [
     {
       "year": 2007,
-      "champion": null,
-      "runnerUp": null,
+      "champion": "0015",
+      "runnerUp": "0007",
       "thirdPlace": null,
       "mvpFranchise": "0010",
       "jerryJonesFranchise": "0003",
@@ -34,8 +34,8 @@
     },
     {
       "year": 2008,
-      "champion": null,
-      "runnerUp": null,
+      "champion": "0015",
+      "runnerUp": "0008",
       "thirdPlace": null,
       "mvpFranchise": "0013",
       "jerryJonesFranchise": "0016",
@@ -43,8 +43,8 @@
     },
     {
       "year": 2009,
-      "champion": null,
-      "runnerUp": null,
+      "champion": "0004",
+      "runnerUp": "0006",
       "thirdPlace": null,
       "mvpFranchise": "0015",
       "jerryJonesFranchise": "0010",
@@ -52,8 +52,8 @@
     },
     {
       "year": 2010,
-      "champion": null,
-      "runnerUp": null,
+      "champion": "0007",
+      "runnerUp": "0006",
       "thirdPlace": null,
       "mvpFranchise": "0016",
       "jerryJonesFranchise": "0010",
@@ -61,8 +61,8 @@
     },
     {
       "year": 2011,
-      "champion": null,
-      "runnerUp": null,
+      "champion": "0013",
+      "runnerUp": "0007",
       "thirdPlace": null,
       "mvpFranchise": "0006",
       "jerryJonesFranchise": "0002",
@@ -70,8 +70,8 @@
     },
     {
       "year": 2012,
-      "champion": null,
-      "runnerUp": null,
+      "champion": "0014",
+      "runnerUp": "0012",
       "thirdPlace": null,
       "mvpFranchise": "0007",
       "jerryJonesFranchise": "0002",
@@ -79,8 +79,8 @@
     },
     {
       "year": 2013,
-      "champion": null,
-      "runnerUp": null,
+      "champion": "0014",
+      "runnerUp": "0003",
       "thirdPlace": null,
       "mvpFranchise": "0006",
       "jerryJonesFranchise": "0003",
@@ -88,8 +88,8 @@
     },
     {
       "year": 2014,
-      "champion": null,
-      "runnerUp": null,
+      "champion": "0008",
+      "runnerUp": "0001",
       "thirdPlace": null,
       "mvpFranchise": "0006",
       "jerryJonesFranchise": "0003",
@@ -97,8 +97,8 @@
     },
     {
       "year": 2015,
-      "champion": null,
-      "runnerUp": null,
+      "champion": "0011",
+      "runnerUp": "0005",
       "thirdPlace": null,
       "mvpFranchise": "0007",
       "jerryJonesFranchise": "0012",
@@ -106,8 +106,8 @@
     },
     {
       "year": 2016,
-      "champion": null,
-      "runnerUp": null,
+      "champion": "0006",
+      "runnerUp": "0015",
       "thirdPlace": null,
       "mvpFranchise": "0006",
       "jerryJonesFranchise": "0006",
@@ -115,8 +115,8 @@
     },
     {
       "year": 2017,
-      "champion": null,
-      "runnerUp": null,
+      "champion": "0007",
+      "runnerUp": "0013",
       "thirdPlace": null,
       "mvpFranchise": "0009",
       "jerryJonesFranchise": "0010",
@@ -124,8 +124,8 @@
     },
     {
       "year": 2018,
-      "champion": null,
-      "runnerUp": null,
+      "champion": "0011",
+      "runnerUp": "0004",
       "thirdPlace": null,
       "mvpFranchise": "0001",
       "jerryJonesFranchise": "0008",
@@ -133,8 +133,8 @@
     },
     {
       "year": 2019,
-      "champion": null,
-      "runnerUp": null,
+      "champion": "0008",
+      "runnerUp": "0011",
       "thirdPlace": null,
       "mvpFranchise": "0008",
       "jerryJonesFranchise": "0016",
@@ -178,8 +178,8 @@
     },
     {
       "year": 2024,
-      "champion": null,
-      "runnerUp": null,
+      "champion": "0009",
+      "runnerUp": "0002",
       "thirdPlace": null,
       "mvpFranchise": "0012",
       "jerryJonesFranchise": "0014",
@@ -476,7 +476,7 @@
           "divisionId": "00",
           "divisionName": "Northwest",
           "wonDivision": true,
-          "playoffResult": "missed"
+          "playoffResult": "runner-up"
         },
         {
           "year": 2011,
@@ -572,7 +572,9 @@
       "championships": [
         2022
       ],
-      "runnerUps": [],
+      "runnerUps": [
+        2012
+      ],
       "thirdPlaces": [],
       "divisionTitles": [
         {
@@ -970,7 +972,7 @@
           "divisionId": "03",
           "divisionName": "Eastern",
           "wonDivision": false,
-          "playoffResult": "missed"
+          "playoffResult": "runner-up"
         },
         {
           "year": 2014,
@@ -1078,7 +1080,7 @@
           "divisionId": "00",
           "divisionName": "Pacific",
           "wonDivision": true,
-          "playoffResult": "missed"
+          "playoffResult": "champion"
         },
         {
           "year": 2007,
@@ -1096,11 +1098,15 @@
           "divisionId": "01",
           "divisionName": "Midwest",
           "wonDivision": false,
-          "playoffResult": "missed"
+          "playoffResult": "champion"
         }
       ],
-      "championships": [],
+      "championships": [
+        2007,
+        2008
+      ],
       "runnerUps": [
+        2016,
         2022,
         2025
       ],
@@ -1495,7 +1501,7 @@
           "divisionId": "00",
           "divisionName": "Northwest",
           "wonDivision": true,
-          "playoffResult": "missed"
+          "playoffResult": "runner-up"
         },
         {
           "year": 2013,
@@ -1625,7 +1631,9 @@
         }
       ],
       "championships": [],
-      "runnerUps": [],
+      "runnerUps": [
+        2014
+      ],
       "thirdPlaces": [],
       "divisionTitles": [
         {
@@ -2024,7 +2032,7 @@
           "divisionId": "03",
           "divisionName": "Eastern",
           "wonDivision": true,
-          "playoffResult": "missed"
+          "playoffResult": "champion"
         },
         {
           "year": 2016,
@@ -2132,7 +2140,7 @@
           "divisionId": "03",
           "divisionName": "East",
           "wonDivision": true,
-          "playoffResult": "missed"
+          "playoffResult": "runner-up"
         },
         {
           "year": 2010,
@@ -2150,7 +2158,7 @@
           "divisionId": "03",
           "divisionName": "Atlantic",
           "wonDivision": true,
-          "playoffResult": "missed"
+          "playoffResult": "champion"
         },
         {
           "year": 2009,
@@ -2204,13 +2212,18 @@
           "divisionId": "03",
           "divisionName": "Atlantic",
           "wonDivision": false,
-          "playoffResult": "missed"
+          "playoffResult": "runner-up"
         }
       ],
       "championships": [
+        2010,
+        2017,
         2023
       ],
-      "runnerUps": [],
+      "runnerUps": [
+        2007,
+        2011
+      ],
       "thirdPlaces": [],
       "divisionTitles": [
         {
@@ -2481,7 +2494,7 @@
           "divisionId": "03",
           "divisionName": "Eastern",
           "wonDivision": false,
-          "playoffResult": "missed"
+          "playoffResult": "champion"
         },
         {
           "year": 2023,
@@ -2790,7 +2803,9 @@
           "playoffResult": "missed"
         }
       ],
-      "championships": [],
+      "championships": [
+        2024
+      ],
       "runnerUps": [],
       "thirdPlaces": [
         2020
@@ -3115,7 +3130,7 @@
           "divisionId": "02",
           "divisionName": "Central",
           "wonDivision": true,
-          "playoffResult": "missed"
+          "playoffResult": "champion"
         },
         {
           "year": 2018,
@@ -3205,7 +3220,7 @@
           "divisionId": "02",
           "divisionName": "Central",
           "wonDivision": false,
-          "playoffResult": "missed"
+          "playoffResult": "champion"
         },
         {
           "year": 2013,
@@ -3313,7 +3328,7 @@
           "divisionId": "02",
           "divisionName": "Central",
           "wonDivision": true,
-          "playoffResult": "missed"
+          "playoffResult": "runner-up"
         },
         {
           "year": 2007,
@@ -3335,9 +3350,12 @@
         }
       ],
       "championships": [
+        2014,
+        2019,
         2020
       ],
       "runnerUps": [
+        2008,
         2021
       ],
       "thirdPlaces": [],
@@ -3669,7 +3687,7 @@
           "divisionId": "01",
           "divisionName": "Southwest",
           "wonDivision": true,
-          "playoffResult": "missed"
+          "playoffResult": "runner-up"
         },
         {
           "year": 2015,
@@ -3747,7 +3765,9 @@
       "championships": [
         2021
       ],
-      "runnerUps": [],
+      "runnerUps": [
+        2019
+      ],
       "thirdPlaces": [],
       "divisionTitles": [
         {
@@ -4463,7 +4483,7 @@
           "divisionId": "01",
           "divisionName": "Southwest",
           "wonDivision": false,
-          "playoffResult": "missed"
+          "playoffResult": "runner-up"
         },
         {
           "year": 2016,
@@ -4503,7 +4523,9 @@
         }
       ],
       "championships": [],
-      "runnerUps": [],
+      "runnerUps": [
+        2017
+      ],
       "thirdPlaces": [],
       "divisionTitles": [
         {
@@ -4729,7 +4751,7 @@
           "divisionId": "00",
           "divisionName": "Northwest",
           "wonDivision": true,
-          "playoffResult": "missed"
+          "playoffResult": "runner-up"
         },
         {
           "year": 2023,
@@ -4896,7 +4918,8 @@
       ],
       "championships": [],
       "runnerUps": [
-        2023
+        2023,
+        2024
       ],
       "thirdPlaces": [
         2025

--- a/data/theleague/derived/franchise-history.json
+++ b/data/theleague/derived/franchise-history.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-07T19:09:10.563Z",
+  "generatedAt": "2026-05-07T19:21:01.547Z",
   "yearsCovered": [
     2007,
     2008,
@@ -205,574 +205,6 @@
     }
   ],
   "franchises": {
-    "0012": {
-      "franchiseId": "0012",
-      "yearByYear": [
-        {
-          "year": 2026,
-          "name": "Vitside Mafia",
-          "nameMedium": "Vitside",
-          "icon": "/assets/theleague/icons/vitside_mafia.png",
-          "banner": "/assets/theleague/banners/vitside_mafia.png",
-          "isHistorical": false,
-          "sourceFranchiseId": null,
-          "wins": 0,
-          "losses": 0,
-          "ties": 0,
-          "pointsFor": 0,
-          "regSeasonRank": 12,
-          "divisionId": "00",
-          "divisionName": "Northwest",
-          "wonDivision": false,
-          "playoffResult": "missed"
-        },
-        {
-          "year": 2025,
-          "name": "Vitside Mafia",
-          "nameMedium": "Vitside",
-          "icon": "/assets/theleague/icons/vitside_mafia.png",
-          "banner": "/assets/theleague/banners/vitside_mafia.png",
-          "isHistorical": false,
-          "sourceFranchiseId": null,
-          "wins": 12,
-          "losses": 6,
-          "ties": 0,
-          "pointsFor": 1953.88,
-          "regSeasonRank": 5,
-          "divisionId": "00",
-          "divisionName": "Northwest",
-          "wonDivision": true,
-          "playoffResult": "playoffs"
-        },
-        {
-          "year": 2024,
-          "name": "Vitside Mafia",
-          "nameMedium": "Vitside",
-          "icon": "/assets/theleague/icons/vitside_mafia.png",
-          "banner": "/assets/theleague/banners/vitside_mafia.png",
-          "isHistorical": false,
-          "sourceFranchiseId": null,
-          "wins": 12,
-          "losses": 6,
-          "ties": 0,
-          "pointsFor": 1809.79,
-          "regSeasonRank": 4,
-          "divisionId": "00",
-          "divisionName": "Northwest",
-          "wonDivision": false,
-          "playoffResult": "missed"
-        },
-        {
-          "year": 2023,
-          "name": "Vitside Mafia",
-          "nameMedium": "Vitside",
-          "icon": "/assets/theleague/icons/vitside_mafia.png",
-          "banner": "/assets/theleague/banners/vitside_mafia.png",
-          "isHistorical": false,
-          "sourceFranchiseId": null,
-          "wins": 12,
-          "losses": 6,
-          "ties": 0,
-          "pointsFor": 1843.49,
-          "regSeasonRank": 4,
-          "divisionId": "00",
-          "divisionName": "Northwest",
-          "wonDivision": false,
-          "playoffResult": "playoffs"
-        },
-        {
-          "year": 2022,
-          "name": "Vitside Mafia",
-          "nameMedium": "Vitside",
-          "icon": "/assets/theleague/icons/vitside_mafia.png",
-          "banner": "/assets/theleague/banners/vitside_mafia.png",
-          "isHistorical": false,
-          "sourceFranchiseId": null,
-          "wins": 0,
-          "losses": 0,
-          "ties": 0,
-          "pointsFor": 1994.1,
-          "regSeasonRank": 1,
-          "divisionId": "00",
-          "divisionName": "Northwest",
-          "wonDivision": true,
-          "playoffResult": "champion"
-        },
-        {
-          "year": 2021,
-          "name": "Vitside Mafia",
-          "nameMedium": "Vitside",
-          "icon": "/assets/theleague/icons/vitside_mafia.png",
-          "banner": "/assets/theleague/banners/vitside_mafia.png",
-          "isHistorical": false,
-          "sourceFranchiseId": null,
-          "wins": 11,
-          "losses": 7,
-          "ties": 0,
-          "pointsFor": 1875.91,
-          "regSeasonRank": 4,
-          "divisionId": "00",
-          "divisionName": "Northwest",
-          "wonDivision": false,
-          "playoffResult": "playoffs"
-        },
-        {
-          "year": 2020,
-          "name": "Vitside Mafia",
-          "nameMedium": "Vitside",
-          "icon": "/assets/theleague/icons/vitside_mafia.png",
-          "banner": "/assets/theleague/banners/vitside_mafia.png",
-          "isHistorical": false,
-          "sourceFranchiseId": null,
-          "wins": 5,
-          "losses": 13,
-          "ties": 0,
-          "pointsFor": 1513.28,
-          "regSeasonRank": 15,
-          "divisionId": "00",
-          "divisionName": "Northwest",
-          "wonDivision": false,
-          "playoffResult": "missed"
-        },
-        {
-          "year": 2019,
-          "name": "Vitside Mafia",
-          "nameMedium": "Vitside",
-          "icon": "/assets/theleague/icons/vitside_mafia.png",
-          "banner": "/assets/theleague/banners/vitside_mafia.png",
-          "isHistorical": false,
-          "sourceFranchiseId": null,
-          "wins": 10,
-          "losses": 6,
-          "ties": 0,
-          "pointsFor": 1738.07,
-          "regSeasonRank": 4,
-          "divisionId": "00",
-          "divisionName": "Northwest",
-          "wonDivision": false,
-          "playoffResult": "missed"
-        },
-        {
-          "year": 2018,
-          "name": "Vitside Mafia",
-          "nameMedium": "Vitside",
-          "icon": "/assets/theleague/icons/vitside_mafia.png",
-          "banner": "/assets/theleague/banners/vitside_mafia.png",
-          "isHistorical": false,
-          "sourceFranchiseId": null,
-          "wins": 5,
-          "losses": 11,
-          "ties": 0,
-          "pointsFor": 1609.46,
-          "regSeasonRank": 14,
-          "divisionId": "00",
-          "divisionName": "Northwest",
-          "wonDivision": false,
-          "playoffResult": "missed"
-        },
-        {
-          "year": 2017,
-          "name": "Vitside Mafia",
-          "nameMedium": "Vitside",
-          "icon": "/assets/theleague/icons/vitside_mafia.png",
-          "banner": "/assets/theleague/banners/vitside_mafia.png",
-          "isHistorical": false,
-          "sourceFranchiseId": null,
-          "wins": 10,
-          "losses": 8,
-          "ties": 0,
-          "pointsFor": 1720.43,
-          "regSeasonRank": 8,
-          "divisionId": "00",
-          "divisionName": "Northwest",
-          "wonDivision": false,
-          "playoffResult": "missed"
-        },
-        {
-          "year": 2016,
-          "name": "Vitside Mafia",
-          "nameMedium": "Vitside",
-          "icon": "/assets/theleague/icons/vitside_mafia.png",
-          "banner": "/assets/theleague/banners/vitside_mafia.png",
-          "isHistorical": false,
-          "sourceFranchiseId": null,
-          "wins": 5,
-          "losses": 11,
-          "ties": 0,
-          "pointsFor": 1514.57,
-          "regSeasonRank": 14,
-          "divisionId": "00",
-          "divisionName": "Northwest",
-          "wonDivision": false,
-          "playoffResult": "missed"
-        },
-        {
-          "year": 2015,
-          "name": "Vitside Mafia",
-          "nameMedium": "Vitside",
-          "icon": "/assets/theleague/icons/vitside_mafia.png",
-          "banner": "/assets/theleague/banners/vitside_mafia.png",
-          "isHistorical": false,
-          "sourceFranchiseId": null,
-          "wins": 8,
-          "losses": 5,
-          "ties": 0,
-          "pointsFor": 1328.5,
-          "regSeasonRank": 3,
-          "divisionId": "00",
-          "divisionName": "Northwest",
-          "wonDivision": true,
-          "playoffResult": "missed"
-        },
-        {
-          "year": 2014,
-          "name": "Vitside Mafia",
-          "nameMedium": "Vitside",
-          "icon": "/assets/theleague/icons/vitside_mafia.png",
-          "banner": "/assets/theleague/banners/vitside_mafia.png",
-          "isHistorical": false,
-          "sourceFranchiseId": null,
-          "wins": 8,
-          "losses": 8,
-          "ties": 0,
-          "pointsFor": 1888.94,
-          "regSeasonRank": 8,
-          "divisionId": "00",
-          "divisionName": "Northwest",
-          "wonDivision": false,
-          "playoffResult": "missed"
-        },
-        {
-          "year": 2013,
-          "name": "Vitside Mafia",
-          "nameMedium": "Vitside",
-          "icon": "/assets/theleague/icons/vitside_mafia.png",
-          "banner": "/assets/theleague/banners/vitside_mafia.png",
-          "isHistorical": false,
-          "sourceFranchiseId": null,
-          "wins": 13,
-          "losses": 5,
-          "ties": 0,
-          "pointsFor": 1885.18,
-          "regSeasonRank": 1,
-          "divisionId": "00",
-          "divisionName": "Northwest",
-          "wonDivision": true,
-          "playoffResult": "missed"
-        },
-        {
-          "year": 2012,
-          "name": "Vitside Mafia",
-          "nameMedium": "Vitside",
-          "icon": "/assets/theleague/icons/vitside_mafia.png",
-          "banner": "/assets/theleague/banners/vitside_mafia.png",
-          "isHistorical": false,
-          "sourceFranchiseId": null,
-          "wins": 13,
-          "losses": 5,
-          "ties": 0,
-          "pointsFor": 1884.01,
-          "regSeasonRank": 2,
-          "divisionId": "00",
-          "divisionName": "Northwest",
-          "wonDivision": true,
-          "playoffResult": "runner-up"
-        },
-        {
-          "year": 2011,
-          "name": "Vitside Mafia",
-          "nameMedium": "Vitside",
-          "icon": "/assets/theleague/icons/vitside_mafia.png",
-          "banner": "/assets/theleague/banners/vitside_mafia.png",
-          "isHistorical": false,
-          "sourceFranchiseId": null,
-          "wins": 5,
-          "losses": 13,
-          "ties": 0,
-          "pointsFor": 1508.38,
-          "regSeasonRank": 13,
-          "divisionId": "00",
-          "divisionName": "Northwest",
-          "wonDivision": false,
-          "playoffResult": "missed"
-        },
-        {
-          "year": 2010,
-          "name": "Vitside Mafia",
-          "nameMedium": "Vitside",
-          "icon": "/assets/theleague/icons/vitside_mafia.png",
-          "banner": "/assets/theleague/banners/vitside_mafia.png",
-          "isHistorical": false,
-          "sourceFranchiseId": null,
-          "wins": 8,
-          "losses": 6,
-          "ties": 0,
-          "pointsFor": 2028,
-          "regSeasonRank": 5,
-          "divisionId": "01",
-          "divisionName": "Midwest",
-          "wonDivision": false,
-          "playoffResult": "missed"
-        },
-        {
-          "year": 2009,
-          "name": "Vitside Mafia",
-          "nameMedium": "Vitside",
-          "icon": "/assets/theleague/icons/vitside_mafia.png",
-          "banner": "/assets/theleague/banners/vitside_mafia.png",
-          "isHistorical": false,
-          "sourceFranchiseId": null,
-          "wins": 8,
-          "losses": 10,
-          "ties": 0,
-          "pointsFor": 1667.71,
-          "regSeasonRank": 9,
-          "divisionId": "01",
-          "divisionName": "Midwest",
-          "wonDivision": false,
-          "playoffResult": "missed"
-        },
-        {
-          "year": 2008,
-          "name": "Vitside Mafia",
-          "nameMedium": "Vitside",
-          "icon": "/assets/theleague/icons/vitside_mafia.png",
-          "banner": "/assets/theleague/banners/vitside_mafia.png",
-          "isHistorical": false,
-          "sourceFranchiseId": null,
-          "wins": 10,
-          "losses": 8,
-          "ties": 0,
-          "pointsFor": 1736.81,
-          "regSeasonRank": 5,
-          "divisionId": "01",
-          "divisionName": "Midwest",
-          "wonDivision": false,
-          "playoffResult": "missed"
-        },
-        {
-          "year": 2007,
-          "name": "Vitside Mafia",
-          "nameMedium": "Vitside",
-          "icon": "/assets/theleague/icons/vitside_mafia.png",
-          "banner": "/assets/theleague/banners/vitside_mafia.png",
-          "isHistorical": false,
-          "sourceFranchiseId": null,
-          "wins": 14,
-          "losses": 4,
-          "ties": 0,
-          "pointsFor": 1850.86,
-          "regSeasonRank": 1,
-          "divisionId": "01",
-          "divisionName": "Midwest",
-          "wonDivision": true,
-          "playoffResult": "missed"
-        }
-      ],
-      "championships": [
-        2022
-      ],
-      "runnerUps": [
-        2012
-      ],
-      "thirdPlaces": [],
-      "divisionTitles": [
-        {
-          "year": 2007,
-          "divisionId": "01",
-          "divisionName": "Midwest"
-        },
-        {
-          "year": 2012,
-          "divisionId": "00",
-          "divisionName": "Northwest"
-        },
-        {
-          "year": 2013,
-          "divisionId": "00",
-          "divisionName": "Northwest"
-        },
-        {
-          "year": 2015,
-          "divisionId": "00",
-          "divisionName": "Northwest"
-        },
-        {
-          "year": 2022,
-          "divisionId": "00",
-          "divisionName": "Northwest"
-        },
-        {
-          "year": 2025,
-          "divisionId": "00",
-          "divisionName": "Northwest"
-        }
-      ],
-      "mvpAwards": [
-        {
-          "year": 2020,
-          "playerId": "13589",
-          "playerName": "Allen, Josh",
-          "position": "QB",
-          "points": 500.34,
-          "salary": 574750,
-          "sourceFranchiseId": null
-        },
-        {
-          "year": 2024,
-          "playerId": "13592",
-          "playerName": "Darnold, Sam",
-          "position": "QB",
-          "points": 394.74,
-          "salary": 425000,
-          "sourceFranchiseId": null
-        }
-      ],
-      "jerryJonesAwards": [
-        {
-          "year": 2015,
-          "costPerPoint": 18622.482498100966,
-          "totalSalary": 27212475,
-          "totalPoints": 1461.2700000000002,
-          "sourceFranchiseId": null
-        }
-      ],
-      "brockOsweilerAwards": [
-        {
-          "year": 2007,
-          "playerId": "8700",
-          "playerName": "Gonzalez, Anthony",
-          "position": "WR",
-          "points": 5.4,
-          "salary": 1700000,
-          "sourceFranchiseId": null
-        }
-      ],
-      "playoffAppearances": 4,
-      "careerWins": 169,
-      "careerLosses": 138,
-      "careerTies": 0,
-      "careerPointsFor": 33351.37,
-      "yearsActive": 20,
-      "highlights": {
-        "highestSingleGame": {
-          "year": 2015,
-          "week": 3,
-          "score": 214.14,
-          "sourceFranchiseId": null
-        },
-        "lowestSingleGame": {
-          "year": 2018,
-          "week": 5,
-          "score": 47.04,
-          "sourceFranchiseId": null
-        },
-        "biggestBlowoutWin": {
-          "year": 2015,
-          "week": 3,
-          "score": 214.14,
-          "opponentScore": 93,
-          "opponentFranchiseId": "0010",
-          "margin": 121.13999999999999,
-          "sourceFranchiseId": null
-        },
-        "biggestBlowoutLoss": {
-          "year": 2015,
-          "week": 15,
-          "score": 94.46,
-          "opponentScore": 219.61,
-          "opponentFranchiseId": "0006",
-          "margin": 125.15000000000002,
-          "sourceFranchiseId": null
-        }
-      },
-      "headToHead": {
-        "0003": {
-          "wins": 11,
-          "losses": 13,
-          "ties": 0
-        },
-        "0016": {
-          "wins": 8,
-          "losses": 10,
-          "ties": 0
-        },
-        "0015": {
-          "wins": 11,
-          "losses": 8,
-          "ties": 0
-        },
-        "0014": {
-          "wins": 12,
-          "losses": 6,
-          "ties": 0
-        },
-        "0013": {
-          "wins": 16,
-          "losses": 10,
-          "ties": 0
-        },
-        "0001": {
-          "wins": 17,
-          "losses": 17,
-          "ties": 0
-        },
-        "0006": {
-          "wins": 12,
-          "losses": 8,
-          "ties": 0
-        },
-        "0004": {
-          "wins": 13,
-          "losses": 4,
-          "ties": 0
-        },
-        "0009": {
-          "wins": 8,
-          "losses": 11,
-          "ties": 0
-        },
-        "0011": {
-          "wins": 13,
-          "losses": 6,
-          "ties": 0
-        },
-        "0008": {
-          "wins": 8,
-          "losses": 10,
-          "ties": 0
-        },
-        "0002": {
-          "wins": 13,
-          "losses": 16,
-          "ties": 0
-        },
-        "0010": {
-          "wins": 22,
-          "losses": 12,
-          "ties": 0
-        },
-        "0007": {
-          "wins": 7,
-          "losses": 12,
-          "ties": 0
-        },
-        "0005": {
-          "wins": 12,
-          "losses": 9,
-          "ties": 0
-        }
-      },
-      "currentName": "Vitside Mafia",
-      "currentNameMedium": "Vitside",
-      "currentNameShort": "Vitside",
-      "currentAbbrev": "VIT",
-      "currentIcon": "/assets/theleague/icons/vitside_mafia.png",
-      "currentBanner": "/assets/theleague/banners/vitside_mafia.png",
-      "currentDivision": "Northwest",
-      "currentColor": "#f06abc",
-      "currentOwnerSince": null
-    },
     "0015": {
       "franchiseId": "0015",
       "yearByYear": [
@@ -1851,1140 +1283,6 @@
       "currentColor": "#cc2936",
       "currentOwnerSince": null
     },
-    "0007": {
-      "franchiseId": "0007",
-      "yearByYear": [
-        {
-          "year": 2026,
-          "name": "Fire Ready Aim",
-          "nameMedium": "Fire Ready",
-          "icon": "/assets/theleague/icons/fire_ready_aim.png",
-          "banner": "/assets/theleague/banners/fire_ready_aim.png",
-          "isHistorical": false,
-          "sourceFranchiseId": null,
-          "wins": 0,
-          "losses": 0,
-          "ties": 0,
-          "pointsFor": 0,
-          "regSeasonRank": 7,
-          "divisionId": "03",
-          "divisionName": "Eastern",
-          "wonDivision": true,
-          "playoffResult": "missed"
-        },
-        {
-          "year": 2025,
-          "name": "Fire Ready Aim",
-          "nameMedium": "Fire Ready",
-          "icon": "/assets/theleague/icons/fire_ready_aim.png",
-          "banner": "/assets/theleague/banners/fire_ready_aim.png",
-          "isHistorical": false,
-          "sourceFranchiseId": null,
-          "wins": 2,
-          "losses": 16,
-          "ties": 0,
-          "pointsFor": 1453.35,
-          "regSeasonRank": 16,
-          "divisionId": "03",
-          "divisionName": "Eastern",
-          "wonDivision": false,
-          "playoffResult": "missed"
-        },
-        {
-          "year": 2024,
-          "name": "Fire Ready Aim",
-          "nameMedium": "Fire Ready",
-          "icon": "/assets/theleague/icons/fire_ready_aim.png",
-          "banner": "/assets/theleague/banners/fire_ready_aim.png",
-          "isHistorical": false,
-          "sourceFranchiseId": null,
-          "wins": 11,
-          "losses": 7,
-          "ties": 0,
-          "pointsFor": 2005.32,
-          "regSeasonRank": 5,
-          "divisionId": "03",
-          "divisionName": "Eastern",
-          "wonDivision": true,
-          "playoffResult": "missed"
-        },
-        {
-          "year": 2023,
-          "name": "Fire Ready Aim",
-          "nameMedium": "Fire Ready",
-          "icon": "/assets/theleague/icons/fire_ready_aim.png",
-          "banner": "/assets/theleague/banners/fire_ready_aim.png",
-          "isHistorical": false,
-          "sourceFranchiseId": null,
-          "wins": 15,
-          "losses": 3,
-          "ties": 0,
-          "pointsFor": 2028.28,
-          "regSeasonRank": 1,
-          "divisionId": "03",
-          "divisionName": "Eastern",
-          "wonDivision": true,
-          "playoffResult": "champion"
-        },
-        {
-          "year": 2022,
-          "name": "Fire Ready Aim",
-          "nameMedium": "Fire Ready",
-          "icon": "/assets/theleague/icons/fire_ready_aim.png",
-          "banner": "/assets/theleague/banners/fire_ready_aim.png",
-          "isHistorical": false,
-          "sourceFranchiseId": null,
-          "wins": 0,
-          "losses": 0,
-          "ties": 0,
-          "pointsFor": 1590.18,
-          "regSeasonRank": 7,
-          "divisionId": "03",
-          "divisionName": "Eastern",
-          "wonDivision": true,
-          "playoffResult": "playoffs"
-        },
-        {
-          "year": 2021,
-          "name": "Fire Ready Aim",
-          "nameMedium": "Fire Ready",
-          "icon": "/assets/theleague/icons/fire_ready_aim.png",
-          "banner": "/assets/theleague/banners/fire_ready_aim.png",
-          "isHistorical": false,
-          "sourceFranchiseId": null,
-          "wins": 7,
-          "losses": 11,
-          "ties": 0,
-          "pointsFor": 1546.8,
-          "regSeasonRank": 13,
-          "divisionId": "03",
-          "divisionName": "Eastern",
-          "wonDivision": false,
-          "playoffResult": "missed"
-        },
-        {
-          "year": 2020,
-          "name": "Fire Ready Aim",
-          "nameMedium": "Fire Ready",
-          "icon": "/assets/theleague/icons/fire_ready_aim.png",
-          "banner": "/assets/theleague/banners/fire_ready_aim.png",
-          "isHistorical": false,
-          "sourceFranchiseId": null,
-          "wins": 5,
-          "losses": 13,
-          "ties": 0,
-          "pointsFor": 1464.1,
-          "regSeasonRank": 16,
-          "divisionId": "03",
-          "divisionName": "Eastern",
-          "wonDivision": false,
-          "playoffResult": "missed"
-        },
-        {
-          "year": 2019,
-          "name": "Fire Ready Aim",
-          "nameMedium": "Fire Ready",
-          "icon": "/assets/theleague/icons/fire_ready_aim.png",
-          "banner": "/assets/theleague/banners/fire_ready_aim.png",
-          "isHistorical": false,
-          "sourceFranchiseId": null,
-          "wins": 10,
-          "losses": 6,
-          "ties": 0,
-          "pointsFor": 1711.44,
-          "regSeasonRank": 5,
-          "divisionId": "03",
-          "divisionName": "Eastern",
-          "wonDivision": false,
-          "playoffResult": "missed"
-        },
-        {
-          "year": 2018,
-          "name": "Fire Ready Aim",
-          "nameMedium": "Fire Ready",
-          "icon": "/assets/theleague/icons/fire_ready_aim.png",
-          "banner": "/assets/theleague/banners/fire_ready_aim.png",
-          "isHistorical": false,
-          "sourceFranchiseId": null,
-          "wins": 7,
-          "losses": 9,
-          "ties": 0,
-          "pointsFor": 1855.43,
-          "regSeasonRank": 9,
-          "divisionId": "03",
-          "divisionName": "Eastern",
-          "wonDivision": false,
-          "playoffResult": "missed"
-        },
-        {
-          "year": 2017,
-          "name": "Fire Ready Aim",
-          "nameMedium": "Fire Ready",
-          "icon": "/assets/theleague/icons/fire_ready_aim.png",
-          "banner": "/assets/theleague/banners/fire_ready_aim.png",
-          "isHistorical": false,
-          "sourceFranchiseId": null,
-          "wins": 12,
-          "losses": 6,
-          "ties": 0,
-          "pointsFor": 1979.66,
-          "regSeasonRank": 2,
-          "divisionId": "03",
-          "divisionName": "Eastern",
-          "wonDivision": true,
-          "playoffResult": "champion"
-        },
-        {
-          "year": 2016,
-          "name": "Fire Ready Aim",
-          "nameMedium": "Fire Ready",
-          "icon": "/assets/theleague/icons/fire_ready_aim.png",
-          "banner": "/assets/theleague/banners/fire_ready_aim.png",
-          "isHistorical": false,
-          "sourceFranchiseId": null,
-          "wins": 8,
-          "losses": 8,
-          "ties": 0,
-          "pointsFor": 1595.13,
-          "regSeasonRank": 8,
-          "divisionId": "03",
-          "divisionName": "Eastern",
-          "wonDivision": true,
-          "playoffResult": "missed"
-        },
-        {
-          "year": 2015,
-          "name": "Fire Ready Aim",
-          "nameMedium": "Fire Ready",
-          "icon": "/assets/theleague/icons/fire_ready_aim.png",
-          "banner": "/assets/theleague/banners/fire_ready_aim.png",
-          "isHistorical": false,
-          "sourceFranchiseId": null,
-          "wins": 8,
-          "losses": 5,
-          "ties": 0,
-          "pointsFor": 1034.5,
-          "regSeasonRank": 5,
-          "divisionId": "03",
-          "divisionName": "Eastern",
-          "wonDivision": true,
-          "playoffResult": "missed"
-        },
-        {
-          "year": 2014,
-          "name": "Fire Ready Aim",
-          "nameMedium": "Fire Ready",
-          "icon": "/assets/theleague/icons/fire_ready_aim.png",
-          "banner": "/assets/theleague/banners/fire_ready_aim.png",
-          "isHistorical": false,
-          "sourceFranchiseId": null,
-          "wins": 5,
-          "losses": 11,
-          "ties": 0,
-          "pointsFor": 1447.77,
-          "regSeasonRank": 13,
-          "divisionId": "03",
-          "divisionName": "Eastern",
-          "wonDivision": false,
-          "playoffResult": "missed"
-        },
-        {
-          "year": 2013,
-          "name": "Fire Ready Aim",
-          "nameMedium": "Fire Ready",
-          "icon": "/assets/theleague/icons/fire_ready_aim.png",
-          "banner": "/assets/theleague/banners/fire_ready_aim.png",
-          "isHistorical": false,
-          "sourceFranchiseId": null,
-          "wins": 7,
-          "losses": 11,
-          "ties": 0,
-          "pointsFor": 1572.69,
-          "regSeasonRank": 12,
-          "divisionId": "03",
-          "divisionName": "Eastern",
-          "wonDivision": false,
-          "playoffResult": "missed"
-        },
-        {
-          "year": 2012,
-          "name": "Fire Ready Aim",
-          "nameMedium": "Fire Ready",
-          "icon": "/assets/theleague/icons/fire_ready_aim.png",
-          "banner": "/assets/theleague/banners/fire_ready_aim.png",
-          "isHistorical": false,
-          "sourceFranchiseId": null,
-          "wins": 9,
-          "losses": 9,
-          "ties": 0,
-          "pointsFor": 1850.94,
-          "regSeasonRank": 8,
-          "divisionId": "03",
-          "divisionName": "Eastern",
-          "wonDivision": false,
-          "playoffResult": "missed"
-        },
-        {
-          "year": 2011,
-          "name": "Fire Ready Aim",
-          "nameMedium": "Fire Ready",
-          "icon": "/assets/theleague/icons/fire_ready_aim.png",
-          "banner": "/assets/theleague/banners/fire_ready_aim.png",
-          "isHistorical": false,
-          "sourceFranchiseId": null,
-          "wins": 14,
-          "losses": 4,
-          "ties": 0,
-          "pointsFor": 1968.6,
-          "regSeasonRank": 2,
-          "divisionId": "03",
-          "divisionName": "East",
-          "wonDivision": true,
-          "playoffResult": "runner-up"
-        },
-        {
-          "year": 2010,
-          "name": "Fire Ready Aim",
-          "nameMedium": "Fire Ready",
-          "icon": "/assets/theleague/icons/fire_ready_aim.png",
-          "banner": "/assets/theleague/banners/fire_ready_aim.png",
-          "isHistorical": false,
-          "sourceFranchiseId": null,
-          "wins": 9,
-          "losses": 5,
-          "ties": 0,
-          "pointsFor": 1863,
-          "regSeasonRank": 3,
-          "divisionId": "03",
-          "divisionName": "Atlantic",
-          "wonDivision": true,
-          "playoffResult": "champion"
-        },
-        {
-          "year": 2009,
-          "name": "Fire Ready Aim",
-          "nameMedium": "Fire Ready",
-          "icon": "/assets/theleague/icons/fire_ready_aim.png",
-          "banner": "/assets/theleague/banners/fire_ready_aim.png",
-          "isHistorical": false,
-          "sourceFranchiseId": null,
-          "wins": 14,
-          "losses": 4,
-          "ties": 0,
-          "pointsFor": 1782.03,
-          "regSeasonRank": 1,
-          "divisionId": "03",
-          "divisionName": "Atlantic",
-          "wonDivision": true,
-          "playoffResult": "missed"
-        },
-        {
-          "year": 2008,
-          "name": "Fire Ready Aim",
-          "nameMedium": "Fire Ready",
-          "icon": "/assets/theleague/icons/fire_ready_aim.png",
-          "banner": "/assets/theleague/banners/fire_ready_aim.png",
-          "isHistorical": false,
-          "sourceFranchiseId": null,
-          "wins": 15,
-          "losses": 3,
-          "ties": 0,
-          "pointsFor": 1843.24,
-          "regSeasonRank": 2,
-          "divisionId": "03",
-          "divisionName": "Atlantic",
-          "wonDivision": true,
-          "playoffResult": "missed"
-        },
-        {
-          "year": 2007,
-          "name": "Fire Ready Aim",
-          "nameMedium": "Fire Ready",
-          "icon": "/assets/theleague/icons/fire_ready_aim.png",
-          "banner": "/assets/theleague/banners/fire_ready_aim.png",
-          "isHistorical": false,
-          "sourceFranchiseId": null,
-          "wins": 11,
-          "losses": 7,
-          "ties": 0,
-          "pointsFor": 1910.76,
-          "regSeasonRank": 5,
-          "divisionId": "03",
-          "divisionName": "Atlantic",
-          "wonDivision": false,
-          "playoffResult": "runner-up"
-        }
-      ],
-      "championships": [
-        2010,
-        2017,
-        2023
-      ],
-      "runnerUps": [
-        2007,
-        2011
-      ],
-      "thirdPlaces": [],
-      "divisionTitles": [
-        {
-          "year": 2008,
-          "divisionId": "03",
-          "divisionName": "Atlantic"
-        },
-        {
-          "year": 2009,
-          "divisionId": "03",
-          "divisionName": "Atlantic"
-        },
-        {
-          "year": 2010,
-          "divisionId": "03",
-          "divisionName": "Atlantic"
-        },
-        {
-          "year": 2011,
-          "divisionId": "03",
-          "divisionName": "East"
-        },
-        {
-          "year": 2015,
-          "divisionId": "03",
-          "divisionName": "Eastern"
-        },
-        {
-          "year": 2016,
-          "divisionId": "03",
-          "divisionName": "Eastern"
-        },
-        {
-          "year": 2017,
-          "divisionId": "03",
-          "divisionName": "Eastern"
-        },
-        {
-          "year": 2022,
-          "divisionId": "03",
-          "divisionName": "Eastern"
-        },
-        {
-          "year": 2023,
-          "divisionId": "03",
-          "divisionName": "Eastern"
-        },
-        {
-          "year": 2024,
-          "divisionId": "03",
-          "divisionName": "Eastern"
-        },
-        {
-          "year": 2026,
-          "divisionId": "03",
-          "divisionName": "Eastern"
-        }
-      ],
-      "mvpAwards": [
-        {
-          "year": 2012,
-          "playerId": "10313",
-          "playerName": "Dalton, Andy",
-          "position": "QB",
-          "points": 382.86,
-          "salary": 467500,
-          "sourceFranchiseId": null
-        },
-        {
-          "year": 2015,
-          "playerId": "11642",
-          "playerName": "Bortles, Blake",
-          "position": "QB",
-          "points": 446.22,
-          "salary": 467500,
-          "sourceFranchiseId": null
-        }
-      ],
-      "jerryJonesAwards": [],
-      "brockOsweilerAwards": [
-        {
-          "year": 2019,
-          "playerId": "14113",
-          "playerName": "Hardman, Mecole",
-          "position": "WR",
-          "points": 20.23,
-          "salary": 1675000,
-          "sourceFranchiseId": null
-        }
-      ],
-      "playoffAppearances": 2,
-      "careerWins": 169,
-      "careerLosses": 138,
-      "careerTies": 0,
-      "careerPointsFor": 32503.219999999994,
-      "yearsActive": 20,
-      "highlights": {
-        "highestSingleGame": {
-          "year": 2024,
-          "week": 11,
-          "score": 180.27,
-          "sourceFranchiseId": null
-        },
-        "lowestSingleGame": {
-          "year": 2014,
-          "week": 10,
-          "score": 19.29,
-          "sourceFranchiseId": null
-        },
-        "biggestBlowoutWin": {
-          "year": 2008,
-          "week": 5,
-          "score": 140.4,
-          "opponentScore": 56.54,
-          "opponentFranchiseId": "0005",
-          "margin": 83.86000000000001,
-          "sourceFranchiseId": null
-        },
-        "biggestBlowoutLoss": {
-          "year": 2009,
-          "week": 15,
-          "score": 73.75,
-          "opponentScore": 190.02,
-          "opponentFranchiseId": "0006",
-          "margin": 116.27000000000001,
-          "sourceFranchiseId": null
-        }
-      },
-      "headToHead": {
-        "0016": {
-          "wins": 22,
-          "losses": 14,
-          "ties": 0
-        },
-        "0013": {
-          "wins": 12,
-          "losses": 7,
-          "ties": 0
-        },
-        "0014": {
-          "wins": 16,
-          "losses": 14,
-          "ties": 0
-        },
-        "0015": {
-          "wins": 20,
-          "losses": 15,
-          "ties": 0
-        },
-        "0010": {
-          "wins": 12,
-          "losses": 11,
-          "ties": 0
-        },
-        "0011": {
-          "wins": 9,
-          "losses": 8,
-          "ties": 0
-        },
-        "0005": {
-          "wins": 11,
-          "losses": 6,
-          "ties": 0
-        },
-        "0008": {
-          "wins": 7,
-          "losses": 12,
-          "ties": 0
-        },
-        "0006": {
-          "wins": 7,
-          "losses": 15,
-          "ties": 0
-        },
-        "0004": {
-          "wins": 9,
-          "losses": 10,
-          "ties": 0
-        },
-        "0001": {
-          "wins": 7,
-          "losses": 9,
-          "ties": 0
-        },
-        "0009": {
-          "wins": 12,
-          "losses": 12,
-          "ties": 0
-        },
-        "0003": {
-          "wins": 9,
-          "losses": 9,
-          "ties": 0
-        },
-        "0012": {
-          "wins": 12,
-          "losses": 7,
-          "ties": 0
-        },
-        "0002": {
-          "wins": 6,
-          "losses": 15,
-          "ties": 0
-        }
-      },
-      "currentName": "Fire Ready Aim",
-      "currentNameMedium": "Fire Ready",
-      "currentNameShort": "Fire",
-      "currentAbbrev": "FIRE",
-      "currentIcon": "/assets/theleague/icons/fire_ready_aim.png",
-      "currentBanner": "/assets/theleague/banners/fire_ready_aim.png",
-      "currentDivision": "East",
-      "currentColor": "#e88370",
-      "currentOwnerSince": null
-    },
-    "0009": {
-      "franchiseId": "0009",
-      "yearByYear": [
-        {
-          "year": 2026,
-          "name": "Wascawy Wabbits",
-          "nameMedium": "Wascawy Wabbits",
-          "icon": "/assets/theleague/icons/wabbits.png",
-          "banner": "/assets/theleague/banners/wabbits.png",
-          "isHistorical": false,
-          "sourceFranchiseId": null,
-          "wins": 0,
-          "losses": 0,
-          "ties": 0,
-          "pointsFor": 0,
-          "regSeasonRank": 9,
-          "divisionId": "03",
-          "divisionName": "Eastern",
-          "wonDivision": false,
-          "playoffResult": "missed"
-        },
-        {
-          "year": 2025,
-          "name": "Wascawy Wabbits",
-          "nameMedium": "Wascawy Wabbits",
-          "icon": "/assets/theleague/icons/wabbits.png",
-          "banner": "/assets/theleague/banners/wabbits.png",
-          "isHistorical": false,
-          "sourceFranchiseId": null,
-          "wins": 15,
-          "losses": 3,
-          "ties": 0,
-          "pointsFor": 1998.36,
-          "regSeasonRank": 1,
-          "divisionId": "03",
-          "divisionName": "Eastern",
-          "wonDivision": true,
-          "playoffResult": "playoffs"
-        },
-        {
-          "year": 2024,
-          "name": "Wascawy Wabbits",
-          "nameMedium": "Wascawy Wabbits",
-          "icon": "/assets/theleague/icons/wabbits.png",
-          "banner": "/assets/theleague/banners/wabbits.png",
-          "isHistorical": false,
-          "sourceFranchiseId": null,
-          "wins": 14,
-          "losses": 4,
-          "ties": 0,
-          "pointsFor": 2140.71,
-          "regSeasonRank": 1,
-          "divisionId": "03",
-          "divisionName": "Eastern",
-          "wonDivision": false,
-          "playoffResult": "champion"
-        },
-        {
-          "year": 2023,
-          "name": "Wascawy Wabbits",
-          "nameMedium": "Wascawy Wabbits",
-          "icon": "/assets/theleague/icons/wabbits.png",
-          "banner": "/assets/theleague/banners/wabbits.png",
-          "isHistorical": false,
-          "sourceFranchiseId": null,
-          "wins": 6,
-          "losses": 12,
-          "ties": 0,
-          "pointsFor": 1665.09,
-          "regSeasonRank": 12,
-          "divisionId": "03",
-          "divisionName": "Eastern",
-          "wonDivision": false,
-          "playoffResult": "missed"
-        },
-        {
-          "year": 2022,
-          "name": "Wascawy Wabbits",
-          "nameMedium": "Wascawy Wabbits",
-          "icon": "/assets/theleague/icons/wabbits.png",
-          "banner": "/assets/theleague/banners/wabbits.png",
-          "isHistorical": false,
-          "sourceFranchiseId": null,
-          "wins": 0,
-          "losses": 0,
-          "ties": 0,
-          "pointsFor": 1715.4,
-          "regSeasonRank": 9,
-          "divisionId": "03",
-          "divisionName": "Eastern",
-          "wonDivision": false,
-          "playoffResult": "missed"
-        },
-        {
-          "year": 2021,
-          "name": "Wascawy Wabbits",
-          "nameMedium": "Wascawy Wabbits",
-          "icon": "/assets/theleague/icons/wabbits.png",
-          "banner": "/assets/theleague/banners/wabbits.png",
-          "isHistorical": false,
-          "sourceFranchiseId": null,
-          "wins": 15,
-          "losses": 3,
-          "ties": 0,
-          "pointsFor": 2114.36,
-          "regSeasonRank": 1,
-          "divisionId": "03",
-          "divisionName": "Eastern",
-          "wonDivision": true,
-          "playoffResult": "playoffs"
-        },
-        {
-          "year": 2020,
-          "name": "Wascawy Wabbits",
-          "nameMedium": "Wascawy Wabbits",
-          "icon": "/assets/theleague/icons/wabbits.png",
-          "banner": "/assets/theleague/banners/wabbits.png",
-          "isHistorical": false,
-          "sourceFranchiseId": null,
-          "wins": 14,
-          "losses": 4,
-          "ties": 0,
-          "pointsFor": 2183.75,
-          "regSeasonRank": 1,
-          "divisionId": "03",
-          "divisionName": "Eastern",
-          "wonDivision": false,
-          "playoffResult": "third-place"
-        },
-        {
-          "year": 2019,
-          "name": "Wascawy Wabbits",
-          "nameMedium": "Wascawy Wabbits",
-          "icon": "/assets/theleague/icons/wabbits.png",
-          "banner": "/assets/theleague/banners/wabbits.png",
-          "isHistorical": false,
-          "sourceFranchiseId": null,
-          "wins": 9,
-          "losses": 7,
-          "ties": 0,
-          "pointsFor": 1896,
-          "regSeasonRank": 7,
-          "divisionId": "03",
-          "divisionName": "Eastern",
-          "wonDivision": true,
-          "playoffResult": "missed"
-        },
-        {
-          "year": 2018,
-          "name": "Wascawy Wabbits",
-          "nameMedium": "Wascawy Wabbits",
-          "icon": "/assets/theleague/icons/wabbits.png",
-          "banner": "/assets/theleague/banners/wabbits.png",
-          "isHistorical": false,
-          "sourceFranchiseId": null,
-          "wins": 16,
-          "losses": 0,
-          "ties": 0,
-          "pointsFor": 2453.05,
-          "regSeasonRank": 1,
-          "divisionId": "03",
-          "divisionName": "Eastern",
-          "wonDivision": true,
-          "playoffResult": "missed"
-        },
-        {
-          "year": 2017,
-          "name": "Wascawy Wabbits",
-          "nameMedium": "Wascawy Wabbits",
-          "icon": "/assets/theleague/icons/wabbits.png",
-          "banner": "/assets/theleague/banners/wabbits.png",
-          "isHistorical": false,
-          "sourceFranchiseId": null,
-          "wins": 8,
-          "losses": 10,
-          "ties": 0,
-          "pointsFor": 1513.85,
-          "regSeasonRank": 10,
-          "divisionId": "03",
-          "divisionName": "Eastern",
-          "wonDivision": false,
-          "playoffResult": "missed"
-        },
-        {
-          "year": 2016,
-          "name": "Wascawy Wabbits",
-          "nameMedium": "Wascawy Wabbits",
-          "icon": "/assets/theleague/icons/wabbits.png",
-          "banner": "/assets/theleague/banners/wabbits.png",
-          "isHistorical": false,
-          "sourceFranchiseId": null,
-          "wins": 5,
-          "losses": 11,
-          "ties": 0,
-          "pointsFor": 1754.01,
-          "regSeasonRank": 13,
-          "divisionId": "03",
-          "divisionName": "Eastern",
-          "wonDivision": false,
-          "playoffResult": "missed"
-        },
-        {
-          "year": 2015,
-          "name": "Wascawy Wabbits",
-          "nameMedium": "Wascawy Wabbits",
-          "icon": "/assets/theleague/icons/wabbits.png",
-          "banner": "/assets/theleague/banners/wabbits.png",
-          "isHistorical": false,
-          "sourceFranchiseId": null,
-          "wins": 7,
-          "losses": 6,
-          "ties": 0,
-          "pointsFor": 1213,
-          "regSeasonRank": 6,
-          "divisionId": "02",
-          "divisionName": "Central",
-          "wonDivision": true,
-          "playoffResult": "missed"
-        },
-        {
-          "year": 2014,
-          "name": "Wascawy Wabbits",
-          "nameMedium": "Wascawy Wabbits",
-          "icon": "/assets/theleague/icons/wabbits.png",
-          "banner": "/assets/theleague/banners/wabbits.png",
-          "isHistorical": false,
-          "sourceFranchiseId": null,
-          "wins": 7,
-          "losses": 9,
-          "ties": 0,
-          "pointsFor": 1711.04,
-          "regSeasonRank": 9,
-          "divisionId": "02",
-          "divisionName": "Central",
-          "wonDivision": false,
-          "playoffResult": "missed"
-        },
-        {
-          "year": 2013,
-          "name": "Wascawy Wabbits",
-          "nameMedium": "Wascawy Wabbits",
-          "icon": "/assets/theleague/icons/wabbits.png",
-          "banner": "/assets/theleague/banners/wabbits.png",
-          "isHistorical": false,
-          "sourceFranchiseId": null,
-          "wins": 9,
-          "losses": 9,
-          "ties": 0,
-          "pointsFor": 1981.95,
-          "regSeasonRank": 9,
-          "divisionId": "02",
-          "divisionName": "Central",
-          "wonDivision": false,
-          "playoffResult": "missed"
-        },
-        {
-          "year": 2012,
-          "name": "Wascawy Wabbits",
-          "nameMedium": "Wascawy Wabbits",
-          "icon": "/assets/theleague/icons/wabbits.png",
-          "banner": "/assets/theleague/banners/wabbits.png",
-          "isHistorical": false,
-          "sourceFranchiseId": null,
-          "wins": 12,
-          "losses": 6,
-          "ties": 0,
-          "pointsFor": 1697.7,
-          "regSeasonRank": 6,
-          "divisionId": "02",
-          "divisionName": "Central",
-          "wonDivision": true,
-          "playoffResult": "missed"
-        },
-        {
-          "year": 2011,
-          "name": "Wascawy Wabbits",
-          "nameMedium": "Wascawy Wabbits",
-          "icon": "/assets/theleague/icons/wabbits.png",
-          "banner": "/assets/theleague/banners/wabbits.png",
-          "isHistorical": false,
-          "sourceFranchiseId": null,
-          "wins": 4,
-          "losses": 14,
-          "ties": 0,
-          "pointsFor": 1403.3,
-          "regSeasonRank": 15,
-          "divisionId": "02",
-          "divisionName": "Central",
-          "wonDivision": false,
-          "playoffResult": "missed"
-        },
-        {
-          "year": 2010,
-          "name": "Wascawy Wabbits",
-          "nameMedium": "Wascawy Wabbits",
-          "icon": "/assets/theleague/icons/wabbits.png",
-          "banner": "/assets/theleague/banners/wabbits.png",
-          "isHistorical": false,
-          "sourceFranchiseId": null,
-          "wins": 7,
-          "losses": 7,
-          "ties": 0,
-          "pointsFor": 1778,
-          "regSeasonRank": 7,
-          "divisionId": "02",
-          "divisionName": "Central",
-          "wonDivision": false,
-          "playoffResult": "missed"
-        },
-        {
-          "year": 2009,
-          "name": "Wascawy Wabbits",
-          "nameMedium": "Wascawy Wabbits",
-          "icon": "/assets/theleague/icons/wabbits.png",
-          "banner": "/assets/theleague/banners/wabbits.png",
-          "isHistorical": false,
-          "sourceFranchiseId": null,
-          "wins": 5,
-          "losses": 13,
-          "ties": 0,
-          "pointsFor": 1670.89,
-          "regSeasonRank": 15,
-          "divisionId": "02",
-          "divisionName": "Central",
-          "wonDivision": false,
-          "playoffResult": "missed"
-        },
-        {
-          "year": 2008,
-          "name": "Wascawy Wabbits",
-          "nameMedium": "Wascawy Wabbits",
-          "icon": "/assets/theleague/icons/wabbits.png",
-          "banner": "/assets/theleague/banners/wabbits.png",
-          "isHistorical": false,
-          "sourceFranchiseId": null,
-          "wins": 4,
-          "losses": 14,
-          "ties": 0,
-          "pointsFor": 1301.74,
-          "regSeasonRank": 16,
-          "divisionId": "02",
-          "divisionName": "Central",
-          "wonDivision": false,
-          "playoffResult": "missed"
-        },
-        {
-          "year": 2007,
-          "name": "Wascawy Wabbits",
-          "nameMedium": "Wascawy Wabbits",
-          "icon": "/assets/theleague/icons/wabbits.png",
-          "banner": "/assets/theleague/banners/wabbits.png",
-          "isHistorical": false,
-          "sourceFranchiseId": null,
-          "wins": 10,
-          "losses": 8,
-          "ties": 0,
-          "pointsFor": 1506.32,
-          "regSeasonRank": 8,
-          "divisionId": "02",
-          "divisionName": "Central",
-          "wonDivision": true,
-          "playoffResult": "missed"
-        }
-      ],
-      "championships": [
-        2024
-      ],
-      "runnerUps": [],
-      "thirdPlaces": [
-        2020
-      ],
-      "divisionTitles": [
-        {
-          "year": 2007,
-          "divisionId": "02",
-          "divisionName": "Central"
-        },
-        {
-          "year": 2012,
-          "divisionId": "02",
-          "divisionName": "Central"
-        },
-        {
-          "year": 2015,
-          "divisionId": "02",
-          "divisionName": "Central"
-        },
-        {
-          "year": 2018,
-          "divisionId": "03",
-          "divisionName": "Eastern"
-        },
-        {
-          "year": 2019,
-          "divisionId": "03",
-          "divisionName": "Eastern"
-        },
-        {
-          "year": 2021,
-          "divisionId": "03",
-          "divisionName": "Eastern"
-        },
-        {
-          "year": 2025,
-          "divisionId": "03",
-          "divisionName": "Eastern"
-        }
-      ],
-      "mvpAwards": [
-        {
-          "year": 2017,
-          "playerId": "12620",
-          "playerName": "Prescott, Dak",
-          "position": "QB",
-          "points": 358.88,
-          "salary": 495000,
-          "sourceFranchiseId": null
-        }
-      ],
-      "jerryJonesAwards": [],
-      "brockOsweilerAwards": [],
-      "playoffAppearances": 3,
-      "careerWins": 167,
-      "careerLosses": 140,
-      "careerTies": 0,
-      "careerPointsFor": 33698.520000000004,
-      "yearsActive": 20,
-      "highlights": {
-        "highestSingleGame": {
-          "year": 2018,
-          "week": 1,
-          "score": 199.29,
-          "sourceFranchiseId": null
-        },
-        "lowestSingleGame": {
-          "year": 2011,
-          "week": 15,
-          "score": 34.66,
-          "sourceFranchiseId": null
-        },
-        "biggestBlowoutWin": {
-          "year": 2024,
-          "week": 11,
-          "score": 165.04,
-          "opponentScore": 56.84,
-          "opponentFranchiseId": "0011",
-          "margin": 108.19999999999999,
-          "sourceFranchiseId": null
-        },
-        "biggestBlowoutLoss": {
-          "year": 2015,
-          "week": 3,
-          "score": 68.91,
-          "opponentScore": 149.7,
-          "opponentFranchiseId": "0006",
-          "margin": 80.78999999999999,
-          "sourceFranchiseId": null
-        }
-      },
-      "headToHead": {
-        "0011": {
-          "wins": 11,
-          "losses": 17,
-          "ties": 0
-        },
-        "0001": {
-          "wins": 14,
-          "losses": 10,
-          "ties": 0
-        },
-        "0005": {
-          "wins": 16,
-          "losses": 11,
-          "ties": 0
-        },
-        "0002": {
-          "wins": 11,
-          "losses": 9,
-          "ties": 0
-        },
-        "0008": {
-          "wins": 13,
-          "losses": 14,
-          "ties": 0
-        },
-        "0010": {
-          "wins": 10,
-          "losses": 10,
-          "ties": 0
-        },
-        "0014": {
-          "wins": 8,
-          "losses": 9,
-          "ties": 0
-        },
-        "0016": {
-          "wins": 19,
-          "losses": 10,
-          "ties": 0
-        },
-        "0012": {
-          "wins": 11,
-          "losses": 8,
-          "ties": 0
-        },
-        "0003": {
-          "wins": 9,
-          "losses": 9,
-          "ties": 0
-        },
-        "0013": {
-          "wins": 11,
-          "losses": 9,
-          "ties": 0
-        },
-        "0007": {
-          "wins": 12,
-          "losses": 12,
-          "ties": 0
-        },
-        "0004": {
-          "wins": 9,
-          "losses": 8,
-          "ties": 0
-        },
-        "0006": {
-          "wins": 8,
-          "losses": 9,
-          "ties": 0
-        },
-        "0015": {
-          "wins": 10,
-          "losses": 16,
-          "ties": 0
-        }
-      },
-      "currentName": "Wascawy Wabbits",
-      "currentNameMedium": "Wascawy Wabbits",
-      "currentNameShort": "Wabbits",
-      "currentAbbrev": "WABS",
-      "currentIcon": "/assets/theleague/icons/wabbits.png",
-      "currentBanner": "/assets/theleague/banners/wabbits.png",
-      "currentDivision": "East",
-      "currentColor": "#5c5c5c",
-      "currentOwnerSince": null
-    },
     "0008": {
       "franchiseId": "0008",
       "yearByYear": [
@@ -3760,6 +2058,42 @@
           "divisionName": "Northwest",
           "wonDivision": false,
           "playoffResult": "missed"
+        },
+        {
+          "year": 2011,
+          "name": "Midwestside Connection",
+          "nameMedium": "Midwestside Connection",
+          "icon": "https://theleague.us/images/team_banners/midwestside_icon.png",
+          "banner": "https://theleague.us/images/team_banners/midwestside.png",
+          "isHistorical": true,
+          "sourceFranchiseId": "0010",
+          "wins": 5,
+          "losses": 13,
+          "ties": 0,
+          "pointsFor": 1345.99,
+          "regSeasonRank": 14,
+          "divisionId": "00",
+          "divisionName": "Northwest",
+          "wonDivision": false,
+          "playoffResult": "missed"
+        },
+        {
+          "year": 2010,
+          "name": "Midwestside Connection",
+          "nameMedium": "Midwestside Connection",
+          "icon": "https://theleague.us/images/team_banners/midwestside_icon.png",
+          "banner": "https://theleague.us/images/team_banners/midwestside.png",
+          "isHistorical": true,
+          "sourceFranchiseId": "0010",
+          "wins": 9,
+          "losses": 5,
+          "ties": 0,
+          "pointsFor": 1995,
+          "regSeasonRank": 2,
+          "divisionId": "03",
+          "divisionName": "Atlantic",
+          "wonDivision": false,
+          "playoffResult": "missed"
         }
       ],
       "championships": [
@@ -3792,14 +2126,22 @@
         }
       ],
       "mvpAwards": [],
-      "jerryJonesAwards": [],
+      "jerryJonesAwards": [
+        {
+          "year": 2010,
+          "costPerPoint": 17045.35539407199,
+          "totalSalary": 26177575,
+          "totalPoints": 1535.76,
+          "sourceFranchiseId": "0010"
+        }
+      ],
       "brockOsweilerAwards": [],
       "playoffAppearances": 2,
-      "careerWins": 84,
-      "careerLosses": 87,
+      "careerWins": 98,
+      "careerLosses": 105,
       "careerTies": 0,
-      "careerPointsFor": 18478.330000000005,
-      "yearsActive": 12,
+      "careerPointsFor": 21819.320000000003,
+      "yearsActive": 14,
       "highlights": {
         "highestSingleGame": {
           "year": 2019,
@@ -3808,9 +2150,9 @@
           "sourceFranchiseId": null
         },
         "lowestSingleGame": {
-          "year": 2015,
-          "week": 10,
-          "score": 39.1,
+          "year": 2011,
+          "week": 7,
+          "score": 35.18,
           "sourceFranchiseId": "0010"
         },
         "biggestBlowoutWin": {
@@ -3833,79 +2175,79 @@
         }
       },
       "headToHead": {
-        "0012": {
-          "wins": 2,
-          "losses": 11,
-          "ties": 0
-        },
-        "0007": {
-          "wins": 6,
-          "losses": 3,
-          "ties": 0
-        },
-        "0013": {
-          "wins": 12,
-          "losses": 7,
-          "ties": 0
-        },
-        "0015": {
-          "wins": 4,
-          "losses": 4,
-          "ties": 0
-        },
         "0014": {
-          "wins": 7,
-          "losses": 3,
+          "wins": 8,
+          "losses": 5,
           "ties": 0
         },
-        "0001": {
-          "wins": 7,
+        "0008": {
+          "wins": 5,
           "losses": 8,
           "ties": 0
         },
-        "0004": {
-          "wins": 11,
-          "losses": 1,
+        "0016": {
+          "wins": 5,
+          "losses": 8,
           "ties": 0
         },
-        "0006": {
-          "wins": 5,
+        "0013": {
+          "wins": 14,
           "losses": 9,
           "ties": 0
         },
-        "0002": {
-          "wins": 4,
+        "0012": {
+          "wins": 5,
+          "losses": 12,
+          "ties": 0
+        },
+        "0001": {
+          "wins": 8,
+          "losses": 10,
+          "ties": 0
+        },
+        "0005": {
+          "wins": 5,
           "losses": 8,
           "ties": 0
         },
         "0011": {
           "wins": 3,
-          "losses": 2,
+          "losses": 5,
           "ties": 0
         },
         "0009": {
-          "wins": 5,
-          "losses": 6,
-          "ties": 0
-        },
-        "0003": {
           "wins": 6,
           "losses": 7,
           "ties": 0
         },
-        "0008": {
+        "0004": {
+          "wins": 11,
+          "losses": 3,
+          "ties": 0
+        },
+        "0006": {
           "wins": 5,
+          "losses": 11,
+          "ties": 0
+        },
+        "0003": {
+          "wins": 7,
+          "losses": 9,
+          "ties": 0
+        },
+        "0007": {
+          "wins": 6,
           "losses": 6,
           "ties": 0
         },
-        "0016": {
-          "wins": 5,
-          "losses": 5,
+        "0002": {
+          "wins": 4,
+          "losses": 10,
           "ties": 0
         },
-        "0005": {
-          "wins": 5,
-          "losses": 5,
+        "0015": {
+          "wins": 4,
+          "losses": 6,
           "ties": 0
         },
         "0010": {
@@ -3922,6 +2264,1461 @@
       "currentBanner": "/assets/theleague/banners/midwestside.png",
       "currentDivision": "Southwest",
       "currentColor": "#ffcd00",
+      "currentOwnerSince": 2010
+    },
+    "0007": {
+      "franchiseId": "0007",
+      "yearByYear": [
+        {
+          "year": 2026,
+          "name": "Fire Ready Aim",
+          "nameMedium": "Fire Ready",
+          "icon": "/assets/theleague/icons/fire_ready_aim.png",
+          "banner": "/assets/theleague/banners/fire_ready_aim.png",
+          "isHistorical": false,
+          "sourceFranchiseId": null,
+          "wins": 0,
+          "losses": 0,
+          "ties": 0,
+          "pointsFor": 0,
+          "regSeasonRank": 7,
+          "divisionId": "03",
+          "divisionName": "Eastern",
+          "wonDivision": true,
+          "playoffResult": "missed"
+        },
+        {
+          "year": 2025,
+          "name": "Fire Ready Aim",
+          "nameMedium": "Fire Ready",
+          "icon": "/assets/theleague/icons/fire_ready_aim.png",
+          "banner": "/assets/theleague/banners/fire_ready_aim.png",
+          "isHistorical": false,
+          "sourceFranchiseId": null,
+          "wins": 2,
+          "losses": 16,
+          "ties": 0,
+          "pointsFor": 1453.35,
+          "regSeasonRank": 16,
+          "divisionId": "03",
+          "divisionName": "Eastern",
+          "wonDivision": false,
+          "playoffResult": "missed"
+        },
+        {
+          "year": 2024,
+          "name": "Fire Ready Aim",
+          "nameMedium": "Fire Ready",
+          "icon": "/assets/theleague/icons/fire_ready_aim.png",
+          "banner": "/assets/theleague/banners/fire_ready_aim.png",
+          "isHistorical": false,
+          "sourceFranchiseId": null,
+          "wins": 11,
+          "losses": 7,
+          "ties": 0,
+          "pointsFor": 2005.32,
+          "regSeasonRank": 5,
+          "divisionId": "03",
+          "divisionName": "Eastern",
+          "wonDivision": true,
+          "playoffResult": "missed"
+        },
+        {
+          "year": 2023,
+          "name": "Fire Ready Aim",
+          "nameMedium": "Fire Ready",
+          "icon": "/assets/theleague/icons/fire_ready_aim.png",
+          "banner": "/assets/theleague/banners/fire_ready_aim.png",
+          "isHistorical": false,
+          "sourceFranchiseId": null,
+          "wins": 15,
+          "losses": 3,
+          "ties": 0,
+          "pointsFor": 2028.28,
+          "regSeasonRank": 1,
+          "divisionId": "03",
+          "divisionName": "Eastern",
+          "wonDivision": true,
+          "playoffResult": "champion"
+        },
+        {
+          "year": 2022,
+          "name": "Fire Ready Aim",
+          "nameMedium": "Fire Ready",
+          "icon": "/assets/theleague/icons/fire_ready_aim.png",
+          "banner": "/assets/theleague/banners/fire_ready_aim.png",
+          "isHistorical": false,
+          "sourceFranchiseId": null,
+          "wins": 0,
+          "losses": 0,
+          "ties": 0,
+          "pointsFor": 1590.18,
+          "regSeasonRank": 7,
+          "divisionId": "03",
+          "divisionName": "Eastern",
+          "wonDivision": true,
+          "playoffResult": "playoffs"
+        },
+        {
+          "year": 2021,
+          "name": "Fire Ready Aim",
+          "nameMedium": "Fire Ready",
+          "icon": "/assets/theleague/icons/fire_ready_aim.png",
+          "banner": "/assets/theleague/banners/fire_ready_aim.png",
+          "isHistorical": false,
+          "sourceFranchiseId": null,
+          "wins": 7,
+          "losses": 11,
+          "ties": 0,
+          "pointsFor": 1546.8,
+          "regSeasonRank": 13,
+          "divisionId": "03",
+          "divisionName": "Eastern",
+          "wonDivision": false,
+          "playoffResult": "missed"
+        },
+        {
+          "year": 2020,
+          "name": "Fire Ready Aim",
+          "nameMedium": "Fire Ready",
+          "icon": "/assets/theleague/icons/fire_ready_aim.png",
+          "banner": "/assets/theleague/banners/fire_ready_aim.png",
+          "isHistorical": false,
+          "sourceFranchiseId": null,
+          "wins": 5,
+          "losses": 13,
+          "ties": 0,
+          "pointsFor": 1464.1,
+          "regSeasonRank": 16,
+          "divisionId": "03",
+          "divisionName": "Eastern",
+          "wonDivision": false,
+          "playoffResult": "missed"
+        },
+        {
+          "year": 2019,
+          "name": "Fire Ready Aim",
+          "nameMedium": "Fire Ready",
+          "icon": "/assets/theleague/icons/fire_ready_aim.png",
+          "banner": "/assets/theleague/banners/fire_ready_aim.png",
+          "isHistorical": false,
+          "sourceFranchiseId": null,
+          "wins": 10,
+          "losses": 6,
+          "ties": 0,
+          "pointsFor": 1711.44,
+          "regSeasonRank": 5,
+          "divisionId": "03",
+          "divisionName": "Eastern",
+          "wonDivision": false,
+          "playoffResult": "missed"
+        },
+        {
+          "year": 2018,
+          "name": "Fire Ready Aim",
+          "nameMedium": "Fire Ready",
+          "icon": "/assets/theleague/icons/fire_ready_aim.png",
+          "banner": "/assets/theleague/banners/fire_ready_aim.png",
+          "isHistorical": false,
+          "sourceFranchiseId": null,
+          "wins": 7,
+          "losses": 9,
+          "ties": 0,
+          "pointsFor": 1855.43,
+          "regSeasonRank": 9,
+          "divisionId": "03",
+          "divisionName": "Eastern",
+          "wonDivision": false,
+          "playoffResult": "missed"
+        },
+        {
+          "year": 2017,
+          "name": "Fire Ready Aim",
+          "nameMedium": "Fire Ready",
+          "icon": "/assets/theleague/icons/fire_ready_aim.png",
+          "banner": "/assets/theleague/banners/fire_ready_aim.png",
+          "isHistorical": false,
+          "sourceFranchiseId": null,
+          "wins": 12,
+          "losses": 6,
+          "ties": 0,
+          "pointsFor": 1979.66,
+          "regSeasonRank": 2,
+          "divisionId": "03",
+          "divisionName": "Eastern",
+          "wonDivision": true,
+          "playoffResult": "champion"
+        },
+        {
+          "year": 2016,
+          "name": "Fire Ready Aim",
+          "nameMedium": "Fire Ready",
+          "icon": "/assets/theleague/icons/fire_ready_aim.png",
+          "banner": "/assets/theleague/banners/fire_ready_aim.png",
+          "isHistorical": false,
+          "sourceFranchiseId": null,
+          "wins": 8,
+          "losses": 8,
+          "ties": 0,
+          "pointsFor": 1595.13,
+          "regSeasonRank": 8,
+          "divisionId": "03",
+          "divisionName": "Eastern",
+          "wonDivision": true,
+          "playoffResult": "missed"
+        },
+        {
+          "year": 2015,
+          "name": "Fire Ready Aim",
+          "nameMedium": "Fire Ready",
+          "icon": "/assets/theleague/icons/fire_ready_aim.png",
+          "banner": "/assets/theleague/banners/fire_ready_aim.png",
+          "isHistorical": false,
+          "sourceFranchiseId": null,
+          "wins": 8,
+          "losses": 5,
+          "ties": 0,
+          "pointsFor": 1034.5,
+          "regSeasonRank": 5,
+          "divisionId": "03",
+          "divisionName": "Eastern",
+          "wonDivision": true,
+          "playoffResult": "missed"
+        },
+        {
+          "year": 2014,
+          "name": "Fire Ready Aim",
+          "nameMedium": "Fire Ready",
+          "icon": "/assets/theleague/icons/fire_ready_aim.png",
+          "banner": "/assets/theleague/banners/fire_ready_aim.png",
+          "isHistorical": false,
+          "sourceFranchiseId": null,
+          "wins": 5,
+          "losses": 11,
+          "ties": 0,
+          "pointsFor": 1447.77,
+          "regSeasonRank": 13,
+          "divisionId": "03",
+          "divisionName": "Eastern",
+          "wonDivision": false,
+          "playoffResult": "missed"
+        },
+        {
+          "year": 2013,
+          "name": "Fire Ready Aim",
+          "nameMedium": "Fire Ready",
+          "icon": "/assets/theleague/icons/fire_ready_aim.png",
+          "banner": "/assets/theleague/banners/fire_ready_aim.png",
+          "isHistorical": false,
+          "sourceFranchiseId": null,
+          "wins": 7,
+          "losses": 11,
+          "ties": 0,
+          "pointsFor": 1572.69,
+          "regSeasonRank": 12,
+          "divisionId": "03",
+          "divisionName": "Eastern",
+          "wonDivision": false,
+          "playoffResult": "missed"
+        },
+        {
+          "year": 2012,
+          "name": "Fire Ready Aim",
+          "nameMedium": "Fire Ready",
+          "icon": "/assets/theleague/icons/fire_ready_aim.png",
+          "banner": "/assets/theleague/banners/fire_ready_aim.png",
+          "isHistorical": false,
+          "sourceFranchiseId": null,
+          "wins": 9,
+          "losses": 9,
+          "ties": 0,
+          "pointsFor": 1850.94,
+          "regSeasonRank": 8,
+          "divisionId": "03",
+          "divisionName": "Eastern",
+          "wonDivision": false,
+          "playoffResult": "missed"
+        },
+        {
+          "year": 2011,
+          "name": "Fire Ready Aim",
+          "nameMedium": "Fire Ready",
+          "icon": "/assets/theleague/icons/fire_ready_aim.png",
+          "banner": "/assets/theleague/banners/fire_ready_aim.png",
+          "isHistorical": false,
+          "sourceFranchiseId": null,
+          "wins": 14,
+          "losses": 4,
+          "ties": 0,
+          "pointsFor": 1968.6,
+          "regSeasonRank": 2,
+          "divisionId": "03",
+          "divisionName": "East",
+          "wonDivision": true,
+          "playoffResult": "runner-up"
+        },
+        {
+          "year": 2010,
+          "name": "Fire Ready Aim",
+          "nameMedium": "Fire Ready",
+          "icon": "/assets/theleague/icons/fire_ready_aim.png",
+          "banner": "/assets/theleague/banners/fire_ready_aim.png",
+          "isHistorical": false,
+          "sourceFranchiseId": null,
+          "wins": 9,
+          "losses": 5,
+          "ties": 0,
+          "pointsFor": 1863,
+          "regSeasonRank": 3,
+          "divisionId": "03",
+          "divisionName": "Atlantic",
+          "wonDivision": true,
+          "playoffResult": "champion"
+        }
+      ],
+      "championships": [
+        2010,
+        2017,
+        2023
+      ],
+      "runnerUps": [
+        2011
+      ],
+      "thirdPlaces": [],
+      "divisionTitles": [
+        {
+          "year": 2010,
+          "divisionId": "03",
+          "divisionName": "Atlantic"
+        },
+        {
+          "year": 2011,
+          "divisionId": "03",
+          "divisionName": "East"
+        },
+        {
+          "year": 2015,
+          "divisionId": "03",
+          "divisionName": "Eastern"
+        },
+        {
+          "year": 2016,
+          "divisionId": "03",
+          "divisionName": "Eastern"
+        },
+        {
+          "year": 2017,
+          "divisionId": "03",
+          "divisionName": "Eastern"
+        },
+        {
+          "year": 2022,
+          "divisionId": "03",
+          "divisionName": "Eastern"
+        },
+        {
+          "year": 2023,
+          "divisionId": "03",
+          "divisionName": "Eastern"
+        },
+        {
+          "year": 2024,
+          "divisionId": "03",
+          "divisionName": "Eastern"
+        },
+        {
+          "year": 2026,
+          "divisionId": "03",
+          "divisionName": "Eastern"
+        }
+      ],
+      "mvpAwards": [
+        {
+          "year": 2012,
+          "playerId": "10313",
+          "playerName": "Dalton, Andy",
+          "position": "QB",
+          "points": 382.86,
+          "salary": 467500,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "11642",
+          "playerName": "Bortles, Blake",
+          "position": "QB",
+          "points": 446.22,
+          "salary": 467500,
+          "sourceFranchiseId": null
+        }
+      ],
+      "jerryJonesAwards": [],
+      "brockOsweilerAwards": [
+        {
+          "year": 2019,
+          "playerId": "14113",
+          "playerName": "Hardman, Mecole",
+          "position": "WR",
+          "points": 20.23,
+          "salary": 1675000,
+          "sourceFranchiseId": null
+        }
+      ],
+      "playoffAppearances": 2,
+      "careerWins": 129,
+      "careerLosses": 124,
+      "careerTies": 0,
+      "careerPointsFor": 26967.189999999995,
+      "yearsActive": 17,
+      "highlights": {
+        "highestSingleGame": {
+          "year": 2024,
+          "week": 11,
+          "score": 180.27,
+          "sourceFranchiseId": null
+        },
+        "lowestSingleGame": {
+          "year": 2014,
+          "week": 10,
+          "score": 19.29,
+          "sourceFranchiseId": null
+        },
+        "biggestBlowoutWin": {
+          "year": 2011,
+          "week": 13,
+          "score": 129.28,
+          "opponentScore": 45.57,
+          "opponentFranchiseId": "0014",
+          "margin": 83.71000000000001,
+          "sourceFranchiseId": null
+        },
+        "biggestBlowoutLoss": {
+          "year": 2025,
+          "week": 7,
+          "score": 80.87,
+          "opponentScore": 195.26,
+          "opponentFranchiseId": "0008",
+          "margin": 114.38999999999999,
+          "sourceFranchiseId": null
+        }
+      },
+      "headToHead": {
+        "0016": {
+          "wins": 16,
+          "losses": 14,
+          "ties": 0
+        },
+        "0005": {
+          "wins": 8,
+          "losses": 6,
+          "ties": 0
+        },
+        "0014": {
+          "wins": 12,
+          "losses": 11,
+          "ties": 0
+        },
+        "0006": {
+          "wins": 7,
+          "losses": 11,
+          "ties": 0
+        },
+        "0003": {
+          "wins": 6,
+          "losses": 9,
+          "ties": 0
+        },
+        "0013": {
+          "wins": 9,
+          "losses": 7,
+          "ties": 0
+        },
+        "0011": {
+          "wins": 6,
+          "losses": 8,
+          "ties": 0
+        },
+        "0009": {
+          "wins": 9,
+          "losses": 12,
+          "ties": 0
+        },
+        "0008": {
+          "wins": 5,
+          "losses": 11,
+          "ties": 0
+        },
+        "0001": {
+          "wins": 4,
+          "losses": 8,
+          "ties": 0
+        },
+        "0004": {
+          "wins": 6,
+          "losses": 10,
+          "ties": 0
+        },
+        "0002": {
+          "wins": 4,
+          "losses": 12,
+          "ties": 0
+        },
+        "0010": {
+          "wins": 9,
+          "losses": 8,
+          "ties": 0
+        },
+        "0015": {
+          "wins": 19,
+          "losses": 12,
+          "ties": 0
+        },
+        "0012": {
+          "wins": 9,
+          "losses": 6,
+          "ties": 0
+        }
+      },
+      "currentName": "Fire Ready Aim",
+      "currentNameMedium": "Fire Ready",
+      "currentNameShort": "Fire",
+      "currentAbbrev": "FIRE",
+      "currentIcon": "/assets/theleague/icons/fire_ready_aim.png",
+      "currentBanner": "/assets/theleague/banners/fire_ready_aim.png",
+      "currentDivision": "East",
+      "currentColor": "#e88370",
+      "currentOwnerSince": 2010
+    },
+    "0012": {
+      "franchiseId": "0012",
+      "yearByYear": [
+        {
+          "year": 2026,
+          "name": "Vitside Mafia",
+          "nameMedium": "Vitside",
+          "icon": "/assets/theleague/icons/vitside_mafia.png",
+          "banner": "/assets/theleague/banners/vitside_mafia.png",
+          "isHistorical": false,
+          "sourceFranchiseId": null,
+          "wins": 0,
+          "losses": 0,
+          "ties": 0,
+          "pointsFor": 0,
+          "regSeasonRank": 12,
+          "divisionId": "00",
+          "divisionName": "Northwest",
+          "wonDivision": false,
+          "playoffResult": "missed"
+        },
+        {
+          "year": 2025,
+          "name": "Vitside Mafia",
+          "nameMedium": "Vitside",
+          "icon": "/assets/theleague/icons/vitside_mafia.png",
+          "banner": "/assets/theleague/banners/vitside_mafia.png",
+          "isHistorical": false,
+          "sourceFranchiseId": null,
+          "wins": 12,
+          "losses": 6,
+          "ties": 0,
+          "pointsFor": 1953.88,
+          "regSeasonRank": 5,
+          "divisionId": "00",
+          "divisionName": "Northwest",
+          "wonDivision": true,
+          "playoffResult": "playoffs"
+        },
+        {
+          "year": 2024,
+          "name": "Vitside Mafia",
+          "nameMedium": "Vitside",
+          "icon": "/assets/theleague/icons/vitside_mafia.png",
+          "banner": "/assets/theleague/banners/vitside_mafia.png",
+          "isHistorical": false,
+          "sourceFranchiseId": null,
+          "wins": 12,
+          "losses": 6,
+          "ties": 0,
+          "pointsFor": 1809.79,
+          "regSeasonRank": 4,
+          "divisionId": "00",
+          "divisionName": "Northwest",
+          "wonDivision": false,
+          "playoffResult": "missed"
+        },
+        {
+          "year": 2023,
+          "name": "Vitside Mafia",
+          "nameMedium": "Vitside",
+          "icon": "/assets/theleague/icons/vitside_mafia.png",
+          "banner": "/assets/theleague/banners/vitside_mafia.png",
+          "isHistorical": false,
+          "sourceFranchiseId": null,
+          "wins": 12,
+          "losses": 6,
+          "ties": 0,
+          "pointsFor": 1843.49,
+          "regSeasonRank": 4,
+          "divisionId": "00",
+          "divisionName": "Northwest",
+          "wonDivision": false,
+          "playoffResult": "playoffs"
+        },
+        {
+          "year": 2022,
+          "name": "Vitside Mafia",
+          "nameMedium": "Vitside",
+          "icon": "/assets/theleague/icons/vitside_mafia.png",
+          "banner": "/assets/theleague/banners/vitside_mafia.png",
+          "isHistorical": false,
+          "sourceFranchiseId": null,
+          "wins": 0,
+          "losses": 0,
+          "ties": 0,
+          "pointsFor": 1994.1,
+          "regSeasonRank": 1,
+          "divisionId": "00",
+          "divisionName": "Northwest",
+          "wonDivision": true,
+          "playoffResult": "champion"
+        },
+        {
+          "year": 2021,
+          "name": "Vitside Mafia",
+          "nameMedium": "Vitside",
+          "icon": "/assets/theleague/icons/vitside_mafia.png",
+          "banner": "/assets/theleague/banners/vitside_mafia.png",
+          "isHistorical": false,
+          "sourceFranchiseId": null,
+          "wins": 11,
+          "losses": 7,
+          "ties": 0,
+          "pointsFor": 1875.91,
+          "regSeasonRank": 4,
+          "divisionId": "00",
+          "divisionName": "Northwest",
+          "wonDivision": false,
+          "playoffResult": "playoffs"
+        },
+        {
+          "year": 2020,
+          "name": "Vitside Mafia",
+          "nameMedium": "Vitside",
+          "icon": "/assets/theleague/icons/vitside_mafia.png",
+          "banner": "/assets/theleague/banners/vitside_mafia.png",
+          "isHistorical": false,
+          "sourceFranchiseId": null,
+          "wins": 5,
+          "losses": 13,
+          "ties": 0,
+          "pointsFor": 1513.28,
+          "regSeasonRank": 15,
+          "divisionId": "00",
+          "divisionName": "Northwest",
+          "wonDivision": false,
+          "playoffResult": "missed"
+        },
+        {
+          "year": 2019,
+          "name": "Vitside Mafia",
+          "nameMedium": "Vitside",
+          "icon": "/assets/theleague/icons/vitside_mafia.png",
+          "banner": "/assets/theleague/banners/vitside_mafia.png",
+          "isHistorical": false,
+          "sourceFranchiseId": null,
+          "wins": 10,
+          "losses": 6,
+          "ties": 0,
+          "pointsFor": 1738.07,
+          "regSeasonRank": 4,
+          "divisionId": "00",
+          "divisionName": "Northwest",
+          "wonDivision": false,
+          "playoffResult": "missed"
+        },
+        {
+          "year": 2018,
+          "name": "Vitside Mafia",
+          "nameMedium": "Vitside",
+          "icon": "/assets/theleague/icons/vitside_mafia.png",
+          "banner": "/assets/theleague/banners/vitside_mafia.png",
+          "isHistorical": false,
+          "sourceFranchiseId": null,
+          "wins": 5,
+          "losses": 11,
+          "ties": 0,
+          "pointsFor": 1609.46,
+          "regSeasonRank": 14,
+          "divisionId": "00",
+          "divisionName": "Northwest",
+          "wonDivision": false,
+          "playoffResult": "missed"
+        },
+        {
+          "year": 2017,
+          "name": "Vitside Mafia",
+          "nameMedium": "Vitside",
+          "icon": "/assets/theleague/icons/vitside_mafia.png",
+          "banner": "/assets/theleague/banners/vitside_mafia.png",
+          "isHistorical": false,
+          "sourceFranchiseId": null,
+          "wins": 10,
+          "losses": 8,
+          "ties": 0,
+          "pointsFor": 1720.43,
+          "regSeasonRank": 8,
+          "divisionId": "00",
+          "divisionName": "Northwest",
+          "wonDivision": false,
+          "playoffResult": "missed"
+        },
+        {
+          "year": 2016,
+          "name": "Vitside Mafia",
+          "nameMedium": "Vitside",
+          "icon": "/assets/theleague/icons/vitside_mafia.png",
+          "banner": "/assets/theleague/banners/vitside_mafia.png",
+          "isHistorical": false,
+          "sourceFranchiseId": null,
+          "wins": 5,
+          "losses": 11,
+          "ties": 0,
+          "pointsFor": 1514.57,
+          "regSeasonRank": 14,
+          "divisionId": "00",
+          "divisionName": "Northwest",
+          "wonDivision": false,
+          "playoffResult": "missed"
+        },
+        {
+          "year": 2015,
+          "name": "Vitside Mafia",
+          "nameMedium": "Vitside",
+          "icon": "/assets/theleague/icons/vitside_mafia.png",
+          "banner": "/assets/theleague/banners/vitside_mafia.png",
+          "isHistorical": false,
+          "sourceFranchiseId": null,
+          "wins": 8,
+          "losses": 5,
+          "ties": 0,
+          "pointsFor": 1328.5,
+          "regSeasonRank": 3,
+          "divisionId": "00",
+          "divisionName": "Northwest",
+          "wonDivision": true,
+          "playoffResult": "missed"
+        },
+        {
+          "year": 2014,
+          "name": "Vitside Mafia",
+          "nameMedium": "Vitside",
+          "icon": "/assets/theleague/icons/vitside_mafia.png",
+          "banner": "/assets/theleague/banners/vitside_mafia.png",
+          "isHistorical": false,
+          "sourceFranchiseId": null,
+          "wins": 8,
+          "losses": 8,
+          "ties": 0,
+          "pointsFor": 1888.94,
+          "regSeasonRank": 8,
+          "divisionId": "00",
+          "divisionName": "Northwest",
+          "wonDivision": false,
+          "playoffResult": "missed"
+        },
+        {
+          "year": 2013,
+          "name": "Vitside Mafia",
+          "nameMedium": "Vitside",
+          "icon": "/assets/theleague/icons/vitside_mafia.png",
+          "banner": "/assets/theleague/banners/vitside_mafia.png",
+          "isHistorical": false,
+          "sourceFranchiseId": null,
+          "wins": 13,
+          "losses": 5,
+          "ties": 0,
+          "pointsFor": 1885.18,
+          "regSeasonRank": 1,
+          "divisionId": "00",
+          "divisionName": "Northwest",
+          "wonDivision": true,
+          "playoffResult": "missed"
+        },
+        {
+          "year": 2012,
+          "name": "Vitside Mafia",
+          "nameMedium": "Vitside",
+          "icon": "/assets/theleague/icons/vitside_mafia.png",
+          "banner": "/assets/theleague/banners/vitside_mafia.png",
+          "isHistorical": false,
+          "sourceFranchiseId": null,
+          "wins": 13,
+          "losses": 5,
+          "ties": 0,
+          "pointsFor": 1884.01,
+          "regSeasonRank": 2,
+          "divisionId": "00",
+          "divisionName": "Northwest",
+          "wonDivision": true,
+          "playoffResult": "runner-up"
+        },
+        {
+          "year": 2011,
+          "name": "Vitside Mafia",
+          "nameMedium": "Vitside",
+          "icon": "/assets/theleague/icons/vitside_mafia.png",
+          "banner": "/assets/theleague/banners/vitside_mafia.png",
+          "isHistorical": false,
+          "sourceFranchiseId": null,
+          "wins": 5,
+          "losses": 13,
+          "ties": 0,
+          "pointsFor": 1508.38,
+          "regSeasonRank": 13,
+          "divisionId": "00",
+          "divisionName": "Northwest",
+          "wonDivision": false,
+          "playoffResult": "missed"
+        }
+      ],
+      "championships": [
+        2022
+      ],
+      "runnerUps": [
+        2012
+      ],
+      "thirdPlaces": [],
+      "divisionTitles": [
+        {
+          "year": 2012,
+          "divisionId": "00",
+          "divisionName": "Northwest"
+        },
+        {
+          "year": 2013,
+          "divisionId": "00",
+          "divisionName": "Northwest"
+        },
+        {
+          "year": 2015,
+          "divisionId": "00",
+          "divisionName": "Northwest"
+        },
+        {
+          "year": 2022,
+          "divisionId": "00",
+          "divisionName": "Northwest"
+        },
+        {
+          "year": 2025,
+          "divisionId": "00",
+          "divisionName": "Northwest"
+        }
+      ],
+      "mvpAwards": [
+        {
+          "year": 2020,
+          "playerId": "13589",
+          "playerName": "Allen, Josh",
+          "position": "QB",
+          "points": 500.34,
+          "salary": 574750,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "13592",
+          "playerName": "Darnold, Sam",
+          "position": "QB",
+          "points": 394.74,
+          "salary": 425000,
+          "sourceFranchiseId": null
+        }
+      ],
+      "jerryJonesAwards": [
+        {
+          "year": 2015,
+          "costPerPoint": 18622.482498100966,
+          "totalSalary": 27212475,
+          "totalPoints": 1461.2700000000002,
+          "sourceFranchiseId": null
+        }
+      ],
+      "brockOsweilerAwards": [],
+      "playoffAppearances": 4,
+      "careerWins": 129,
+      "careerLosses": 110,
+      "careerTies": 0,
+      "careerPointsFor": 26067.99,
+      "yearsActive": 16,
+      "highlights": {
+        "highestSingleGame": {
+          "year": 2015,
+          "week": 3,
+          "score": 214.14,
+          "sourceFranchiseId": null
+        },
+        "lowestSingleGame": {
+          "year": 2018,
+          "week": 5,
+          "score": 47.04,
+          "sourceFranchiseId": null
+        },
+        "biggestBlowoutWin": {
+          "year": 2015,
+          "week": 3,
+          "score": 214.14,
+          "opponentScore": 93,
+          "opponentFranchiseId": "0010",
+          "margin": 121.13999999999999,
+          "sourceFranchiseId": null
+        },
+        "biggestBlowoutLoss": {
+          "year": 2015,
+          "week": 15,
+          "score": 94.46,
+          "opponentScore": 219.61,
+          "opponentFranchiseId": "0006",
+          "margin": 125.15000000000002,
+          "sourceFranchiseId": null
+        }
+      },
+      "headToHead": {
+        "0010": {
+          "wins": 18,
+          "losses": 9,
+          "ties": 0
+        },
+        "0016": {
+          "wins": 6,
+          "losses": 8,
+          "ties": 0
+        },
+        "0001": {
+          "wins": 15,
+          "losses": 15,
+          "ties": 0
+        },
+        "0007": {
+          "wins": 6,
+          "losses": 8,
+          "ties": 0
+        },
+        "0013": {
+          "wins": 12,
+          "losses": 8,
+          "ties": 0
+        },
+        "0004": {
+          "wins": 11,
+          "losses": 1,
+          "ties": 0
+        },
+        "0006": {
+          "wins": 11,
+          "losses": 4,
+          "ties": 0
+        },
+        "0002": {
+          "wins": 7,
+          "losses": 15,
+          "ties": 0
+        },
+        "0003": {
+          "wins": 7,
+          "losses": 8,
+          "ties": 0
+        },
+        "0005": {
+          "wins": 9,
+          "losses": 8,
+          "ties": 0
+        },
+        "0011": {
+          "wins": 9,
+          "losses": 6,
+          "ties": 0
+        },
+        "0015": {
+          "wins": 7,
+          "losses": 5,
+          "ties": 0
+        },
+        "0009": {
+          "wins": 4,
+          "losses": 11,
+          "ties": 0
+        },
+        "0014": {
+          "wins": 9,
+          "losses": 5,
+          "ties": 0
+        },
+        "0008": {
+          "wins": 6,
+          "losses": 7,
+          "ties": 0
+        }
+      },
+      "currentName": "Vitside Mafia",
+      "currentNameMedium": "Vitside",
+      "currentNameShort": "Vitside",
+      "currentAbbrev": "VIT",
+      "currentIcon": "/assets/theleague/icons/vitside_mafia.png",
+      "currentBanner": "/assets/theleague/banners/vitside_mafia.png",
+      "currentDivision": "Northwest",
+      "currentColor": "#f06abc",
+      "currentOwnerSince": 2011
+    },
+    "0009": {
+      "franchiseId": "0009",
+      "yearByYear": [
+        {
+          "year": 2026,
+          "name": "Wascawy Wabbits",
+          "nameMedium": "Wascawy Wabbits",
+          "icon": "/assets/theleague/icons/wabbits.png",
+          "banner": "/assets/theleague/banners/wabbits.png",
+          "isHistorical": false,
+          "sourceFranchiseId": null,
+          "wins": 0,
+          "losses": 0,
+          "ties": 0,
+          "pointsFor": 0,
+          "regSeasonRank": 9,
+          "divisionId": "03",
+          "divisionName": "Eastern",
+          "wonDivision": false,
+          "playoffResult": "missed"
+        },
+        {
+          "year": 2025,
+          "name": "Wascawy Wabbits",
+          "nameMedium": "Wascawy Wabbits",
+          "icon": "/assets/theleague/icons/wabbits.png",
+          "banner": "/assets/theleague/banners/wabbits.png",
+          "isHistorical": false,
+          "sourceFranchiseId": null,
+          "wins": 15,
+          "losses": 3,
+          "ties": 0,
+          "pointsFor": 1998.36,
+          "regSeasonRank": 1,
+          "divisionId": "03",
+          "divisionName": "Eastern",
+          "wonDivision": true,
+          "playoffResult": "playoffs"
+        },
+        {
+          "year": 2024,
+          "name": "Wascawy Wabbits",
+          "nameMedium": "Wascawy Wabbits",
+          "icon": "/assets/theleague/icons/wabbits.png",
+          "banner": "/assets/theleague/banners/wabbits.png",
+          "isHistorical": false,
+          "sourceFranchiseId": null,
+          "wins": 14,
+          "losses": 4,
+          "ties": 0,
+          "pointsFor": 2140.71,
+          "regSeasonRank": 1,
+          "divisionId": "03",
+          "divisionName": "Eastern",
+          "wonDivision": false,
+          "playoffResult": "champion"
+        },
+        {
+          "year": 2023,
+          "name": "Wascawy Wabbits",
+          "nameMedium": "Wascawy Wabbits",
+          "icon": "/assets/theleague/icons/wabbits.png",
+          "banner": "/assets/theleague/banners/wabbits.png",
+          "isHistorical": false,
+          "sourceFranchiseId": null,
+          "wins": 6,
+          "losses": 12,
+          "ties": 0,
+          "pointsFor": 1665.09,
+          "regSeasonRank": 12,
+          "divisionId": "03",
+          "divisionName": "Eastern",
+          "wonDivision": false,
+          "playoffResult": "missed"
+        },
+        {
+          "year": 2022,
+          "name": "Wascawy Wabbits",
+          "nameMedium": "Wascawy Wabbits",
+          "icon": "/assets/theleague/icons/wabbits.png",
+          "banner": "/assets/theleague/banners/wabbits.png",
+          "isHistorical": false,
+          "sourceFranchiseId": null,
+          "wins": 0,
+          "losses": 0,
+          "ties": 0,
+          "pointsFor": 1715.4,
+          "regSeasonRank": 9,
+          "divisionId": "03",
+          "divisionName": "Eastern",
+          "wonDivision": false,
+          "playoffResult": "missed"
+        },
+        {
+          "year": 2021,
+          "name": "Wascawy Wabbits",
+          "nameMedium": "Wascawy Wabbits",
+          "icon": "/assets/theleague/icons/wabbits.png",
+          "banner": "/assets/theleague/banners/wabbits.png",
+          "isHistorical": false,
+          "sourceFranchiseId": null,
+          "wins": 15,
+          "losses": 3,
+          "ties": 0,
+          "pointsFor": 2114.36,
+          "regSeasonRank": 1,
+          "divisionId": "03",
+          "divisionName": "Eastern",
+          "wonDivision": true,
+          "playoffResult": "playoffs"
+        },
+        {
+          "year": 2020,
+          "name": "Wascawy Wabbits",
+          "nameMedium": "Wascawy Wabbits",
+          "icon": "/assets/theleague/icons/wabbits.png",
+          "banner": "/assets/theleague/banners/wabbits.png",
+          "isHistorical": false,
+          "sourceFranchiseId": null,
+          "wins": 14,
+          "losses": 4,
+          "ties": 0,
+          "pointsFor": 2183.75,
+          "regSeasonRank": 1,
+          "divisionId": "03",
+          "divisionName": "Eastern",
+          "wonDivision": false,
+          "playoffResult": "third-place"
+        },
+        {
+          "year": 2019,
+          "name": "Wascawy Wabbits",
+          "nameMedium": "Wascawy Wabbits",
+          "icon": "/assets/theleague/icons/wabbits.png",
+          "banner": "/assets/theleague/banners/wabbits.png",
+          "isHistorical": false,
+          "sourceFranchiseId": null,
+          "wins": 9,
+          "losses": 7,
+          "ties": 0,
+          "pointsFor": 1896,
+          "regSeasonRank": 7,
+          "divisionId": "03",
+          "divisionName": "Eastern",
+          "wonDivision": true,
+          "playoffResult": "missed"
+        },
+        {
+          "year": 2018,
+          "name": "Wascawy Wabbits",
+          "nameMedium": "Wascawy Wabbits",
+          "icon": "/assets/theleague/icons/wabbits.png",
+          "banner": "/assets/theleague/banners/wabbits.png",
+          "isHistorical": false,
+          "sourceFranchiseId": null,
+          "wins": 16,
+          "losses": 0,
+          "ties": 0,
+          "pointsFor": 2453.05,
+          "regSeasonRank": 1,
+          "divisionId": "03",
+          "divisionName": "Eastern",
+          "wonDivision": true,
+          "playoffResult": "missed"
+        },
+        {
+          "year": 2017,
+          "name": "Wascawy Wabbits",
+          "nameMedium": "Wascawy Wabbits",
+          "icon": "/assets/theleague/icons/wabbits.png",
+          "banner": "/assets/theleague/banners/wabbits.png",
+          "isHistorical": false,
+          "sourceFranchiseId": null,
+          "wins": 8,
+          "losses": 10,
+          "ties": 0,
+          "pointsFor": 1513.85,
+          "regSeasonRank": 10,
+          "divisionId": "03",
+          "divisionName": "Eastern",
+          "wonDivision": false,
+          "playoffResult": "missed"
+        },
+        {
+          "year": 2016,
+          "name": "Wascawy Wabbits",
+          "nameMedium": "Wascawy Wabbits",
+          "icon": "/assets/theleague/icons/wabbits.png",
+          "banner": "/assets/theleague/banners/wabbits.png",
+          "isHistorical": false,
+          "sourceFranchiseId": null,
+          "wins": 5,
+          "losses": 11,
+          "ties": 0,
+          "pointsFor": 1754.01,
+          "regSeasonRank": 13,
+          "divisionId": "03",
+          "divisionName": "Eastern",
+          "wonDivision": false,
+          "playoffResult": "missed"
+        },
+        {
+          "year": 2015,
+          "name": "Wascawy Wabbits",
+          "nameMedium": "Wascawy Wabbits",
+          "icon": "/assets/theleague/icons/wabbits.png",
+          "banner": "/assets/theleague/banners/wabbits.png",
+          "isHistorical": false,
+          "sourceFranchiseId": null,
+          "wins": 7,
+          "losses": 6,
+          "ties": 0,
+          "pointsFor": 1213,
+          "regSeasonRank": 6,
+          "divisionId": "02",
+          "divisionName": "Central",
+          "wonDivision": true,
+          "playoffResult": "missed"
+        },
+        {
+          "year": 2014,
+          "name": "Wascawy Wabbits",
+          "nameMedium": "Wascawy Wabbits",
+          "icon": "/assets/theleague/icons/wabbits.png",
+          "banner": "/assets/theleague/banners/wabbits.png",
+          "isHistorical": false,
+          "sourceFranchiseId": null,
+          "wins": 7,
+          "losses": 9,
+          "ties": 0,
+          "pointsFor": 1711.04,
+          "regSeasonRank": 9,
+          "divisionId": "02",
+          "divisionName": "Central",
+          "wonDivision": false,
+          "playoffResult": "missed"
+        },
+        {
+          "year": 2013,
+          "name": "Wascawy Wabbits",
+          "nameMedium": "Wascawy Wabbits",
+          "icon": "/assets/theleague/icons/wabbits.png",
+          "banner": "/assets/theleague/banners/wabbits.png",
+          "isHistorical": false,
+          "sourceFranchiseId": null,
+          "wins": 9,
+          "losses": 9,
+          "ties": 0,
+          "pointsFor": 1981.95,
+          "regSeasonRank": 9,
+          "divisionId": "02",
+          "divisionName": "Central",
+          "wonDivision": false,
+          "playoffResult": "missed"
+        },
+        {
+          "year": 2012,
+          "name": "Wascawy Wabbits",
+          "nameMedium": "Wascawy Wabbits",
+          "icon": "/assets/theleague/icons/wabbits.png",
+          "banner": "/assets/theleague/banners/wabbits.png",
+          "isHistorical": false,
+          "sourceFranchiseId": null,
+          "wins": 12,
+          "losses": 6,
+          "ties": 0,
+          "pointsFor": 1697.7,
+          "regSeasonRank": 6,
+          "divisionId": "02",
+          "divisionName": "Central",
+          "wonDivision": true,
+          "playoffResult": "missed"
+        }
+      ],
+      "championships": [
+        2024
+      ],
+      "runnerUps": [],
+      "thirdPlaces": [
+        2020
+      ],
+      "divisionTitles": [
+        {
+          "year": 2012,
+          "divisionId": "02",
+          "divisionName": "Central"
+        },
+        {
+          "year": 2015,
+          "divisionId": "02",
+          "divisionName": "Central"
+        },
+        {
+          "year": 2018,
+          "divisionId": "03",
+          "divisionName": "Eastern"
+        },
+        {
+          "year": 2019,
+          "divisionId": "03",
+          "divisionName": "Eastern"
+        },
+        {
+          "year": 2021,
+          "divisionId": "03",
+          "divisionName": "Eastern"
+        },
+        {
+          "year": 2025,
+          "divisionId": "03",
+          "divisionName": "Eastern"
+        }
+      ],
+      "mvpAwards": [
+        {
+          "year": 2017,
+          "playerId": "12620",
+          "playerName": "Prescott, Dak",
+          "position": "QB",
+          "points": 358.88,
+          "salary": 495000,
+          "sourceFranchiseId": null
+        }
+      ],
+      "jerryJonesAwards": [],
+      "brockOsweilerAwards": [],
+      "playoffAppearances": 3,
+      "careerWins": 137,
+      "careerLosses": 84,
+      "careerTies": 0,
+      "careerPointsFor": 26038.270000000004,
+      "yearsActive": 15,
+      "highlights": {
+        "highestSingleGame": {
+          "year": 2018,
+          "week": 1,
+          "score": 199.29,
+          "sourceFranchiseId": null
+        },
+        "lowestSingleGame": {
+          "year": 2017,
+          "week": 13,
+          "score": 53.95,
+          "sourceFranchiseId": null
+        },
+        "biggestBlowoutWin": {
+          "year": 2024,
+          "week": 11,
+          "score": 165.04,
+          "opponentScore": 56.84,
+          "opponentFranchiseId": "0011",
+          "margin": 108.19999999999999,
+          "sourceFranchiseId": null
+        },
+        "biggestBlowoutLoss": {
+          "year": 2015,
+          "week": 3,
+          "score": 68.91,
+          "opponentScore": 149.7,
+          "opponentFranchiseId": "0006",
+          "margin": 80.78999999999999,
+          "sourceFranchiseId": null
+        }
+      },
+      "headToHead": {
+        "0008": {
+          "wins": 10,
+          "losses": 7,
+          "ties": 0
+        },
+        "0003": {
+          "wins": 7,
+          "losses": 4,
+          "ties": 0
+        },
+        "0005": {
+          "wins": 9,
+          "losses": 7,
+          "ties": 0
+        },
+        "0002": {
+          "wins": 8,
+          "losses": 7,
+          "ties": 0
+        },
+        "0006": {
+          "wins": 6,
+          "losses": 5,
+          "ties": 0
+        },
+        "0011": {
+          "wins": 7,
+          "losses": 11,
+          "ties": 0
+        },
+        "0016": {
+          "wins": 17,
+          "losses": 6,
+          "ties": 0
+        },
+        "0007": {
+          "wins": 12,
+          "losses": 7,
+          "ties": 0
+        },
+        "0014": {
+          "wins": 5,
+          "losses": 7,
+          "ties": 0
+        },
+        "0001": {
+          "wins": 11,
+          "losses": 5,
+          "ties": 0
+        },
+        "0010": {
+          "wins": 9,
+          "losses": 6,
+          "ties": 0
+        },
+        "0015": {
+          "wins": 8,
+          "losses": 12,
+          "ties": 0
+        },
+        "0012": {
+          "wins": 10,
+          "losses": 3,
+          "ties": 0
+        },
+        "0004": {
+          "wins": 7,
+          "losses": 4,
+          "ties": 0
+        },
+        "0013": {
+          "wins": 10,
+          "losses": 5,
+          "ties": 0
+        }
+      },
+      "currentName": "Wascawy Wabbits",
+      "currentNameMedium": "Wascawy Wabbits",
+      "currentNameShort": "Wabbits",
+      "currentAbbrev": "WABS",
+      "currentIcon": "/assets/theleague/icons/wabbits.png",
+      "currentBanner": "/assets/theleague/banners/wabbits.png",
+      "currentDivision": "East",
+      "currentColor": "#5c5c5c",
       "currentOwnerSince": 2012
     },
     "0016": {

--- a/data/theleague/derived/franchise-history.json
+++ b/data/theleague/derived/franchise-history.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-07T18:16:10.459Z",
+  "generatedAt": "2026-05-07T18:59:12.598Z",
   "yearsCovered": [
     2007,
     2008,
@@ -664,6 +664,101 @@
           "week": 5,
           "score": 47.04,
           "sourceFranchiseId": null
+        },
+        "biggestBlowoutWin": {
+          "year": 2015,
+          "week": 3,
+          "score": 214.14,
+          "opponentScore": 93,
+          "opponentFranchiseId": "0010",
+          "margin": 121.13999999999999,
+          "sourceFranchiseId": null
+        },
+        "biggestBlowoutLoss": {
+          "year": 2015,
+          "week": 15,
+          "score": 94.46,
+          "opponentScore": 219.61,
+          "opponentFranchiseId": "0006",
+          "margin": 125.15000000000002,
+          "sourceFranchiseId": null
+        }
+      },
+      "headToHead": {
+        "0003": {
+          "wins": 11,
+          "losses": 13,
+          "ties": 0
+        },
+        "0016": {
+          "wins": 8,
+          "losses": 10,
+          "ties": 0
+        },
+        "0015": {
+          "wins": 11,
+          "losses": 8,
+          "ties": 0
+        },
+        "0014": {
+          "wins": 12,
+          "losses": 6,
+          "ties": 0
+        },
+        "0013": {
+          "wins": 16,
+          "losses": 10,
+          "ties": 0
+        },
+        "0001": {
+          "wins": 17,
+          "losses": 17,
+          "ties": 0
+        },
+        "0006": {
+          "wins": 12,
+          "losses": 8,
+          "ties": 0
+        },
+        "0004": {
+          "wins": 13,
+          "losses": 4,
+          "ties": 0
+        },
+        "0009": {
+          "wins": 8,
+          "losses": 11,
+          "ties": 0
+        },
+        "0011": {
+          "wins": 13,
+          "losses": 6,
+          "ties": 0
+        },
+        "0008": {
+          "wins": 8,
+          "losses": 10,
+          "ties": 0
+        },
+        "0002": {
+          "wins": 13,
+          "losses": 16,
+          "ties": 0
+        },
+        "0010": {
+          "wins": 22,
+          "losses": 12,
+          "ties": 0
+        },
+        "0007": {
+          "wins": 7,
+          "losses": 12,
+          "ties": 0
+        },
+        "0005": {
+          "wins": 12,
+          "losses": 9,
+          "ties": 0
         }
       },
       "currentName": "Vitside Mafia",
@@ -1058,6 +1153,101 @@
           "week": 15,
           "score": 26.92,
           "sourceFranchiseId": null
+        },
+        "biggestBlowoutWin": {
+          "year": 2020,
+          "week": 12,
+          "score": 169.28,
+          "opponentScore": 53.67,
+          "opponentFranchiseId": "0002",
+          "margin": 115.61,
+          "sourceFranchiseId": null
+        },
+        "biggestBlowoutLoss": {
+          "year": 2019,
+          "week": 7,
+          "score": 70.17,
+          "opponentScore": 165.56,
+          "opponentFranchiseId": "0011",
+          "margin": 95.39,
+          "sourceFranchiseId": null
+        }
+      },
+      "headToHead": {
+        "0013": {
+          "wins": 9,
+          "losses": 11,
+          "ties": 0
+        },
+        "0010": {
+          "wins": 11,
+          "losses": 10,
+          "ties": 0
+        },
+        "0012": {
+          "wins": 8,
+          "losses": 11,
+          "ties": 0
+        },
+        "0007": {
+          "wins": 15,
+          "losses": 20,
+          "ties": 0
+        },
+        "0003": {
+          "wins": 14,
+          "losses": 7,
+          "ties": 0
+        },
+        "0004": {
+          "wins": 13,
+          "losses": 9,
+          "ties": 0
+        },
+        "0002": {
+          "wins": 13,
+          "losses": 7,
+          "ties": 0
+        },
+        "0001": {
+          "wins": 14,
+          "losses": 5,
+          "ties": 0
+        },
+        "0005": {
+          "wins": 13,
+          "losses": 8,
+          "ties": 0
+        },
+        "0008": {
+          "wins": 16,
+          "losses": 7,
+          "ties": 0
+        },
+        "0011": {
+          "wins": 12,
+          "losses": 6,
+          "ties": 0
+        },
+        "0006": {
+          "wins": 7,
+          "losses": 13,
+          "ties": 0
+        },
+        "0016": {
+          "wins": 17,
+          "losses": 12,
+          "ties": 0
+        },
+        "0014": {
+          "wins": 17,
+          "losses": 9,
+          "ties": 0
+        },
+        "0009": {
+          "wins": 16,
+          "losses": 10,
+          "ties": 0
         }
       },
       "currentName": "Dark Magicians of Chaos",
@@ -1546,6 +1736,101 @@
           "week": 13,
           "score": 31.3,
           "sourceFranchiseId": null
+        },
+        "biggestBlowoutWin": {
+          "year": 2015,
+          "week": 6,
+          "score": 126,
+          "opponentScore": 41.28,
+          "opponentFranchiseId": "0004",
+          "margin": 84.72,
+          "sourceFranchiseId": null
+        },
+        "biggestBlowoutLoss": {
+          "year": 2025,
+          "week": 13,
+          "score": 31.3,
+          "opponentScore": 121.92,
+          "opponentFranchiseId": "0012",
+          "margin": 90.62,
+          "sourceFranchiseId": null
+        }
+      },
+      "headToHead": {
+        "0006": {
+          "wins": 10,
+          "losses": 12,
+          "ties": 0
+        },
+        "0009": {
+          "wins": 10,
+          "losses": 14,
+          "ties": 0
+        },
+        "0004": {
+          "wins": 15,
+          "losses": 8,
+          "ties": 0
+        },
+        "0008": {
+          "wins": 12,
+          "losses": 9,
+          "ties": 0
+        },
+        "0002": {
+          "wins": 16,
+          "losses": 10,
+          "ties": 0
+        },
+        "0012": {
+          "wins": 17,
+          "losses": 17,
+          "ties": 0
+        },
+        "0003": {
+          "wins": 9,
+          "losses": 10,
+          "ties": 0
+        },
+        "0015": {
+          "wins": 5,
+          "losses": 14,
+          "ties": 0
+        },
+        "0010": {
+          "wins": 17,
+          "losses": 12,
+          "ties": 0
+        },
+        "0014": {
+          "wins": 13,
+          "losses": 6,
+          "ties": 0
+        },
+        "0007": {
+          "wins": 9,
+          "losses": 7,
+          "ties": 0
+        },
+        "0013": {
+          "wins": 17,
+          "losses": 8,
+          "ties": 0
+        },
+        "0005": {
+          "wins": 13,
+          "losses": 9,
+          "ties": 0
+        },
+        "0011": {
+          "wins": 13,
+          "losses": 9,
+          "ties": 0
+        },
+        "0016": {
+          "wins": 10,
+          "losses": 8,
+          "ties": 0
         }
       },
       "currentName": "Pacific Pigskins",
@@ -2034,6 +2319,101 @@
           "week": 10,
           "score": 19.29,
           "sourceFranchiseId": null
+        },
+        "biggestBlowoutWin": {
+          "year": 2008,
+          "week": 5,
+          "score": 140.4,
+          "opponentScore": 56.54,
+          "opponentFranchiseId": "0005",
+          "margin": 83.86000000000001,
+          "sourceFranchiseId": null
+        },
+        "biggestBlowoutLoss": {
+          "year": 2009,
+          "week": 15,
+          "score": 73.75,
+          "opponentScore": 190.02,
+          "opponentFranchiseId": "0006",
+          "margin": 116.27000000000001,
+          "sourceFranchiseId": null
+        }
+      },
+      "headToHead": {
+        "0016": {
+          "wins": 22,
+          "losses": 14,
+          "ties": 0
+        },
+        "0013": {
+          "wins": 12,
+          "losses": 7,
+          "ties": 0
+        },
+        "0014": {
+          "wins": 16,
+          "losses": 14,
+          "ties": 0
+        },
+        "0015": {
+          "wins": 20,
+          "losses": 15,
+          "ties": 0
+        },
+        "0010": {
+          "wins": 12,
+          "losses": 11,
+          "ties": 0
+        },
+        "0011": {
+          "wins": 9,
+          "losses": 8,
+          "ties": 0
+        },
+        "0005": {
+          "wins": 11,
+          "losses": 6,
+          "ties": 0
+        },
+        "0008": {
+          "wins": 7,
+          "losses": 12,
+          "ties": 0
+        },
+        "0006": {
+          "wins": 7,
+          "losses": 15,
+          "ties": 0
+        },
+        "0004": {
+          "wins": 9,
+          "losses": 10,
+          "ties": 0
+        },
+        "0001": {
+          "wins": 7,
+          "losses": 9,
+          "ties": 0
+        },
+        "0009": {
+          "wins": 12,
+          "losses": 12,
+          "ties": 0
+        },
+        "0003": {
+          "wins": 9,
+          "losses": 9,
+          "ties": 0
+        },
+        "0012": {
+          "wins": 12,
+          "losses": 7,
+          "ties": 0
+        },
+        "0002": {
+          "wins": 6,
+          "losses": 15,
+          "ties": 0
         }
       },
       "currentName": "Fire Ready Aim",
@@ -2483,6 +2863,101 @@
           "week": 15,
           "score": 34.66,
           "sourceFranchiseId": null
+        },
+        "biggestBlowoutWin": {
+          "year": 2024,
+          "week": 11,
+          "score": 165.04,
+          "opponentScore": 56.84,
+          "opponentFranchiseId": "0011",
+          "margin": 108.19999999999999,
+          "sourceFranchiseId": null
+        },
+        "biggestBlowoutLoss": {
+          "year": 2015,
+          "week": 3,
+          "score": 68.91,
+          "opponentScore": 149.7,
+          "opponentFranchiseId": "0006",
+          "margin": 80.78999999999999,
+          "sourceFranchiseId": null
+        }
+      },
+      "headToHead": {
+        "0011": {
+          "wins": 11,
+          "losses": 17,
+          "ties": 0
+        },
+        "0001": {
+          "wins": 14,
+          "losses": 10,
+          "ties": 0
+        },
+        "0005": {
+          "wins": 16,
+          "losses": 11,
+          "ties": 0
+        },
+        "0002": {
+          "wins": 11,
+          "losses": 9,
+          "ties": 0
+        },
+        "0008": {
+          "wins": 13,
+          "losses": 14,
+          "ties": 0
+        },
+        "0010": {
+          "wins": 10,
+          "losses": 10,
+          "ties": 0
+        },
+        "0014": {
+          "wins": 8,
+          "losses": 9,
+          "ties": 0
+        },
+        "0016": {
+          "wins": 19,
+          "losses": 10,
+          "ties": 0
+        },
+        "0012": {
+          "wins": 11,
+          "losses": 8,
+          "ties": 0
+        },
+        "0003": {
+          "wins": 9,
+          "losses": 9,
+          "ties": 0
+        },
+        "0013": {
+          "wins": 11,
+          "losses": 9,
+          "ties": 0
+        },
+        "0007": {
+          "wins": 12,
+          "losses": 12,
+          "ties": 0
+        },
+        "0004": {
+          "wins": 9,
+          "losses": 8,
+          "ties": 0
+        },
+        "0006": {
+          "wins": 8,
+          "losses": 9,
+          "ties": 0
+        },
+        "0015": {
+          "wins": 10,
+          "losses": 16,
+          "ties": 0
         }
       },
       "currentName": "Wascawy Wabbits",
@@ -2942,6 +3417,101 @@
           "week": 15,
           "score": 47.58,
           "sourceFranchiseId": null
+        },
+        "biggestBlowoutWin": {
+          "year": 2025,
+          "week": 7,
+          "score": 195.26,
+          "opponentScore": 80.87,
+          "opponentFranchiseId": "0007",
+          "margin": 114.38999999999999,
+          "sourceFranchiseId": null
+        },
+        "biggestBlowoutLoss": {
+          "year": 2020,
+          "week": 12,
+          "score": 59.73,
+          "opponentScore": 164.39,
+          "opponentFranchiseId": "0011",
+          "margin": 104.66,
+          "sourceFranchiseId": null
+        }
+      },
+      "headToHead": {
+        "0005": {
+          "wins": 23,
+          "losses": 10,
+          "ties": 0
+        },
+        "0006": {
+          "wins": 10,
+          "losses": 12,
+          "ties": 0
+        },
+        "0011": {
+          "wins": 15,
+          "losses": 13,
+          "ties": 0
+        },
+        "0001": {
+          "wins": 9,
+          "losses": 12,
+          "ties": 0
+        },
+        "0009": {
+          "wins": 14,
+          "losses": 13,
+          "ties": 0
+        },
+        "0014": {
+          "wins": 20,
+          "losses": 6,
+          "ties": 0
+        },
+        "0016": {
+          "wins": 14,
+          "losses": 4,
+          "ties": 0
+        },
+        "0007": {
+          "wins": 12,
+          "losses": 7,
+          "ties": 0
+        },
+        "0003": {
+          "wins": 15,
+          "losses": 9,
+          "ties": 0
+        },
+        "0015": {
+          "wins": 7,
+          "losses": 16,
+          "ties": 0
+        },
+        "0012": {
+          "wins": 10,
+          "losses": 8,
+          "ties": 0
+        },
+        "0010": {
+          "wins": 16,
+          "losses": 6,
+          "ties": 0
+        },
+        "0002": {
+          "wins": 11,
+          "losses": 9,
+          "ties": 0
+        },
+        "0004": {
+          "wins": 11,
+          "losses": 8,
+          "ties": 0
+        },
+        "0013": {
+          "wins": 14,
+          "losses": 3,
+          "ties": 0
         }
       },
       "currentName": "Bring The Pain",
@@ -3222,6 +3792,106 @@
           "week": 10,
           "score": 39.1,
           "sourceFranchiseId": "0010"
+        },
+        "biggestBlowoutWin": {
+          "year": 2020,
+          "week": 12,
+          "score": 164.39,
+          "opponentScore": 59.73,
+          "opponentFranchiseId": "0008",
+          "margin": 104.66,
+          "sourceFranchiseId": null
+        },
+        "biggestBlowoutLoss": {
+          "year": 2015,
+          "week": 3,
+          "score": 93,
+          "opponentScore": 214.14,
+          "opponentFranchiseId": "0012",
+          "margin": 121.13999999999999,
+          "sourceFranchiseId": "0010"
+        }
+      },
+      "headToHead": {
+        "0012": {
+          "wins": 2,
+          "losses": 11,
+          "ties": 0
+        },
+        "0007": {
+          "wins": 6,
+          "losses": 3,
+          "ties": 0
+        },
+        "0013": {
+          "wins": 12,
+          "losses": 7,
+          "ties": 0
+        },
+        "0015": {
+          "wins": 4,
+          "losses": 4,
+          "ties": 0
+        },
+        "0014": {
+          "wins": 7,
+          "losses": 3,
+          "ties": 0
+        },
+        "0001": {
+          "wins": 7,
+          "losses": 8,
+          "ties": 0
+        },
+        "0004": {
+          "wins": 11,
+          "losses": 1,
+          "ties": 0
+        },
+        "0006": {
+          "wins": 5,
+          "losses": 9,
+          "ties": 0
+        },
+        "0002": {
+          "wins": 4,
+          "losses": 8,
+          "ties": 0
+        },
+        "0011": {
+          "wins": 3,
+          "losses": 2,
+          "ties": 0
+        },
+        "0009": {
+          "wins": 5,
+          "losses": 6,
+          "ties": 0
+        },
+        "0003": {
+          "wins": 6,
+          "losses": 7,
+          "ties": 0
+        },
+        "0008": {
+          "wins": 5,
+          "losses": 6,
+          "ties": 0
+        },
+        "0016": {
+          "wins": 5,
+          "losses": 5,
+          "ties": 0
+        },
+        "0005": {
+          "wins": 5,
+          "losses": 5,
+          "ties": 0
+        },
+        "0010": {
+          "wins": 1,
+          "losses": 3,
+          "ties": 0
         }
       },
       "currentName": "Midwestside Connection",
@@ -3505,6 +4175,101 @@
           "week": 9,
           "score": 47.21,
           "sourceFranchiseId": null
+        },
+        "biggestBlowoutWin": {
+          "year": 2019,
+          "week": 7,
+          "score": 140.68,
+          "opponentScore": 51.3,
+          "opponentFranchiseId": "0013",
+          "margin": 89.38000000000001,
+          "sourceFranchiseId": null
+        },
+        "biggestBlowoutLoss": {
+          "year": 2018,
+          "week": 1,
+          "score": 94.05,
+          "opponentScore": 199.29,
+          "opponentFranchiseId": "0009",
+          "margin": 105.24,
+          "sourceFranchiseId": null
+        }
+      },
+      "headToHead": {
+        "0007": {
+          "wins": 11,
+          "losses": 8,
+          "ties": 0
+        },
+        "0013": {
+          "wins": 7,
+          "losses": 4,
+          "ties": 0
+        },
+        "0014": {
+          "wins": 8,
+          "losses": 4,
+          "ties": 0
+        },
+        "0002": {
+          "wins": 8,
+          "losses": 7,
+          "ties": 0
+        },
+        "0015": {
+          "wins": 10,
+          "losses": 9,
+          "ties": 0
+        },
+        "0011": {
+          "wins": 4,
+          "losses": 7,
+          "ties": 0
+        },
+        "0009": {
+          "wins": 6,
+          "losses": 15,
+          "ties": 0
+        },
+        "0008": {
+          "wins": 2,
+          "losses": 9,
+          "ties": 0
+        },
+        "0005": {
+          "wins": 2,
+          "losses": 10,
+          "ties": 0
+        },
+        "0003": {
+          "wins": 5,
+          "losses": 4,
+          "ties": 0
+        },
+        "0006": {
+          "wins": 5,
+          "losses": 7,
+          "ties": 0
+        },
+        "0004": {
+          "wins": 5,
+          "losses": 7,
+          "ties": 0
+        },
+        "0010": {
+          "wins": 4,
+          "losses": 5,
+          "ties": 0
+        },
+        "0012": {
+          "wins": 5,
+          "losses": 5,
+          "ties": 0
+        },
+        "0001": {
+          "wins": 4,
+          "losses": 6,
+          "ties": 0
         }
       },
       "currentName": "Running down the Dream",
@@ -3802,6 +4567,101 @@
           "week": 9,
           "score": 47.35,
           "sourceFranchiseId": null
+        },
+        "biggestBlowoutWin": {
+          "year": 2023,
+          "week": 3,
+          "score": 176.9,
+          "opponentScore": 89.66,
+          "opponentFranchiseId": "0006",
+          "margin": 87.24000000000001,
+          "sourceFranchiseId": null
+        },
+        "biggestBlowoutLoss": {
+          "year": 2018,
+          "week": 9,
+          "score": 47.35,
+          "opponentScore": 144.98,
+          "opponentFranchiseId": "0008",
+          "margin": 97.63,
+          "sourceFranchiseId": null
+        }
+      },
+      "headToHead": {
+        "0001": {
+          "wins": 5,
+          "losses": 8,
+          "ties": 0
+        },
+        "0016": {
+          "wins": 4,
+          "losses": 7,
+          "ties": 0
+        },
+        "0010": {
+          "wins": 8,
+          "losses": 4,
+          "ties": 0
+        },
+        "0009": {
+          "wins": 5,
+          "losses": 8,
+          "ties": 0
+        },
+        "0012": {
+          "wins": 5,
+          "losses": 8,
+          "ties": 0
+        },
+        "0006": {
+          "wins": 7,
+          "losses": 11,
+          "ties": 0
+        },
+        "0002": {
+          "wins": 4,
+          "losses": 8,
+          "ties": 0
+        },
+        "0003": {
+          "wins": 5,
+          "losses": 6,
+          "ties": 0
+        },
+        "0004": {
+          "wins": 10,
+          "losses": 11,
+          "ties": 0
+        },
+        "0008": {
+          "wins": 2,
+          "losses": 8,
+          "ties": 0
+        },
+        "0011": {
+          "wins": 5,
+          "losses": 11,
+          "ties": 0
+        },
+        "0005": {
+          "wins": 6,
+          "losses": 5,
+          "ties": 0
+        },
+        "0014": {
+          "wins": 5,
+          "losses": 5,
+          "ties": 0
+        },
+        "0007": {
+          "wins": 4,
+          "losses": 7,
+          "ties": 0
+        },
+        "0015": {
+          "wins": 7,
+          "losses": 3,
+          "ties": 0
         }
       },
       "currentName": "Gridiron Geeks",
@@ -4104,6 +4964,101 @@
           "week": 12,
           "score": 53.67,
           "sourceFranchiseId": null
+        },
+        "biggestBlowoutWin": {
+          "year": 2015,
+          "week": 2,
+          "score": 136.9,
+          "opponentScore": 55.41,
+          "opponentFranchiseId": "0004",
+          "margin": 81.49000000000001,
+          "sourceFranchiseId": null
+        },
+        "biggestBlowoutLoss": {
+          "year": 2020,
+          "week": 12,
+          "score": 53.67,
+          "opponentScore": 169.28,
+          "opponentFranchiseId": "0015",
+          "margin": 115.61,
+          "sourceFranchiseId": null
+        }
+      },
+      "headToHead": {
+        "0006": {
+          "wins": 2,
+          "losses": 8,
+          "ties": 0
+        },
+        "0008": {
+          "wins": 4,
+          "losses": 7,
+          "ties": 0
+        },
+        "0004": {
+          "wins": 6,
+          "losses": 5,
+          "ties": 0
+        },
+        "0009": {
+          "wins": 6,
+          "losses": 5,
+          "ties": 0
+        },
+        "0011": {
+          "wins": 3,
+          "losses": 5,
+          "ties": 0
+        },
+        "0003": {
+          "wins": 10,
+          "losses": 2,
+          "ties": 0
+        },
+        "0013": {
+          "wins": 7,
+          "losses": 4,
+          "ties": 0
+        },
+        "0012": {
+          "wins": 13,
+          "losses": 5,
+          "ties": 0
+        },
+        "0010": {
+          "wins": 12,
+          "losses": 7,
+          "ties": 0
+        },
+        "0015": {
+          "wins": 3,
+          "losses": 6,
+          "ties": 0
+        },
+        "0014": {
+          "wins": 5,
+          "losses": 5,
+          "ties": 0
+        },
+        "0001": {
+          "wins": 6,
+          "losses": 11,
+          "ties": 0
+        },
+        "0007": {
+          "wins": 6,
+          "losses": 3,
+          "ties": 0
+        },
+        "0005": {
+          "wins": 4,
+          "losses": 4,
+          "ties": 0
+        },
+        "0016": {
+          "wins": 6,
+          "losses": 6,
+          "ties": 0
         }
       },
       "currentName": "Da Dangsters",
@@ -4364,6 +5319,101 @@
           "week": 14,
           "score": 40.67,
           "sourceFranchiseId": null
+        },
+        "biggestBlowoutWin": {
+          "year": 2021,
+          "week": 1,
+          "score": 139.47,
+          "opponentScore": 61.52,
+          "opponentFranchiseId": "0011",
+          "margin": 77.94999999999999,
+          "sourceFranchiseId": null
+        },
+        "biggestBlowoutLoss": {
+          "year": 2020,
+          "week": 14,
+          "score": 73.35,
+          "opponentScore": 165.21,
+          "opponentFranchiseId": "0015",
+          "margin": 91.86000000000001,
+          "sourceFranchiseId": null
+        }
+      },
+      "headToHead": {
+        "0011": {
+          "wins": 3,
+          "losses": 6,
+          "ties": 0
+        },
+        "0012": {
+          "wins": 7,
+          "losses": 4,
+          "ties": 0
+        },
+        "0014": {
+          "wins": 9,
+          "losses": 7,
+          "ties": 0
+        },
+        "0001": {
+          "wins": 4,
+          "losses": 7,
+          "ties": 0
+        },
+        "0008": {
+          "wins": 6,
+          "losses": 8,
+          "ties": 0
+        },
+        "0007": {
+          "wins": 4,
+          "losses": 3,
+          "ties": 0
+        },
+        "0009": {
+          "wins": 3,
+          "losses": 5,
+          "ties": 0
+        },
+        "0015": {
+          "wins": 3,
+          "losses": 9,
+          "ties": 0
+        },
+        "0016": {
+          "wins": 7,
+          "losses": 2,
+          "ties": 0
+        },
+        "0004": {
+          "wins": 9,
+          "losses": 1,
+          "ties": 0
+        },
+        "0013": {
+          "wins": 3,
+          "losses": 5,
+          "ties": 0
+        },
+        "0006": {
+          "wins": 6,
+          "losses": 3,
+          "ties": 0
+        },
+        "0003": {
+          "wins": 10,
+          "losses": 5,
+          "ties": 0
+        },
+        "0010": {
+          "wins": 5,
+          "losses": 4,
+          "ties": 0
+        },
+        "0002": {
+          "wins": 3,
+          "losses": 4,
+          "ties": 0
         }
       },
       "currentName": "The Mariachi Ninjas",
@@ -4634,6 +5684,101 @@
           "week": 6,
           "score": 34.8,
           "sourceFranchiseId": null
+        },
+        "biggestBlowoutWin": {
+          "year": 2023,
+          "week": 4,
+          "score": 139.49,
+          "opponentScore": 65.04,
+          "opponentFranchiseId": "0008",
+          "margin": 74.45,
+          "sourceFranchiseId": null
+        },
+        "biggestBlowoutLoss": {
+          "year": 2017,
+          "week": 12,
+          "score": 82.44,
+          "opponentScore": 178.57,
+          "opponentFranchiseId": "0008",
+          "margin": 96.13,
+          "sourceFranchiseId": null
+        }
+      },
+      "headToHead": {
+        "0013": {
+          "wins": 5,
+          "losses": 4,
+          "ties": 0
+        },
+        "0009": {
+          "wins": 4,
+          "losses": 4,
+          "ties": 0
+        },
+        "0006": {
+          "wins": 3,
+          "losses": 6,
+          "ties": 0
+        },
+        "0007": {
+          "wins": 5,
+          "losses": 3,
+          "ties": 0
+        },
+        "0004": {
+          "wins": 5,
+          "losses": 5,
+          "ties": 0
+        },
+        "0010": {
+          "wins": 3,
+          "losses": 7,
+          "ties": 0
+        },
+        "0001": {
+          "wins": 3,
+          "losses": 5,
+          "ties": 0
+        },
+        "0002": {
+          "wins": 2,
+          "losses": 8,
+          "ties": 0
+        },
+        "0012": {
+          "wins": 5,
+          "losses": 4,
+          "ties": 0
+        },
+        "0008": {
+          "wins": 5,
+          "losses": 11,
+          "ties": 0
+        },
+        "0014": {
+          "wins": 8,
+          "losses": 6,
+          "ties": 0
+        },
+        "0011": {
+          "wins": 4,
+          "losses": 7,
+          "ties": 0
+        },
+        "0005": {
+          "wins": 5,
+          "losses": 10,
+          "ties": 0
+        },
+        "0015": {
+          "wins": 2,
+          "losses": 5,
+          "ties": 0
+        },
+        "0016": {
+          "wins": 3,
+          "losses": 4,
+          "ties": 0
         }
       },
       "currentName": "Maverick",
@@ -4920,6 +6065,101 @@
           "week": 14,
           "score": 56.52,
           "sourceFranchiseId": null
+        },
+        "biggestBlowoutWin": {
+          "year": 2025,
+          "week": 11,
+          "score": 166.14,
+          "opponentScore": 76.46,
+          "opponentFranchiseId": "0008",
+          "margin": 89.67999999999999,
+          "sourceFranchiseId": null
+        },
+        "biggestBlowoutLoss": {
+          "year": 2023,
+          "week": 5,
+          "score": 67.21,
+          "opponentScore": 158.43,
+          "opponentFranchiseId": "0004",
+          "margin": 91.22000000000001,
+          "sourceFranchiseId": null
+        }
+      },
+      "headToHead": {
+        "0012": {
+          "wins": 5,
+          "losses": 11,
+          "ties": 0
+        },
+        "0014": {
+          "wins": 7,
+          "losses": 2,
+          "ties": 0
+        },
+        "0002": {
+          "wins": 6,
+          "losses": 11,
+          "ties": 0
+        },
+        "0008": {
+          "wins": 2,
+          "losses": 8,
+          "ties": 0
+        },
+        "0001": {
+          "wins": 3,
+          "losses": 11,
+          "ties": 0
+        },
+        "0003": {
+          "wins": 7,
+          "losses": 3,
+          "ties": 0
+        },
+        "0004": {
+          "wins": 5,
+          "losses": 4,
+          "ties": 0
+        },
+        "0006": {
+          "wins": 4,
+          "losses": 4,
+          "ties": 0
+        },
+        "0013": {
+          "wins": 3,
+          "losses": 5,
+          "ties": 0
+        },
+        "0007": {
+          "wins": 5,
+          "losses": 5,
+          "ties": 0
+        },
+        "0009": {
+          "wins": 4,
+          "losses": 6,
+          "ties": 0
+        },
+        "0016": {
+          "wins": 4,
+          "losses": 3,
+          "ties": 0
+        },
+        "0015": {
+          "wins": 6,
+          "losses": 5,
+          "ties": 0
+        },
+        "0005": {
+          "wins": 4,
+          "losses": 5,
+          "ties": 0
+        },
+        "0011": {
+          "wins": 4,
+          "losses": 2,
+          "ties": 0
         }
       },
       "currentName": "Computer Jocks",
@@ -5157,6 +6397,101 @@
           "week": 9,
           "score": 48.2,
           "sourceFranchiseId": null
+        },
+        "biggestBlowoutWin": {
+          "year": 2019,
+          "week": 6,
+          "score": 132.03,
+          "opponentScore": 73.43,
+          "opponentFranchiseId": "0002",
+          "margin": 58.599999999999994,
+          "sourceFranchiseId": null
+        },
+        "biggestBlowoutLoss": {
+          "year": 2025,
+          "week": 7,
+          "score": 93.99,
+          "opponentScore": 157.21,
+          "opponentFranchiseId": "0009",
+          "margin": 63.22000000000001,
+          "sourceFranchiseId": null
+        }
+      },
+      "headToHead": {
+        "0008": {
+          "wins": 3,
+          "losses": 9,
+          "ties": 0
+        },
+        "0007": {
+          "wins": 4,
+          "losses": 4,
+          "ties": 0
+        },
+        "0005": {
+          "wins": 6,
+          "losses": 6,
+          "ties": 0
+        },
+        "0009": {
+          "wins": 2,
+          "losses": 4,
+          "ties": 0
+        },
+        "0003": {
+          "wins": 4,
+          "losses": 6,
+          "ties": 0
+        },
+        "0001": {
+          "wins": 3,
+          "losses": 5,
+          "ties": 0
+        },
+        "0010": {
+          "wins": 1,
+          "losses": 6,
+          "ties": 0
+        },
+        "0002": {
+          "wins": 3,
+          "losses": 3,
+          "ties": 0
+        },
+        "0012": {
+          "wins": 2,
+          "losses": 5,
+          "ties": 0
+        },
+        "0004": {
+          "wins": 2,
+          "losses": 5,
+          "ties": 0
+        },
+        "0011": {
+          "wins": 0,
+          "losses": 7,
+          "ties": 0
+        },
+        "0013": {
+          "wins": 2,
+          "losses": 4,
+          "ties": 0
+        },
+        "0006": {
+          "wins": 1,
+          "losses": 5,
+          "ties": 0
+        },
+        "0015": {
+          "wins": 2,
+          "losses": 4,
+          "ties": 0
+        },
+        "0016": {
+          "wins": 3,
+          "losses": 3,
+          "ties": 0
         }
       },
       "currentName": "Cowboy Up",
@@ -5363,6 +6698,101 @@
           "week": 8,
           "score": 42.61,
           "sourceFranchiseId": null
+        },
+        "biggestBlowoutWin": {
+          "year": 2020,
+          "week": 7,
+          "score": 155.1,
+          "opponentScore": 100.91,
+          "opponentFranchiseId": "0001",
+          "margin": 54.19,
+          "sourceFranchiseId": null
+        },
+        "biggestBlowoutLoss": {
+          "year": 2023,
+          "week": 3,
+          "score": 89.66,
+          "opponentScore": 176.9,
+          "opponentFranchiseId": "0013",
+          "margin": 87.24000000000001,
+          "sourceFranchiseId": null
+        }
+      },
+      "headToHead": {
+        "0004": {
+          "wins": 6,
+          "losses": 4,
+          "ties": 0
+        },
+        "0008": {
+          "wins": 3,
+          "losses": 4,
+          "ties": 0
+        },
+        "0007": {
+          "wins": 4,
+          "losses": 3,
+          "ties": 0
+        },
+        "0016": {
+          "wins": 1,
+          "losses": 5,
+          "ties": 0
+        },
+        "0015": {
+          "wins": 3,
+          "losses": 2,
+          "ties": 0
+        },
+        "0009": {
+          "wins": 2,
+          "losses": 4,
+          "ties": 0
+        },
+        "0014": {
+          "wins": 4,
+          "losses": 1,
+          "ties": 0
+        },
+        "0012": {
+          "wins": 1,
+          "losses": 5,
+          "ties": 0
+        },
+        "0010": {
+          "wins": 2,
+          "losses": 4,
+          "ties": 0
+        },
+        "0001": {
+          "wins": 3,
+          "losses": 2,
+          "ties": 0
+        },
+        "0013": {
+          "wins": 3,
+          "losses": 5,
+          "ties": 0
+        },
+        "0005": {
+          "wins": 1,
+          "losses": 5,
+          "ties": 0
+        },
+        "0011": {
+          "wins": 6,
+          "losses": 4,
+          "ties": 0
+        },
+        "0002": {
+          "wins": 2,
+          "losses": 2,
+          "ties": 0
+        },
+        "0003": {
+          "wins": 3,
+          "losses": 2,
+          "ties": 0
         }
       },
       "currentName": "Music City Mafia",
@@ -5446,6 +6876,101 @@
           "week": 8,
           "score": 45.96,
           "sourceFranchiseId": null
+        },
+        "biggestBlowoutWin": {
+          "year": 2025,
+          "week": 9,
+          "score": 137.8,
+          "opponentScore": 81.25,
+          "opponentFranchiseId": "0016",
+          "margin": 56.55000000000001,
+          "sourceFranchiseId": null
+        },
+        "biggestBlowoutLoss": {
+          "year": 2025,
+          "week": 14,
+          "score": 78.26,
+          "opponentScore": 144.74,
+          "opponentFranchiseId": "0011",
+          "margin": 66.48,
+          "sourceFranchiseId": null
+        }
+      },
+      "headToHead": {
+        "0009": {
+          "wins": 1,
+          "losses": 0,
+          "ties": 0
+        },
+        "0008": {
+          "wins": 1,
+          "losses": 0,
+          "ties": 0
+        },
+        "0014": {
+          "wins": 0,
+          "losses": 2,
+          "ties": 0
+        },
+        "0006": {
+          "wins": 1,
+          "losses": 1,
+          "ties": 0
+        },
+        "0011": {
+          "wins": 0,
+          "losses": 2,
+          "ties": 0
+        },
+        "0003": {
+          "wins": 0,
+          "losses": 1,
+          "ties": 0
+        },
+        "0013": {
+          "wins": 1,
+          "losses": 1,
+          "ties": 0
+        },
+        "0010": {
+          "wins": 0,
+          "losses": 1,
+          "ties": 0
+        },
+        "0001": {
+          "wins": 0,
+          "losses": 1,
+          "ties": 0
+        },
+        "0002": {
+          "wins": 0,
+          "losses": 1,
+          "ties": 0
+        },
+        "0007": {
+          "wins": 0,
+          "losses": 1,
+          "ties": 0
+        },
+        "0016": {
+          "wins": 1,
+          "losses": 0,
+          "ties": 0
+        },
+        "0012": {
+          "wins": 0,
+          "losses": 1,
+          "ties": 0
+        },
+        "0015": {
+          "wins": 0,
+          "losses": 1,
+          "ties": 0
+        },
+        "0005": {
+          "wins": 0,
+          "losses": 2,
+          "ties": 0
         }
       },
       "currentName": "Dead Cap Walking",

--- a/docs/plans/franchise-history-phases.md
+++ b/docs/plans/franchise-history-phases.md
@@ -1,0 +1,199 @@
+# Franchise History — Phases 2-5 Plan
+
+## Context
+
+Phase 1 (`/theleague/franchises` index + `/theleague/franchises/[id]` detail pages) shipped in PR #177 and PR #181. This doc captures everything that was deferred so a future session can resume cleanly without re-discovering the data shapes or design decisions.
+
+## What's already built (don't redo)
+
+- **Aggregation pipeline:** `scripts/compute-franchise-history.mjs` runs in prebuild (`pnpm compute:franchise-history`) and writes `data/theleague/derived/franchise-history.json`. It walks every year of MFL feeds 2007-present and emits per-franchise career stats, year-by-year tables, championships, division titles, MVPs, Jerry Jones, Brock Osweiler, single-game highlights, biggest blowouts, and **a full head-to-head ledger** (the data backbone Phase 2 needs).
+
+- **Backfill workflow:** `.github/workflows/backfill-historical-feeds.yml` (manual `workflow_dispatch`) re-fetches gap years from MFL — already used to recover 2007, 2009, 2011 + schedule + per-week weeklyResults across the full 20-year history. Run it again whenever historical data drifts.
+
+- **`scripts/backfill-historical-feeds.mjs`** — per-endpoint refetcher; picks any missing/invalid file per year and pulls it. Add `--force` to refetch everything.
+
+- **Hand-curated `data/theleague/championship-history.json`** — covers 2007-2025 because MFL retired pre-2020 bracket winners. Aggregation prefers MFL when present, falls back to this file.
+
+- **`src/data/theleague.config.json`** — every franchise's name, banner, division, color, full `history` array (including all the pre-2012 owner transitions we audited in PR #181), and `ownerHistory` for cross-franchise stints (currently just franchise 0011's 2010-2015 detour onto 0010).
+
+- **`currentOwnerSince` inference** in the aggregation script — derives the current owner's first year from `ownerHistory` or by walking back the `history` array until names stop matching. Filters former-owner years out of every franchise page.
+
+- **Detail page features:** hero with crown overlay for champions, badges bar, quick stats, biggest blowout / loss highlight cards, points-by-season bar chart, awards honor roll, era history with sticky-thead scrollable year-by-year tables, local icon resolver that maps row identity names to current franchise icons.
+
+## Open data needs (block on Brandon)
+
+| Need | Why | Format I'm expecting |
+|---|---|---|
+| **Owner names** — franchise → human name per era | Phase 2 rivalry pages will read better with names; Phase 3 badges like "Roger Tormentor" need to attach to humans | `data/theleague/owners.json` with `{ "0001": [{name, yearStart, yearEnd}], … }`. Same shape as `ownerHistory` but with human names. |
+| **2007 / 2011 / 2024 / 2026 championship confirmations** | Have all years now from Brandon's audit; just need to keep championship-history.json fresh as new seasons end | Brandon updates the JSON manually each January after the title game |
+
+If owner-name data shows up, the franchise pages should:
+1. Show "Owned by Brandon · since 2010" on the hero
+2. Tag each era card with the owner who held it
+3. On the index "Former Identities" listing, append owner name (e.g. "Heavy Chevy *(Joe)* · 2020-2024")
+
+## Phase 2: Rivalry pages
+
+### Goal
+
+Every pair of franchises gets a permanent URL with shared history. This is the highest-value follow-on because the data is already computed and sitting in `franchise-history.json`.
+
+### Routes
+
+- `/theleague/rivalries/[id1]-vs-[id2]` — H2H detail page. Canonical URL has the smaller franchise ID first. The reverse order should 301 to the canonical.
+- `/theleague/rivalries/` — index showing the full 16×16 matrix.
+
+### Detail page sections (in order)
+
+1. **Hero** — both team banners side-by-side, all-time record between them ("Pigskins lead 17-12"), most-recent meeting, "intensity score" badge if any (computed from playoff meetings + lopsidedness).
+2. **Year-by-year meetings table** — every game between the two: year, week, home/away, scores, winner, regular season vs playoffs flag.
+3. **Highlights** — biggest blowout (largest margin in the rivalry), closest game, highest-scoring matchup, longest winning streak by either side.
+4. **Playoff meetings** — separate sub-list (these usually carry the most lore).
+5. **Trades between them** — every trade involving these two franchises, parsed from `transactions.json` for every year.
+6. **Side-by-side badges** — both franchises' awards bars next to each other (visual comparison).
+
+### Data dependencies
+
+All already in `franchise-history.json`:
+
+- `franchises[id].headToHead[opponentId]` → `{ wins, losses, ties }`
+- For per-meeting detail, we need to walk `weekly-results-raw.json` per year and extract matchups where both `franchise.id` values are the rivalry pair. **This is one extra read in `compute-franchise-history.mjs`** — add a `franchises[id].matchupHistory[opponentId][]` array with `{ year, week, score, opponentScore, isPlayoff }` entries.
+- Trades: parse `data/theleague/mfl-feeds/<year>/transactions.json` filtering by `type=TRADE` and the pair of franchise IDs.
+- Playoff flag for matchups: cross-reference week number against playoff weeks (typically 15-17) — already detectable from `playoff-brackets.json`.
+
+### Auto-detect "named" rivalries
+
+On each franchise's detail page (Phase 1), surface the top 3-5 rivalries by:
+
+- Number of playoff meetings (highest weight)
+- Win-loss closeness (50/50 = high intensity)
+- Total games played
+
+Format as a "Rivals" carousel/strip linking into rivalry pages.
+
+### Deliverables checklist
+
+- [ ] Add `matchupHistory` aggregation to `compute-franchise-history.mjs`
+- [ ] Build `src/pages/theleague/rivalries/[pair].astro` (SSR, like franchise detail)
+- [ ] Build `src/pages/theleague/rivalries/index.astro` with the 16×16 mini-matrix
+- [ ] Add "Rivals" section to franchise detail page linking into rivalry pages
+- [ ] Add nav link under League Reports
+
+## Phase 3: Badge engine
+
+### Goal
+
+Declarative badge rules so new badges can be added without touching the franchise-page render code.
+
+### Architecture
+
+- `src/data/theleague/badges.ts` — array of badge definitions:
+  ```ts
+  type Badge = {
+    id: string;
+    name: string;
+    description: string;
+    icon: string;
+    tier: 'career' | 'season' | 'game' | 'trade' | 'fun';
+    test: (franchise: Franchise, history: FranchiseHistory) => Award[];
+  };
+  ```
+- Each `test` function returns `Award[]` — possibly multiple awards (e.g. one per year qualifying).
+- `compute-franchise-history.mjs` runs every badge against every franchise; writes results to `franchises[id].badges[]`.
+- Detail page renders `franchises[id].badges` grouped by tier.
+
+### Initial badge catalogue (from earlier doc planning)
+
+**Career milestones:** Champion, Runner-Up (already shipped as awards), Playoff appearance count, 100/200/500 all-time wins, decade-long owner.
+
+**Single-season:** Best regular-season record, highest scoring season, perfect division record, comeback (worst-to-first).
+
+**Single-game:** Highest score ever (already in highlights), biggest blowout (already), biggest comeback, lowest winning score, weirdest game.
+
+**Trades:** Trade Steal of the Year (post-hoc by VORP delta), Most Active Trader, Hoarder (no trades 2+ yrs).
+
+**Draft/auction:** Best Draft Class (RoY-weighted), Auction Whale (most spent on a single player), Bust King.
+
+**Quirky/fun:** Roger Tormentor (most rules questions — needs Roger usage data), Schefter Headlines (most posts about you — needs Schefter feed parsing), Underdog Slayer (beat #1 seed as low seed).
+
+## Phase 4: Trade ledger + draft history per franchise
+
+### Goal
+
+Two new sections on each franchise detail page.
+
+### Trade ledger
+
+- Walk `data/theleague/mfl-feeds/<year>/transactions.json` for every year, filter `type=TRADE` involving this franchise.
+- Render a chronological list with each trade's date, partner franchise (linked), every asset gained/lost.
+- Group by year; collapsible by default.
+- Aggregation produces `franchises[id].trades[]` for cheap render.
+
+### Draft history
+
+- Walk `data/theleague/mfl-feeds/<year>/draftResults.json` and `auctionResults.json` for every year.
+- Render every pick the franchise made: round/pick number, player name, salary (if auction), career arc indicator (current contract status if still rostered).
+- Useful sub-stat: best pick by VORP (cross-reference salary + scoring data we already have).
+
+## Phase 5: Schefter milestone integration
+
+### Goal
+
+When a franchise crosses a badge threshold, auto-post to the Schefter feed.
+
+### Hooks
+
+- `compute-franchise-history.mjs` already runs in prebuild + after each backfill.
+- Add a step that diffs the new `franchises[id].badges` against the previous run's snapshot. New badges → emit Schefter posts.
+- Use the existing `scripts/schefter-scan.mjs` style — append to `src/data/theleague/schefter-feed.json`.
+- Phrasing should match the existing voice (see `data/schefter/league-lore.md`). Examples:
+  - First championship: "BRENNAN ROCKS. Pigskins lift the trophy for the first time in 19 years."
+  - 5th title: "DYNASTY STATUS. Bring The Pain ties Dark Magicians for most all-time."
+
+## Phase 1.5 (small wins, before Phase 2)
+
+If we want quick wins before Phase 2:
+
+- **Add owner-name overlays** once the data lands.
+- **Render top 3 rivals** on each franchise detail page as a teaser, even before the rivalry pages exist (just shows the H2H record vs each top rival).
+- **Fix the "Earlier eras" placeholder rendering** — currently shows "Earlier eras" for franchises with pre-config-history years even if those are filtered out. Should suppress the era card if `seasons.length === 0` (already handled, but verify).
+
+## File / data inventory for the next session
+
+```
+scripts/
+  compute-franchise-history.mjs        # main aggregation; extend for matchupHistory + badges
+  backfill-historical-feeds.mjs        # one-shot historical fetcher
+data/theleague/
+  derived/franchise-history.json       # consumed by all franchise/rivalry pages
+  championship-history.json            # hand-curated; update each January
+  mfl-feeds/<year>/
+    standings.json
+    league.json                        # franchise → division mapping per year
+    schedule.json                      # 2026+ matchup pairings (NEW from backfill)
+    weekly-results.json                # scores per week
+    weekly-results-raw.json            # full matchup pairings — KEY for Phase 2
+    playoff-brackets.json              # 2020+ has winners; pre-2020 metadata only
+    transactions.json                  # for Phase 4 trade ledger
+    draftResults.json                  # for Phase 4 draft history
+    auctionResults.json                # 2009+
+src/
+  pages/theleague/franchises/
+    index.astro                        # 16-team grid
+    [id].astro                         # per-franchise detail
+  pages/theleague/rivalries/           # NEW (Phase 2)
+    index.astro
+    [pair].astro
+  data/theleague.config.json           # franchise definitions (history + ownerHistory)
+.github/workflows/
+  backfill-historical-feeds.yml        # manual dispatch — runs the backfill on the cloud
+```
+
+## Tribal knowledge / gotchas
+
+- **MFL retired old yearly leagues** — pre-2020 playoff brackets return metadata only. Backfilling beyond what we already have is a dead end without scraping the HTML pages directly.
+- **`workflow_dispatch` UI requires the YAML on main** — the backfill workflow is on main; the scripts it calls live on the selected branch via the checkout step.
+- **Config history `ownerEra`** field marks when same-owner re-renames should collapse into one display entry (e.g. franchise 0003 Poker→Generals→Poker pre-Maverick all share `ownerEra: 1`).
+- **Same-name continuity** — when a config history entry shares a name with the current top-level, the `currentOwnerSince` walk-back consolidates them automatically. Don't add `ownerEra` for these.
+- **Cross-franchise stints** — only franchise 0011 currently has `ownerHistory` (Midwestside owner held 0010 from 2010-2015). If another franchise's owner ever moved IDs, add an entry to that franchise's `ownerHistory` and the aggregation will follow.
+- **20 years of weekly-results-raw is heavy** — the `data/theleague/derived/franchise-history.json` is ~1.5MB. If it grows unwieldy, split per-franchise into separate files with an index.

--- a/scripts/compute-franchise-history.mjs
+++ b/scripts/compute-franchise-history.mjs
@@ -23,6 +23,7 @@ const ROOT = path.resolve(__dirname, '..');
 const FEEDS_DIR = path.join(ROOT, 'data/theleague/mfl-feeds');
 const SALARIES_DIR = path.join(ROOT, 'data/theleague');
 const LEAGUE_CONFIG_PATH = path.join(ROOT, 'src/data/theleague.config.json');
+const CHAMPIONSHIP_HISTORY_PATH = path.join(ROOT, 'data/theleague/championship-history.json');
 const OUTPUT_PATH = path.join(ROOT, 'data/theleague/derived/franchise-history.json');
 
 const INDIVIDUAL_AWARD_MIN_SALARY = 1_500_000;
@@ -59,6 +60,18 @@ const years = fs
 // --- Load league config for current identities ---
 const leagueConfig = readJson(LEAGUE_CONFIG_PATH);
 const currentTeams = leagueConfig.teams || [];
+
+// Hand-curated championship history for years where MFL's playoff-bracket
+// export has metadata only (2007-2019, plus in-season years where the
+// bracket isn't decided yet). Maps year → { champion, runnerUp } with
+// franchise IDs that owned those slots at the time.
+const championshipHistory = readJson(CHAMPIONSHIP_HISTORY_PATH);
+const championshipManualByYear = new Map();
+if (championshipHistory?.championships) {
+  for (const entry of championshipHistory.championships) {
+    championshipManualByYear.set(entry.year, entry);
+  }
+}
 
 const getIdentityForYear = (franchiseId, year) => {
   const team = currentTeams.find((t) => t.franchiseId === franchiseId);
@@ -434,7 +447,20 @@ for (const year of years) {
   }
 
   // Championship results
-  const champResult = getChampionshipResult(playoffBrackets);
+  // Prefer MFL's bracket data when it has actual franchise winners; otherwise
+  // fall back to the hand-curated championship-history.json. MFL's pre-2020
+  // brackets are metadata-only.
+  let champResult = getChampionshipResult(playoffBrackets);
+  if (!champResult) {
+    const manual = championshipManualByYear.get(year);
+    if (manual?.champion || manual?.runnerUp) {
+      champResult = {
+        champion: manual.champion ?? null,
+        runnerUp: manual.runnerUp ?? null,
+        thirdPlace: manual.thirdPlace ?? null,
+      };
+    }
+  }
   const playoffParticipants = getPlayoffParticipants(playoffBrackets);
 
   // Awards from salaries

--- a/scripts/compute-franchise-history.mjs
+++ b/scripts/compute-franchise-history.mjs
@@ -349,7 +349,13 @@ const ensureFranchise = (id) => {
       careerTies: 0,
       careerPointsFor: 0,
       yearsActive: 0,
-      highlights: { highestSingleGame: null, lowestSingleGame: null },
+      highlights: {
+        highestSingleGame: null,
+        lowestSingleGame: null,
+        biggestBlowoutWin: null,
+        biggestBlowoutLoss: null,
+      },
+      headToHead: {}, // opponentFranchiseId -> { wins, losses, ties }
     });
   }
   return franchiseMap.get(id);
@@ -557,6 +563,79 @@ for (const year of years) {
         }
       });
     });
+  }
+
+  // Head-to-head records + biggest blowouts from weekly-results-raw (which
+  // has matchup pairings — weekly-results.json only has scores).
+  const weeklyRaw = readJson(path.join(yearDir, 'weekly-results-raw.json'));
+  if (Array.isArray(weeklyRaw)) {
+    for (const wkPayload of weeklyRaw) {
+      const weekNum = parseNum(wkPayload?.weeklyResults?.week);
+      const matchups = toArray(wkPayload?.weeklyResults?.matchup);
+      for (const m of matchups) {
+        const fr = toArray(m?.franchise);
+        if (fr.length !== 2) continue;
+        const a = fr[0], b = fr[1];
+        const aId = a?.id, bId = b?.id;
+        const aScore = parseNum(a?.score);
+        const bScore = parseNum(b?.score);
+        if (!aId || !bId) continue;
+        if (aScore === 0 && bScore === 0) continue; // unplayed week
+
+        const aTarget = attributeYear(aId, year);
+        const bTarget = attributeYear(bId, year);
+
+        // Skip games where either side belongs to a former owner (target null).
+        // Each side gets credit independently — even if one franchise's owner
+        // changed mid-season, we still record the other side's H2H + blowout.
+        if (aTarget) {
+          const frA = ensureFranchise(aTarget);
+          // H2H opponent is the OTHER side's source franchise (stable across
+          // owner changes — Phase 2 rivalry pages key off this).
+          if (!frA.headToHead[bId]) frA.headToHead[bId] = { wins: 0, losses: 0, ties: 0 };
+          if (aScore > bScore) frA.headToHead[bId].wins++;
+          else if (aScore < bScore) frA.headToHead[bId].losses++;
+          else frA.headToHead[bId].ties++;
+
+          const margin = aScore - bScore;
+          const game = {
+            year, week: weekNum,
+            score: aScore, opponentScore: bScore,
+            opponentFranchiseId: bId,
+            margin: Math.abs(margin),
+            sourceFranchiseId: aId !== aTarget ? aId : null,
+          };
+          if (margin > 0 && (!frA.highlights.biggestBlowoutWin || margin > frA.highlights.biggestBlowoutWin.margin)) {
+            frA.highlights.biggestBlowoutWin = game;
+          }
+          if (margin < 0 && (!frA.highlights.biggestBlowoutLoss || -margin > frA.highlights.biggestBlowoutLoss.margin)) {
+            frA.highlights.biggestBlowoutLoss = game;
+          }
+        }
+        if (bTarget) {
+          const frB = ensureFranchise(bTarget);
+          if (!frB.headToHead[aId]) frB.headToHead[aId] = { wins: 0, losses: 0, ties: 0 };
+          if (bScore > aScore) frB.headToHead[aId].wins++;
+          else if (bScore < aScore) frB.headToHead[aId].losses++;
+          else frB.headToHead[aId].ties++;
+
+          const margin = bScore - aScore;
+          const game = {
+            year, week: weekNum,
+            score: bScore, opponentScore: aScore,
+            opponentFranchiseId: aId,
+            margin: Math.abs(margin),
+            sourceFranchiseId: bId !== bTarget ? bId : null,
+          };
+          if (margin > 0 && (!frB.highlights.biggestBlowoutWin || margin > frB.highlights.biggestBlowoutWin.margin)) {
+            frB.highlights.biggestBlowoutWin = game;
+          }
+          if (margin < 0 && (!frB.highlights.biggestBlowoutLoss || -margin > frB.highlights.biggestBlowoutLoss.margin)) {
+            frB.highlights.biggestBlowoutLoss = game;
+          }
+        }
+      }
+    }
   }
 
   yearSummaries.push({

--- a/src/data/theleague.config.json
+++ b/src/data/theleague.config.json
@@ -42,11 +42,17 @@
       "groupMe": "/assets/theleague/group-me/da_dangsters.png",
       "history": [
         {
+          "name": "Sabertooths",
+          "abbrev": "SBR",
+          "yearStart": 2007,
+          "yearEnd": 2007
+        },
+        {
           "name": "Degenerates",
           "abbrev": "DEG",
           "icon": "https://theleague.us/images/team_banners/degenerates_icon.png",
           "banner": "https://theleague.us/images/team_banners/degenerates.png",
-          "yearStart": 2012,
+          "yearStart": 2008,
           "yearEnd": 2014
         },
         {
@@ -75,6 +81,18 @@
       "banner": "/assets/theleague/banners/maverick.png",
       "groupMe": "/assets/theleague/group-me/maverick.png",
       "history": [
+        {
+          "name": "Mistakes Were Made",
+          "abbrev": "MWM",
+          "yearStart": 2007,
+          "yearEnd": 2009
+        },
+        {
+          "name": "Georgia Punishers",
+          "abbrev": "GAP",
+          "yearStart": 2010,
+          "yearEnd": 2011
+        },
         {
           "name": "Poker in the Rear",
           "icon": "https://www.theleague.us/images/team_banners/poker_in_the_rear_icon.png",
@@ -249,7 +267,15 @@
       "color": "#e88370",
       "icon": "/assets/theleague/icons/fire_ready_aim.png",
       "banner": "/assets/theleague/banners/fire_ready_aim.png",
-      "groupMe": "/assets/theleague/group-me/fire_ready_aim.png"
+      "groupMe": "/assets/theleague/group-me/fire_ready_aim.png",
+      "history": [
+        {
+          "name": "Acer FC Edge",
+          "abbrev": "ACER",
+          "yearStart": 2007,
+          "yearEnd": 2009
+        }
+      ]
     },
     {
       "franchiseId": "0008",
@@ -281,7 +307,15 @@
       "color": "#5c5c5c",
       "icon": "/assets/theleague/icons/wabbits.png",
       "banner": "/assets/theleague/banners/wabbits.png",
-      "groupMe": "/assets/theleague/group-me/wabbits.png"
+      "groupMe": "/assets/theleague/group-me/wabbits.png",
+      "history": [
+        {
+          "name": "Rolling Rockers",
+          "abbrev": "ROCK",
+          "yearStart": 2007,
+          "yearEnd": 2011
+        }
+      ]
     },
     {
       "franchiseId": "0010",
@@ -301,11 +335,17 @@
       "groupMe": "/assets/theleague/group-me/computer_jocks.png",
       "history": [
         {
+          "name": "Witch City Warlocks",
+          "abbrev": "WCW",
+          "yearStart": 2007,
+          "yearEnd": 2009
+        },
+        {
           "name": "Midwestside Connection",
           "abbrev": "MWSC",
           "icon": "https://theleague.us/images/team_banners/midwestside_icon.png",
           "banner": "https://theleague.us/images/team_banners/midwestside.png",
-          "yearStart": 2012,
+          "yearStart": 2010,
           "yearEnd": 2015
         },
         {
@@ -342,7 +382,7 @@
           "abbrev": "AMIS",
           "icon": "https://theleague.us/images/team_banners/amish_rakefighters_icon.png",
           "banner": "https://theleague.us/images/team_banners/rakefighters.png",
-          "yearStart": 2012,
+          "yearStart": 2007,
           "yearEnd": 2015
         },
         {
@@ -365,7 +405,7 @@
       "ownerHistory": [
         {
           "franchiseId": "0010",
-          "yearStart": 2012,
+          "yearStart": 2010,
           "yearEnd": 2015
         },
         {
@@ -386,7 +426,15 @@
       "color": "#f06abc",
       "icon": "/assets/theleague/icons/vitside_mafia.png",
       "banner": "/assets/theleague/banners/vitside_mafia.png",
-      "groupMe": "/assets/theleague/group-me/vitside_mafia.png"
+      "groupMe": "/assets/theleague/group-me/vitside_mafia.png",
+      "history": [
+        {
+          "name": "BOYZ II MEN",
+          "abbrev": "BOYZ",
+          "yearStart": 2007,
+          "yearEnd": 2010
+        }
+      ]
     },
     {
       "franchiseId": "0013",
@@ -409,7 +457,7 @@
           "abbrev": "SABR",
           "icon": "https://theleague.us/images/team_banners/sabertooths_icon.png",
           "banner": "https://theleague.us/images/team_banners/sabertooths.png",
-          "yearStart": 2012,
+          "yearStart": 2007,
           "yearEnd": 2013
         },
         {
@@ -496,11 +544,17 @@
       "groupMe": "/assets/theleague/group-me/the_dream.png",
       "history": [
         {
+          "name": "Silver Bullets",
+          "abbrev": "SLVR",
+          "yearStart": 2007,
+          "yearEnd": 2010
+        },
+        {
           "name": "Treasure Coast Swamp Bandits",
           "abbrev": "TCSB",
           "icon": "https://theleague.us/images/team_banners/treasure_coast_icon.png",
           "banner": "https://theleague.us/images/team_banners/treasure_coast.png",
-          "yearStart": 2012,
+          "yearStart": 2011,
           "yearEnd": 2013
         },
         {

--- a/src/pages/theleague/franchises/[id].astro
+++ b/src/pages/theleague/franchises/[id].astro
@@ -16,6 +16,14 @@ if (!fr) {
 
 const team = (leagueConfig.teams as any[]).find((t) => t.franchiseId === id);
 
+// franchiseId → display name lookup, used by H2H/blowout opponent labels.
+const franchiseNameLookup: Record<string, string> = Object.fromEntries(
+  (leagueConfig.teams as any[]).map((t) => [
+    t.franchiseId,
+    t.nameMedium ?? t.name ?? t.franchiseId,
+  ])
+);
+
 // Build eras keyed by NAME CHANGES only — config history entries that share
 // the current name (or each other) are banner refreshes, not real eras, so
 // they get merged into one continuous span.
@@ -317,7 +325,7 @@ const formatCurrency = (n: number) => `$${(n / 1_000_000).toFixed(1)}M`;
       </div>
     </section>
 
-    {(fr.highlights?.highestSingleGame || fr.highlights?.lowestSingleGame) && (
+    {(fr.highlights?.highestSingleGame || fr.highlights?.lowestSingleGame || fr.highlights?.biggestBlowoutWin || fr.highlights?.biggestBlowoutLoss) && (
       <section class="highlights">
         <h2>Single-Game Highlights</h2>
         <div class="highlight-grid">
@@ -335,8 +343,63 @@ const formatCurrency = (n: number) => `$${(n / 1_000_000).toFixed(1)}M`;
               <div class="hl-context">Week {fr.highlights.lowestSingleGame.week}, {fr.highlights.lowestSingleGame.year}</div>
             </div>
           )}
+          {fr.highlights.biggestBlowoutWin && (
+            <div class="highlight highlight--win">
+              <div class="hl-label">Biggest Blowout Win</div>
+              <div class="hl-value">+{fr.highlights.biggestBlowoutWin.margin.toFixed(2)}</div>
+              <div class="hl-context">
+                {fr.highlights.biggestBlowoutWin.score.toFixed(1)}–{fr.highlights.biggestBlowoutWin.opponentScore.toFixed(1)}
+                {' vs '}
+                {franchiseNameLookup[fr.highlights.biggestBlowoutWin.opponentFranchiseId] ?? fr.highlights.biggestBlowoutWin.opponentFranchiseId}
+                <br />Week {fr.highlights.biggestBlowoutWin.week}, {fr.highlights.biggestBlowoutWin.year}
+              </div>
+            </div>
+          )}
+          {fr.highlights.biggestBlowoutLoss && (
+            <div class="highlight highlight--loss">
+              <div class="hl-label">Biggest Blowout Loss</div>
+              <div class="hl-value">−{fr.highlights.biggestBlowoutLoss.margin.toFixed(2)}</div>
+              <div class="hl-context">
+                {fr.highlights.biggestBlowoutLoss.score.toFixed(1)}–{fr.highlights.biggestBlowoutLoss.opponentScore.toFixed(1)}
+                {' vs '}
+                {franchiseNameLookup[fr.highlights.biggestBlowoutLoss.opponentFranchiseId] ?? fr.highlights.biggestBlowoutLoss.opponentFranchiseId}
+                <br />Week {fr.highlights.biggestBlowoutLoss.week}, {fr.highlights.biggestBlowoutLoss.year}
+              </div>
+            </div>
+          )}
         </div>
-        <p class="dim small">Single-game data available 2019+</p>
+      </section>
+    )}
+
+    {fr.yearByYear && fr.yearByYear.length > 0 && (
+      <section class="scoring-chart-section">
+        <h2>Points by Season</h2>
+        {(() => {
+          const seasons = [...fr.yearByYear].sort((a: any, b: any) => a.year - b.year);
+          const max = Math.max(...seasons.map((s: any) => s.pointsFor));
+          const min = Math.min(...seasons.map((s: any) => s.pointsFor));
+          const span = max - min || 1;
+          const barWidth = 100 / seasons.length;
+          return (
+            <div class="scoring-chart" role="img" aria-label="Points scored per season">
+              {seasons.map((s: any) => {
+                const heightPct = ((s.pointsFor - min) / span) * 90 + 10;
+                const isChamp = fr.championships.includes(s.year);
+                const isRunnerUp = fr.runnerUps?.includes(s.year);
+                return (
+                  <div
+                    class={`bar ${isChamp ? 'bar--champ' : ''} ${isRunnerUp ? 'bar--runnerup' : ''}`}
+                    style={`height: ${heightPct.toFixed(1)}%; width: ${barWidth.toFixed(2)}%;`}
+                    title={`${s.year}: ${Math.round(s.pointsFor)} pts (${formatRecord(s.wins, s.losses, s.ties)})${isChamp ? ' 🏆' : isRunnerUp ? ' 🥈' : ''}`}
+                  >
+                    <span class="bar-label">{String(s.year).slice(-2)}</span>
+                  </div>
+                );
+              })}
+            </div>
+          );
+        })()}
+        <p class="dim small">Bar height = points-for. 🏆 = championship · 🥈 = runner-up. Hover/tap for season detail.</p>
       </section>
     )}
 
@@ -629,6 +692,50 @@ const formatCurrency = (n: number) => `$${(n / 1_000_000).toFixed(1)}M`;
   .hl-context {
     font-size: 0.8125rem;
     color: var(--text-secondary, #666);
+    line-height: 1.4;
+  }
+  .highlight--win { background: #e6f7e6; }
+  .highlight--win .hl-value { color: #1f5d2d; }
+  .highlight--loss { background: #fff5f3; }
+  .highlight--loss .hl-value { color: #8b2a1f; }
+
+  .scoring-chart-section {
+    margin: 2.5rem 0;
+  }
+  .scoring-chart {
+    display: flex;
+    align-items: flex-end;
+    gap: 2px;
+    height: 180px;
+    padding: 0.5rem 0.25rem 1.5rem;
+    background: var(--surface-2, #f5f5f5);
+    border-radius: 0.5rem;
+  }
+  .bar {
+    background: var(--accent);
+    border-radius: 2px 2px 0 0;
+    position: relative;
+    min-height: 4px;
+    transition: filter 0.15s ease;
+    cursor: default;
+  }
+  .bar:hover { filter: brightness(1.15); }
+  .bar--champ {
+    background: linear-gradient(180deg, #fff3c4 0%, #d4a000 100%);
+    box-shadow: 0 0 0 1px #b58a00;
+  }
+  .bar--runnerup {
+    background: linear-gradient(180deg, #e0e0e0 0%, #888 100%);
+  }
+  .bar-label {
+    position: absolute;
+    bottom: -1.25rem;
+    left: 0;
+    right: 0;
+    text-align: center;
+    font-size: 0.625rem;
+    color: var(--text-tertiary, #888);
+    font-variant-numeric: tabular-nums;
   }
 
   .awards-grid {

--- a/src/pages/theleague/franchises/[id].astro
+++ b/src/pages/theleague/franchises/[id].astro
@@ -24,6 +24,31 @@ const franchiseNameLookup: Record<string, string> = Object.fromEntries(
   ])
 );
 
+// Many older config history entries point at retired theleague.us/
+// mfladdons.com icon URLs that 404. Resolve every year-by-year row to a
+// local /assets icon: prefer one whose franchise NAME matches the row
+// (so a "Midwestside Connection" row rendered for 0011's 2010-2015
+// stint on franchise 0010 still gets the Midwestside icon), otherwise
+// fall back to the row's source franchise per-id icon.
+const normalize = (s: string): string =>
+  (s || '').trim().toLowerCase().replace(/^the\s+/, '').replace(/\s+/g, ' ');
+
+const localIcon = (path: string | undefined): boolean =>
+  !!path && path.startsWith('/assets/');
+
+const nameToIconLookup: Record<string, string> = {};
+for (const t of leagueConfig.teams as any[]) {
+  if (localIcon(t.icon)) nameToIconLookup[normalize(t.name)] = t.icon;
+}
+
+const resolveRowIcon = (s: any): string => {
+  if (localIcon(s.icon)) return s.icon!;
+  const byName = nameToIconLookup[normalize(s.name || '')];
+  if (byName) return byName;
+  const sourceId = s.sourceFranchiseId ?? id;
+  return `/assets/theleague/icons/${sourceId}.png`;
+};
+
 // Build eras keyed by NAME CHANGES only — config history entries that share
 // the current name (or each other) are banner refreshes, not real eras, so
 // they get merged into one continuous span.
@@ -491,6 +516,7 @@ const formatCurrency = (n: number) => `$${(n / 1_000_000).toFixed(1)}M`;
             </div>
           </div>
           {seasons.length > 0 ? (
+            <div class="year-by-year-scroll">
             <table class="year-by-year">
               <thead>
                 <tr>
@@ -507,7 +533,7 @@ const formatCurrency = (n: number) => `$${(n / 1_000_000).toFixed(1)}M`;
                   <tr>
                     <td>{s.year}</td>
                     <td>
-                      {s.icon && <img src={s.icon} alt="" class="row-icon" />}
+                      <img src={resolveRowIcon(s)} alt="" class="row-icon" loading="lazy" />
                       {s.nameMedium || s.name}
                     </td>
                     <td>{formatRecord(s.wins, s.losses, s.ties)}</td>
@@ -521,6 +547,7 @@ const formatCurrency = (n: number) => `$${(n / 1_000_000).toFixed(1)}M`;
                 ))}
               </tbody>
             </table>
+            </div>
           ) : (
             <p class="dim">No games played in this era yet.</p>
           )}
@@ -773,6 +800,25 @@ const formatCurrency = (n: number) => `$${(n / 1_000_000).toFixed(1)}M`;
     padding: 1rem 1.25rem;
     border: 1px solid var(--border, #e5e5e5);
     border-radius: 0.625rem;
+    background: #fff;
+  }
+  .year-by-year-scroll {
+    max-height: 480px;
+    overflow-y: auto;
+    margin: 0 -0.25rem;
+    padding: 0 0.25rem;
+    /* contain scrolling so a fast scroll inside the table doesn't bubble
+       up and start scrolling the page once it hits the boundary */
+    overscroll-behavior: contain;
+    border-radius: 0.375rem;
+    background: #fff;
+  }
+  .year-by-year-scroll thead th {
+    position: sticky;
+    top: 0;
+    background: #fff;
+    z-index: 1;
+    box-shadow: inset 0 -1px 0 var(--border, #ececec);
   }
   .era-header {
     display: flex;


### PR DESCRIPTION
Wraps up Phase 1 of the franchise history feature. PR #177 was merged before these went in.

## What's in this PR

### Highlights & charts
- **Biggest Blowout Win / Loss** highlight cards on the detail page, computed from `weekly-results-raw.json` (now backfilled to 2007). Each shows margin, final score, opponent name, year, week.
- **Points by Season** bar chart — height = points-for, championship years gold-tinted, runner-up years silver. Each bar tooltip shows year + points + record.
- Removed the "Single-game data available 2019+" caveat (no longer true).

### Head-to-head data
- Per-franchise head-to-head record vs every other current franchise computed and exported to `franchise-history.json`. Both `ownerHistory` attribution and the `currentOwnerSince` filter apply, so H2H follows the human owner across franchise-ID changes (Midwestside owner's 2012-2015 games on 0010 land on 0011's H2H ledger). Not yet rendered on the page — this is the data backbone for the Phase 2 rivalry pages.

### Championship backfill
- Hand-curated `data/theleague/championship-history.json` with the league's full title history (2007-2025). Used as fallback when MFL's playoff-bracket export has metadata only — which is true for everything pre-2020. MFL data still wins when both are present.
- Result: 19 championship years tracked, attributed to current owners only:
  - **Bring The Pain (3)**: 2014, 2019, 2020
  - **Fire Ready Aim (3)**: 2010, 2017, 2023
  - **Dark Magicians (2)**: 2007, 2008
  - Wabbits, Computer Jocks, Midwestside, Vitside: 1 each

### Pre-2012 owner transitions
- Added missing history config entries for Acer FC Edge → Fire Ready Aim, Rolling Rockers → Wabbits, BOYZ II MEN → Vitside, Witch City Warlocks → Midwestside era → Computer Jocks, Sabertooths → Gridiron Geeks, Mistakes Were Made / Georgia Punishers → Maverick lineage, Silver Bullets → Treasure Coast → Running Down The Dream, Sabertooths(2007) → Degenerates → Da Dangsters.
- Extended franchise 0011's `ownerHistory` to claim 0010 from **2010**-2015 (was 2012-2015) per Brandon's audit — Midwestside era was 2010+, not 2012+.
- Knock-on effects on career stats:
  - Fire Ready Aim: 17 seasons (was 20). 2007 Acer FC Edge runner-up correctly removed from trophy case.
  - Wabbits: 15 seasons (was 20)
  - Vitside Mafia: 16 seasons (was 20)
  - Midwestside: 14 seasons (was 12) — gained 2010-2011 on 0010
  - All other franchises with no pre-2012 owner change: unchanged

### Detail page polish
- Year-by-year row icons resolve to local `/assets/theleague/icons/` — broken external `theleague.us` / `mfladdons.com` URLs no longer cause placeholder images. The resolver matches the row's identity name (e.g. "Midwestside Connection") to the relevant current franchise's icon, so icons stay accurate even for cross-franchise stints.
- Era cards now have a white background.
- Year-by-year tables wrapped in a `max-height: 480px` `overflow-y: auto` container with sticky thead and `overscroll-behavior: contain` — long histories (Pigskins, Bring The Pain, Wabbits at 15-20 seasons) scroll inside the card instead of pulling the whole page along.

## What's NOT in this PR (deferred)

- **Owner names** — Brandon is going to provide; will plumb through later.
- **Phase 2: Rivalry pages** — the data is in `franchise-history.json` ready to consume.
- **Phase 3+: Badge engine, trade ledger, draft history, Schefter milestone integration** — original phase plan, future work.

## How it was tested

- `pnpm compute:franchise-history` re-runs cleanly; produces 16 franchises × 20 years scanned × 19 championship years.
- `pnpm exec astro dev` — verified rendering for franchise pages 0001, 0002, 0003, 0004, 0007, 0008, 0009, 0010, 0011, 0012, 0015. All highlight cards, bar charts, era sections, scrollable tables, and resolved icons render as expected.
- Vitest baseline: same 10 pre-existing failures as `main`, no new failures.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mx96c6BYJe2gLQNXGamHcp)_