### PR TITLE
docs: feature plans — power rankings, schedule strength, smack talk, trade speculation, cap projection

### DIFF
--- a/docs/plans/cap-projection-gap-analysis.md
+++ b/docs/plans/cap-projection-gap-analysis.md
@@ -1,0 +1,75 @@
+# Cap Projection — Gap Analysis vs. Idea #13
+
+## Original idea
+
+Multi-year cap simulator where you toggle extensions, cuts, and tags and see resulting cap space across the next 3 seasons.
+
+## What the rosters page already does
+
+Audited `src/pages/theleague/rosters.astro` and the supporting components. Current capabilities:
+
+| Capability | Where | Notes |
+|---|---|---|
+| Per-team **2026 cap projection** | `TeamCapAnalysis.astro` | Single year, all 16 teams, championship windows |
+| **Veteran extension candidates** | `VeteranExtensionCandidates.astro` (in League Planner section) | Lists eligible players + extension cost per year, doesn't simulate scenarios |
+| **Free-agent needs** analysis | `FreeAgentNeedsCard.astro` + `analyzeFreeAgentNeeds` util | Per-position needs vs roster, single year |
+| **Budget Planner** with what-if scenarios | `BudgetPlannerPanel.astro` | Auction-prep, target lists, scenario buttons (Aggressive / Conservative / Balanced) but **single year** |
+| **Draft picks** for 2026 + 2027 | `DraftCapitalTable.astro` | Reference data, not interactive |
+| **Multi-year cap impact for a TRADE** | `MultiYearCapTable.tsx` (in Trade Builder, not roster page) | Shows cap delta across N years for one specific proposed trade |
+| **Salary escalation** (10% annual) | Embedded in roster calcs | Applied automatically to multi-year contracts |
+| **Cap opportunity cost** | `cap-opportunity-cost.md` (docs); calc helpers exist | Used in trade analysis |
+
+## Gap vs. the original idea
+
+The existing tooling is mostly **single-year + reactive**. The idea was **multi-year + proactive scenario planning**. Specific gaps:
+
+1. **No 3-year side-by-side cap projection on the roster page itself.**
+   The MultiYearCapTable component exists for trades, but the rosters page only displays 2026 numbers. An owner planning their off-season can't see 2027/2028 implications without running individual trades.
+
+2. **No "what if I extend everyone eligible" toggle.**
+   VeteranExtensionCandidates lists candidates but you can't click a checkbox to apply the extension and watch your 2027/2028 cap re-compute.
+
+3. **No "what if I cut player X today" simulation.**
+   Roster shows the cut would generate dead money, but doesn't fold that into the multi-year cap projection.
+
+4. **No "what if I franchise-tag player Y" simulation.**
+   FranchiseTagPanel exists but isn't wired into a multi-year cap projection view.
+
+5. **No saved scenarios.**
+   You can fiddle in the BudgetPlanner (single year), but you can't save "scenario A: aggressive cut + extend top 3" vs "scenario B: hoard cap, let everyone walk" and compare them side-by-side.
+
+6. **No comp-pick projection** when an FA walks.
+   The roster shows projected free agents but doesn't say "if you let this guy walk, here's the comp pick you'd get and when."
+
+7. **No "your team vs rival X" side-by-side projection.**
+   Useful for trade leverage and championship-window analysis. Lives in TeamCapAnalysis as 16 separate cards, not pairwise compare.
+
+## Recommendation
+
+Treat #13 as a **set of small follow-up enhancements to the existing planner section**, not a new page. Most of the data pipes already exist — the work is mostly UI wiring.
+
+### Phase 1 (highest value, lowest effort)
+
+- **Add 3-year cap projection table** to the existing TeamCapAnalysis card. Display 2026 / 2027 / 2028 columns side-by-side. Reuse `MultiYearCapTable.tsx` data shape and salary escalation logic.
+
+### Phase 2 (interactive scenario toggles)
+
+- **Add toggle UI to VeteranExtensionCandidates** so each row has an "apply extension" checkbox. Toggling re-runs the multi-year cap projection in place.
+- **Same toggle for cuts** — each rostered player gets a "simulate cut" checkbox.
+- **Same for franchise tags** — FranchiseTagPanel toggles flow into the projection.
+
+### Phase 3 (saved scenarios)
+
+- **Scenario save/load** in the planner. Each scenario is a named bag of toggles (cut/extend/tag selections). Stored in localStorage initially, then in the existing `data/<league>/contract-declarations.json` if Brandon wants commish-visibility.
+- **Side-by-side compare:** pick two saved scenarios, see cap projection delta across 3 years.
+
+### Phase 4 (comp picks + rivals)
+
+- **Comp-pick projection** — when an FA walks in a scenario, project the comp pick (round + year) per the league rule.
+- **Pairwise team compare** — pick two teams, see their 3-year cap projections side-by-side.
+
+## Open questions
+
+- Confirm with Brandon: is the 3-year projection (idea #13) genuinely missing, or did he expect the existing single-year planner to cover this and found it sufficient? Quick chat before scoping further.
+- Salary escalation rule: 10% annual is current — confirm that applies to all contract types (extensions, FA contracts, draft picks).
+- Comp pick formula: should be in the constitution (`docs/claude/league-rules.md`); the projection logic must match exactly.

--- a/docs/plans/schedule-strength-dashboard.md
+++ b/docs/plans/schedule-strength-dashboard.md
@@ -1,0 +1,102 @@
+# Schedule Strength Dashboard
+
+## Context
+
+Brandon wants a single page that shows **remaining-schedule difficulty for every franchise**, updated weekly. The point: see at a glance who has the easy run-in to the playoffs and who has a buzz-saw ahead of them. This is read-only analytics, not interactive — like the standings page, refreshes once per week.
+
+## Route
+
+`/theleague/schedule-strength` — single page, current season, current week.
+
+Year selector for past seasons (read-only historical strength once known).
+
+## Data sources
+
+All on disk:
+
+- `data/theleague/mfl-feeds/<year>/schedule.json` — per-week H2H pairings (just backfilled across all 20 years)
+- `data/theleague/mfl-feeds/<year>/weekly-results.json` — completed weeks' actual scores
+- `data/theleague/mfl-feeds/<year>/standings.json` — current records
+- `data/theleague/derived/franchise-history.json` — multi-year ppg, optionally factor in opponent rolling form
+- `data/theleague/mfl-feeds/<year>/projectedScores.json` — MFL projections (forward-looking)
+
+## Three views to surface
+
+### 1. Remaining-schedule strength (the headline)
+
+For each franchise, compute the **average opponent strength** over their remaining weeks.
+
+Opponent strength = composite of:
+- 50% opponent's current points-per-game (this season)
+- 25% opponent's all-play record (luck-adjusted)
+- 25% opponent's last-3-week rolling ppg (recent form)
+
+Output is a per-franchise score on a 0-100 scale (or rendered as a difficulty rating: ★ to ★★★★★). Rank franchises by remaining-schedule difficulty.
+
+### 2. Past schedule strength (already-known)
+
+Same composite but applied to the **already-played** weeks. Shows who had a friendly run-in vs who was in a meat grinder. This explains why a 3-5 team might actually be one of the better squads in the league.
+
+### 3. Week-by-week heat map
+
+Grid: 16 franchises × remaining weeks. Each cell = the opponent's difficulty rating for that week, color-coded green (easy) → red (brutal). Lets owners scan their own row to see which weeks to lock in their best lineups for.
+
+## Page structure
+
+```
+Hero
+  Title: "Schedule Strength · Week 5 · 2026"
+  Subhead: How hard is the rest of the season for each team?
+
+Section 1: "The Run-In" (remaining-schedule rankings)
+  Table: rank | franchise | remaining ppg-avg | difficulty | trend (vs last week)
+  Easy on top, brutal on bottom (or invert — TBD with Brandon)
+
+Section 2: "What They've Been Through" (past-schedule strength)
+  Same table shape, applied to weeks already played
+  Highlight the 3 franchises with the biggest gap between their record and their schedule strength
+    e.g. "Pigskins are 5-0 with the easiest schedule" or "Bring The Pain are 1-4 against the hardest"
+
+Section 3: Week-by-week heat map
+  16 rows × N columns (one per remaining week)
+  Color: green (easy) → yellow → red (brutal)
+  Click a cell → opponent's franchise page
+
+Section 4: "Soft spots" — single-week heat map of league-average difficulty
+  Identifies "trap weeks" where multiple top teams have hard matchups simultaneously
+```
+
+## Generation pipeline
+
+`scripts/compute-schedule-strength.mjs` runs in prebuild + after each weekly roster sync:
+
+1. Load schedule.json + standings.json + weekly-results.json for current year
+2. For each franchise:
+   - Get remaining weeks' opponents from schedule.json
+   - Compute opponent composite strength (ppg + all-play + rolling form)
+   - Average across remaining weeks → difficulty score
+   - Same calculation for played weeks → past difficulty
+   - Generate heat-map row of per-week difficulties
+3. Write `data/theleague/derived/schedule-strength-<year>-<week>.json`
+4. Page reads the latest file
+
+## Cadence
+
+- Update Tuesday morning (same as the weekly power rankings — both depend on settled stats)
+- Backfill historical: for any past completed season, generate the final schedule-strength data once and cache forever
+
+## Phasing
+
+| Phase | Scope | Effort |
+|---|---|---|
+| 1 | Composite-strength algorithm + remaining-schedule ranked table (sections 1 + 2). | 1 day |
+| 2 | Week-by-week heat map (section 3) | 0.5 day |
+| 3 | Trap-week aggregate (section 4) + tooltip details | 0.5 day |
+| 4 | Year selector + historical backfill | 0.5 day |
+
+## Open questions
+
+- **Is "difficulty" easy-on-top or hard-on-top?** UX-wise easy-on-top is more legible (the team in front is the cushy one). Hard-on-top reads more like a ranking.
+- **Strength composite weights** — those are first-pass guesses. Worth tuning against historical seasons (does our model predict actual outcomes for 2025?).
+- **How much does projection data help?** If MFL's projectedScores has next-week numbers, we could blend in projection-based strength too. Worth A/B testing.
+- **Visibility:** public to all owners or admin-only? Probably public — competitive intel that owners can act on.

--- a/docs/plans/schefter-smack-talk.md
+++ b/docs/plans/schefter-smack-talk.md
@@ -1,0 +1,147 @@
+# Schefter Smack Talk Hooks
+
+## Context
+
+Schefter already drops a **Friday tips digest** (all outstanding tips from the rumor box, posted to GroupMe weekly). Owners love it — it's been the best smack-talk fuel in the league. This doc catalogues additional smack-talk content angles Schefter can bake into his posts to keep the heat on.
+
+Goal: more reasons for owners to react in the GroupMe. Smack talk drives engagement, engagement drives the league.
+
+## Voice rules (preserve)
+
+- Schefter is **deadpan-confident**, never sneering. He's reporting what he's heard.
+- Always uses **named honors as if they're real**: Jerry Jones Award, Brock Osweiler Award (per `data/schefter/league-lore.md`).
+- Never invents player or franchise names.
+- Caps sarcasm — let the facts (cost-per-point, dead money, point differentials) do the cutting.
+- One award/jab per post max — stacking kills the bit.
+
+## Smack talk angle bank
+
+### 1. "Receipts" callbacks
+
+Schefter remembers what owners said. Reference past brags, predictions, or hot takes from the GroupMe and call them out when reality breaks the other way.
+
+> *Two weeks after Music City declared they were "the most dangerous team in the league," they sit 1-4 with the worst points-against and a Brock Osweiler-tier contract on Cooper Kupp. Sources unavailable for comment.*
+
+Implementation: tap the GroupMe message archive (we already sync it in `data/schefter/groupme-archive/` — verify) and extract owner brags via keyword + sentiment. Pin them with context for later callback when the team underperforms.
+
+### 2. Cap-shaming
+
+When an owner makes a roster move that aligns the cap badly, Schefter calls it out by referencing existing awards.
+
+> *Computer Jocks just declared $4M of dead cap on a Day-1 cut. That's Jerry Jones leaderboard energy.*
+
+> *That Drake London extension is now in Brock Osweiler territory. $/point at $14.5M is heading the wrong way.*
+
+Already partially implemented in the rumor-mill bucket logic — extend it to surface in regular Schefter posts, not just rumor responses.
+
+### 3. Standings shade
+
+Weekly Tuesday Power Rankings (separate plan) gives the prime venue, but smaller jabs can drop in mid-week.
+
+> *Bring The Pain are 5-0 against the easiest schedule in the league per our Schedule Strength dashboard. The good news: their next 4 opponents are top-5 in points-for. The bad news: Brandon hasn't said anything to Bring The Pain about it yet.*
+
+Pulls schedule-strength data + GroupMe activity to set up the burn.
+
+### 4. "What if" trade comparisons
+
+When a trade goes down, Schefter retrospectively compares it to similar past trades in TheLeague history (we now have 20 years of `transactions.json`).
+
+> *Tonight's Pigskins-Wabbits trade — Saquon for a 2027 1st and a bench piece — is the most lopsided 1-for-2 swap in TheLeague since the 2018 Devil Dogs deal that aged like milk. (Devil Dogs lost the championship a year later.)*
+
+Needs the Phase 4 trade ledger groundwork first; smack talk emerges naturally from the historical comparisons.
+
+### 5. Streak watch
+
+Track ongoing streaks and call them out when they reach milestones:
+
+- **Win streak** — "Fire Ready Aim has won 4 straight. The last team to start 4-0? The 2010 Acer FC Edge — and we know how that ended (champion, 0-1 in Schefter callbacks)."
+- **Loss streak** — *"Cowboy Up dropped their fifth straight. Last 5-game skid in the league: 2024 Maverick. They missed the playoffs by 0.4 points."*
+- **Bench-blunder streak** — "Music City has left more than 30 points on their bench in 3 consecutive weeks. That's a Brock Osweiler-grade lineup process."
+- **All-play loser streak** — "Vitside is 0-4 in all-play despite a 3-1 record. Math says regression is coming."
+
+Compute streaks from `weekly-results.json` history. Surface when a streak hits 3+, 5+, 7+.
+
+### 6. "Looking ahead" — divisional drama
+
+Schefter primes upcoming matchups by referencing rivalry stakes.
+
+> *Pigskins-Vitside this Sunday. Pigskins lead the all-time series 17-17. The last 3 meetings have been decided by single digits. Both teams are in the playoff hunt and Vitside hasn't beaten the Pigskins in their last 4 tries.*
+
+Once Phase 2 rivalry pages exist, this writes itself — pull the H2H record and the most recent meetings.
+
+### 7. Rookie report cards
+
+After Week 8, drop a Schefter post grading every team's rookie draft class so far.
+
+> *Wabbits drafted Caleb Williams 1.01 to be a franchise QB and through 8 weeks he's averaging 22.3 PPG. Best rookie investment of the offseason.*
+
+> *Pigskins gambled a 1st on a Day-3 RB project. Through 8 weeks he has 4 touches. The Jerry Jones Award committee has taken notice.*
+
+Pulls from `draftResults.json` + per-week scoring.
+
+### 8. "Trash heap" weekly
+
+A single post highlighting the **3 worst single-week roster decisions** of the past week. Bench points left, dead-money cuts, scoring 50- in a winnable matchup.
+
+> *🗑️ This week's Trash Heap*
+> 1. *Music City: 38 points on the bench in a 4-point loss*
+> 2. *Cowboy Up: started Russell Wilson on bye*
+> 3. *Mavericks: 0 fantasy points from QB1*
+
+Algorithmic, lands every Friday alongside the tips digest.
+
+### 9. Schefter Live Reactions to MFL chat
+
+Already partially implemented (Schefter watches the GroupMe). Extend with:
+
+- React to **owner brag posts** with a lightweight tease ("Bold claim with that $/point heading into Sunday — we'll see").
+- React to **owner complaints about lineup losses** with a relevant historical receipt ("This is the 4th week this season Music City has been on the wrong end of that conversation").
+- React to **trade announcements** with a retrospective grade tied to existing awards.
+
+### 10. End-of-year roast
+
+In Week 18, Schefter publishes a Year in Review with three superlatives per franchise (best moment, worst moment, defining stat). Maximum smack-talk density for the season finale.
+
+## Implementation routes
+
+These ideas don't need a single new endpoint — they slot into existing Schefter generation paths:
+
+| Smack-talk angle | Where it lives |
+|---|---|
+| Receipts callbacks (#1) | `scripts/schefter-rumor-scan.mjs` and `scripts/schefter-scan.mjs` — both already generate posts from triggers; add a "callback" trigger type that watches for hypocrisy |
+| Cap-shaming (#2) | Already in rumor-mill bucket logic — extend to standalone Schefter posts |
+| Standings shade (#3) | New script `scripts/schefter-standings-shade.mjs` runs Wed/Thu after Tuesday Power Rankings publishes |
+| Trade comparisons (#4) | Hook into existing transaction-detection in `schefter-scan.mjs` |
+| Streak watch (#5) | Tuesday Power Rankings article surfaces streaks; standalone alerts when a streak hits a threshold |
+| Looking-ahead matchups (#6) | Friday post (alongside tips digest) — pulls rivalry data |
+| Rookie report cards (#7) | One-time generation, Week 8 + Week 14 |
+| Trash heap weekly (#8) | New Friday script, posts alongside tips |
+| Live reactions (#9) | Extend `scripts/schefter-groupme-listen.mjs` |
+| End-of-year roast (#10) | Existing weekly-recap pipeline; Week 18 special issue |
+
+## Sequencing
+
+Don't implement all ten at once. Suggested order:
+
+1. **Trash Heap weekly** (#8) — low-risk, deterministic, runs alongside the existing Friday tips digest. Smack-talk gold from day 1.
+2. **Streak watch** (#5) — easy to compute, naturally drops into Tuesday Power Rankings.
+3. **Cap-shaming standalone posts** (#2) — extend existing logic, doesn't add new infrastructure.
+4. **Looking-ahead matchups** (#6) — depends on Phase 2 rivalry data.
+5. **Receipts callbacks** (#1) — most engaging but riskiest; needs sentiment + GroupMe archive parsing.
+6. **Trade comparisons** (#4) — depends on Phase 4 trade ledger.
+7. **Rookie report cards** (#7) — can ship anytime.
+8. **End-of-year roast** (#10) — December delivery.
+9. **Live reactions** (#9) — already partial; refine.
+10. **Standings shade** (#3) — wraps after the Power Rankings article is live.
+
+## Smack-talk tone tester
+
+Before any new angle ships, gut-check the generated copy:
+
+- Would a reasonable owner laugh, or feel attacked?
+- Does it punch up (cap mismanagement) rather than down (kicking a player who got injured)?
+- Does it use the canon awards (Jerry Jones / Osweiler) without inventing new ones?
+- Is it ONE jab, or stacked? Stacked = cut.
+- Would Schefter actually say it on TV?
+
+If any answer is no, regenerate.

--- a/docs/plans/schefter-trade-speculation.md
+++ b/docs/plans/schefter-trade-speculation.md
@@ -1,0 +1,147 @@
+# Schefter Trade Speculation Posts (GroupMe)
+
+## Context
+
+Original idea #14 was a "Trade Block Matchmaker" — algorithm that takes everyone's `tradeBait.json` listings and surfaces viable two- and three-way trades. Brandon's reframe: **don't make this an interactive page; turn it into Schefter speculation posts that drop into GroupMe periodically.** Owners will use them for smack talk, jokes, and occasional "wait actually, let's do this" moments.
+
+This is a content-generation feature, not a tool. Output is GroupMe posts (and Schefter feed entries) that read like:
+
+> 🟡 **Schefter sources tell me…** *Pacific Pigskins are circling Wabbits TE Brock Bowers. They're sitting on Russell Wilson and a 2027 2nd, both said to be on the table. Sources note Wilson alone won't move it — there's likely a pick involved.*
+
+The post is **speculation** — not a real trade offer. Built from `tradeBait.json` overlap + cap math + dynasty value diffs. Schefter's voice frames it as a rumor. Owners react in the GroupMe.
+
+## Cadence
+
+Two flavors:
+
+1. **Daily quiet drops** — once a day at a randomized time (1 PM Pacific, ±2hrs jitter) drop ONE speculation post. Keeps the feed alive without being spammy.
+2. **Block-buster Mondays** — every Monday at 11 AM Pacific, drop the **best three-way trade speculation** of the week. This is the marquee one — uses 3-team graph search and surfaces the most absurd-but-mathematically-viable swap.
+
+## Routes / surfaces
+
+- **GroupMe** — main delivery channel (where owners hang out)
+- **Schefter feed** (`/news`) — same post drops into the feed for permanence
+- **Each franchise's detail page** — pinned "Latest Trade Buzz" card in the trade-block section, showing the most recent speculation involving that franchise
+
+## Data sources
+
+All on disk already:
+
+- `data/theleague/mfl-feeds/<year>/tradeBait.json` — explicit player listings owners are shopping. Has been fetched daily for years.
+- `data/theleague/mfl-feeds/<year>/rosters.json` — current roster of each franchise (for cap math + finding match candidates)
+- `data/theleague/mfl-player-salaries-<year>.json` — salaries (cap fit)
+- `data/theleague/derived/franchise-history.json` — recent franchise form (post should reference: are they buyers or sellers?)
+- ADP / KTC / RSP data — dynasty value for matching pieces fairly
+
+## Speculation matching algorithm
+
+`scripts/schefter-trade-speculation.mjs` runs daily:
+
+### Step 1: Build "wants" and "haves"
+
+For each franchise:
+- **Wants** = positions they need (from existing `analyzeFreeAgentNeeds` utility) + players in their division they've been losing to (suggests hole)
+- **Haves** = active `tradeBait.json` listings + roster bench depth at saturated positions
+
+### Step 2: Two-team match search
+
+For each pair (Buyer, Seller):
+- Pick a "have" from Seller (high dynasty value)
+- Find a return package from Buyer's "haves" that:
+  - Hits Seller's "wants"
+  - Is within 15% dynasty-value parity (use ADP/KTC + age curve)
+  - Fits Seller's cap space
+- Score the trade by:
+  - Dynasty fit (how well it serves both sides)
+  - Drama factor (rivals trading > random pair)
+  - Cap-relief drama (does it dump a Brock Osweiler-tier contract?)
+- Top 5 highest-scoring pairs become candidate posts
+
+### Step 3: Three-team match search (Monday only)
+
+Build a graph: every franchise's wants/haves as nodes. Find a 3-cycle where:
+- A trades to B (B wants what A has)
+- B trades to C
+- C trades to A
+- All three have ~equal dynasty value swings
+
+Surface the best one weekly.
+
+### Step 4: Quality gate
+
+Reject any candidate that:
+- Has shown up in actual MFL trade activity in the last 14 days (boring)
+- Has been speculation-posted in the last 30 days (rotation)
+- Has a participant who hasn't logged into the site in 14+ days (dead franchise)
+- Involves a player on IR or with major injury status (insensitive)
+
+### Step 5: Schefter blurb generation
+
+Use Claude API. System prompt enforces:
+- Schefter voice (mirror `data/schefter/league-lore.md`)
+- Speculation framing — "sources tell me", "circling", "kicking the tires", "in talks"
+- Lead with the marquee player; reference cap or pick context as the angle
+- Cap at 3 sentences
+- Never fabricate names of players not in the candidate package
+- Tag both franchises with their `nameMedium` for GroupMe formatting
+
+Sample outputs to aim for:
+
+> 🟡 *Sources tell me Bring The Pain has been kicking the tires on Wabbits WR Drake London. The ask is steep — multiple sources point to Davante Adams and a 2027 1st as the starting point. Pain is short on cap room to absorb London's $14M, so a third team may need to facilitate.*
+
+> 🟢 *Computer Jocks are signaling they want to win now. Sources say they've reached out to Maverick about a Patrick Mahomes / 2027 2nd swap. Maverick is reportedly listening — the pick alone isn't enough but Jocks might be willing to attach a bench piece.*
+
+> 🔴 *Three-team buzz: Pigskins, Vitside, and Music City are reportedly working on a deal that would send Saquon to the Pigskins, Justin Jefferson to Vitside, and a haul of picks to Music City. None of the three have confirmed but sources say the framework is real.*
+
+Color emojis for tier:
+- 🔴 Three-team mega-deal (Mondays only)
+- 🟡 Two-team blockbuster (high dynasty value)
+- 🟢 Two-team value pick-up (depth move)
+
+### Step 6: Posting
+
+- Append to `src/data/theleague/schefter-feed.json` with `type: "trade-speculation"` and the franchises involved
+- Post to GroupMe via the existing `scripts/schefter-groupme-listen.mjs` posting hook (or its underlying primitive — check current pattern). Include a deep link back to a specific Schefter feed post URL.
+- Mark candidates as "consumed" in a small ledger (`data/theleague/derived/speculation-history.json`) so step 4's rotation gate works.
+
+## Smack-talk hooks built in
+
+The whole point is to bait owners into reacting. The blurbs should include conversational hooks owners can riff on:
+
+- **Reference the rivalry** — "If this goes through, Pigskins-Vitside Week 11 just got spicier."
+- **Reference cap pain** — "Music City would need to cut Brock Osweiler-tier money to fit the salary in."
+- **Reference recent form** — "Coming off a 1-4 stretch, Music City is in pure asset-collection mode."
+- **Tease at insider info** — "One source close to the deal says talks are in the 'mutual interest' phase."
+- **Quote a fictitious agent or scout** — "An NL exec told me, 'this is the kind of move that ends with somebody getting roasted in GroupMe.'" *(meta humor)*
+
+## Operational notes
+
+- **GitHub Actions** — `.github/workflows/schefter-trade-speculation.yml`
+  - Daily cron at 8 PM UTC = 1 PM Pacific (well within league active hours)
+  - Monday cron at 7 PM UTC = noon Pacific for the three-team blockbuster
+  - Both runs commit to main with the new feed entry + speculation-history ledger
+- **Off-season behavior** — speculation actually increases during off-season (auction/draft prep is when trades happen). Don't disable seasonally.
+- **Owner opt-out** — let any franchise mute speculation posts about themselves via a config field (e.g. `theleague.config.json`'s team config: `"speculationMute": true`). For owners who don't want to be public targets.
+
+## Phasing
+
+| Phase | Scope | Effort |
+|---|---|---|
+| 1 | Two-team matching algorithm + Schefter blurb generation + Schefter feed post (no GroupMe yet) | 1.5 days |
+| 2 | GroupMe posting hook + speculation-history ledger for rotation | 0.5 day |
+| 3 | Three-team match search + Monday block-buster cadence | 1 day |
+| 4 | Per-franchise pinned "Latest Trade Buzz" card on detail pages | 0.5 day |
+| 5 | Quality-gate refinements + dynasty-value model tuning against historical real trades | open-ended |
+
+## Risk / failure modes
+
+- **Posting a trade speculation that's offensive or insensitive** — the quality gate must catch IR/injury players. Sentiment review of generated blurbs.
+- **Over-targeting one franchise** — rotation gate prevents posting about the same franchise twice in a 7-day window.
+- **Stale `tradeBait.json`** — if an owner forgets to update their listings, our matching might be irrelevant. Display a "based on listings as of X" footnote on each post.
+- **Owners getting tired of it** — start daily and dial down to 3x/week if signal-to-noise drops.
+
+## Smack-talk ideas the user wants in the feed
+
+(Pulled from Brandon's intent for the Friday tips digest reframe — these belong in the broader Schefter content engine, not just speculation posts. Captured here so we have one source of truth for "what content does Schefter generate.")
+
+See `docs/plans/schefter-smack-talk.md` for the full ideas list.

--- a/docs/plans/tuesday-power-rankings.md
+++ b/docs/plans/tuesday-power-rankings.md
@@ -1,0 +1,145 @@
+# Tuesday Power Rankings — Weekly Article
+
+## Context
+
+Brandon wants a single weekly article — published every **Tuesday morning** during the season — that combines:
+
+- **Power Rankings** (idea #6) — Schefter-voiced rankings of all 16 franchises with one-line takes per team, auto-generated from results + cap health + roster age + recent form.
+- **Weekly Awards** (idea #7) — Stat of the Week, Bench Blunder, Trade of the Week, Cut of Shame, Heater, Cooler, etc.
+- **Standings snapshot** — current divisional + all-play standings at the top.
+
+This becomes the canonical "what happened last week, where do we stand, who's hot, who's not" page that owners read with their morning coffee on Tuesday.
+
+## Why Tuesday?
+
+- Sunday/Monday games complete by Monday night
+- Score corrections and stat fixes settle by Tuesday morning
+- Wednesday is roster-decision day for many owners (waivers, lineup tinkering ahead of TNF)
+- Gives the article a 24-hour reading window before the next news cycle
+
+## Routes
+
+- `/theleague/power-rankings` — current week (defaults to most recent published)
+- `/theleague/power-rankings/[year]/[week]` — permalink to historical issues
+- Index: `/theleague/power-rankings` shows the latest plus a list of prior issues
+
+Re-use the Schefter feed pattern — each issue is a JSON document on disk that the page reads.
+
+## Data shape
+
+`data/theleague/power-rankings/<year>-<week>.json`:
+
+```json
+{
+  "year": 2026,
+  "week": 5,
+  "publishedAt": "2026-10-07T07:00:00-07:00",
+  "headline": "Pigskins surge to #1, Vitside collapses",
+  "lede": "One paragraph in Schefter's voice setting up the week.",
+  "rankings": [
+    {
+      "rank": 1,
+      "franchiseId": "0001",
+      "previousRank": 3,
+      "trend": "up",
+      "blurb": "Three straight wins by 30+. The schedule eases. They're locked in.",
+      "metrics": {
+        "weekScore": 142.5,
+        "regSeason": "4-1",
+        "ppg": 128.4,
+        "capHealth": "tight"
+      }
+    }
+  ],
+  "awards": {
+    "statOfWeek":    { "franchiseId": "0008", "title": "Stat of the Week", "blurb": "..." },
+    "benchBlunder":  { "franchiseId": "0014", "title": "Bench Blunder of the Week", "blurb": "..." },
+    "tradeOfWeek":   { "franchiseId": "0011", "title": "Trade of the Week", "blurb": "..." },
+    "cutOfShame":    { "franchiseId": "0006", "title": "Cut of Shame", "blurb": "..." },
+    "heaterOfWeek":  { "franchiseId": "0007", "title": "Heater (Hot Streak)", "blurb": "..." },
+    "coolerOfWeek":  { "franchiseId": "0015", "title": "Cooler (Cold Streak)", "blurb": "..." },
+    "matchupOfWeek": { "title": "Matchup of the Week", "homeId": "0010", "awayId": "0012", "blurb": "..." }
+  },
+  "standings": {
+    "divisions": [
+      { "name": "Northwest", "teams": [/* franchiseId, w, l, ppg */] }
+    ],
+    "allPlay":   [/* same shape, sorted by all-play */]
+  }
+}
+```
+
+## Generation pipeline
+
+`scripts/generate-power-rankings.mjs`:
+
+1. **Inputs** — for the target `<year, week>`:
+   - `data/theleague/mfl-feeds/<year>/weekly-results.json` (scores)
+   - `data/theleague/mfl-feeds/<year>/weekly-results-raw.json` (matchup pairings — for matchup of the week, biggest blowout)
+   - `data/theleague/mfl-feeds/<year>/standings.json` (records + all-play)
+   - `data/theleague/mfl-feeds/<year>/transactions.json` (cuts, trades for award detection)
+   - `data/theleague/derived/franchise-history.json` (career context for blurbs)
+   - `data/theleague/mfl-player-salaries-<year>.json` (cap health, bench-blunder detection)
+   - Live odds + projections if available for matchup-of-the-week pick
+
+2. **Power ranking algorithm** — composite score per franchise:
+   - 50%: rolling-3-week average points-for
+   - 25%: record above .500
+   - 15%: all-play % (luck-adjusted strength)
+   - 10%: roster health (cap headroom + injury list)
+   - Sort descending; record `previousRank` from the prior week's published JSON for trend arrows.
+
+3. **Award detection** — deterministic signals from feeds:
+   - **Stat of the Week**: highest single-game score across all 16 franchises this week
+   - **Bench Blunder**: largest gap between (actual lineup score) and (optimal lineup) — needs `weekly-results-raw.json` `optimal` field which already exists
+   - **Trade of the Week**: most lopsided trade (by salary delta + dynasty value) executed this week
+   - **Cut of Shame**: highest-salary player cut to make a roster move (or biggest dead-money commit if accrued)
+   - **Heater**: longest active winning streak with margin
+   - **Cooler**: longest active losing streak; or biggest week-over-week ranking drop
+   - **Matchup of the Week**: by current rankings (closest top-half matchup) — picked for the upcoming week
+
+4. **Blurb generation** — call Claude API with system prompt that enforces the Schefter voice (mirror `data/schefter/league-lore.md`). Pass franchise context: career W-L, current streak, recent moves, roster age, cap health. Cap blurbs at one sentence each. Run a quality gate on the output (length, banned phrases, sanity check that no franchise name is invented).
+
+5. **Output** — write JSON to `data/theleague/power-rankings/<year>-<week>.json` and append a Schefter feed post pointing at the article URL.
+
+## Page
+
+`src/pages/theleague/power-rankings/index.astro` (current week) and `[year]/[week].astro` (historical):
+
+- **Hero** — issue headline, week number, published date, lede paragraph
+- **Standings snapshot** — divisional table left, all-play table right
+- **Power Rankings 1-16** — ordered cards with banner, rank number with trend arrow, one-sentence blurb, key metrics row. Click a card to jump to the franchise page.
+- **Awards Grid** — 7 cards (Stat / Bench / Trade / Cut / Heater / Cooler / Matchup) with title, recipient banner + name, blurb.
+- **Footer** — link to prior week, link to next-week stub if not yet published, "Sign up for GroupMe digest" CTA.
+
+## Operational notes
+
+- **GitHub Actions:** `.github/workflows/weekly-power-rankings.yml` — cron `0 14 * * 2` (UTC = 7 AM Pacific Tuesday) during NFL season. Runs `pnpm generate:power-rankings`, commits the new JSON to main, and posts a teaser to GroupMe via the existing schefter-groupme posting pattern.
+- **Off-season:** skip generation. The cron can run year-round but `generate-power-rankings.mjs` should detect off-season weeks and exit cleanly.
+- **Manual override:** `pnpm generate:power-rankings -- --year 2026 --week 5 --regenerate` for ad-hoc regens.
+
+## GroupMe integration
+
+When a new issue ships, post a digest to GroupMe:
+
+> 🏈 **TheLeague Power Rankings — Week 5**
+> #1 Pigskins (↑2) — *"Three straight wins by 30+."*
+> 🏆 Stat of the Week: Bring The Pain dropped 178.4
+> 💸 Cut of Shame: Music City eats $4.2M on a Day-1 cut
+> Read the full breakdown ▸ https://www.theleague.us/power-rankings
+
+## Phasing
+
+| Phase | Scope | Effort |
+|---|---|---|
+| 1 | Generation script + JSON output + page renderer (no LLM blurbs yet — use templated strings). Manually triggered. | 1 day |
+| 2 | Wire LLM blurbs through Claude API with quality gate. | 0.5 day |
+| 3 | GH Action cron + GroupMe digest. | 0.5 day |
+| 4 | Historical backfill — generate retroactive power rankings for past weeks of 2025+ (anything where we have all the source data). | 0.5 day |
+
+## Open questions
+
+- **Voice owner:** Claude Schefter (matches the existing news feed). Confirm with Brandon before shipping.
+- **Tie-breakers in rankings:** if two teams have identical composite scores, rank by previous week's rank to minimize churn. OK?
+- **Should award winners get a Schefter post too,** or only the article itself? Award posts could be too noisy.
+- **Do we publish during playoff weeks** or pivot to bracket coverage? Probably the latter — playoff weeks get a "Bracket Watch" issue instead of standard rankings.


### PR DESCRIPTION
Five planning docs for the next batch of features Brandon picked from the original 17-ideas list. No code in this PR — review the plans, sequence them, and we'll start implementation in a new session.

## What's in here

| File | Idea # | What it plans |
|---|---|---|
| `docs/plans/tuesday-power-rankings.md` | #6 + #7 (combined) | Weekly Tuesday-morning article: power rankings (1-16 with Schefter blurbs + trend arrows) + 7 weekly awards (Stat / Bench Blunder / Trade / Cut of Shame / Heater / Cooler / Matchup) + standings snapshot. Generation pipeline pulls from existing weekly-results-raw, salary, transactions feeds. GroupMe digest on publish. |
| `docs/plans/schedule-strength-dashboard.md` | #10 | Read-only weekly dashboard. Three views: remaining-schedule run-in (ranked), past schedule (already-known), and a 16-row × N-week heat map. Pure aggregation — no LLM. |
| `docs/plans/schefter-smack-talk.md` | #5 reframe | Brandon's existing Friday tips digest is the best smack-talk fuel in the league. Doc adds 10 more Schefter content angles (receipts callbacks, cap-shaming, streak watch, trash heap weekly, rookie report cards, end-of-year roast, etc.) with implementation routes, sequencing, and a tone tester. |
| `docs/plans/schefter-trade-speculation.md` | #14 reframe | Instead of an interactive trade-block matchmaker page, generate periodic Schefter speculation posts to GroupMe and the news feed. Daily quiet drops (1 PM PT) + Monday three-team block-busters. Two- and three-team graph search over `tradeBait.json`, dynasty-value parity gate, rotation ledger to avoid spam. |
| `docs/plans/cap-projection-gap-analysis.md` | #13 audit | The roster page's planner already covers most of #13 but is single-year. Doc lists 7 specific gaps (no 3-year side-by-side, no extension/cut/tag scenario toggles, no saved scenarios, no comp-pick projection, etc.) and recommends a 4-phase incremental rollout that extends existing components rather than building a new page. |

## Decisions to make before implementation

- **Sequence** — which of the five do we ship first? My read on highest-value-lowest-effort:
  1. **Schedule Strength Dashboard** (1-2 days, all data ready, immediately useful)
  2. **Tuesday Power Rankings** (~3 days; depends partly on schedule strength being ready)
  3. **Schefter Trade Speculation** (~3 days; ties into existing Schefter pipeline)
  4. **Cap Projection enhancements** (incremental; can be done in parallel)
  5. **Schefter Smack Talk angles** (each angle is small; cherry-pick which ones)

- **Voice ownership** — Tuesday Power Rankings + speculation posts both need Schefter blurbs via Claude API. OK to use the same prompt/pipeline as the existing rumor-mill?

- **Owner opt-out for speculation** — should `theleague.config.json` get a `"speculationMute": true` field per franchise? Worth confirming with the league before launching.

## Smack talk inline preview

Quick taste of what the smack-talk angles produce, without needing to open the doc:

> *"Two weeks after Music City declared they were 'the most dangerous team in the league,' they sit 1-4 with the worst points-against and a Brock Osweiler-tier contract on Cooper Kupp. Sources unavailable for comment."*

> *🗑️ This week's Trash Heap*
> *1. Music City: 38 points on the bench in a 4-point loss*
> *2. Cowboy Up: started Russell Wilson on bye*
> *3. Mavericks: 0 fantasy points from QB1*

> *"Bring The Pain are 5-0 against the easiest schedule in the league per our Schedule Strength dashboard. Their next 4 opponents are top-5 in points-for. Brandon hasn't said anything to Bring The Pain about it yet."*

Punch-up tone, never punching at injured players, one jab per post max.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mx96c6BYJe2gLQNXGamHcp)_