### PR TITLE
feat: schefter trade speculation — phase 1 (algorithm + feed posts)

### DIFF
--- a/.github/workflows/schefter-trade-speculation.yml
+++ b/.github/workflows/schefter-trade-speculation.yml
@@ -1,0 +1,83 @@
+name: Schefter Trade Speculation
+
+on:
+  schedule:
+    # Daily at 8pm UTC = 1pm Pacific. NFL-calendar-aware cadence (per
+    # scripts/lib/speculation-cadence.mjs) decides whether to actually post —
+    # the cron just gives the scanner a once-a-day chance.
+    - cron: "0 20 * * *"
+    # Extra Monday slot at 7pm UTC = noon Pacific. Phase 1 still uses the
+    # same two-team matcher; the three-team blockbuster lands in Phase 3
+    # but the daily slot already exists so we don't need a workflow change
+    # when that ships.
+    - cron: "0 19 * * 1"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Run without mutating feed/ledger"
+        required: false
+        default: "false"
+
+concurrency:
+  group: schefter-trade-speculation
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  speculate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
+          fetch-depth: 0
+
+      - name: Use Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: npm ci --omit=dev --ignore-scripts || npm install --omit=dev --ignore-scripts
+
+      - name: Refresh trade-bait feed
+        env:
+          MFL_LEAGUE_ID: "13522"
+          MFL_LEAGUE_SLUG: theleague
+        run: node scripts/fetch-trade-bait.mjs
+
+      - name: Run speculation scanner
+        env:
+          SCHEFTER_TRADE_SPECULATION_ENABLED: ${{ vars.SCHEFTER_TRADE_SPECULATION_ENABLED }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
+          UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
+          KV_REST_API_URL: ${{ secrets.KV_REST_API_URL }}
+          KV_REST_API_TOKEN: ${{ secrets.KV_REST_API_TOKEN }}
+          DRY_RUN_INPUT: ${{ github.event.inputs.dry_run }}
+        run: |
+          if [ "$DRY_RUN_INPUT" = "true" ]; then
+            node scripts/schefter-trade-speculation.mjs --dry-run
+          else
+            node scripts/schefter-trade-speculation.mjs
+          fi
+
+      - name: Commit and push feed + ledger updates
+        env:
+          DRY_RUN_INPUT: ${{ github.event.inputs.dry_run }}
+        if: github.event.inputs.dry_run != 'true'
+        run: |
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "No speculation post produced."
+            exit 0
+          fi
+
+          git config user.name "Schefter Bot"
+          git config user.email "actions@users.noreply.github.com"
+          git add src/data/theleague/schefter-feed.json data/theleague/derived/speculation-history.json data/theleague/mfl-feeds
+          git commit -m "chore: schefter speculation — new trade speculation post"
+          git pull --rebase origin main
+          git push

--- a/.github/workflows/schefter-trade-speculation.yml
+++ b/.github/workflows/schefter-trade-speculation.yml
@@ -51,7 +51,6 @@ jobs:
 
       - name: Run speculation scanner
         env:
-          SCHEFTER_TRADE_SPECULATION_ENABLED: ${{ vars.SCHEFTER_TRADE_SPECULATION_ENABLED }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
           UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,19 @@ entries for gotchas that have bitten us and would bite a future session too.
 - **Prebuild:** `scripts/prebuild.mjs` runs build steps + network fetches in
   parallel. Add new build-time fetches there.
 
+## Feature flags — code, not GitHub Actions variables
+
+Do not introduce new `vars.*` references in workflows as feature gates
+(`SCHEFTER_FOO_ENABLED`, etc.). Editing a GitHub variable is never easier
+than editing code in this repo, and the indirection just splits the
+source of truth across two places. To disable a scheduled job, comment
+out (or delete) its `cron:` line. To gate behavior, use a `const` in the
+script itself.
+
+A few legacy vars predate this rule (`SCHEFTER_RUMOR_MILL_ENABLED`,
+`SCHEFTER_TRADE_OFFER_RUMORS_ENABLED`). Don't add more, and prefer
+moving the existing ones into code if you're already touching the file.
+
 ## Roger date-handling gotchas
 
 There are **two** independent code paths named "Roger". Both have hallucinated

--- a/docs/plans/schefter-trade-speculation.md
+++ b/docs/plans/schefter-trade-speculation.md
@@ -79,19 +79,31 @@ Reject any candidate that:
 
 Use Claude API. System prompt enforces:
 - Schefter voice (mirror `data/schefter/league-lore.md`)
-- Speculation framing — "sources tell me", "circling", "kicking the tires", "in talks"
+- **Local-media / fan-chatter framing** — the speculation does NOT come from
+  owners or front offices. It comes from beat writers, talk-radio callers,
+  fan boards, and barstool chatter. Schefter REPORTS on that buzz; he is
+  not relaying a leak from inside either team. Both front offices should be
+  framed as silent or non-committal ("neither front office has commented",
+  "[team] hasn't acknowledged", "this isn't coming from the building").
+- Phrases to lean on: "the talk-radio crowd in [team]-country", "fan boards
+  are floating", "local beat writers have been speculating", "season-ticket
+  holders have been wondering aloud", "a Wednesday call-in show floated".
+- Phrases to AVOID: "sources tell me [team] is shopping/circling", "in talks",
+  "front-office sources" — those imply a leak from inside the team and
+  defeat the framing.
 - Lead with the marquee player; reference cap or pick context as the angle
 - Cap at 3 sentences
 - Never fabricate names of players not in the candidate package
 - Tag both franchises with their `nameMedium` for GroupMe formatting
 
-Sample outputs to aim for:
+Sample outputs to aim for (note the local-media / fan-chatter framing —
+NOT a leak from either team):
 
-> 🟡 *Sources tell me Bring The Pain has been kicking the tires on Wabbits WR Drake London. The ask is steep — multiple sources point to Davante Adams and a 2027 1st as the starting point. Pain is short on cap room to absorb London's $14M, so a third team may need to facilitate.*
+> 🟡 *The talk-radio crowd in Bring-The-Pain country has spent the week chewing on whether Drake London makes sense in their offense. Local boards are floating Davante Adams and a 2027 1st as the kind of return Wabbits would have to consider — neither front office has acknowledged the chatter.*
 
-> 🟢 *Computer Jocks are signaling they want to win now. Sources say they've reached out to Maverick about a Patrick Mahomes / 2027 2nd swap. Maverick is reportedly listening — the pick alone isn't enough but Jocks might be willing to attach a bench piece.*
+> 🟢 *Computer Jocks fan boards have been wondering aloud whether a Patrick Mahomes / 2027 2nd swap with Maverick fits both teams' timelines. The buzz is coming from outside the buildings — Maverick has not commented and Jocks have stayed quiet.*
 
-> 🔴 *Three-team buzz: Pigskins, Vitside, and Music City are reportedly working on a deal that would send Saquon to the Pigskins, Justin Jefferson to Vitside, and a haul of picks to Music City. None of the three have confirmed but sources say the framework is real.*
+> 🔴 *Three-team mock-up making the rounds on Wednesday's regional shows: Saquon to Pigskins, Justin Jefferson to Vitside, and a haul of picks to Music City. All three front offices have stayed silent — this is fan-driven speculation, not a deal anyone's confirmed.*
 
 Color emojis for tier:
 - 🔴 Three-team mega-deal (Mondays only)

--- a/scripts/lib/speculation-budget.mjs
+++ b/scripts/lib/speculation-budget.mjs
@@ -1,0 +1,62 @@
+/**
+ * Speculation Budget Gate — shared rumor-mill / speculation post counter.
+ *
+ * The rumor-mill (`scripts/schefter-rumor-scan.mjs`) writes a daily counter
+ * to Redis at `schefter:rumor:posts_today`, capped at MAX_GLOBAL_POSTS_PER_DAY.
+ * Speculation participates in the same budget so the news feed never gets
+ * more than 3 Schefter-voiced posts in a single PT day.
+ *
+ * Two extra rules layered on top of the raw counter:
+ *
+ *   - MIN_SPACING_MS — speculation can't post within 4 hours of any prior
+ *     Schefter post (rumor or speculation). Mirrors the rumor-mill's spacing
+ *     rule so multiple Schefter beats in the same morning don't blur together.
+ *   - reservesGlobalSlot — only the trade-deadline peak-week cadence may
+ *     exceed the soft cap by RESERVED_PEAK_SLOT (=1). This lets a marquee
+ *     Wednesday-of-deadline-week speculation still ship even if the
+ *     rumor-mill already burned all 3 normal slots.
+ */
+
+export const RUMOR_POSTS_TODAY_KEY = 'schefter:rumor:posts_today';
+export const RUMOR_LAST_POST_TS_KEY = 'schefter:rumor:last_post_ts';
+
+export const MAX_GLOBAL_POSTS_PER_DAY = 3;
+export const RESERVED_PEAK_SLOT = 1;
+export const MIN_SPACING_MS = 4 * 60 * 60 * 1000;
+
+/**
+ * @param {object} args
+ * @param {{ reservesGlobalSlot:boolean }} args.cadence - resolved cadence object
+ * @param {number} args.globalPostsToday - current value of the shared counter
+ * @param {number|null} args.lastPostTs - ms-epoch of last shared post, or null
+ * @param {Date} [args.now]
+ * @returns {{ allowed:boolean, reason?:string, ceiling:number }}
+ */
+export function checkGlobalBudgetGate({ cadence, globalPostsToday, lastPostTs, now = new Date() }) {
+  const ceiling = cadence.reservesGlobalSlot
+    ? MAX_GLOBAL_POSTS_PER_DAY + RESERVED_PEAK_SLOT
+    : MAX_GLOBAL_POSTS_PER_DAY;
+
+  if (globalPostsToday >= ceiling) {
+    return {
+      allowed: false,
+      reason: `posts_today=${globalPostsToday} ≥ ceiling=${ceiling} (${cadence.reservesGlobalSlot ? 'peak-week reservation already used' : 'normal cap'})`,
+      ceiling,
+    };
+  }
+
+  if (lastPostTs) {
+    const age = now.getTime() - Number(lastPostTs);
+    if (age >= 0 && age < MIN_SPACING_MS) {
+      const minutesAgo = Math.round(age / 60000);
+      const minutesNeeded = MIN_SPACING_MS / 60000;
+      return {
+        allowed: false,
+        reason: `last Schefter post was ${minutesAgo}m ago; need ${minutesNeeded}m spacing`,
+        ceiling,
+      };
+    }
+  }
+
+  return { allowed: true, ceiling };
+}

--- a/scripts/lib/speculation-cadence.mjs
+++ b/scripts/lib/speculation-cadence.mjs
@@ -70,8 +70,8 @@ export const CADENCE_LADDER = [
   },
   {
     id: 'regular-season-default',
-    label: 'Regular season default (1 every 2 days)',
-    maxPerDay: 0.5,
+    label: 'Regular season default (1 every 5 days)',
+    maxPerDay: 1 / 5,
     reservesGlobalSlot: false,
     betweenEvents: { startId: 'nfl-season-starts', endId: 'trading-deadline', endOffsetDays: -22 },
   },
@@ -84,8 +84,8 @@ export const CADENCE_LADDER = [
   },
   {
     id: 'quiet-offseason-default',
-    label: 'Quiet offseason (1 every 3 days)',
-    maxPerDay: 1 / 3,
+    label: 'Quiet offseason (1 every 14 days)',
+    maxPerDay: 1 / 14,
     reservesGlobalSlot: false,
     fallback: true,
   },

--- a/scripts/lib/speculation-cadence.mjs
+++ b/scripts/lib/speculation-cadence.mjs
@@ -1,0 +1,221 @@
+/**
+ * Speculation Cadence — calendar-aware daily quota for trade-speculation posts.
+ *
+ * Reads `src/data/theleague/resolved-events.json` and returns the maximum number
+ * of speculation posts to publish on a given calendar day, plus a tag describing
+ * which window we're in. Higher quotas during the week before the trade deadline,
+ * NFL Draft week, the rookie draft, the tagging period, and offseason FA opens.
+ *
+ * Output values are intentionally small. Speculation shares the rumor-mill's
+ * 3-posts-per-day budget (`schefter:rumor:posts_today`) — see
+ * scripts/schefter-trade-speculation.mjs. The cadence quota is the LOCAL cap
+ * for THIS lane; the daily-rumor cap is the global cap.
+ *
+ * The schedule is intentionally tunable as a single CADENCE_LADDER constant.
+ * If Brandon wants a different ramp, change the numbers here, not the matcher.
+ */
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+// Highest priority wins. Each rule looks at the current calendar day and the
+// `resolved-events.json` event list, returns true/false. The first match
+// supplies the day's `maxPerDay` and tag.
+//
+// `maxPerDay` is interpreted as a daily cap for THIS speculation lane only.
+// Fractional caps (e.g. 0.5) mean "1 post every 1/x days" — the runner script
+// honors this by checking the date of the most recent speculation post in the
+// rotation ledger before deciding to publish.
+export const CADENCE_LADDER = [
+  {
+    id: 'trade-deadline-peak-week',
+    label: 'Trade Deadline week (≤7d before)',
+    maxPerDay: 2,
+    reservesGlobalSlot: true, // peak week reserves 1 of the 3 daily rumor slots
+    daysBeforeEvent: { eventId: 'trading-deadline', range: [0, 7] },
+  },
+  {
+    id: 'trade-deadline-ramp',
+    label: 'Trade Deadline ramp (8–21d before)',
+    maxPerDay: 1,
+    reservesGlobalSlot: false,
+    daysBeforeEvent: { eventId: 'trading-deadline', range: [8, 21] },
+  },
+  {
+    id: 'nfl-draft-window',
+    label: 'NFL Draft week (≤7d before through 1d after)',
+    maxPerDay: 1,
+    reservesGlobalSlot: false,
+    daysAroundEvent: { eventId: 'nfl-draft', before: 7, after: 1 },
+  },
+  {
+    id: 'rookie-draft-window',
+    label: 'Rookie Draft week (≤7d before through 1d after)',
+    maxPerDay: 1,
+    reservesGlobalSlot: false,
+    daysAroundEvent: { eventId: 'rookie-draft', before: 7, after: 1 },
+  },
+  {
+    id: 'tagging-period-window',
+    label: 'Tagging period (Feb 1 → tag-matching close)',
+    maxPerDay: 1,
+    reservesGlobalSlot: false,
+    betweenEvents: { startId: 'tagging-period', endId: 'tag-matching-period', endOffsetDays: 14 },
+  },
+  {
+    id: 'fa-opens-window',
+    label: 'Offseason FA opens (±7 days)',
+    maxPerDay: 1,
+    reservesGlobalSlot: false,
+    daysAroundEvent: { eventId: 'offseason-fa-opens', before: 7, after: 7 },
+  },
+  {
+    id: 'regular-season-default',
+    label: 'Regular season default (1 every 2 days)',
+    maxPerDay: 0.5,
+    reservesGlobalSlot: false,
+    betweenEvents: { startId: 'nfl-season-starts', endId: 'trading-deadline', endOffsetDays: -22 },
+  },
+  {
+    id: 'post-deadline-regular-season',
+    label: 'Post-deadline regular season (no in-season trades possible)',
+    maxPerDay: 0,
+    reservesGlobalSlot: false,
+    afterEvent: { eventId: 'trading-deadline', untilEventId: 'league-championship' },
+  },
+  {
+    id: 'quiet-offseason-default',
+    label: 'Quiet offseason (1 every 3 days)',
+    maxPerDay: 1 / 3,
+    reservesGlobalSlot: false,
+    fallback: true,
+  },
+];
+
+/**
+ * Return the calendar-day diff (midnight-to-midnight in PT) between two
+ * timestamps. Positive = `target` is in the future relative to `from`.
+ */
+export function calendarDaysUntil(target, from = new Date()) {
+  const targetDate = new Date(target);
+  const fromDate = new Date(from);
+  // Normalize both to UTC midnight of their PT calendar day. Using the
+  // en-CA YYYY-MM-DD format in the LA tz makes this round-trip clean.
+  const fmt = new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'America/Los_Angeles',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  });
+  const targetDay = new Date(`${fmt.format(targetDate)}T00:00:00Z`).getTime();
+  const fromDay = new Date(`${fmt.format(fromDate)}T00:00:00Z`).getTime();
+  return Math.round((targetDay - fromDay) / DAY_MS);
+}
+
+function findEvent(events, id) {
+  return events.find((e) => e.id === id) ?? null;
+}
+
+function ruleMatches(rule, events, now) {
+  if (rule.fallback) return true;
+
+  if (rule.daysBeforeEvent) {
+    const event = findEvent(events, rule.daysBeforeEvent.eventId);
+    if (!event) return false;
+    const days = calendarDaysUntil(event.startDate, now);
+    const [lo, hi] = rule.daysBeforeEvent.range;
+    return days >= lo && days <= hi;
+  }
+
+  if (rule.daysAroundEvent) {
+    const event = findEvent(events, rule.daysAroundEvent.eventId);
+    if (!event) return false;
+    const days = calendarDaysUntil(event.startDate, now);
+    return days >= -rule.daysAroundEvent.after && days <= rule.daysAroundEvent.before;
+  }
+
+  if (rule.betweenEvents) {
+    const start = findEvent(events, rule.betweenEvents.startId);
+    const end = findEvent(events, rule.betweenEvents.endId);
+    if (!start || !end) return false;
+    const startDays = calendarDaysUntil(start.startDate, now);
+    const endDays = calendarDaysUntil(end.startDate, now) + (rule.betweenEvents.endOffsetDays ?? 0);
+    return startDays <= 0 && endDays >= 0;
+  }
+
+  if (rule.afterEvent) {
+    const start = findEvent(events, rule.afterEvent.eventId);
+    if (!start) return false;
+    const startDays = calendarDaysUntil(start.startDate, now);
+    if (startDays > 0) return false; // event still in future
+    if (rule.afterEvent.untilEventId) {
+      const end = findEvent(events, rule.afterEvent.untilEventId);
+      if (end && calendarDaysUntil(end.startDate, now) < 0) return false;
+    }
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Resolve today's speculation cadence based on the league calendar.
+ *
+ * @param {object} args
+ * @param {Array<{id:string,startDate:string}>} args.events - resolved-events.json `.events`
+ * @param {Date} [args.now] - reference time, defaults to `new Date()`
+ * @returns {{ tag: string, label: string, maxPerDay: number, reservesGlobalSlot: boolean, ladderId: string }}
+ */
+export function resolveCadence({ events, now = new Date() }) {
+  const list = Array.isArray(events) ? events : [];
+  for (const rule of CADENCE_LADDER) {
+    if (ruleMatches(rule, list, now)) {
+      return {
+        tag: rule.id,
+        ladderId: rule.id,
+        label: rule.label,
+        maxPerDay: rule.maxPerDay,
+        reservesGlobalSlot: rule.reservesGlobalSlot,
+      };
+    }
+  }
+  // Defensive: ladder ends with the fallback rule, but if someone re-orders
+  // the ladder accidentally, return zero rather than blow up.
+  return {
+    tag: 'no-rule',
+    ladderId: 'no-rule',
+    label: 'No rule matched',
+    maxPerDay: 0,
+    reservesGlobalSlot: false,
+  };
+}
+
+/**
+ * Decide whether today's cadence permits a fresh post given the rotation
+ * ledger. Handles fractional `maxPerDay` (1 post every N days) by checking
+ * the most recent post timestamp.
+ */
+export function permitsPost({ cadence, postsTodayInLane, lastPostAt, now = new Date() }) {
+  if (!cadence || cadence.maxPerDay === 0) {
+    return { allowed: false, reason: `cadence ${cadence?.tag ?? 'unknown'} bans posts` };
+  }
+  if (cadence.maxPerDay >= 1) {
+    if (postsTodayInLane >= Math.floor(cadence.maxPerDay)) {
+      return { allowed: false, reason: `lane cap ${cadence.maxPerDay}/day already met` };
+    }
+    return { allowed: true };
+  }
+  // Fractional cap (e.g. 1/2 → "every other day", 1/3 → "every 3 days").
+  // Express as "must wait at least (1/maxPerDay - 1) full calendar days
+  // since the most recent post". 1 every 2 days = wait 1 day. 1 every 3
+  // days = wait 2 days.
+  if (!lastPostAt) return { allowed: true };
+  const minCalendarGap = Math.max(0, Math.round(1 / cadence.maxPerDay) - 1);
+  const daysSince = -calendarDaysUntil(lastPostAt, now); // positive = past
+  if (daysSince < minCalendarGap) {
+    return {
+      allowed: false,
+      reason: `fractional cadence ${cadence.maxPerDay.toFixed(2)}/day — wait ${minCalendarGap}d, only ${daysSince}d since last post`,
+    };
+  }
+  return { allowed: true };
+}

--- a/scripts/lib/speculation-history.mjs
+++ b/scripts/lib/speculation-history.mjs
@@ -1,0 +1,131 @@
+/**
+ * Speculation History Ledger — file-backed rotation gate.
+ *
+ * Every time we publish a trade-speculation post we append a row here so the
+ * next run can:
+ *   - Reject candidates that have been speculation-posted in the last 30 days
+ *     (rotation — no spamming the same trade twice in a month)
+ *   - Reject candidates whose participants have BOTH been featured in a
+ *     speculation post in the last 7 days (per-franchise rotation)
+ *   - Track when the last post was published to honor fractional cadences
+ *     (1 every N days windows)
+ *
+ * The ledger lives at `data/theleague/derived/speculation-history.json` and
+ * is committed to the repo by the cron job, the same way schefter-feed.json
+ * is. Old entries are pruned when they age out of the longest window.
+ */
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+const SAME_TRADE_ROTATION_MS = 30 * DAY_MS;
+const SAME_FRANCHISE_ROTATION_MS = 7 * DAY_MS;
+const PRUNE_HORIZON_MS = 35 * DAY_MS;
+
+export const SPECULATION_HISTORY_REL_PATH = path.join(
+  'data',
+  'theleague',
+  'derived',
+  'speculation-history.json',
+);
+
+export function defaultLedgerPath(projectRoot) {
+  return path.join(projectRoot, SPECULATION_HISTORY_REL_PATH);
+}
+
+export async function loadLedger(filePath) {
+  try {
+    const raw = await fs.readFile(filePath, 'utf8');
+    const parsed = JSON.parse(raw);
+    if (!parsed || !Array.isArray(parsed.entries)) {
+      return { version: 1, entries: [] };
+    }
+    return parsed;
+  } catch {
+    return { version: 1, entries: [] };
+  }
+}
+
+export async function saveLedger(filePath, ledger, { now = new Date() } = {}) {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  const pruned = pruneLedger(ledger, now);
+  await fs.writeFile(filePath, JSON.stringify(pruned, null, 2) + '\n');
+  return pruned;
+}
+
+export function pruneLedger(ledger, now = new Date()) {
+  const cutoff = now.getTime() - PRUNE_HORIZON_MS;
+  const entries = (ledger.entries ?? []).filter(
+    (e) => Number(e.postedAt) >= cutoff,
+  );
+  return { version: ledger.version ?? 1, entries };
+}
+
+/**
+ * A "trade signature" is the canonical representation of a candidate trade —
+ * the sorted-and-joined player IDs from both sides plus the franchise pair.
+ * Two candidates with the same signature are the same trade for rotation
+ * purposes.
+ */
+export function tradeSignature({ seller, buyer, marqueeId, returnPkgIds }) {
+  const sellerIds = [String(marqueeId)].sort();
+  const buyerIds = [...returnPkgIds.map(String)].sort();
+  const franchisePair = [String(seller), String(buyer)].sort().join('::');
+  return `${franchisePair}|${sellerIds.join(',')}|${buyerIds.join(',')}`;
+}
+
+export function recentlyPostedTrade(ledger, signature, now = new Date()) {
+  const cutoff = now.getTime() - SAME_TRADE_ROTATION_MS;
+  return (ledger.entries ?? []).some(
+    (e) => e.signature === signature && Number(e.postedAt) >= cutoff,
+  );
+}
+
+export function franchiseInRecentRotation(ledger, franchiseId, now = new Date()) {
+  const cutoff = now.getTime() - SAME_FRANCHISE_ROTATION_MS;
+  const fid = String(franchiseId);
+  return (ledger.entries ?? []).some(
+    (e) =>
+      Number(e.postedAt) >= cutoff &&
+      Array.isArray(e.franchiseIds) &&
+      e.franchiseIds.map(String).includes(fid),
+  );
+}
+
+export function postsToday(ledger, now = new Date()) {
+  // Use PT calendar day so we line up with the rumor-mill counter behavior.
+  const fmt = new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'America/Los_Angeles',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  });
+  const today = fmt.format(now);
+  return (ledger.entries ?? []).filter(
+    (e) => fmt.format(new Date(Number(e.postedAt) || 0)) === today,
+  ).length;
+}
+
+export function lastPostAt(ledger) {
+  let max = 0;
+  for (const e of ledger.entries ?? []) {
+    if (Number(e.postedAt) > max) max = Number(e.postedAt);
+  }
+  return max > 0 ? new Date(max) : null;
+}
+
+export function appendEntry(ledger, entry) {
+  const next = {
+    version: ledger.version ?? 1,
+    entries: [...(ledger.entries ?? []), entry],
+  };
+  return next;
+}
+
+export const __testing__ = {
+  SAME_TRADE_ROTATION_MS,
+  SAME_FRANCHISE_ROTATION_MS,
+  PRUNE_HORIZON_MS,
+};

--- a/scripts/lib/speculation-matching.mjs
+++ b/scripts/lib/speculation-matching.mjs
@@ -33,6 +33,26 @@ function adpRankToValue(rank) {
   return 1;
 }
 
+// Salary-based value fallback. The on-disk MFL adp-dynasty.json only ranks
+// the rookie class — veterans like Lamar Jackson don't appear. Salary is a
+// surprisingly good proxy in this league because contracts have been priced
+// at auction over many seasons, so high salary correlates with high quality.
+//
+// Curve calibrated against actual top-10 salaries ($9–11M for elite skill
+// players, ~$4.5M for the 90th-percentile cutoff, sub-$1M median).
+function salaryToValue(salary) {
+  if (!salary || salary <= 0) return 0;
+  const m = salary / 1_000_000;
+  if (m >= 9) return 95;
+  if (m >= 7) return 80;
+  if (m >= 5) return 65;
+  if (m >= 3) return 48;
+  if (m >= 1.5) return 32;
+  if (m >= 0.75) return 18;
+  if (m >= 0.5) return 10;
+  return 4;
+}
+
 // Age curve — penalize older players at positions that age fast (RB),
 // minor lift for younger players. Returns a multiplier ∈ [0.4, 1.15].
 function ageMultiplier(position, age) {
@@ -55,12 +75,19 @@ function ageMultiplier(position, age) {
 }
 
 /**
- * Calculate a single dynasty value for a player. Combines the ADP-rank curve
- * and the age multiplier. Players outside ADP get a floor (3).
+ * Calculate a single dynasty value for a player. Tries ADP-rank first
+ * (best for rookies), then falls back to a salary-based curve (best for
+ * veterans whose ADP rank isn't published in the rookie-only feed). Age
+ * multiplier applies on top of either.
  */
 export function valuePlayer({ player, adpRankById }) {
   const rank = adpRankById.get(player.id) ?? null;
-  const base = rank ? adpRankToValue(rank) : 3;
+  let base;
+  if (rank) {
+    base = adpRankToValue(rank);
+  } else {
+    base = salaryToValue(player.salary);
+  }
   const mult = ageMultiplier(player.position, player.age);
   return Math.max(0, Math.round(base * mult));
 }
@@ -78,22 +105,62 @@ function isWithinParity(sellerValue, buyerValue) {
 }
 
 /**
- * Sum positions that a franchise has fewer than 3 active rosterable bodies in.
- * That gives a coarse "wants" set — fancy version belongs in Phase 5.
+ * Coarse fixed-threshold variant — kept for unit tests and any caller that
+ * doesn't have league-wide context. Use buildPositionalWantsRelative when
+ * you can pass the per-position league medians.
  */
 export function buildPositionalWants(franchisePlayers) {
-  const counts = { QB: 0, RB: 0, WR: 0, TE: 0 };
-  for (const p of franchisePlayers) {
-    if (p.status !== 'ROSTER') continue;
-    if (counts[p.position] === undefined) continue;
-    counts[p.position] += 1;
-  }
+  const counts = countPositions(franchisePlayers);
   const wants = [];
   if (counts.QB < 2) wants.push('QB');
   if (counts.RB < 4) wants.push('RB');
   if (counts.WR < 5) wants.push('WR');
   if (counts.TE < 2) wants.push('TE');
   return wants;
+}
+
+function countPositions(franchisePlayers) {
+  const counts = { QB: 0, RB: 0, WR: 0, TE: 0 };
+  for (const p of franchisePlayers) {
+    if (p.status !== 'ROSTER') continue;
+    if (counts[p.position] === undefined) continue;
+    counts[p.position] += 1;
+  }
+  return counts;
+}
+
+/**
+ * League-relative variant: a franchise "wants" any position where it sits
+ * at or below the league median minus 1. Computes medians from the league
+ * map. Use this in production — fixed thresholds don't translate across
+ * months because rosters fatten dramatically right after the rookie draft
+ * and trim down again before the August cut.
+ */
+export function buildPositionalWantsRelative(franchisePlayers, leagueMedians) {
+  const counts = countPositions(franchisePlayers);
+  const wants = [];
+  for (const pos of ['QB', 'RB', 'WR', 'TE']) {
+    const median = leagueMedians?.[pos] ?? 0;
+    if (counts[pos] <= median - 1) wants.push(pos);
+  }
+  return wants;
+}
+
+/**
+ * Compute the per-position median count across all franchises.
+ */
+export function computeLeagueMedians(playersByFranchise) {
+  const buckets = { QB: [], RB: [], WR: [], TE: [] };
+  for (const players of playersByFranchise.values()) {
+    const counts = countPositions(players);
+    for (const pos of Object.keys(buckets)) buckets[pos].push(counts[pos]);
+  }
+  const medians = {};
+  for (const pos of Object.keys(buckets)) {
+    const sorted = [...buckets[pos]].sort((a, b) => a - b);
+    medians[pos] = sorted.length ? sorted[Math.floor(sorted.length / 2)] : 0;
+  }
+  return medians;
 }
 
 /**
@@ -214,11 +281,13 @@ export function findTwoTeamCandidates({
   adpRankById,
   teams,
   limit = 5,
+  medians: medianOverride = null,
 }) {
   const franchiseIds = Array.from(playersByFranchise.keys());
   const haves = new Map();
   const wants = new Map();
   const capRoom = new Map();
+  const medians = medianOverride ?? computeLeagueMedians(playersByFranchise);
 
   for (const fid of franchiseIds) {
     const players = playersByFranchise.get(fid) ?? [];
@@ -230,7 +299,7 @@ export function findTwoTeamCandidates({
         adpRankById,
       }),
     );
-    wants.set(fid, buildPositionalWants(players));
+    wants.set(fid, buildPositionalWantsRelative(players, medians));
     capRoom.set(fid, franchiseCapSpace({ franchisePlayers: players }));
   }
 

--- a/scripts/lib/speculation-matching.mjs
+++ b/scripts/lib/speculation-matching.mjs
@@ -1,0 +1,298 @@
+/**
+ * Speculation Matching — turns raw league state into ranked candidate trades.
+ *
+ * Two-team match search (per docs/plans/schefter-trade-speculation.md, §Step 2):
+ *
+ *   For each ordered (Buyer, Seller) pair:
+ *     - Pick a "marquee" piece from Seller's tradeBait listings
+ *     - Find a return package from Buyer's haves that:
+ *         (a) hits at least one of Seller's positional wants
+ *         (b) is within DYNASTY_PARITY_TOLERANCE of Seller's piece in dynasty value
+ *         (c) fits within Seller's remaining cap space
+ *     - Score by dynasty fit + drama + cap-relief drama
+ *
+ * Dynasty value comes from MFL's adp-dynasty.json (rank → curve) tweaked by an
+ * age curve. The curve is intentionally rough — these are SPECULATION posts,
+ * not optimizer output. KTC integration is left for a later phase.
+ */
+
+const DYNASTY_PARITY_TOLERANCE = 0.15;
+const SALARY_CAP = 45_000_000;
+const MIN_MARQUEE_VALUE = 35; // floor on the seller-piece dynasty value worth speculating about
+const TARGET_PACKAGE_MIN = 1;
+const TARGET_PACKAGE_MAX = 3;
+
+// Dynasty-value floor curve. Rank-1 dynasty player = 100. Falls off
+// concave-up so the top 24 stay valuable, then drops fast through ~150.
+function adpRankToValue(rank) {
+  if (!rank || rank <= 0) return 0;
+  if (rank <= 12) return Math.round(100 - (rank - 1) * 1.5); // 100 → 83.5
+  if (rank <= 36) return Math.round(82 - (rank - 12) * 1.7); // 82 → 41
+  if (rank <= 100) return Math.max(8, Math.round(41 - (rank - 36) * 0.45));
+  if (rank <= 200) return Math.max(2, Math.round(12 - (rank - 100) * 0.10));
+  return 1;
+}
+
+// Age curve — penalize older players at positions that age fast (RB),
+// minor lift for younger players. Returns a multiplier ∈ [0.4, 1.15].
+function ageMultiplier(position, age) {
+  if (!age || age <= 0) return 1.0;
+  const pos = (position || '').toUpperCase();
+  const peakWindow = {
+    RB: { peak: 25, falloffStart: 27, multAtFalloff: 0.85, terminalAge: 31 },
+    WR: { peak: 26, falloffStart: 29, multAtFalloff: 0.85, terminalAge: 33 },
+    TE: { peak: 27, falloffStart: 30, multAtFalloff: 0.85, terminalAge: 34 },
+    QB: { peak: 28, falloffStart: 33, multAtFalloff: 0.85, terminalAge: 38 },
+  }[pos];
+  if (!peakWindow) return 1.0;
+  if (age <= peakWindow.peak - 3) return 1.15;
+  if (age <= peakWindow.falloffStart) return 1.0;
+  if (age >= peakWindow.terminalAge) return 0.4;
+  // Linear from falloffStart (1.0) → terminalAge (0.4)
+  const span = peakWindow.terminalAge - peakWindow.falloffStart;
+  const t = (age - peakWindow.falloffStart) / span;
+  return Math.max(0.4, 1.0 - t * 0.6);
+}
+
+/**
+ * Calculate a single dynasty value for a player. Combines the ADP-rank curve
+ * and the age multiplier. Players outside ADP get a floor (3).
+ */
+export function valuePlayer({ player, adpRankById }) {
+  const rank = adpRankById.get(player.id) ?? null;
+  const base = rank ? adpRankToValue(rank) : 3;
+  const mult = ageMultiplier(player.position, player.age);
+  return Math.max(0, Math.round(base * mult));
+}
+
+function valueDraftPick(/* pick */) {
+  // Phase 1 doesn't include picks in speculation. Reserved for Phase 3 when
+  // we're ready to model rookie draft slots and future-pick discounting.
+  return 0;
+}
+
+function isWithinParity(sellerValue, buyerValue) {
+  if (sellerValue <= 0) return false;
+  const diff = Math.abs(sellerValue - buyerValue);
+  return diff / sellerValue <= DYNASTY_PARITY_TOLERANCE;
+}
+
+/**
+ * Sum positions that a franchise has fewer than 3 active rosterable bodies in.
+ * That gives a coarse "wants" set — fancy version belongs in Phase 5.
+ */
+export function buildPositionalWants(franchisePlayers) {
+  const counts = { QB: 0, RB: 0, WR: 0, TE: 0 };
+  for (const p of franchisePlayers) {
+    if (p.status !== 'ROSTER') continue;
+    if (counts[p.position] === undefined) continue;
+    counts[p.position] += 1;
+  }
+  const wants = [];
+  if (counts.QB < 2) wants.push('QB');
+  if (counts.RB < 4) wants.push('RB');
+  if (counts.WR < 5) wants.push('WR');
+  if (counts.TE < 2) wants.push('TE');
+  return wants;
+}
+
+/**
+ * "Haves" = trade-bait listings the franchise has explicitly shopped, plus
+ * roster surplus at saturated positions. Surplus is defined as more than
+ * SURPLUS_THRESHOLD active players at a position.
+ */
+const SURPLUS_THRESHOLD = { QB: 3, RB: 6, WR: 7, TE: 3 };
+
+export function buildHaves({ franchisePlayers, tradeBaitIds, adpRankById }) {
+  const baitSet = new Set((tradeBaitIds ?? []).map(String));
+  const positionCounts = {};
+  for (const p of franchisePlayers) {
+    if (p.status !== 'ROSTER') continue;
+    positionCounts[p.position] = (positionCounts[p.position] ?? 0) + 1;
+  }
+  const haves = [];
+  for (const p of franchisePlayers) {
+    if (p.status !== 'ROSTER') continue;
+    const onBait = baitSet.has(String(p.id));
+    const isSurplus =
+      SURPLUS_THRESHOLD[p.position] !== undefined &&
+      positionCounts[p.position] > SURPLUS_THRESHOLD[p.position];
+    if (!onBait && !isSurplus) continue;
+    const value = valuePlayer({ player: p, adpRankById });
+    if (value <= 0) continue;
+    haves.push({
+      id: p.id,
+      name: p.name,
+      position: p.position,
+      salary: p.salary,
+      contractYear: p.contractYear,
+      age: p.age,
+      onTradeBait: onBait,
+      surplus: isSurplus,
+      value,
+    });
+  }
+  haves.sort((a, b) => b.value - a.value);
+  return haves;
+}
+
+/**
+ * Sum currently committed cap so we can ballpark each franchise's open room.
+ * Uses the salary feed's enriched current-year salary (already escalated by MFL).
+ */
+export function franchiseCapSpace({ franchisePlayers }) {
+  let committed = 0;
+  for (const p of franchisePlayers) {
+    if (p.status !== 'ROSTER') continue;
+    committed += Number(p.salary) || 0;
+  }
+  return Math.max(0, SALARY_CAP - committed);
+}
+
+/**
+ * Try to assemble a return package for `seller` that hits one of `seller`'s
+ * positional wants and stays within parity tolerance. Greedy: start with the
+ * highest-value buyer have that fits the seller's want, then pad with the
+ * next-best surplus piece if the gap is too wide.
+ */
+function assembleReturnPackage({ buyerHaves, sellerWants, sellerMarqueeValue, sellerCapRoom }) {
+  const sellerWantSet = new Set(sellerWants);
+  const wantHits = buyerHaves
+    .filter((h) => sellerWantSet.has(h.position))
+    .filter((h) => Number(h.salary) <= sellerCapRoom);
+
+  for (const head of wantHits) {
+    if (isWithinParity(sellerMarqueeValue, head.value)) {
+      return [head];
+    }
+    const remaining = sellerMarqueeValue - head.value;
+    if (remaining <= 0) continue; // head is too valuable; would over-pay seller
+    // Find a "throw-in" surplus piece that closes the gap to within parity.
+    const throwIn = buyerHaves.find(
+      (h) =>
+        h.id !== head.id &&
+        Number(h.salary) <= Math.max(0, sellerCapRoom - Number(head.salary)) &&
+        Math.abs(remaining - h.value) / sellerMarqueeValue <= DYNASTY_PARITY_TOLERANCE,
+    );
+    if (throwIn) return [head, throwIn];
+  }
+  return null;
+}
+
+function detectCapReliefDrama({ marqueeSalary, sellerCapRoom }) {
+  // Fires when the seller is unloading a Brock-Osweiler-tier piece — i.e.
+  // the marquee salary exceeds the seller's open cap room by 1.5×. That's
+  // a "they had to clear room" framing for Schefter to lean on.
+  return marqueeSalary > sellerCapRoom * 1.5;
+}
+
+function scoreCandidate({ marquee, returnPkg, divisionsAreSame }) {
+  const valuePack = returnPkg.reduce((sum, p) => sum + p.value, 0);
+  const fit = Math.max(0, 100 - Math.abs(marquee.value - valuePack));
+  const drama = divisionsAreSame ? 25 : 10;
+  const baitBonus = marquee.onTradeBait ? 15 : 0;
+  const surplusPenalty = !marquee.onTradeBait && marquee.surplus ? -5 : 0;
+  return Math.round(fit + drama + baitBonus + surplusPenalty);
+}
+
+/**
+ * Top-level: enumerate every ordered (Buyer, Seller) pair and produce the
+ * top candidates by score. Caller passes already-loaded data — this helper
+ * stays IO-free for testability.
+ *
+ * @param {object} args
+ * @param {Map<string, Array>} args.playersByFranchise - franchiseId → enriched player rows
+ * @param {Map<string, Array<string>>} args.tradeBaitByFranchise - franchiseId → player IDs
+ * @param {Map<string, number>} args.adpRankById - playerId → ADP rank
+ * @param {Map<string, {division:string,nameMedium:string}>} args.teams
+ * @param {number} [args.limit=5]
+ * @returns {Array<{seller:string, buyer:string, marquee:object, returnPkg:Array, score:number, capRelief:boolean, scoreBreakdown?:string}>}
+ */
+export function findTwoTeamCandidates({
+  playersByFranchise,
+  tradeBaitByFranchise,
+  adpRankById,
+  teams,
+  limit = 5,
+}) {
+  const franchiseIds = Array.from(playersByFranchise.keys());
+  const haves = new Map();
+  const wants = new Map();
+  const capRoom = new Map();
+
+  for (const fid of franchiseIds) {
+    const players = playersByFranchise.get(fid) ?? [];
+    haves.set(
+      fid,
+      buildHaves({
+        franchisePlayers: players,
+        tradeBaitIds: tradeBaitByFranchise.get(fid) ?? [],
+        adpRankById,
+      }),
+    );
+    wants.set(fid, buildPositionalWants(players));
+    capRoom.set(fid, franchiseCapSpace({ franchisePlayers: players }));
+  }
+
+  const candidates = [];
+  for (const sellerId of franchiseIds) {
+    const sellerHaves = haves.get(sellerId) ?? [];
+    const sellerCapOpen = capRoom.get(sellerId) ?? 0;
+    const sellerTeam = teams.get(sellerId);
+    for (const marquee of sellerHaves) {
+      if (marquee.value < MIN_MARQUEE_VALUE) continue;
+      for (const buyerId of franchiseIds) {
+        if (buyerId === sellerId) continue;
+        const buyerHaves = haves.get(buyerId) ?? [];
+        const buyerWants = wants.get(buyerId) ?? [];
+        // Buyer must have a stated need that the marquee piece fills,
+        // otherwise the speculation has no narrative hook.
+        if (!buyerWants.includes(marquee.position)) continue;
+        const sellerWants = wants.get(sellerId) ?? [];
+        if (sellerWants.length === 0) continue; // seller has no holes to plug
+        const returnPkg = assembleReturnPackage({
+          buyerHaves,
+          sellerWants,
+          sellerMarqueeValue: marquee.value,
+          sellerCapRoom: sellerCapOpen,
+        });
+        if (!returnPkg || returnPkg.length < TARGET_PACKAGE_MIN) continue;
+        if (returnPkg.length > TARGET_PACKAGE_MAX) continue;
+        const buyerTeam = teams.get(buyerId);
+        const score = scoreCandidate({
+          marquee,
+          returnPkg,
+          divisionsAreSame:
+            !!sellerTeam &&
+            !!buyerTeam &&
+            sellerTeam.division === buyerTeam.division,
+        });
+        candidates.push({
+          seller: sellerId,
+          buyer: buyerId,
+          marquee,
+          returnPkg,
+          score,
+          capRelief: detectCapReliefDrama({
+            marqueeSalary: Number(marquee.salary) || 0,
+            sellerCapRoom: sellerCapOpen,
+          }),
+        });
+      }
+    }
+  }
+
+  candidates.sort((a, b) => b.score - a.score);
+  return candidates.slice(0, limit);
+}
+
+export const __testing__ = {
+  adpRankToValue,
+  ageMultiplier,
+  isWithinParity,
+  DYNASTY_PARITY_TOLERANCE,
+  SALARY_CAP,
+  MIN_MARQUEE_VALUE,
+  scoreCandidate,
+  assembleReturnPackage,
+};

--- a/scripts/schefter-trade-speculation.mjs
+++ b/scripts/schefter-trade-speculation.mjs
@@ -69,7 +69,14 @@ const FEED_PATH = path.join(projectRoot, 'src', 'data', 'theleague', LEAGUE_SLUG
 const RESOLVED_EVENTS_PATH = path.join(projectRoot, 'src', 'data', 'theleague', 'resolved-events.json');
 const TEAMS_CONFIG_PATH = path.join(projectRoot, 'src', 'data', 'theleague.config.json');
 
-const SPECULATION_TIER_TWO_TEAM = 'speculation_two_team';
+// Match the rumor-mill's wire shape so the existing feed renderer treats
+// speculation posts as rumor-style cards (visual styling, anonymous
+// reactions, impression tracking). The `transactionSubType` field is the
+// only thing distinguishing speculation from a real anonymous-tip rumor;
+// the renderer uses it to skip whisper-back and thread-link UI on
+// speculation posts (those make no sense for algorithmic content).
+const SPECULATION_POST_TYPE = 'transaction';
+const SPECULATION_POST_TIER = 'rumor';
 const SPECULATION_SUB_TYPE = 'trade_speculation';
 
 const log = (...args) => console.log(...args);
@@ -489,9 +496,9 @@ async function main() {
   const post = {
     id: generatePostId(),
     timestamp: now.toISOString(),
-    type: 'rumor',
+    type: SPECULATION_POST_TYPE,
     transactionSubType: SPECULATION_SUB_TYPE,
-    tier: SPECULATION_TIER_TWO_TEAM,
+    tier: SPECULATION_POST_TIER,
     headline: 'Schefter speculating…',
     body: body.startsWith(TIER_EMOJI) ? body : `${TIER_EMOJI} ${body}`,
     authorId: 'claude',

--- a/scripts/schefter-trade-speculation.mjs
+++ b/scripts/schefter-trade-speculation.mjs
@@ -1,0 +1,542 @@
+#!/usr/bin/env node
+/**
+ * Schefter Trade Speculation — daily scanner that turns the league's tradeBait
+ * + roster + cap state into Schefter-voiced speculation posts on the news feed.
+ *
+ * Phase 1 scope (per docs/plans/schefter-trade-speculation.md):
+ *   - Two-team match search (no three-team yet)
+ *   - Schefter blurb via Claude API (falls back to template on API failure)
+ *   - Append to src/data/theleague/schefter-feed.json
+ *   - Append to data/theleague/derived/speculation-history.json (rotation gate)
+ *   - Honor calendar-aware cadence (scripts/lib/speculation-cadence.mjs)
+ *   - Share the 3-posts/day rumor-mill budget (`schefter:rumor:posts_today`),
+ *     with a peak-week reservation that lets speculation skip past a saturated
+ *     budget the week before the trade deadline
+ *   - NO GroupMe posting yet — that lands in Phase 2
+ *
+ * Usage:
+ *   node scripts/schefter-trade-speculation.mjs           # live run
+ *   node scripts/schefter-trade-speculation.mjs --dry-run # no mutations
+ *
+ * Env (required for live posting):
+ *   ANTHROPIC_API_KEY        Claude API key for blurb generation
+ *   UPSTASH_REDIS_REST_URL   Redis URL (required for shared daily counter)
+ *   UPSTASH_REDIS_REST_TOKEN Redis token
+ *   (KV_* / STORAGE_* fallbacks also accepted, mirroring the rumor-mill)
+ *
+ * Optional:
+ *   SCHEFTER_TRADE_SPECULATION_ENABLED  gate flag — must be truthy to run
+ */
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createHash } from 'node:crypto';
+
+import {
+  resolveCadence,
+  permitsPost,
+} from './lib/speculation-cadence.mjs';
+import {
+  findTwoTeamCandidates,
+  valuePlayer,
+} from './lib/speculation-matching.mjs';
+import {
+  defaultLedgerPath,
+  loadLedger,
+  saveLedger,
+  appendEntry,
+  postsToday as ledgerPostsToday,
+  lastPostAt as ledgerLastPostAt,
+  recentlyPostedTrade,
+  franchiseInRecentRotation,
+  tradeSignature,
+} from './lib/speculation-history.mjs';
+
+const projectRoot = path.resolve(fileURLToPath(new URL('..', import.meta.url)));
+const DRY_RUN = process.argv.includes('--dry-run');
+
+// ── Constants ──
+
+const LEAGUE_SLUG = 'theleague';
+const FEED_PATH = path.join(projectRoot, 'src', 'data', 'theleague', LEAGUE_SLUG === 'theleague' ? 'schefter-feed.json' : `${LEAGUE_SLUG}-schefter-feed.json`);
+const RESOLVED_EVENTS_PATH = path.join(projectRoot, 'src', 'data', 'theleague', 'resolved-events.json');
+const TEAMS_CONFIG_PATH = path.join(projectRoot, 'src', 'data', 'theleague.config.json');
+
+// Shared rumor-mill daily counter — keep in sync with scripts/schefter-rumor-scan.mjs
+const RUMOR_POSTS_TODAY_KEY = 'schefter:rumor:posts_today';
+const RUMOR_LAST_POST_TS_KEY = 'schefter:rumor:last_post_ts';
+const MAX_GLOBAL_POSTS_PER_DAY = 3;
+const RESERVED_PEAK_SLOT = 1; // peak-week speculation may use this slot even if 3 are burned
+
+const SPECULATION_TIER_TWO_TEAM = 'speculation_two_team';
+const SPECULATION_SUB_TYPE = 'trade_speculation';
+
+const log = (...args) => console.log(...args);
+const warn = (...args) => console.warn(...args);
+
+// ── Time helpers (mirror rumor-scan) ──
+
+function getPtHour(now = new Date()) {
+  const fmt = new Intl.DateTimeFormat('en-US', {
+    timeZone: 'America/Los_Angeles',
+    hour: 'numeric',
+    hour12: false,
+  });
+  return parseInt(fmt.format(now), 10);
+}
+
+function isQuietHours(now = new Date()) {
+  const h = getPtHour(now);
+  return h >= 23 || h < 7;
+}
+
+function secondsUntilPtMidnight(now = new Date()) {
+  const fmt = new Intl.DateTimeFormat('en-US', {
+    timeZone: 'America/Los_Angeles',
+    hour: 'numeric',
+    minute: 'numeric',
+    second: 'numeric',
+    hour12: false,
+  });
+  const parts = Object.fromEntries(
+    fmt.formatToParts(now).filter((p) => p.type !== 'literal').map((p) => [p.type, p.value]),
+  );
+  const h = parseInt(parts.hour, 10);
+  const m = parseInt(parts.minute, 10);
+  const s = parseInt(parts.second, 10);
+  return 24 * 3600 - (h * 3600 + m * 60 + s);
+}
+
+// ── Redis ──
+
+let _redis;
+async function getRedis() {
+  if (_redis !== undefined) return _redis;
+  const url =
+    process.env.UPSTASH_REDIS_REST_URL ||
+    process.env.KV_REST_API_URL ||
+    process.env.STORAGE_REST_API_URL;
+  const token =
+    process.env.UPSTASH_REDIS_REST_TOKEN ||
+    process.env.KV_REST_API_TOKEN ||
+    process.env.STORAGE_REST_API_TOKEN;
+  if (!url || !token) {
+    warn('[speculation] Redis credentials not set — running without budget gate');
+    _redis = null;
+    return null;
+  }
+  try {
+    const { Redis } = await import('@upstash/redis');
+    _redis = new Redis({ url, token });
+    return _redis;
+  } catch (err) {
+    warn(`[speculation] Redis import failed: ${err.message}`);
+    _redis = null;
+    return null;
+  }
+}
+
+// ── File loaders ──
+
+async function loadJson(filePath, fallback) {
+  try {
+    return JSON.parse(await fs.readFile(filePath, 'utf8'));
+  } catch (err) {
+    warn(`[speculation] read ${filePath} failed: ${err.message}`);
+    return fallback;
+  }
+}
+
+async function loadResolvedEvents() {
+  const data = await loadJson(RESOLVED_EVENTS_PATH, { events: [] });
+  return Array.isArray(data?.events) ? data.events : [];
+}
+
+async function loadTeams() {
+  const config = await loadJson(TEAMS_CONFIG_PATH, { teams: [] });
+  const map = new Map();
+  for (const t of config.teams ?? []) {
+    map.set(t.franchiseId, {
+      name: t.name,
+      nameMedium: t.nameMedium ?? t.name,
+      nameShort: t.nameShort ?? t.nameMedium ?? t.name,
+      abbrev: t.abbrev,
+      division: t.division,
+    });
+  }
+  return map;
+}
+
+function detectCurrentSeason(now = new Date()) {
+  // Mirrors scripts/fetch-trade-bait.mjs season-detection logic so we read
+  // the same year's feeds.
+  const calendarYear = now.getFullYear();
+  const febCutoff = new Date(calendarYear, 1, 14, 16, 45, 0, 0);
+  return now >= febCutoff ? calendarYear : calendarYear - 1;
+}
+
+async function loadEnrichedSalaries(year) {
+  const file = path.join(projectRoot, 'src', 'data', 'theleague', `mfl-player-salaries-${year}.json`);
+  const data = await loadJson(file, { players: [] });
+  const playersByFranchise = new Map();
+  for (const p of data.players ?? []) {
+    if (!p.franchiseId) continue;
+    const arr = playersByFranchise.get(p.franchiseId) ?? [];
+    arr.push({
+      id: String(p.id),
+      name: p.name,
+      position: p.position,
+      salary: Number(p.salary) || 0,
+      contractYear: p.contractYear,
+      status: p.status,
+      age: p.sleeper?.age ?? null,
+      team: p.team,
+    });
+    playersByFranchise.set(p.franchiseId, arr);
+  }
+  return playersByFranchise;
+}
+
+async function loadAdpRanks(year) {
+  const file = path.join(projectRoot, 'data', 'theleague', 'mfl-feeds', String(year), 'adp-dynasty.json');
+  const data = await loadJson(file, { adp: { player: [] } });
+  const arr = Array.isArray(data?.adp?.player) ? data.adp.player : [];
+  const map = new Map();
+  for (const row of arr) {
+    if (!row?.id) continue;
+    const rank = parseInt(row.rank, 10);
+    if (Number.isFinite(rank)) map.set(String(row.id), rank);
+  }
+  return map;
+}
+
+async function loadTradeBaitByFranchise(year) {
+  const file = path.join(projectRoot, 'data', 'theleague', 'mfl-feeds', String(year), 'tradeBait-by-franchise.json');
+  const data = await loadJson(file, null);
+  if (!data?.franchises) return null;
+  const map = new Map();
+  for (const [fid, entry] of Object.entries(data.franchises)) {
+    map.set(fid, Array.isArray(entry.playerIds) ? entry.playerIds.map(String) : []);
+  }
+  return map;
+}
+
+async function loadFeed() {
+  return loadJson(FEED_PATH, { lastScanTimestamp: '', lastProcessedMflTimestamp: '0', posts: [] });
+}
+
+// ── Schefter blurb generation ──
+
+const TIER_EMOJI = '🟡';
+
+// Local-media / fan-chatter framing — the speculation does NOT come from
+// owners or front-office sources. It comes from beat writers, talk-radio
+// callers, fan blogs, and barstool chatter speculating about whether a
+// hypothetical move makes sense. Schefter is REPORTING on that buzz.
+function templateBlurb({ marquee, returnPkg, sellerName, buyerName, capRelief }) {
+  const pkgStr = returnPkg.map((p) => p.name).join(' and ');
+  const lines = [
+    `${TIER_EMOJI} The talk-radio crowd in ${buyerName}-country has been chewing on a fit for ${sellerName} ${marquee.position} ${marquee.name}.`,
+    `Local fan boards are floating ${pkgStr} as the kind of return ${sellerName} would have to take seriously — neither front office has commented.`,
+  ];
+  if (capRelief) {
+    lines.push(`${sellerName} would clear meaningful cap room in any version of this deal, which is half the reason the speculation has legs.`);
+  }
+  return lines.join(' ');
+}
+
+async function generateBlurbWithClaude({ marquee, returnPkg, sellerName, buyerName, capRelief }) {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey || DRY_RUN) {
+    return null;
+  }
+
+  const system = `You are Claude Schefter — a dynasty fantasy football beat reporter channeling Adam Schefter's voice.
+You are writing a SPECULATION post about a hypothetical two-team trade. The trade is NOT real — it has NOT been offered. It is fan/media chatter generated from publicly-listed trade-bait + roster fits + cap math.
+
+CRITICAL FRAMING (self-enforce):
+- The speculation comes from LOCAL MEDIA and FANS, not from the front offices or owners. Frame the post as Schefter REPORTING on what fans / talk radio / beat writers / fan blogs / barstool chatter are kicking around — not as Schefter relaying a leak from team sources.
+- Use phrases like: "the talk-radio crowd in [team]-country", "fan boards are floating", "local beat writers have been speculating", "the [team] fan base has been kicking around", "a Wednesday night call-in show floated", "barstool chatter from [team] country", "season-ticket holders have been wondering aloud".
+- NEVER imply either GM, owner, or front office is shopping or pursuing. Do NOT use phrases like "sources tell me [team] is shopping/circling/in talks". The story is the BUZZ around the move, not the move itself. Both front offices in the post should be framed as silent, surprised, or non-committal ("neither front office has commented", "[team] hasn't acknowledged", "this isn't coming from the building — it's coming from outside it").
+
+HARD RULES (self-enforce):
+- 1–3 sentences total. Tight, beat-reporter cadence.
+- Lead with the marquee piece moving from seller → buyer in the fan/media speculation. Use the franchise nameMedium values exactly as given.
+- Do NOT invent any player names beyond the marquee + return-package list. If a name isn't in the input, it doesn't exist.
+- Do NOT name the dollar amount of any salary; you may say "the cap fit makes sense" or "cap relief" only when the input flag says so.
+- No emojis (the post is prefixed with a tier emoji separately).
+- No hashtags, no @-mentions, no meta-commentary about the speculation engine, no markdown.
+- OUTPUT CONTRACT: respond with JSON only — {"post": "<the speculation copy as a single string>"}.`;
+
+  const userMessage = `Generate a fan/media speculation post for the following candidate trade. Remember: this is NOT a leak from the teams — it's chatter from outside the buildings.
+
+INPUT:
+${JSON.stringify(
+  {
+    seller: sellerName,
+    buyer: buyerName,
+    marquee: { name: marquee.name, position: marquee.position, age: marquee.age ?? null, onTradeBait: marquee.onTradeBait },
+    returnPackage: returnPkg.map((p) => ({ name: p.name, position: p.position, age: p.age ?? null })),
+    capReliefAngle: capRelief,
+  },
+  null,
+  2,
+)}`;
+
+  try {
+    const res = await fetch('https://api.anthropic.com/v1/messages', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': apiKey,
+        'anthropic-version': '2023-06-01',
+      },
+      body: JSON.stringify({
+        model: 'claude-haiku-4-5-20251001',
+        max_tokens: 260,
+        system,
+        messages: [{ role: 'user', content: userMessage }],
+      }),
+    });
+    if (!res.ok) {
+      warn(`[speculation AI] HTTP ${res.status} — using template`);
+      return null;
+    }
+    const data = await res.json();
+    const text = (data.content?.[0]?.text ?? '').trim();
+    return parseAiResponse(text);
+  } catch (err) {
+    warn(`[speculation AI] ${err.message} — using template`);
+    return null;
+  }
+}
+
+function parseAiResponse(raw) {
+  try {
+    // Tolerate code fences / surrounding prose
+    const match = raw.match(/\{[\s\S]*\}/);
+    if (!match) return null;
+    const obj = JSON.parse(match[0]);
+    const post = typeof obj.post === 'string' ? obj.post.trim() : null;
+    if (!post) return null;
+    // Sanity guard: reject any output that contains markdown or meta-commentary
+    if (/^\s*here\b|\bspeculation engine\b/i.test(post)) return null;
+    return post;
+  } catch {
+    return null;
+  }
+}
+
+// ── Post id ──
+
+function generatePostId() {
+  const hash = createHash('sha256').update(`${Date.now()}${Math.random()}`).digest('hex').slice(0, 8);
+  return `sf_speculation_${Date.now()}_${hash}`;
+}
+
+// ── Main ──
+
+async function main() {
+  log(`\n=== Schefter Trade Speculation ${DRY_RUN ? '[DRY RUN]' : ''} ===`);
+  const now = new Date();
+  log(`  Timestamp: ${now.toISOString()}`);
+
+  // Enable gate (defaults to OFF in production unless explicitly enabled —
+  // mirrors how the rumor-mill rolled out).
+  const enabled = process.env.SCHEFTER_TRADE_SPECULATION_ENABLED;
+  if (!enabled || enabled === '0' || String(enabled).toLowerCase() === 'false') {
+    log('  SCHEFTER_TRADE_SPECULATION_ENABLED is not truthy — exiting');
+    return 0;
+  }
+
+  if (isQuietHours(now)) {
+    log(`  Quiet hours (PT ${getPtHour(now)}:00) — exiting`);
+    return 0;
+  }
+
+  // 1. Resolve calendar cadence.
+  const events = await loadResolvedEvents();
+  const cadence = resolveCadence({ events, now });
+  log(`  Cadence: ${cadence.tag} (maxPerDay=${cadence.maxPerDay}, reservesGlobalSlot=${cadence.reservesGlobalSlot})`);
+  if (cadence.maxPerDay === 0) {
+    log('  Cadence quota = 0 — exiting');
+    return 0;
+  }
+
+  // 2. Lane permission check (against the local rotation ledger).
+  const ledgerPath = defaultLedgerPath(projectRoot);
+  const ledger = await loadLedger(ledgerPath);
+  const laneToday = ledgerPostsToday(ledger, now);
+  const laneLast = ledgerLastPostAt(ledger);
+  const lanePermit = permitsPost({ cadence, postsTodayInLane: laneToday, lastPostAt: laneLast, now });
+  if (!lanePermit.allowed) {
+    log(`  Lane gate blocked: ${lanePermit.reason} — exiting`);
+    return 0;
+  }
+
+  // 3. Global daily-budget check — share the rumor-mill's `posts_today`
+  // counter so all Schefter-voiced posts (rumors + speculation) honor a
+  // single 3-per-day cap on the feed.
+  const redis = await getRedis();
+  let globalPostsToday = 0;
+  if (redis) {
+    const raw = await redis.get(RUMOR_POSTS_TODAY_KEY);
+    globalPostsToday = typeof raw === 'number' ? raw : parseInt(raw ?? '0', 10) || 0;
+  }
+  const effectiveCap = MAX_GLOBAL_POSTS_PER_DAY - (cadence.reservesGlobalSlot ? 0 : 0);
+  if (globalPostsToday >= MAX_GLOBAL_POSTS_PER_DAY) {
+    if (!cadence.reservesGlobalSlot) {
+      log(`  Global cap met (posts_today=${globalPostsToday}, cap=${MAX_GLOBAL_POSTS_PER_DAY}) — exiting`);
+      return 0;
+    }
+    // Peak-week speculation may exceed the soft cap by RESERVED_PEAK_SLOT.
+    if (globalPostsToday >= MAX_GLOBAL_POSTS_PER_DAY + RESERVED_PEAK_SLOT) {
+      log(`  Even with peak-week reservation, cap met (posts_today=${globalPostsToday}) — exiting`);
+      return 0;
+    }
+    log(`  Global cap normally met but peak-week reservation in effect — proceeding`);
+  } else {
+    log(`  Global posts_today=${globalPostsToday} (cap=${MAX_GLOBAL_POSTS_PER_DAY}); effectiveCap=${effectiveCap}`);
+  }
+
+  // 4. Load league state.
+  const season = detectCurrentSeason(now);
+  const teams = await loadTeams();
+  const playersByFranchise = await loadEnrichedSalaries(season);
+  const adpRankById = await loadAdpRanks(season);
+  const tradeBaitByFranchise = await loadTradeBaitByFranchise(season);
+
+  if (!tradeBaitByFranchise || tradeBaitByFranchise.size === 0) {
+    log('  No tradeBait-by-franchise.json (run scripts/fetch-trade-bait.mjs first) — exiting');
+    return 0;
+  }
+  if (playersByFranchise.size === 0) {
+    log('  Enriched salary feed empty — exiting');
+    return 0;
+  }
+
+  // 5. Find candidates.
+  const rawCandidates = findTwoTeamCandidates({
+    playersByFranchise,
+    tradeBaitByFranchise,
+    adpRankById,
+    teams,
+    limit: 10,
+  });
+  log(`  Raw candidate pool: ${rawCandidates.length}`);
+  if (rawCandidates.length === 0) {
+    log('  No candidates found — exiting');
+    return 0;
+  }
+
+  // 6. Apply rotation gate.
+  const passing = [];
+  for (const c of rawCandidates) {
+    const sig = tradeSignature({
+      seller: c.seller,
+      buyer: c.buyer,
+      marqueeId: c.marquee.id,
+      returnPkgIds: c.returnPkg.map((p) => p.id),
+    });
+    if (recentlyPostedTrade(ledger, sig, now)) continue;
+    if (
+      franchiseInRecentRotation(ledger, c.seller, now) &&
+      franchiseInRecentRotation(ledger, c.buyer, now)
+    ) {
+      // Both already featured in the last 7 days — skip to spread coverage.
+      continue;
+    }
+    passing.push({ ...c, signature: sig });
+  }
+  log(`  After rotation gate: ${passing.length}`);
+  if (passing.length === 0) {
+    log('  All candidates are in the rotation cooldown — exiting');
+    return 0;
+  }
+
+  const winner = passing[0];
+  const sellerTeam = teams.get(winner.seller);
+  const buyerTeam = teams.get(winner.buyer);
+  log(`  Winner (score=${winner.score}): ${sellerTeam?.nameMedium ?? winner.seller} → ${buyerTeam?.nameMedium ?? winner.buyer}: ${winner.marquee.name}`);
+
+  // 7. Generate blurb (Claude + template fallback).
+  const blurbInput = {
+    marquee: winner.marquee,
+    returnPkg: winner.returnPkg,
+    sellerName: sellerTeam?.nameMedium ?? `Franchise ${winner.seller}`,
+    buyerName: buyerTeam?.nameMedium ?? `Franchise ${winner.buyer}`,
+    capRelief: winner.capRelief,
+  };
+  let body = await generateBlurbWithClaude(blurbInput);
+  if (!body) body = templateBlurb(blurbInput);
+  // Tier emoji prefix is the visual spine — match the format from the plan doc.
+  const post = {
+    id: generatePostId(),
+    timestamp: now.toISOString(),
+    type: 'rumor',
+    transactionSubType: SPECULATION_SUB_TYPE,
+    tier: SPECULATION_TIER_TWO_TEAM,
+    headline: 'Schefter speculating…',
+    body: body.startsWith(TIER_EMOJI) ? body : `${TIER_EMOJI} ${body}`,
+    authorId: 'claude',
+    franchiseIds: [winner.seller, winner.buyer],
+    league: LEAGUE_SLUG,
+    speculation: {
+      seller: winner.seller,
+      buyer: winner.buyer,
+      marquee: { id: winner.marquee.id, name: winner.marquee.name, position: winner.marquee.position },
+      returnPkg: winner.returnPkg.map((p) => ({ id: p.id, name: p.name, position: p.position })),
+      score: winner.score,
+      capRelief: winner.capRelief,
+    },
+  };
+
+  if (DRY_RUN) {
+    log('\n  [dry-run] Would append to feed:');
+    log(JSON.stringify(post, null, 2));
+    log('\n  [dry-run] Would append to speculation history:', winner.signature);
+    return 0;
+  }
+
+  // 8. Persist feed + ledger.
+  const feed = await loadFeed();
+  feed.posts = [post, ...(feed.posts ?? [])];
+  feed.lastScanTimestamp = now.toISOString();
+  await fs.writeFile(FEED_PATH, JSON.stringify(feed, null, 2) + '\n');
+  log('  Appended to schefter-feed.json');
+
+  const updatedLedger = appendEntry(ledger, {
+    postedAt: now.getTime(),
+    postId: post.id,
+    signature: winner.signature,
+    franchiseIds: [winner.seller, winner.buyer],
+    cadenceTag: cadence.tag,
+  });
+  await saveLedger(ledgerPath, updatedLedger, { now });
+  log('  Appended to speculation-history.json');
+
+  // 9. Increment shared global counter (so rumor-mill respects this slot).
+  if (redis) {
+    try {
+      const newCount = await redis.incr(RUMOR_POSTS_TODAY_KEY);
+      if (newCount === 1) {
+        await redis.expire(RUMOR_POSTS_TODAY_KEY, secondsUntilPtMidnight(now));
+      }
+      await redis.set(RUMOR_LAST_POST_TS_KEY, now.getTime());
+      await redis.expire(RUMOR_LAST_POST_TS_KEY, secondsUntilPtMidnight(now));
+      log(`  posts_today incremented → ${newCount}`);
+    } catch (err) {
+      warn(`  [speculation] Redis counter update failed: ${err.message}`);
+    }
+  }
+
+  return 0;
+}
+
+main()
+  .then((code) => process.exit(code ?? 0))
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/scripts/schefter-trade-speculation.mjs
+++ b/scripts/schefter-trade-speculation.mjs
@@ -52,6 +52,11 @@ import {
   franchiseInRecentRotation,
   tradeSignature,
 } from './lib/speculation-history.mjs';
+import {
+  checkGlobalBudgetGate,
+  RUMOR_POSTS_TODAY_KEY,
+  RUMOR_LAST_POST_TS_KEY,
+} from './lib/speculation-budget.mjs';
 
 const projectRoot = path.resolve(fileURLToPath(new URL('..', import.meta.url)));
 const DRY_RUN = process.argv.includes('--dry-run');
@@ -62,12 +67,6 @@ const LEAGUE_SLUG = 'theleague';
 const FEED_PATH = path.join(projectRoot, 'src', 'data', 'theleague', LEAGUE_SLUG === 'theleague' ? 'schefter-feed.json' : `${LEAGUE_SLUG}-schefter-feed.json`);
 const RESOLVED_EVENTS_PATH = path.join(projectRoot, 'src', 'data', 'theleague', 'resolved-events.json');
 const TEAMS_CONFIG_PATH = path.join(projectRoot, 'src', 'data', 'theleague.config.json');
-
-// Shared rumor-mill daily counter — keep in sync with scripts/schefter-rumor-scan.mjs
-const RUMOR_POSTS_TODAY_KEY = 'schefter:rumor:posts_today';
-const RUMOR_LAST_POST_TS_KEY = 'schefter:rumor:last_post_ts';
-const MAX_GLOBAL_POSTS_PER_DAY = 3;
-const RESERVED_PEAK_SLOT = 1; // peak-week speculation may use this slot even if 3 are burned
 
 const SPECULATION_TIER_TWO_TEAM = 'speculation_two_team';
 const SPECULATION_SUB_TYPE = 'trade_speculation';
@@ -109,9 +108,16 @@ function secondsUntilPtMidnight(now = new Date()) {
 }
 
 // ── Redis ──
+//
+// Live runs hard-require Redis: speculation shares a daily-post counter
+// with the rumor-mill (RUMOR_POSTS_TODAY_KEY) and a last-post timestamp
+// (RUMOR_LAST_POST_TS_KEY) for spacing. Without those keys the two scanners
+// can't coordinate and would over-post on the same day. Dry-run is the
+// only path that's allowed to run unmetered, since it doesn't mutate
+// anything.
 
 let _redis;
-async function getRedis() {
+async function getRedis({ required }) {
   if (_redis !== undefined) return _redis;
   const url =
     process.env.UPSTASH_REDIS_REST_URL ||
@@ -122,7 +128,13 @@ async function getRedis() {
     process.env.KV_REST_API_TOKEN ||
     process.env.STORAGE_REST_API_TOKEN;
   if (!url || !token) {
-    warn('[speculation] Redis credentials not set — running without budget gate');
+    if (required) {
+      throw new Error(
+        '[speculation] Redis credentials missing (UPSTASH_REDIS_REST_URL/TOKEN or KV_REST_API_URL/TOKEN). ' +
+          'Live mode requires the shared rumor-mill counter — set the secrets or use --dry-run.',
+      );
+    }
+    warn('[speculation] Redis credentials not set — dry-run mode running without budget gate');
     _redis = null;
     return null;
   }
@@ -131,6 +143,9 @@ async function getRedis() {
     _redis = new Redis({ url, token });
     return _redis;
   } catch (err) {
+    if (required) {
+      throw new Error(`[speculation] @upstash/redis import failed: ${err.message}`);
+    }
     warn(`[speculation] Redis import failed: ${err.message}`);
     _redis = null;
     return null;
@@ -386,30 +401,26 @@ async function main() {
     return 0;
   }
 
-  // 3. Global daily-budget check — share the rumor-mill's `posts_today`
-  // counter so all Schefter-voiced posts (rumors + speculation) honor a
-  // single 3-per-day cap on the feed.
-  const redis = await getRedis();
+  // 3. Global daily-budget gate — share the rumor-mill's `posts_today`
+  // counter and last-post timestamp so all Schefter-voiced posts honor
+  // a single 3-per-day cap and a 4-hour spacing rule. Redis is required
+  // in live mode (getRedis throws if creds are missing); dry-run runs
+  // unmetered.
+  const redis = await getRedis({ required: !DRY_RUN });
   let globalPostsToday = 0;
+  let lastPostTs = null;
   if (redis) {
-    const raw = await redis.get(RUMOR_POSTS_TODAY_KEY);
-    globalPostsToday = typeof raw === 'number' ? raw : parseInt(raw ?? '0', 10) || 0;
+    const rawCount = await redis.get(RUMOR_POSTS_TODAY_KEY);
+    globalPostsToday = typeof rawCount === 'number' ? rawCount : parseInt(rawCount ?? '0', 10) || 0;
+    const rawLast = await redis.get(RUMOR_LAST_POST_TS_KEY);
+    lastPostTs = typeof rawLast === 'number' ? rawLast : parseInt(rawLast ?? '0', 10) || null;
   }
-  const effectiveCap = MAX_GLOBAL_POSTS_PER_DAY - (cadence.reservesGlobalSlot ? 0 : 0);
-  if (globalPostsToday >= MAX_GLOBAL_POSTS_PER_DAY) {
-    if (!cadence.reservesGlobalSlot) {
-      log(`  Global cap met (posts_today=${globalPostsToday}, cap=${MAX_GLOBAL_POSTS_PER_DAY}) — exiting`);
-      return 0;
-    }
-    // Peak-week speculation may exceed the soft cap by RESERVED_PEAK_SLOT.
-    if (globalPostsToday >= MAX_GLOBAL_POSTS_PER_DAY + RESERVED_PEAK_SLOT) {
-      log(`  Even with peak-week reservation, cap met (posts_today=${globalPostsToday}) — exiting`);
-      return 0;
-    }
-    log(`  Global cap normally met but peak-week reservation in effect — proceeding`);
-  } else {
-    log(`  Global posts_today=${globalPostsToday} (cap=${MAX_GLOBAL_POSTS_PER_DAY}); effectiveCap=${effectiveCap}`);
+  const budgetGate = checkGlobalBudgetGate({ cadence, globalPostsToday, lastPostTs, now });
+  if (!budgetGate.allowed) {
+    log(`  Global budget gate blocked: ${budgetGate.reason} — exiting`);
+    return 0;
   }
+  log(`  Global budget OK (posts_today=${globalPostsToday}, ceiling=${budgetGate.ceiling})`);
 
   // 4. Load league state.
   const season = detectCurrentSeason(now);

--- a/scripts/schefter-trade-speculation.mjs
+++ b/scripts/schefter-trade-speculation.mjs
@@ -24,8 +24,9 @@
  *   UPSTASH_REDIS_REST_TOKEN Redis token
  *   (KV_* / STORAGE_* fallbacks also accepted, mirroring the rumor-mill)
  *
- * Optional:
- *   SCHEFTER_TRADE_SPECULATION_ENABLED  gate flag — must be truthy to run
+ * To disable: comment out the cron schedule in the workflow file. We do not
+ * use GitHub Actions variables as feature flags — code is always the source
+ * of truth in this repo.
  */
 
 import { promises as fs } from 'node:fs';
@@ -367,14 +368,6 @@ async function main() {
   log(`\n=== Schefter Trade Speculation ${DRY_RUN ? '[DRY RUN]' : ''} ===`);
   const now = new Date();
   log(`  Timestamp: ${now.toISOString()}`);
-
-  // Enable gate (defaults to OFF in production unless explicitly enabled —
-  // mirrors how the rumor-mill rolled out).
-  const enabled = process.env.SCHEFTER_TRADE_SPECULATION_ENABLED;
-  if (!enabled || enabled === '0' || String(enabled).toLowerCase() === 'false') {
-    log('  SCHEFTER_TRADE_SPECULATION_ENABLED is not truthy — exiting');
-    return 0;
-  }
 
   if (isQuietHours(now)) {
     log(`  Quiet hours (PT ${getPtHour(now)}:00) — exiting`);

--- a/scripts/schefter-trade-speculation.mjs
+++ b/scripts/schefter-trade-speculation.mjs
@@ -230,14 +230,25 @@ async function loadFeed() {
 
 const TIER_EMOJI = '🟡';
 
+// MFL stores names as "Last, First" but speculation copy reads better as
+// "First Last". Defensive on edge cases (suffixes, single-token names).
+function normalizeName(raw) {
+  if (typeof raw !== 'string') return '';
+  const trimmed = raw.trim();
+  if (!trimmed.includes(',')) return trimmed;
+  const [last, rest] = trimmed.split(',', 2);
+  return `${rest.trim()} ${last.trim()}`.trim();
+}
+
 // Local-media / fan-chatter framing — the speculation does NOT come from
 // owners or front-office sources. It comes from beat writers, talk-radio
 // callers, fan blogs, and barstool chatter speculating about whether a
 // hypothetical move makes sense. Schefter is REPORTING on that buzz.
 function templateBlurb({ marquee, returnPkg, sellerName, buyerName, capRelief }) {
-  const pkgStr = returnPkg.map((p) => p.name).join(' and ');
+  const pkgStr = returnPkg.map((p) => normalizeName(p.name)).join(' and ');
+  const marqueeName = normalizeName(marquee.name);
   const lines = [
-    `${TIER_EMOJI} The talk-radio crowd in ${buyerName}-country has been chewing on a fit for ${sellerName} ${marquee.position} ${marquee.name}.`,
+    `${TIER_EMOJI} The talk-radio crowd in ${buyerName}-country has been chewing on a fit for ${sellerName} ${marquee.position} ${marqueeName}.`,
     `Local fan boards are floating ${pkgStr} as the kind of return ${sellerName} would have to take seriously — neither front office has commented.`,
   ];
   if (capRelief) {
@@ -276,8 +287,8 @@ ${JSON.stringify(
   {
     seller: sellerName,
     buyer: buyerName,
-    marquee: { name: marquee.name, position: marquee.position, age: marquee.age ?? null, onTradeBait: marquee.onTradeBait },
-    returnPackage: returnPkg.map((p) => ({ name: p.name, position: p.position, age: p.age ?? null })),
+    marquee: { name: normalizeName(marquee.name), position: marquee.position, age: marquee.age ?? null, onTradeBait: marquee.onTradeBait },
+    returnPackage: returnPkg.map((p) => ({ name: normalizeName(p.name), position: p.position, age: p.age ?? null })),
     capReliefAngle: capRelief,
   },
   null,

--- a/src/components/shared/SchefterFeed.astro
+++ b/src/components/shared/SchefterFeed.astro
@@ -13,6 +13,7 @@ import type { SchefterPost } from '../../types/schefter';
 import type { SchefterReactionResponse } from '../../types/schefter';
 import { getBatchReactions, getBatchAnonymousReactions } from '../../utils/schefter-reactions';
 import { hashTipsterId } from '../../utils/schefter-tipster-hash';
+import { isRumorLikePost } from '../../utils/schefter-feed';
 import SchefterPostCard from './SchefterPostCard.astro';
 
 interface Props {
@@ -33,14 +34,11 @@ interface Props {
 const { posts, isAuthenticated = false, userFranchiseId, userTeamName, userTeamIcon, userId, initialLimit = 25 } = Astro.props;
 const now = new Date();
 
-// Partition rumor_mill posts from the rest — they use the anonymous reaction
-// namespace (keyed on hashedOwnerId) so reactor identity never leaks.
-function isRumorPost(p: SchefterPost): boolean {
-  return p.type === 'transaction' && p.transactionSubType === 'rumor_mill';
-}
-
-const rumorPostIds = posts.filter(isRumorPost).map((p) => p.id);
-const regularPostIds = posts.filter((p) => !isRumorPost(p)).map((p) => p.id);
+// Partition rumor-like posts (rumor-mill + speculation) from the rest —
+// they use the anonymous reaction namespace (keyed on hashedOwnerId) so
+// reactor identity never leaks.
+const rumorPostIds = posts.filter(isRumorLikePost).map((p) => p.id);
+const regularPostIds = posts.filter((p) => !isRumorLikePost(p)).map((p) => p.id);
 
 let userHashedOwnerId: string | undefined;
 if (userId) {

--- a/src/components/shared/SchefterPostCard.astro
+++ b/src/components/shared/SchefterPostCard.astro
@@ -15,7 +15,7 @@
  */
 import type { SchefterPost } from '../../types/schefter';
 import { getAuthor, getAuthorAvatar } from '../../types/schefter';
-import { formatRelativeTime } from '../../utils/schefter-feed';
+import { formatRelativeTime, isRumorLikePost } from '../../utils/schefter-feed';
 import type { GroupMePostMeta } from '../../utils/groupme-storage';
 import SchefterReactionBar from './SchefterReactionBar.tsx';
 import SchefterReplyThread from './SchefterReplyThread.tsx';
@@ -43,8 +43,13 @@ const displayName = isGroupMe ? (gmMeta?.name ?? 'Unknown') : author!.name;
 const displayHandle = isGroupMe ? 'via GroupMe' : author!.handle;
 const isArticle = post.type === 'article';
 const isExternal = post.type === 'external';
-const isRumor = post.type === 'transaction' && post.transactionSubType === 'rumor_mill';
-const tierClass = `sf-post ${isGroupMe ? 'sf-post--groupme' : isArticle ? 'sf-post--article' : isExternal ? 'sf-post--external' : `sf-post--${post.tier}`}${isRumor ? ' sf-post--rumor' : ''}`;
+// Rumor-mill is the legacy tip-driven lane (whisper-back + thread links
+// only make sense there). Speculation is algorithmic and shares the
+// rumor-style card treatment (visual + anonymous reactions + impression
+// tracking) but NOT the tip-back UI.
+const isTipRumor = post.type === 'transaction' && post.transactionSubType === 'rumor_mill';
+const isRumorLike = isRumorLikePost(post);
+const tierClass = `sf-post ${isGroupMe ? 'sf-post--groupme' : isArticle ? 'sf-post--article' : isExternal ? 'sf-post--external' : `sf-post--${post.tier}`}${isRumorLike ? ' sf-post--rumor' : ''}`;
 
 // GroupMe rich content: images from attachments, embedded URLs from body
 const gmImages = gmMeta?.attachments?.filter(a => a.type === 'image' && a.url) ?? [];
@@ -81,7 +86,7 @@ for (const url of allUrlsToStrip) {
 gmDisplayBody = gmDisplayBody.replace(/\n{3,}/g, '\n\n').trim();
 ---
 
-<article id={`post-${post.id}`} class={tierClass} data-post-id={post.id} data-tier={post.tier} data-post-type={post.transactionSubType ?? post.type} data-author={post.authorId ?? 'claude'} data-rumor-impression={isRumor ? 'true' : undefined} aria-label={`${displayName}: ${post.headline || post.body?.replace(/<[^>]+>/g, '').slice(0, 80) || 'Post'}`}>
+<article id={`post-${post.id}`} class={tierClass} data-post-id={post.id} data-tier={post.tier} data-post-type={post.transactionSubType ?? post.type} data-author={post.authorId ?? 'claude'} data-rumor-impression={isRumorLike ? 'true' : undefined} aria-label={`${displayName}: ${post.headline || post.body?.replace(/<[^>]+>/g, '').slice(0, 80) || 'Post'}`}>
   <img class={`sf-avatar${isGroupMe ? ' sf-avatar--groupme' : ''}`} src={avatarSrc} alt="" aria-hidden="true" width="40" height="40" loading="lazy" />
 
   <div class="sf-post__content">
@@ -250,9 +255,9 @@ gmDisplayBody = gmDisplayBody.replace(/\n{3,}/g, '\n\n').trim();
             isAuthenticated={isAuthenticated}
             initialReactions={reactions?.reactions}
             initialUserReaction={reactions?.userReaction}
-            anonymous={isRumor}
+            anonymous={isRumorLike}
           />
-          {isRumor && (
+          {isTipRumor && (
             <SchefterWhisperBack
               client:idle
               postId={post.id}
@@ -260,7 +265,7 @@ gmDisplayBody = gmDisplayBody.replace(/\n{3,}/g, '\n\n').trim();
             />
           )}
         </div>
-        {isRumor && post.threadId && (
+        {isTipRumor && post.threadId && (
           <a class="sfc-post__thread-link" href={`/theleague/schefter/thread/${post.threadId}`}>
             View the full thread →
           </a>

--- a/src/utils/schefter-feed.ts
+++ b/src/utils/schefter-feed.ts
@@ -87,3 +87,18 @@ export function formatRelativeTime(isoTimestamp: string, now?: Date): string {
 export function isDuplicatePost(feed: SchefterFeed, sourceTimestamp: string): boolean {
   return feed.posts.some(p => p.sourceTimestamp === sourceTimestamp);
 }
+
+/**
+ * Sub-types that get rumor-style card treatment: anonymous-namespace
+ * reactions, impression tracking, and `sf-post--rumor` styling. Anything
+ * narrower than rumor-style behavior (whisper-back, thread links) should
+ * branch on `transactionSubType === 'rumor_mill'` directly — those are
+ * tip-driven and tied to the anonymous tipster pipeline.
+ */
+const RUMOR_LIKE_SUB_TYPES = new Set(['rumor_mill', 'trade_speculation']);
+
+export function isRumorLikePost(post: { type?: string; transactionSubType?: string }): boolean {
+  if (post.type !== 'transaction') return false;
+  if (!post.transactionSubType) return false;
+  return RUMOR_LIKE_SUB_TYPES.has(post.transactionSubType);
+}

--- a/tests/schefter-feed-utils.test.ts
+++ b/tests/schefter-feed-utils.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { isRumorLikePost } from '../src/utils/schefter-feed';
+
+describe('isRumorLikePost', () => {
+  it('flags rumor-mill anonymous-tip rumors', () => {
+    expect(
+      isRumorLikePost({ type: 'transaction', transactionSubType: 'rumor_mill' }),
+    ).toBe(true);
+  });
+
+  it('flags trade-speculation algorithmic posts', () => {
+    expect(
+      isRumorLikePost({ type: 'transaction', transactionSubType: 'trade_speculation' }),
+    ).toBe(true);
+  });
+
+  it('does NOT flag real MFL transaction posts', () => {
+    expect(isRumorLikePost({ type: 'transaction', transactionSubType: 'TRADE' })).toBe(false);
+    expect(isRumorLikePost({ type: 'transaction', transactionSubType: 'FREE_AGENT' })).toBe(false);
+  });
+
+  it('does NOT flag external / article / groupme posts', () => {
+    expect(isRumorLikePost({ type: 'external' })).toBe(false);
+    expect(isRumorLikePost({ type: 'article' })).toBe(false);
+    expect(isRumorLikePost({ type: 'groupme' })).toBe(false);
+  });
+
+  it('does NOT flag a transaction post with no subType', () => {
+    expect(isRumorLikePost({ type: 'transaction' })).toBe(false);
+  });
+});

--- a/tests/speculation-budget.test.ts
+++ b/tests/speculation-budget.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import {
+  checkGlobalBudgetGate,
+  MAX_GLOBAL_POSTS_PER_DAY,
+  RESERVED_PEAK_SLOT,
+  MIN_SPACING_MS,
+// @ts-expect-error — sibling .mjs module, no .d.ts
+} from '../scripts/lib/speculation-budget.mjs';
+
+const NORMAL = { reservesGlobalSlot: false };
+const PEAK = { reservesGlobalSlot: true };
+const NOW = new Date('2026-11-12T20:00:00Z'); // Nov 12 = peak deadline week
+
+describe('checkGlobalBudgetGate — daily cap', () => {
+  it('allows a post when posts_today is under the cap and no prior post', () => {
+    const result = checkGlobalBudgetGate({
+      cadence: NORMAL,
+      globalPostsToday: 0,
+      lastPostTs: null,
+      now: NOW,
+    });
+    expect(result.allowed).toBe(true);
+    expect(result.ceiling).toBe(MAX_GLOBAL_POSTS_PER_DAY);
+  });
+
+  it('blocks at the soft cap for non-peak cadence', () => {
+    const result = checkGlobalBudgetGate({
+      cadence: NORMAL,
+      globalPostsToday: MAX_GLOBAL_POSTS_PER_DAY,
+      lastPostTs: null,
+      now: NOW,
+    });
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toMatch(/normal cap/);
+  });
+
+  it('peak-week cadence may use the reserved slot when the soft cap is met', () => {
+    const result = checkGlobalBudgetGate({
+      cadence: PEAK,
+      globalPostsToday: MAX_GLOBAL_POSTS_PER_DAY,
+      lastPostTs: null,
+      now: NOW,
+    });
+    expect(result.allowed).toBe(true);
+    expect(result.ceiling).toBe(MAX_GLOBAL_POSTS_PER_DAY + RESERVED_PEAK_SLOT);
+  });
+
+  it('peak-week cadence still blocks once the reservation is also used', () => {
+    const result = checkGlobalBudgetGate({
+      cadence: PEAK,
+      globalPostsToday: MAX_GLOBAL_POSTS_PER_DAY + RESERVED_PEAK_SLOT,
+      lastPostTs: null,
+      now: NOW,
+    });
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toMatch(/peak-week reservation already used/);
+  });
+});
+
+describe('checkGlobalBudgetGate — minimum spacing', () => {
+  it('blocks when the last post landed inside the spacing window', () => {
+    const lastPostTs = NOW.getTime() - 30 * 60 * 1000; // 30 minutes ago
+    const result = checkGlobalBudgetGate({
+      cadence: NORMAL,
+      globalPostsToday: 1,
+      lastPostTs,
+      now: NOW,
+    });
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toMatch(/30m ago/);
+  });
+
+  it('allows the post once the spacing window has elapsed', () => {
+    const lastPostTs = NOW.getTime() - (MIN_SPACING_MS + 1000);
+    const result = checkGlobalBudgetGate({
+      cadence: NORMAL,
+      globalPostsToday: 1,
+      lastPostTs,
+      now: NOW,
+    });
+    expect(result.allowed).toBe(true);
+  });
+
+  it('peak-week reservation does NOT bypass the spacing rule', () => {
+    const lastPostTs = NOW.getTime() - 5 * 60 * 1000; // 5 minutes ago
+    const result = checkGlobalBudgetGate({
+      cadence: PEAK,
+      globalPostsToday: MAX_GLOBAL_POSTS_PER_DAY,
+      lastPostTs,
+      now: NOW,
+    });
+    // Cap check passes (peak slot available) but spacing still blocks.
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toMatch(/spacing/);
+  });
+
+  it('treats a future-dated lastPostTs as "no recent post" rather than blocking', () => {
+    // Defensive: clock skew or stale data shouldn't hard-block forever.
+    const lastPostTs = NOW.getTime() + 10 * 60 * 1000;
+    const result = checkGlobalBudgetGate({
+      cadence: NORMAL,
+      globalPostsToday: 1,
+      lastPostTs,
+      now: NOW,
+    });
+    expect(result.allowed).toBe(true);
+  });
+});

--- a/tests/speculation-cadence.test.ts
+++ b/tests/speculation-cadence.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest';
+// @ts-expect-error — sibling .mjs module, no .d.ts
+import { resolveCadence, permitsPost, calendarDaysUntil, CADENCE_LADDER } from '../scripts/lib/speculation-cadence.mjs';
+
+const events = [
+  { id: 'tagging-period', startDate: '2026-02-01T00:00:00.000Z' },
+  { id: 'tag-matching-period', startDate: '2026-03-01T00:00:00.000Z' },
+  { id: 'offseason-fa-opens', startDate: '2026-03-19T00:00:00.000Z' },
+  { id: 'nfl-draft', startDate: '2026-04-23T00:00:00.000Z' },
+  { id: 'rookie-draft', startDate: '2026-05-02T00:00:00.000Z' },
+  { id: 'nfl-season-starts', startDate: '2026-09-10T00:00:00.000Z' },
+  { id: 'trading-deadline', startDate: '2026-11-13T00:00:00.000Z' },
+  { id: 'league-championship', startDate: '2026-12-31T00:00:00.000Z' },
+];
+
+describe('resolveCadence — calendar-aware quota', () => {
+  it('peaks at 2/day in the 7-day window before the trade deadline', () => {
+    // Nov 10, 2026 = 3 days before Nov 13 deadline
+    const cadence = resolveCadence({ events, now: new Date('2026-11-10T18:00:00Z') });
+    expect(cadence.tag).toBe('trade-deadline-peak-week');
+    expect(cadence.maxPerDay).toBe(2);
+    expect(cadence.reservesGlobalSlot).toBe(true);
+  });
+
+  it('drops to 1/day in the 8–21 day ramp before the deadline', () => {
+    // Oct 28 = 16 days before Nov 13
+    const cadence = resolveCadence({ events, now: new Date('2026-10-28T18:00:00Z') });
+    expect(cadence.tag).toBe('trade-deadline-ramp');
+    expect(cadence.maxPerDay).toBe(1);
+  });
+
+  it('hits NFL Draft window in the days leading up to the draft', () => {
+    const cadence = resolveCadence({ events, now: new Date('2026-04-20T18:00:00Z') });
+    expect(cadence.tag).toBe('nfl-draft-window');
+    expect(cadence.maxPerDay).toBe(1);
+  });
+
+  it('lands on quiet-offseason fallback when nothing else matches (mid-July)', () => {
+    const cadence = resolveCadence({ events, now: new Date('2026-07-15T18:00:00Z') });
+    expect(cadence.tag).toBe('quiet-offseason-default');
+    expect(cadence.maxPerDay).toBeCloseTo(1 / 3, 5);
+  });
+
+  it('returns 0/day after the trade deadline through the championship', () => {
+    const cadence = resolveCadence({ events, now: new Date('2026-11-25T18:00:00Z') });
+    expect(cadence.tag).toBe('post-deadline-regular-season');
+    expect(cadence.maxPerDay).toBe(0);
+  });
+
+  it('uses regular-season default in early October (>22d before deadline)', () => {
+    // Oct 1 is 43 days before Nov 13 — still inside the in-season but pre-ramp window
+    const cadence = resolveCadence({ events, now: new Date('2026-10-01T18:00:00Z') });
+    expect(cadence.tag).toBe('regular-season-default');
+    expect(cadence.maxPerDay).toBe(0.5);
+  });
+
+  it('returns NO rule (0 quota) when no events are available', () => {
+    // Empty event list: only the fallback rule matches → quiet offseason
+    const cadence = resolveCadence({ events: [], now: new Date('2026-06-15T12:00:00Z') });
+    expect(cadence.tag).toBe('quiet-offseason-default');
+  });
+});
+
+describe('permitsPost — fractional vs integer cadence', () => {
+  it('allows a post when integer lane cap not yet met', () => {
+    const cadence = { tag: 'foo', maxPerDay: 2, reservesGlobalSlot: false };
+    expect(permitsPost({ cadence, postsTodayInLane: 1, lastPostAt: null })).toEqual({ allowed: true });
+  });
+
+  it('blocks when integer lane cap already met', () => {
+    const cadence = { tag: 'foo', maxPerDay: 2, reservesGlobalSlot: false };
+    const result = permitsPost({ cadence, postsTodayInLane: 2, lastPostAt: null });
+    expect(result.allowed).toBe(false);
+  });
+
+  it('allows fractional cadence when never posted before', () => {
+    const cadence = { tag: 'quiet', maxPerDay: 1 / 3, reservesGlobalSlot: false };
+    expect(permitsPost({ cadence, postsTodayInLane: 0, lastPostAt: null })).toEqual({ allowed: true });
+  });
+
+  it('blocks fractional cadence (1 per 3 days) when last post was yesterday', () => {
+    const cadence = { tag: 'quiet', maxPerDay: 1 / 3, reservesGlobalSlot: false };
+    const now = new Date('2026-06-10T12:00:00Z');
+    const yesterday = new Date('2026-06-09T12:00:00Z');
+    const result = permitsPost({ cadence, postsTodayInLane: 0, lastPostAt: yesterday, now });
+    expect(result.allowed).toBe(false);
+  });
+
+  it('allows fractional cadence (1 per 2 days) after the required gap has elapsed', () => {
+    const cadence = { tag: 'rs', maxPerDay: 0.5, reservesGlobalSlot: false };
+    const now = new Date('2026-10-05T12:00:00Z');
+    const twoDaysAgo = new Date('2026-10-03T12:00:00Z');
+    const result = permitsPost({ cadence, postsTodayInLane: 0, lastPostAt: twoDaysAgo, now });
+    expect(result.allowed).toBe(true);
+  });
+});
+
+describe('calendarDaysUntil — PT calendar diff', () => {
+  it('returns 0 for same PT calendar day (both at PT noon)', () => {
+    // 19:00 UTC = 12:00 PT in May
+    expect(calendarDaysUntil('2026-05-07T19:00:00Z', new Date('2026-05-07T19:00:00Z'))).toBe(0);
+  });
+
+  it('returns positive for future, negative for past', () => {
+    expect(calendarDaysUntil('2026-05-10T19:00:00Z', new Date('2026-05-07T19:00:00Z'))).toBe(3);
+    expect(calendarDaysUntil('2026-05-03T19:00:00Z', new Date('2026-05-07T19:00:00Z'))).toBe(-4);
+  });
+});
+
+describe('CADENCE_LADDER — sanity', () => {
+  it('ends with a fallback rule', () => {
+    expect(CADENCE_LADDER[CADENCE_LADDER.length - 1].fallback).toBe(true);
+  });
+
+  it('reserves a slot only on peak-deadline week', () => {
+    const reservers = CADENCE_LADDER.filter((r: { reservesGlobalSlot: boolean }) => r.reservesGlobalSlot);
+    expect(reservers.map((r: { id: string }) => r.id)).toEqual(['trade-deadline-peak-week']);
+  });
+});

--- a/tests/speculation-cadence.test.ts
+++ b/tests/speculation-cadence.test.ts
@@ -38,7 +38,7 @@ describe('resolveCadence — calendar-aware quota', () => {
   it('lands on quiet-offseason fallback when nothing else matches (mid-July)', () => {
     const cadence = resolveCadence({ events, now: new Date('2026-07-15T18:00:00Z') });
     expect(cadence.tag).toBe('quiet-offseason-default');
-    expect(cadence.maxPerDay).toBeCloseTo(1 / 3, 5);
+    expect(cadence.maxPerDay).toBeCloseTo(1 / 14, 5);
   });
 
   it('returns 0/day after the trade deadline through the championship', () => {
@@ -51,7 +51,7 @@ describe('resolveCadence — calendar-aware quota', () => {
     // Oct 1 is 43 days before Nov 13 — still inside the in-season but pre-ramp window
     const cadence = resolveCadence({ events, now: new Date('2026-10-01T18:00:00Z') });
     expect(cadence.tag).toBe('regular-season-default');
-    expect(cadence.maxPerDay).toBe(0.5);
+    expect(cadence.maxPerDay).toBeCloseTo(1 / 5, 5);
   });
 
   it('returns NO rule (0 quota) when no events are available', () => {
@@ -92,6 +92,30 @@ describe('permitsPost — fractional vs integer cadence', () => {
     const twoDaysAgo = new Date('2026-10-03T12:00:00Z');
     const result = permitsPost({ cadence, postsTodayInLane: 0, lastPostAt: twoDaysAgo, now });
     expect(result.allowed).toBe(true);
+  });
+
+  it('blocks 1-per-5-day regular-season cadence at 3 days since last post', () => {
+    const cadence = { tag: 'rs', maxPerDay: 1 / 5, reservesGlobalSlot: false };
+    const now = new Date('2026-10-05T12:00:00Z');
+    const threeDaysAgo = new Date('2026-10-02T12:00:00Z');
+    const result = permitsPost({ cadence, postsTodayInLane: 0, lastPostAt: threeDaysAgo, now });
+    expect(result.allowed).toBe(false);
+  });
+
+  it('allows 1-per-5-day regular-season cadence after 4 days have elapsed', () => {
+    const cadence = { tag: 'rs', maxPerDay: 1 / 5, reservesGlobalSlot: false };
+    const now = new Date('2026-10-05T12:00:00Z');
+    const fourDaysAgo = new Date('2026-10-01T12:00:00Z');
+    const result = permitsPost({ cadence, postsTodayInLane: 0, lastPostAt: fourDaysAgo, now });
+    expect(result.allowed).toBe(true);
+  });
+
+  it('blocks 1-per-14-day quiet-offseason cadence after just 1 week', () => {
+    const cadence = { tag: 'quiet', maxPerDay: 1 / 14, reservesGlobalSlot: false };
+    const now = new Date('2026-07-15T12:00:00Z');
+    const sevenDaysAgo = new Date('2026-07-08T12:00:00Z');
+    const result = permitsPost({ cadence, postsTodayInLane: 0, lastPostAt: sevenDaysAgo, now });
+    expect(result.allowed).toBe(false);
   });
 });
 

--- a/tests/speculation-history.test.ts
+++ b/tests/speculation-history.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest';
+import {
+  tradeSignature,
+  recentlyPostedTrade,
+  franchiseInRecentRotation,
+  pruneLedger,
+  appendEntry,
+  postsToday,
+  lastPostAt,
+// @ts-expect-error — sibling .mjs module, no .d.ts
+} from '../scripts/lib/speculation-history.mjs';
+
+const DAY = 24 * 60 * 60 * 1000;
+
+describe('tradeSignature — canonical key', () => {
+  it('is order-independent on franchise pair', () => {
+    const a = tradeSignature({
+      seller: '0001', buyer: '0002', marqueeId: 'p1', returnPkgIds: ['p2', 'p3'],
+    });
+    const b = tradeSignature({
+      seller: '0002', buyer: '0001', marqueeId: 'p1', returnPkgIds: ['p2', 'p3'],
+    });
+    expect(a).toBe(b);
+  });
+
+  it('changes when the package contents change', () => {
+    const a = tradeSignature({
+      seller: '0001', buyer: '0002', marqueeId: 'p1', returnPkgIds: ['p2', 'p3'],
+    });
+    const b = tradeSignature({
+      seller: '0001', buyer: '0002', marqueeId: 'p1', returnPkgIds: ['p2', 'p4'],
+    });
+    expect(a).not.toBe(b);
+  });
+});
+
+describe('recentlyPostedTrade — 30-day rotation gate', () => {
+  const sig = tradeSignature({
+    seller: '0001', buyer: '0002', marqueeId: 'pX', returnPkgIds: ['pA', 'pB'],
+  });
+
+  it('flags as recently posted within the 30-day window', () => {
+    const now = new Date('2026-06-15T12:00:00Z');
+    const ledger = {
+      version: 1,
+      entries: [
+        { signature: sig, postedAt: now.getTime() - 10 * DAY, franchiseIds: ['0001', '0002'] },
+      ],
+    };
+    expect(recentlyPostedTrade(ledger, sig, now)).toBe(true);
+  });
+
+  it('clears once the entry is older than 30 days', () => {
+    const now = new Date('2026-06-15T12:00:00Z');
+    const ledger = {
+      version: 1,
+      entries: [
+        { signature: sig, postedAt: now.getTime() - 31 * DAY, franchiseIds: ['0001', '0002'] },
+      ],
+    };
+    expect(recentlyPostedTrade(ledger, sig, now)).toBe(false);
+  });
+});
+
+describe('franchiseInRecentRotation — 7-day per-franchise cooldown', () => {
+  const now = new Date('2026-06-15T12:00:00Z');
+  const ledger = {
+    version: 1,
+    entries: [
+      { signature: 'sig1', postedAt: now.getTime() - 3 * DAY, franchiseIds: ['0001', '0005'] },
+      { signature: 'sig2', postedAt: now.getTime() - 9 * DAY, franchiseIds: ['0002', '0001'] },
+    ],
+  };
+
+  it('flags franchises featured in the last 7 days', () => {
+    expect(franchiseInRecentRotation(ledger, '0001', now)).toBe(true);
+    expect(franchiseInRecentRotation(ledger, '0005', now)).toBe(true);
+  });
+
+  it('clears once the entry is older than 7 days', () => {
+    // 0002 was only in the 9-day-old entry → has cooled off
+    expect(franchiseInRecentRotation(ledger, '0002', now)).toBe(false);
+  });
+
+  it('returns false for a never-featured franchise', () => {
+    expect(franchiseInRecentRotation(ledger, '0099', now)).toBe(false);
+  });
+});
+
+describe('pruneLedger — drops ancient entries', () => {
+  it('keeps recent and drops older than 35 days', () => {
+    const now = new Date('2026-06-15T12:00:00Z');
+    const ledger = {
+      version: 1,
+      entries: [
+        { signature: 'fresh', postedAt: now.getTime() - 1 * DAY, franchiseIds: ['0001'] },
+        { signature: 'old', postedAt: now.getTime() - 40 * DAY, franchiseIds: ['0001'] },
+      ],
+    };
+    const pruned = pruneLedger(ledger, now);
+    expect(pruned.entries).toHaveLength(1);
+    expect(pruned.entries[0].signature).toBe('fresh');
+  });
+});
+
+describe('appendEntry / postsToday / lastPostAt', () => {
+  it('appendEntry produces a new immutable ledger', () => {
+    const original = { version: 1, entries: [] };
+    const next = appendEntry(original, { signature: 's1', postedAt: 100, franchiseIds: ['0001'] });
+    expect(original.entries).toHaveLength(0);
+    expect(next.entries).toHaveLength(1);
+  });
+
+  it('postsToday counts entries posted in the current PT calendar day', () => {
+    const ptNoon = new Date('2026-06-15T19:00:00Z'); // 12pm PT
+    const ledger = {
+      version: 1,
+      entries: [
+        { signature: 'a', postedAt: new Date('2026-06-15T16:00:00Z').getTime(), franchiseIds: [] },
+        { signature: 'b', postedAt: new Date('2026-06-14T19:00:00Z').getTime(), franchiseIds: [] },
+      ],
+    };
+    expect(postsToday(ledger, ptNoon)).toBe(1);
+  });
+
+  it('lastPostAt returns the newest entry timestamp as a Date', () => {
+    const ledger = {
+      version: 1,
+      entries: [
+        { signature: 'a', postedAt: 100, franchiseIds: [] },
+        { signature: 'b', postedAt: 500, franchiseIds: [] },
+        { signature: 'c', postedAt: 300, franchiseIds: [] },
+      ],
+    };
+    expect(lastPostAt(ledger)?.getTime()).toBe(500);
+  });
+
+  it('lastPostAt returns null on empty ledger', () => {
+    expect(lastPostAt({ version: 1, entries: [] })).toBeNull();
+  });
+});

--- a/tests/speculation-matching.test.ts
+++ b/tests/speculation-matching.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect } from 'vitest';
+// @ts-expect-error — sibling .mjs module, no .d.ts
+import {
+  findTwoTeamCandidates,
+  buildPositionalWants,
+  buildHaves,
+  franchiseCapSpace,
+  valuePlayer,
+  __testing__,
+// @ts-expect-error — sibling .mjs module, no .d.ts
+} from '../scripts/lib/speculation-matching.mjs';
+
+const adpRankById = new Map<string, number>([
+  // Marquee tier (rank 1–12 → ~85–100)
+  ['p_marquee', 5],
+  // Mid tier (~50)
+  ['p_mid_a', 22],
+  ['p_mid_b', 24],
+  // Buyer return pieces — paired so the package value lands within the
+  // 15% parity gate around the marquee.
+  ['p_buyer_top', 14],
+  ['p_buyer_throw_in', 70],
+  // Bench fillers
+  ['p_filler_a', 90],
+  ['p_filler_b', 95],
+]);
+
+const teams = new Map<string, { division: string; nameMedium: string }>([
+  ['0001', { division: 'Northwest', nameMedium: 'Pigskins' }],
+  ['0002', { division: 'Northwest', nameMedium: 'Wabbits' }],
+  ['0003', { division: 'East', nameMedium: 'Vitside' }],
+]);
+
+const sellerRoster = [
+  { id: 'p_marquee', name: 'Star RB', position: 'RB', salary: 8_000_000, contractYear: '2', status: 'ROSTER', age: 25 },
+  { id: 's_qb1', name: 'Pocket QB', position: 'QB', salary: 12_000_000, contractYear: '3', status: 'ROSTER', age: 30 },
+  { id: 's_wr1', name: 'WR1', position: 'WR', salary: 6_000_000, contractYear: '2', status: 'ROSTER', age: 27 },
+  // No TE listed — seller has a TE want
+];
+
+const buyerRoster = [
+  { id: 'b_qb1', name: 'Veteran QB', position: 'QB', salary: 6_000_000, contractYear: '4', status: 'ROSTER', age: 33 },
+  { id: 'b_qb2', name: 'Backup QB', position: 'QB', salary: 1_000_000, contractYear: '1', status: 'ROSTER', age: 26 },
+  // RB-thin so the buyer "wants" RB
+  { id: 'b_rb1', name: 'Aging RB', position: 'RB', salary: 2_000_000, contractYear: '4', status: 'ROSTER', age: 30 },
+  // WR-stacked surplus + TE filler
+  { id: 'b_wr1', name: 'WR1', position: 'WR', salary: 4_000_000, contractYear: '3', status: 'ROSTER', age: 27 },
+  { id: 'b_wr2', name: 'WR2', position: 'WR', salary: 3_500_000, contractYear: '3', status: 'ROSTER', age: 27 },
+  { id: 'b_wr3', name: 'WR3', position: 'WR', salary: 3_000_000, contractYear: '2', status: 'ROSTER', age: 26 },
+  { id: 'b_wr4', name: 'WR4', position: 'WR', salary: 1_000_000, contractYear: '1', status: 'ROSTER', age: 24 },
+  { id: 'b_wr5', name: 'WR5', position: 'WR', salary: 800_000, contractYear: '1', status: 'ROSTER', age: 24 },
+  { id: 'b_wr6', name: 'WR6', position: 'WR', salary: 600_000, contractYear: '1', status: 'ROSTER', age: 24 },
+  // The headline return TE
+  { id: 'p_buyer_top', name: 'Star TE', position: 'TE', salary: 4_500_000, contractYear: '2', status: 'ROSTER', age: 26 },
+  { id: 'p_buyer_throw_in', name: 'Backup TE', position: 'TE', salary: 600_000, contractYear: '1', status: 'ROSTER', age: 25 },
+];
+
+const playersByFranchise = new Map<string, typeof sellerRoster>([
+  ['0001', sellerRoster],
+  ['0002', buyerRoster],
+]);
+
+const tradeBaitByFranchise = new Map<string, string[]>([
+  ['0001', ['p_marquee']],
+  // Buyer lists their top TE plus a throw-in TE so the matcher can pad
+  // the return package within the 15% parity gate.
+  ['0002', ['p_buyer_top', 'p_buyer_throw_in']],
+]);
+
+describe('valuePlayer + age curve', () => {
+  it('top-tier ADP rank yields a high value', () => {
+    const v = valuePlayer({
+      player: { id: 'p_marquee', position: 'RB', age: 25 },
+      adpRankById,
+    });
+    expect(v).toBeGreaterThan(85);
+  });
+
+  it('age 31 RB gets a heavy discount', () => {
+    const youngVal = valuePlayer({ player: { id: 'p_marquee', position: 'RB', age: 25 }, adpRankById });
+    const oldVal = valuePlayer({
+      player: { id: 'p_marquee', position: 'RB', age: 31 },
+      adpRankById,
+    });
+    expect(oldVal).toBeLessThan(youngVal * 0.6);
+  });
+});
+
+describe('isWithinParity (15% tolerance)', () => {
+  it('exact match passes', () => {
+    expect(__testing__.isWithinParity(80, 80)).toBe(true);
+  });
+  it('14% diff passes', () => {
+    expect(__testing__.isWithinParity(100, 87)).toBe(true);
+  });
+  it('20% diff fails', () => {
+    expect(__testing__.isWithinParity(100, 80)).toBe(false);
+  });
+});
+
+describe('buildPositionalWants', () => {
+  it('flags TE as want when seller has zero TEs', () => {
+    expect(buildPositionalWants(sellerRoster)).toContain('TE');
+  });
+
+  it('flags RB as want when buyer is RB-thin', () => {
+    expect(buildPositionalWants(buyerRoster)).toContain('RB');
+  });
+
+  it('does not flag QB when buyer has 2 QBs already (≥2 satisfies threshold)', () => {
+    expect(buildPositionalWants(buyerRoster)).not.toContain('QB');
+  });
+});
+
+describe('franchiseCapSpace', () => {
+  it('returns 45M cap minus committed salaries', () => {
+    const SALARY_CAP = 45_000_000;
+    const sellerCommitted = sellerRoster.reduce((s, p) => s + p.salary, 0);
+    expect(franchiseCapSpace({ franchisePlayers: sellerRoster })).toBe(SALARY_CAP - sellerCommitted);
+  });
+});
+
+describe('findTwoTeamCandidates — end-to-end', () => {
+  it('produces at least one candidate respecting parity + cap-fit', () => {
+    const candidates = findTwoTeamCandidates({
+      playersByFranchise,
+      tradeBaitByFranchise,
+      adpRankById,
+      teams,
+      limit: 5,
+    });
+    expect(candidates.length).toBeGreaterThan(0);
+    const top = candidates[0];
+    expect(top.seller).toBe('0001');
+    expect(top.buyer).toBe('0002');
+    expect(top.marquee.id).toBe('p_marquee');
+    // Buyer's TE return must hit the seller's TE want
+    expect(top.returnPkg.some((p: { position: string }) => p.position === 'TE')).toBe(true);
+  });
+
+  it('returns empty when buyer has no positional want for marquee', () => {
+    // Strip RB want from buyer by pretending they're RB-stacked
+    const stackedBuyer = [
+      ...buyerRoster,
+      { id: 'b_rb_pad_1', name: 'RB Pad 1', position: 'RB', salary: 500_000, contractYear: '1', status: 'ROSTER', age: 24 },
+      { id: 'b_rb_pad_2', name: 'RB Pad 2', position: 'RB', salary: 500_000, contractYear: '1', status: 'ROSTER', age: 24 },
+      { id: 'b_rb_pad_3', name: 'RB Pad 3', position: 'RB', salary: 500_000, contractYear: '1', status: 'ROSTER', age: 24 },
+    ];
+    const altPlayers = new Map([
+      ['0001', sellerRoster],
+      ['0002', stackedBuyer],
+    ]);
+    const altBait = new Map([
+      ['0001', ['p_marquee']],
+      ['0002', []],
+    ]);
+    const candidates = findTwoTeamCandidates({
+      playersByFranchise: altPlayers,
+      tradeBaitByFranchise: altBait,
+      adpRankById,
+      teams,
+      limit: 5,
+    });
+    expect(candidates).toEqual([]);
+  });
+});

--- a/tests/speculation-matching.test.ts
+++ b/tests/speculation-matching.test.ts
@@ -121,12 +121,19 @@ describe('franchiseCapSpace', () => {
 });
 
 describe('findTwoTeamCandidates — end-to-end', () => {
+  // Hand-supplied medians so the want/have heuristic is independent of the
+  // tiny 2-franchise fixture (auto-computed medians on 2 data points are
+  // degenerate). Mirrors what the runner script does in production where it
+  // computes medians across all 16 league franchises.
+  const fixtureMedians = { QB: 2, RB: 4, WR: 5, TE: 2 };
+
   it('produces at least one candidate respecting parity + cap-fit', () => {
     const candidates = findTwoTeamCandidates({
       playersByFranchise,
       tradeBaitByFranchise,
       adpRankById,
       teams,
+      medians: fixtureMedians,
       limit: 5,
     });
     expect(candidates.length).toBeGreaterThan(0);
@@ -159,6 +166,7 @@ describe('findTwoTeamCandidates — end-to-end', () => {
       tradeBaitByFranchise: altBait,
       adpRankById,
       teams,
+      medians: fixtureMedians,
       limit: 5,
     });
     expect(candidates).toEqual([]);


### PR DESCRIPTION
NFL-calendar-aware cadence (peak in deadline week, ramps through draft +
tagging + FA windows, quiet otherwise) decides whether to publish.
Speculation shares the rumor-mill's 3-posts/day Redis budget; peak week
reserves 1 of those slots so high-stakes posts can't get crowded out.

Voice intentionally framed as fan/local-media chatter (talk radio, fan
boards, beat writers) — NOT as front-office leaks. Both teams' offices
are framed as silent / non-committal so speculation doesn't read like a
real offer.

Phase-1 scope: two-team match search, dynasty-value parity gate (15%),
30-day same-trade and 7-day same-franchise rotation, schefter-feed.json
write. No GroupMe yet (Phase 2). No three-team match (Phase 3).

39 new unit tests (cadence ladder, matching, rotation ledger) all green.
Pre-existing failures in hero-resolver / matchup-preview-utils unchanged.

https://claude.ai/code/session_017nVvWQU8KnxxN4qrGXnxXn