### PR TITLE
fix(schefter-admin): render subtype values as colored pill badges

### DIFF
--- a/src/pages/theleague/admin/schefter.astro
+++ b/src/pages/theleague/admin/schefter.astro
@@ -851,9 +851,17 @@ const offerCum48h = fmtPct(cumulativeAfter(48));
     const subtypes = data.feed?.bySubType || {};
     const subtypesBody = document.getElementById('ops-subtypes-body');
     if (subtypesBody) {
+      const subtypePillVariant = (k: string): string => {
+        const key = k.toUpperCase();
+        if (key === 'TRADE' || key.startsWith('TRADE_')) return 'info';
+        if (key === 'AUCTION_WON' || key.startsWith('AUCTION_')) return 'ok';
+        if (key === 'FREE_AGENT') return 'ok';
+        if (key === 'RUMOR_MILL') return 'warn';
+        return 'mute';
+      };
       const rows = Object.entries(subtypes)
         .sort((a: any, b: any) => b[1] - a[1])
-        .map(([k, count]) => `<tr><td><code>${k}</code></td><td class="ops-table__num">${count}</td></tr>`)
+        .map(([k, count]) => `<tr><td><span class="ops-pill ops-pill--${subtypePillVariant(k)}">${escapeHtml(k)}</span></td><td class="ops-table__num">${count}</td></tr>`)
         .join('');
       subtypesBody.innerHTML = rows || '<tr><td colspan="2">—</td></tr>';
     }


### PR DESCRIPTION
The Subtype table on the schefter ops page was displaying values as
plain <code> elements instead of the pill-style badges used elsewhere
on the page. Color-code each known subtype (TRADE/AUCTION/FREE_AGENT/
RUMOR_MILL) and fall back to a neutral pill for unknown values.

https://claude.ai/code/session_012THWxiHgD7hgz7E6zbaTPE