### PR TITLE
feat: tuesday power rankings — phase 1 (templated, no LLM)

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "fetch:adp:rookies": "pnpm run fetch:adp:sleeper && pnpm run fetch:adp:ktc",
     "fetch:nfl-draft-date": "node scripts/fetch-nfl-draft-date.mjs",
     "compute:franchise-history": "node scripts/compute-franchise-history.mjs",
+    "generate:power-rankings": "node scripts/generate-power-rankings.mjs",
     "backfill:historical-feeds": "node scripts/backfill-historical-feeds.mjs",
     "fetch:nfl-news-digest": "node scripts/fetch-nfl-news-digest.mjs",
     "fetch:trade-bait": "MFL_LEAGUE_ID=13522 MFL_LEAGUE_SLUG=theleague node scripts/fetch-trade-bait.mjs",

--- a/scripts/generate-power-rankings.mjs
+++ b/scripts/generate-power-rankings.mjs
@@ -1,0 +1,631 @@
+#!/usr/bin/env node
+/**
+ * Power Rankings Generator — Phase 1 (templated, no LLM)
+ *
+ * Reads weekly results + standings + schedule for the target year/week and writes
+ * a structured JSON document to src/data/theleague/power-rankings/<year>-w<week>.json
+ * that the /theleague/power-rankings page renders.
+ *
+ * Usage:
+ *   pnpm generate:power-rankings --year 2025 --week 14
+ *   pnpm generate:power-rankings --year 2025 --week 14 --regenerate
+ *   pnpm generate:power-rankings --dry-run --year 2025 --week 14
+ *
+ * Phase 1 scope:
+ *  - Composite ranking algorithm (rolling-3wk PF + record + all-play)
+ *  - Award detection (statOfWeek, benchBlunder, heater, cooler, matchupOfWeek)
+ *  - Templated blurbs — no Claude API calls
+ *
+ * Phase 2 will swap templated blurbs for AI-generated ones via the article-utils
+ * AI client. The JSON shape is identical so the page renderer doesn't change.
+ */
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const projectRoot = path.resolve(fileURLToPath(new URL('..', import.meta.url)));
+
+// ─── Algorithm weights (composite ranking score) ───────────────────
+//   60% — rolling-3wk PPG (form)
+//   25% — head-to-head record (results)
+//   15% — all-play % (luck-adjusted strength)
+// Cap-health weight from the design doc is deferred to Phase 2 (needs salary
+// pipeline plumbed in). Total still sums to 1.0 by upweighting form.
+const W_FORM = 0.60;
+const W_RECORD = 0.25;
+const W_ALL_PLAY = 0.15;
+
+// ─── CLI ───────────────────────────────────────────────────────────
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const opts = { year: null, week: null, dryRun: false, regenerate: false };
+  for (let i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case '--year': opts.year = parseInt(args[++i], 10); break;
+      case '--week': opts.week = parseInt(args[++i], 10); break;
+      case '--dry-run': opts.dryRun = true; break;
+      case '--regenerate': opts.regenerate = true; break;
+      case '-h':
+      case '--help':
+        printUsage();
+        process.exit(0);
+    }
+  }
+  return opts;
+}
+
+function printUsage() {
+  console.log(`Usage: node scripts/generate-power-rankings.mjs --year YYYY --week N [--dry-run] [--regenerate]`);
+}
+
+// ─── Loaders ───────────────────────────────────────────────────────
+
+async function loadJSON(p) {
+  return JSON.parse(await fs.readFile(p, 'utf8'));
+}
+
+async function loadTeamsConfig() {
+  const cfg = await loadJSON(path.join(projectRoot, 'src', 'data', 'theleague.config.json'));
+  const teams = new Map();
+  for (const t of cfg.teams) {
+    teams.set(t.franchiseId, {
+      franchiseId: t.franchiseId,
+      name: t.name,
+      nameMedium: t.nameMedium ?? t.name,
+      nameShort: t.nameShort ?? t.name,
+      abbrev: t.abbrev,
+      color: t.color,
+      division: t.division,
+      icon: t.icon,
+      banner: t.banner,
+    });
+  }
+  return { teams, divisions: cfg.divisions };
+}
+
+function feedDir(year) {
+  return path.join(projectRoot, 'data', 'theleague', 'mfl-feeds', String(year));
+}
+
+function powerRankingsDir() {
+  return path.join(projectRoot, 'src', 'data', 'theleague', 'power-rankings');
+}
+
+function rankingsFilePath(year, week) {
+  return path.join(powerRankingsDir(), `${year}-w${String(week).padStart(2, '0')}.json`);
+}
+
+async function tryLoadJSON(p) {
+  try { return await loadJSON(p); } catch { return null; }
+}
+
+// ─── Helpers ───────────────────────────────────────────────────────
+
+function num(v, fallback = 0) {
+  const n = typeof v === 'number' ? v : parseFloat(v);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function int(v, fallback = 0) {
+  const n = typeof v === 'number' ? v : parseInt(v, 10);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+/** Parse MFL streak string "W3" / "L4" / "" → { type: 'W'|'L'|null, length: number } */
+export function parseStreak(strk) {
+  if (!strk || typeof strk !== 'string') return { type: null, length: 0 };
+  const m = strk.trim().match(/^([WL])(\d+)$/i);
+  if (!m) return { type: null, length: 0 };
+  return { type: m[1].toUpperCase(), length: parseInt(m[2], 10) };
+}
+
+/** Average team's last N completed weeks of points. Returns null if no weeks available. */
+export function rollingAvgPF(weeklyResults, franchiseId, throughWeek, n = 3) {
+  const weeks = (weeklyResults?.weeks || [])
+    .filter(w => int(w.week) <= throughWeek && Number.isFinite(num(w.scores?.[franchiseId], NaN)))
+    .sort((a, b) => int(a.week) - int(b.week));
+  if (weeks.length === 0) return null;
+  const slice = weeks.slice(-n);
+  const sum = slice.reduce((acc, w) => acc + num(w.scores?.[franchiseId]), 0);
+  return sum / slice.length;
+}
+
+/** Last-N record from H2H: { wins, losses, ties }. Reads schedule + weekly-results. */
+function rollingRecord(schedule, weeklyResults, franchiseId, throughWeek, n = 3) {
+  const ws = schedule?.schedule?.weeklySchedule || [];
+  const weekScores = new Map();
+  for (const w of (weeklyResults?.weeks || [])) {
+    weekScores.set(int(w.week), w.scores || {});
+  }
+  // Walk completed weeks descending, record per-game outcomes for this franchise
+  const games = [];
+  for (const w of ws) {
+    const wk = int(w.week);
+    if (wk > throughWeek) continue;
+    const scores = weekScores.get(wk);
+    if (!scores) continue;
+    for (const m of (w.matchup || [])) {
+      const fs = m.franchise || [];
+      const me = fs.find(f => f.id === franchiseId);
+      if (!me) continue;
+      const opp = fs.find(f => f.id !== franchiseId);
+      if (!opp) continue;
+      const myScore = num(scores[franchiseId], NaN);
+      const oppScore = num(scores[opp.id], NaN);
+      if (!Number.isFinite(myScore) || !Number.isFinite(oppScore)) continue;
+      games.push({ wk, myScore, oppScore });
+    }
+  }
+  games.sort((a, b) => a.wk - b.wk);
+  const slice = games.slice(-n);
+  let wins = 0, losses = 0, ties = 0;
+  for (const g of slice) {
+    if (g.myScore > g.oppScore) wins++;
+    else if (g.myScore < g.oppScore) losses++;
+    else ties++;
+  }
+  return { wins, losses, ties, gamesCounted: slice.length };
+}
+
+/** Normalize array of values to 0-100 by min-max. */
+function minMax01(values) {
+  const finite = values.filter(v => Number.isFinite(v));
+  if (finite.length === 0) return values.map(() => 50);
+  const min = Math.min(...finite);
+  const max = Math.max(...finite);
+  if (max === min) return values.map(() => 50);
+  return values.map(v => Number.isFinite(v) ? ((v - min) / (max - min)) * 100 : 50);
+}
+
+// ─── Composite ranking ─────────────────────────────────────────────
+
+export function computeRankings({ teams, standingsByFid, weeklyResults, schedule, week }) {
+  const franchiseIds = [...teams.keys()];
+
+  // Compute per-team rolling averages
+  const rolling = franchiseIds.map(fid => ({
+    fid,
+    ppg: rollingAvgPF(weeklyResults, fid, week, 3),
+    seasonPpg: num(standingsByFid.get(fid)?.avgpf, 0),
+  }));
+
+  const ppgRaw = rolling.map(r => r.ppg ?? r.seasonPpg);
+  const ppgScores = minMax01(ppgRaw);
+
+  // Record: H2H pct from standings (.000 to 1.000) → 0-100
+  const recordScores = franchiseIds.map(fid => {
+    const s = standingsByFid.get(fid);
+    return num(s?.h2hpct, 0.5) * 100;
+  });
+
+  // All-play %: from standings → 0-100
+  const allPlayScores = franchiseIds.map(fid => {
+    const s = standingsByFid.get(fid);
+    return num(s?.all_play_pct, 0.5) * 100;
+  });
+
+  const composite = franchiseIds.map((fid, i) =>
+    W_FORM * ppgScores[i] + W_RECORD * recordScores[i] + W_ALL_PLAY * allPlayScores[i]
+  );
+
+  // Rank by composite descending
+  const indexed = franchiseIds.map((fid, i) => ({
+    fid,
+    composite: composite[i],
+    ppgScore: ppgScores[i],
+    recordScore: recordScores[i],
+    allPlayScore: allPlayScores[i],
+    rolling3Ppg: rolling[i].ppg,
+    seasonPpg: rolling[i].seasonPpg,
+  }));
+  indexed.sort((a, b) => {
+    if (b.composite !== a.composite) return b.composite - a.composite;
+    return b.seasonPpg - a.seasonPpg; // tiebreak
+  });
+
+  return indexed.map((row, idx) => ({ rank: idx + 1, ...row }));
+}
+
+// ─── Trend (vs. previous week) ──────────────────────────────────────
+
+async function loadPreviousRankings(year, week) {
+  // First try same-year previous week, then previous week's playoffs etc.
+  for (let w = week - 1; w >= 1; w--) {
+    const prior = await tryLoadJSON(rankingsFilePath(year, w));
+    if (prior?.rankings?.length) return { week: w, rankings: prior.rankings };
+  }
+  return null;
+}
+
+export function attachTrend(rankings, previous) {
+  if (!previous) {
+    return rankings.map(r => ({ ...r, previousRank: null, trend: 'flat' }));
+  }
+  const priorMap = new Map(previous.rankings.map(r => [r.franchiseId, r.rank]));
+  return rankings.map(r => {
+    const prev = priorMap.get(r.fid) ?? null;
+    let trend = 'flat';
+    if (prev != null) {
+      if (prev > r.rank) trend = 'up';
+      else if (prev < r.rank) trend = 'down';
+    }
+    return { ...r, previousRank: prev, trend };
+  });
+}
+
+// ─── Awards (deterministic; templated blurbs in Phase 1) ────────────
+
+function findStatOfWeek({ teams, weeklyResults, week }) {
+  const wk = (weeklyResults?.weeks || []).find(w => int(w.week) === week);
+  if (!wk?.scores) return null;
+  let topFid = null, topScore = -Infinity;
+  for (const [fid, s] of Object.entries(wk.scores)) {
+    const v = num(s, NaN);
+    if (Number.isFinite(v) && v > topScore) { topScore = v; topFid = fid; }
+  }
+  if (!topFid) return null;
+  const team = teams.get(topFid);
+  return {
+    franchiseId: topFid,
+    title: 'Stat of the Week',
+    blurb: `${team?.nameMedium ?? topFid} dropped ${topScore.toFixed(2)} — the highest score in the league this week.`,
+    metric: { score: topScore },
+  };
+}
+
+function findBenchBlunder({ teams, rawWeekly, week }) {
+  const wk = rawWeekly.find(w => int(w?.weeklyResults?.week) === week);
+  if (!wk) return null;
+  let worstFid = null, worstGap = -Infinity, worstActual = 0, worstOptimal = 0;
+  for (const m of (wk.weeklyResults?.matchup || [])) {
+    for (const f of (m.franchise || [])) {
+      const actual = num(f.score, NaN);
+      const optimal = num(f.opt_pts, NaN);
+      if (!Number.isFinite(actual) || !Number.isFinite(optimal)) continue;
+      const gap = optimal - actual;
+      if (gap > worstGap) {
+        worstGap = gap;
+        worstFid = f.id;
+        worstActual = actual;
+        worstOptimal = optimal;
+      }
+    }
+  }
+  if (!worstFid) return null;
+  const team = teams.get(worstFid);
+  return {
+    franchiseId: worstFid,
+    title: 'Bench Blunder of the Week',
+    blurb: `${team?.nameMedium ?? worstFid} left ${worstGap.toFixed(2)} on the bench (${worstActual.toFixed(2)} actual vs ${worstOptimal.toFixed(2)} optimal).`,
+    metric: { actual: worstActual, optimal: worstOptimal, gap: worstGap },
+  };
+}
+
+function findHeaterAndCooler({ teams, standingsByFid }) {
+  let heaterFid = null, heaterLen = 0;
+  let coolerFid = null, coolerLen = 0;
+  for (const [fid, s] of standingsByFid.entries()) {
+    const { type, length } = parseStreak(s.strk);
+    if (type === 'W' && length > heaterLen) { heaterFid = fid; heaterLen = length; }
+    if (type === 'L' && length > coolerLen) { coolerFid = fid; coolerLen = length; }
+  }
+  const heater = heaterFid ? {
+    franchiseId: heaterFid,
+    title: 'Heater of the Week',
+    blurb: `${teams.get(heaterFid)?.nameMedium ?? heaterFid} have won ${heaterLen} straight — longest active win streak in the league.`,
+    metric: { streak: heaterLen },
+  } : null;
+  const cooler = coolerFid ? {
+    franchiseId: coolerFid,
+    title: 'Cooler of the Week',
+    blurb: `${teams.get(coolerFid)?.nameMedium ?? coolerFid} have dropped ${coolerLen} in a row — the longest active losing streak in the league.`,
+    metric: { streak: coolerLen },
+  } : null;
+  return { heater, cooler };
+}
+
+function findMatchupOfWeek({ teams, schedule, rankings, week }) {
+  const ws = schedule?.schedule?.weeklySchedule || [];
+  const next = ws.find(w => int(w.week) === week + 1);
+  if (!next) return null;
+  const rankByFid = new Map(rankings.map(r => [r.franchiseId, r.rank]));
+  let pick = null, pickScore = Infinity;
+  for (const m of (next.matchup || [])) {
+    const fs = m.franchise || [];
+    if (fs.length !== 2) continue;
+    const [a, b] = fs;
+    const ra = rankByFid.get(a.id);
+    const rb = rankByFid.get(b.id);
+    if (ra == null || rb == null) continue;
+    // Closest top-half matchup: minimize avg(rank) + |diff|
+    const avg = (ra + rb) / 2;
+    const diff = Math.abs(ra - rb);
+    const score = avg + diff * 0.25;
+    if (score < pickScore) {
+      pickScore = score;
+      pick = { homeId: a.isHome === '1' ? a.id : b.id, awayId: a.isHome === '1' ? b.id : a.id, ra, rb };
+    }
+  }
+  if (!pick) return null;
+  const home = teams.get(pick.homeId);
+  const away = teams.get(pick.awayId);
+  const homeRank = rankByFid.get(pick.homeId);
+  const awayRank = rankByFid.get(pick.awayId);
+  return {
+    title: 'Matchup of the Week',
+    homeId: pick.homeId,
+    awayId: pick.awayId,
+    blurb: `Week ${week + 1}: #${awayRank} ${away?.nameMedium ?? pick.awayId} at #${homeRank} ${home?.nameMedium ?? pick.homeId}. Highest-ranked clash on the slate.`,
+    metric: { homeRank, awayRank },
+  };
+}
+
+// ─── Templated blurbs for individual rankings (Phase 1) ─────────────
+
+function rankingBlurb(row, teams, standingsByFid, schedule, weeklyResults, week) {
+  const team = teams.get(row.franchiseId);
+  const standing = standingsByFid.get(row.franchiseId);
+  const rec = rollingRecord(schedule, weeklyResults, row.franchiseId, week, 3);
+  const ppg = row.rolling3Ppg ?? row.seasonPpg;
+  const ppgStr = Number.isFinite(ppg) ? `${ppg.toFixed(1)} PPG` : null;
+  const recStr = rec.gamesCounted > 0 ? `${rec.wins}-${rec.losses}${rec.ties ? `-${rec.ties}` : ''} over their last ${rec.gamesCounted}` : null;
+  const trendStr = (() => {
+    if (row.previousRank == null) return null;
+    const delta = row.previousRank - row.rank;
+    if (delta > 0) return `up ${delta} from #${row.previousRank}`;
+    if (delta < 0) return `down ${-delta} from #${row.previousRank}`;
+    return 'holding steady';
+  })();
+  const streak = parseStreak(standing?.strk);
+  const streakStr = streak.length >= 2
+    ? (streak.type === 'W' ? `${streak.length}-game win streak` : `${streak.length}-game skid`)
+    : null;
+
+  const parts = [];
+  if (recStr && ppgStr) parts.push(`${recStr} at ${ppgStr}.`);
+  else if (ppgStr) parts.push(`Averaging ${ppgStr} over recent weeks.`);
+  if (streakStr) parts.push(`Riding a ${streakStr}.`);
+  if (trendStr) parts.push(`Rankings: ${trendStr}.`);
+  if (parts.length === 0) parts.push(`Reset week — limited data.`);
+  return parts.join(' ');
+}
+
+// ─── Standings snapshot ─────────────────────────────────────────────
+
+function buildStandingsSnapshot({ teams, divisions, standingsByFid }) {
+  const byDivision = new Map();
+  for (const div of divisions) byDivision.set(div, []);
+  for (const [fid, t] of teams.entries()) {
+    const s = standingsByFid.get(fid);
+    const wins = int(s?.h2hw, 0);
+    const losses = int(s?.h2hl, 0);
+    const ties = int(s?.h2ht, 0);
+    const pf = num(s?.pf, 0);
+    const pa = num(s?.pa, 0);
+    const ppg = num(s?.avgpf, 0);
+    const allPlayPct = num(s?.all_play_pct, 0);
+    const allPlayWLT = s?.all_play_wlt || '';
+    const row = { franchiseId: fid, name: t.name, nameMedium: t.nameMedium, abbrev: t.abbrev, division: t.division, wins, losses, ties, pf, pa, ppg, allPlayPct, allPlayWLT };
+    if (byDivision.has(t.division)) byDivision.get(t.division).push(row);
+  }
+  const divisionsOut = divisions.map(name => ({
+    name,
+    teams: (byDivision.get(name) || []).slice().sort((a, b) => {
+      if (b.wins !== a.wins) return b.wins - a.wins;
+      return b.pf - a.pf;
+    }),
+  }));
+  const allPlay = [...standingsByFid.entries()]
+    .map(([fid, s]) => {
+      const t = teams.get(fid);
+      return {
+        franchiseId: fid,
+        name: t?.name ?? fid,
+        nameMedium: t?.nameMedium ?? fid,
+        abbrev: t?.abbrev ?? '',
+        division: t?.division ?? '',
+        allPlayPct: num(s?.all_play_pct, 0),
+        allPlayWLT: s?.all_play_wlt || '',
+        pf: num(s?.pf, 0),
+      };
+    })
+    .sort((a, b) => b.allPlayPct - a.allPlayPct);
+  return { divisions: divisionsOut, allPlay };
+}
+
+// ─── Lede headline (Phase 1 templated) ──────────────────────────────
+
+function buildHeadlineAndLede({ teams, rankings, awards, week, year }) {
+  const top = rankings[0];
+  const topTeam = teams.get(top.franchiseId);
+  const moverUp = rankings
+    .filter(r => r.previousRank != null)
+    .sort((a, b) => (b.previousRank - b.rank) - (a.previousRank - a.rank))[0];
+  const moverDown = rankings
+    .filter(r => r.previousRank != null)
+    .sort((a, b) => (a.previousRank - a.rank) - (b.previousRank - b.rank))[0];
+
+  const headline = (() => {
+    if (moverUp && (moverUp.previousRank - moverUp.rank) >= 3) {
+      const team = teams.get(moverUp.franchiseId);
+      return `${team?.nameShort ?? moverUp.franchiseId} surges to #${moverUp.rank}`;
+    }
+    return `${topTeam?.nameShort ?? top.franchiseId} hold #1 entering Week ${week + 1}`;
+  })();
+
+  const ledeParts = [`Through Week ${week}, ${topTeam?.name ?? top.franchiseId} sit atop the rankings.`];
+  if (awards.statOfWeek) ledeParts.push(awards.statOfWeek.blurb);
+  if (moverUp && (moverUp.previousRank - moverUp.rank) >= 2) {
+    const team = teams.get(moverUp.franchiseId);
+    ledeParts.push(`${team?.nameMedium ?? moverUp.franchiseId} jump ${moverUp.previousRank - moverUp.rank} spots to #${moverUp.rank}.`);
+  }
+  if (moverDown && (moverDown.rank - moverDown.previousRank) >= 2) {
+    const team = teams.get(moverDown.franchiseId);
+    ledeParts.push(`${team?.nameMedium ?? moverDown.franchiseId} slide ${moverDown.rank - moverDown.previousRank} to #${moverDown.rank}.`);
+  }
+
+  return { headline, lede: ledeParts.join(' ') };
+}
+
+// ─── Main ──────────────────────────────────────────────────────────
+
+export async function generatePowerRankings({ year, week }) {
+  const dir = feedDir(year);
+  const teamsConfig = await loadTeamsConfig();
+
+  const [weeklyResults, rawWeekly, standings, schedule] = await Promise.all([
+    loadJSON(path.join(dir, 'weekly-results.json')),
+    loadJSON(path.join(dir, 'weekly-results-raw.json')),
+    loadJSON(path.join(dir, 'standings.json')),
+    loadJSON(path.join(dir, 'schedule.json')),
+  ]);
+
+  const standingsByFid = new Map();
+  for (const f of (standings?.leagueStandings?.franchise || [])) {
+    standingsByFid.set(f.id, f);
+  }
+
+  // Composite rankings
+  const rawRankings = computeRankings({
+    teams: teamsConfig.teams,
+    standingsByFid,
+    weeklyResults,
+    schedule,
+    week,
+  });
+
+  // Trend vs previous week
+  const previous = await loadPreviousRankings(year, week);
+  const ranked = attachTrend(rawRankings, previous);
+
+  // Awards
+  const statOfWeek = findStatOfWeek({ teams: teamsConfig.teams, weeklyResults, week });
+  const benchBlunder = findBenchBlunder({ teams: teamsConfig.teams, rawWeekly, week });
+  const { heater, cooler } = findHeaterAndCooler({ teams: teamsConfig.teams, standingsByFid });
+
+  // We need a temporary rankings shape with franchiseId set for matchup lookup
+  const namedRankings = ranked.map(r => ({
+    rank: r.rank,
+    franchiseId: r.fid,
+    previousRank: r.previousRank,
+    trend: r.trend,
+    metrics: {
+      composite: round2(r.composite),
+      rolling3Ppg: r.rolling3Ppg == null ? null : round2(r.rolling3Ppg),
+      seasonPpg: round2(r.seasonPpg),
+      ppgScore: round2(r.ppgScore),
+      recordScore: round2(r.recordScore),
+      allPlayScore: round2(r.allPlayScore),
+    },
+  }));
+
+  const matchupOfWeek = findMatchupOfWeek({
+    teams: teamsConfig.teams,
+    schedule,
+    rankings: namedRankings,
+    week,
+  });
+
+  // Build blurbs (templated)
+  const rankings = namedRankings.map(r => ({
+    ...r,
+    blurb: rankingBlurb(
+      { ...r, rolling3Ppg: r.metrics.rolling3Ppg, seasonPpg: r.metrics.seasonPpg },
+      teamsConfig.teams,
+      standingsByFid,
+      schedule,
+      weeklyResults,
+      week
+    ),
+  }));
+
+  const awards = {
+    statOfWeek,
+    benchBlunder,
+    tradeOfWeek: null,    // Phase 1: deferred (needs transactions parsing + dynasty model)
+    cutOfShame: null,     // Phase 1: deferred (needs salary delta on cut player)
+    heaterOfWeek: heater,
+    coolerOfWeek: cooler,
+    matchupOfWeek,
+  };
+
+  const standingsSnapshot = buildStandingsSnapshot({
+    teams: teamsConfig.teams,
+    divisions: teamsConfig.divisions,
+    standingsByFid,
+  });
+
+  const { headline, lede } = buildHeadlineAndLede({
+    teams: teamsConfig.teams,
+    rankings,
+    awards,
+    week,
+    year,
+  });
+
+  const generatedAt = new Date().toISOString();
+
+  return {
+    year,
+    week,
+    publishedAt: generatedAt,
+    generatedAt,
+    voiceMode: 'templated', // Phase 1; switches to 'schefter' when LLM lands
+    headline,
+    lede,
+    rankings,
+    awards,
+    standings: standingsSnapshot,
+  };
+}
+
+function round2(x) {
+  if (x == null || !Number.isFinite(x)) return null;
+  return Math.round(x * 100) / 100;
+}
+
+async function main() {
+  const opts = parseArgs();
+  if (opts.year == null || opts.week == null) {
+    printUsage();
+    process.exit(1);
+  }
+
+  console.log(`📊 Power Rankings — ${opts.year} Week ${opts.week}\n`);
+
+  const outPath = rankingsFilePath(opts.year, opts.week);
+  if (!opts.regenerate && !opts.dryRun) {
+    const existing = await tryLoadJSON(outPath);
+    if (existing) {
+      console.log(`  ${path.relative(projectRoot, outPath)} already exists. Pass --regenerate to overwrite.`);
+      return;
+    }
+  }
+
+  const issue = await generatePowerRankings({ year: opts.year, week: opts.week });
+
+  if (opts.dryRun) {
+    console.log('--- DRY RUN ---');
+    console.log(JSON.stringify(issue, null, 2));
+    return;
+  }
+
+  await fs.mkdir(powerRankingsDir(), { recursive: true });
+  await fs.writeFile(outPath, JSON.stringify(issue, null, 2) + '\n', 'utf8');
+  console.log(`  ✓ Wrote ${path.relative(projectRoot, outPath)}`);
+  console.log(`  Headline: ${issue.headline}`);
+  console.log(`  Top 3:`);
+  for (const r of issue.rankings.slice(0, 3)) {
+    console.log(`    #${r.rank} ${r.franchiseId} — ${r.blurb}`);
+  }
+}
+
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  main().catch(err => {
+    console.error('Error:', err);
+    process.exit(1);
+  });
+}

--- a/scripts/generate-power-rankings.mjs
+++ b/scripts/generate-power-rankings.mjs
@@ -23,6 +23,13 @@
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { callAnthropic } from './article-utils/ai-client.mjs';
+import {
+  buildFactSheet,
+  getSystemPrompt,
+  getUserPrompt,
+  applyAIVoice,
+} from './lib/power-rankings-ai.mjs';
 
 const projectRoot = path.resolve(fileURLToPath(new URL('..', import.meta.url)));
 
@@ -40,13 +47,15 @@ const W_ALL_PLAY = 0.15;
 
 function parseArgs() {
   const args = process.argv.slice(2);
-  const opts = { year: null, week: null, dryRun: false, regenerate: false };
+  const opts = { year: null, week: null, dryRun: false, regenerate: false, ai: null };
   for (let i = 0; i < args.length; i++) {
     switch (args[i]) {
       case '--year': opts.year = parseInt(args[++i], 10); break;
       case '--week': opts.week = parseInt(args[++i], 10); break;
       case '--dry-run': opts.dryRun = true; break;
       case '--regenerate': opts.regenerate = true; break;
+      case '--ai': opts.ai = true; break;
+      case '--no-ai': opts.ai = false; break;
       case '-h':
       case '--help':
         printUsage();
@@ -57,7 +66,10 @@ function parseArgs() {
 }
 
 function printUsage() {
-  console.log(`Usage: node scripts/generate-power-rankings.mjs --year YYYY --week N [--dry-run] [--regenerate]`);
+  console.log(`Usage: node scripts/generate-power-rankings.mjs --year YYYY --week N [--dry-run] [--regenerate] [--ai|--no-ai]`);
+  console.log(`  --ai       Force Claude voice (requires ANTHROPIC_API_KEY)`);
+  console.log(`  --no-ai    Force templated voice (no API call)`);
+  console.log(`  default    AI when ANTHROPIC_API_KEY is set, templated otherwise`);
 }
 
 // ─── Loaders ───────────────────────────────────────────────────────
@@ -471,7 +483,7 @@ function buildHeadlineAndLede({ teams, rankings, awards, week, year }) {
 
 // ─── Main ──────────────────────────────────────────────────────────
 
-export async function generatePowerRankings({ year, week }) {
+export async function generatePowerRankings({ year, week, useAI = false }) {
   const dir = feedDir(year);
   const teamsConfig = await loadTeamsConfig();
 
@@ -528,18 +540,25 @@ export async function generatePowerRankings({ year, week }) {
     week,
   });
 
-  // Build blurbs (templated)
-  const rankings = namedRankings.map(r => ({
-    ...r,
-    blurb: rankingBlurb(
-      { ...r, rolling3Ppg: r.metrics.rolling3Ppg, seasonPpg: r.metrics.seasonPpg },
-      teamsConfig.teams,
-      standingsByFid,
-      schedule,
-      weeklyResults,
-      week
-    ),
-  }));
+  // Build blurbs (templated baseline). We also stash the structured facts
+  // (last3 record, streak) on each row so the AI fact sheet can reference them.
+  const rankings = namedRankings.map(r => {
+    const last3Record = rollingRecord(schedule, weeklyResults, r.franchiseId, week, 3);
+    const streak = parseStreak(standingsByFid.get(r.franchiseId)?.strk);
+    const factsForBlurb = { last3Record, streak };
+    return {
+      ...r,
+      blurb: rankingBlurb(
+        { ...r, rolling3Ppg: r.metrics.rolling3Ppg, seasonPpg: r.metrics.seasonPpg },
+        teamsConfig.teams,
+        standingsByFid,
+        schedule,
+        weeklyResults,
+        week
+      ),
+      factsForBlurb,
+    };
+  });
 
   const awards = {
     statOfWeek,
@@ -567,18 +586,55 @@ export async function generatePowerRankings({ year, week }) {
 
   const generatedAt = new Date().toISOString();
 
-  return {
+  let issue = {
     year,
     week,
     publishedAt: generatedAt,
     generatedAt,
-    voiceMode: 'templated', // Phase 1; switches to 'schefter' when LLM lands
+    voiceMode: 'templated',
     headline,
     lede,
     rankings,
     awards,
     standings: standingsSnapshot,
   };
+
+  if (useAI) {
+    issue = await applySchefterVoice(issue, teamsConfig.teams);
+  }
+
+  // Strip transient fact-bag from output rows
+  issue.rankings = issue.rankings.map(({ factsForBlurb, ...rest }) => rest);
+
+  return issue;
+}
+
+async function applySchefterVoice(issue, teams) {
+  const factSheet = buildFactSheet({ issue, teams });
+  console.log('  Calling Claude for Schefter voice…');
+  let aiOutput;
+  try {
+    aiOutput = await callAnthropic(getSystemPrompt(), getUserPrompt(factSheet), 4000);
+  } catch (err) {
+    console.warn(`  [warn] AI call failed (${err.message}). Keeping templated voice.`);
+    return issue;
+  }
+
+  const { issue: voiced, report } = applyAIVoice(issue, aiOutput, teams);
+
+  const blurbsApplied = report.blurbs.applied;
+  const blurbsTotal = blurbsApplied + report.blurbs.fallback;
+  const awardsApplied = report.awardBlurbs.applied;
+  const awardsTotal = awardsApplied + report.awardBlurbs.fallback;
+  console.log(`  Voice: headline=${report.headline}, lede=${report.lede}, blurbs=${blurbsApplied}/${blurbsTotal}, awardBlurbs=${awardsApplied}/${awardsTotal}`);
+  if (report.blurbs.fails.length > 0) {
+    for (const f of report.blurbs.fails) {
+      console.warn(`    [fallback] ${f.franchiseId}: ${f.errors.join('; ')}`);
+    }
+  }
+
+  voiced.voiceMode = blurbsApplied > 0 ? 'schefter' : 'templated';
+  return voiced;
 }
 
 function round2(x) {
@@ -604,7 +660,15 @@ async function main() {
     }
   }
 
-  const issue = await generatePowerRankings({ year: opts.year, week: opts.week });
+  // Resolve voice mode: explicit flag wins, otherwise auto on API key.
+  const useAI = opts.ai === true
+    ? true
+    : opts.ai === false
+      ? false
+      : Boolean(process.env.ANTHROPIC_API_KEY);
+  console.log(`  Voice: ${useAI ? 'schefter (AI)' : 'templated'}`);
+
+  const issue = await generatePowerRankings({ year: opts.year, week: opts.week, useAI });
 
   if (opts.dryRun) {
     console.log('--- DRY RUN ---');

--- a/scripts/lib/power-rankings-ai.mjs
+++ b/scripts/lib/power-rankings-ai.mjs
@@ -1,0 +1,285 @@
+/**
+ * Power Rankings — Phase 2 AI voice helpers.
+ *
+ * Builds the fact sheet, defines the prompt, and validates the AI's
+ * structured output. The main generate-power-rankings.mjs orchestrates
+ * the call to callAnthropic; this module is the deterministic surface
+ * around it (so the unit tests don't need an API key).
+ */
+
+import { buildCachedSystem } from '../article-utils/ai-client.mjs';
+
+// ─── Quality-gate constants ────────────────────────────────────────
+
+export const HEADLINE_MAX = 100;
+export const LEDE_MAX = 600;
+export const BLURB_MAX = 240;
+
+// Phrases that betray AI tells or break voice. Case-insensitive substring match.
+export const BANNED_PHRASES = [
+  "i'm an ai",
+  'as an ai',
+  "i am an ai",
+  'as a language model',
+  'large language model',
+  "i cannot",
+  'as claude',
+  "i'm claude",
+  'it appears that',
+  'it seems that',
+  'i hope this helps',
+  'in conclusion',
+];
+
+// Curly/smart quotes break the schefter house style (existing rule).
+const CURLY_QUOTE_RE = /[‘’“”]/;
+
+// ─── Fact sheet builder ────────────────────────────────────────────
+
+/**
+ * Build a deterministic, structured fact sheet that the AI may reference.
+ * The AI is instructed to use ONLY data from this sheet — no invention.
+ *
+ * @param {object} args
+ * @param {object} args.issue — partial issue (rankings + awards), pre-AI.
+ * @param {Map<string, object>} args.teams — franchiseId → team config.
+ * @returns {string} Plaintext fact sheet.
+ */
+export function buildFactSheet({ issue, teams }) {
+  const lines = [];
+  lines.push(`POWER RANKINGS FACT SHEET — ${issue.year} Week ${issue.week}`);
+  lines.push('');
+  lines.push('League: TheLeague (16 dynasty franchises). Voice: Claude Schefter.');
+  lines.push('');
+
+  // ─ Rankings table ─
+  lines.push('=== RANKINGS (1-16) ===');
+  lines.push('Format: rank | team | trend | rolling-3wk record | rolling-3wk PPG | streak | season PPG');
+  for (const r of issue.rankings) {
+    const team = teams.get(r.franchiseId);
+    const name = team?.nameMedium ?? team?.name ?? r.franchiseId;
+    const trend = r.previousRank == null
+      ? 'new'
+      : r.previousRank === r.rank
+        ? 'flat'
+        : r.previousRank > r.rank
+          ? `up ${r.previousRank - r.rank} (was #${r.previousRank})`
+          : `down ${r.rank - r.previousRank} (was #${r.previousRank})`;
+    const ppg = r.metrics.rolling3Ppg != null ? r.metrics.rolling3Ppg.toFixed(1) : '—';
+    const seasonPpg = r.metrics.seasonPpg != null ? r.metrics.seasonPpg.toFixed(1) : '—';
+    const factsForBlurb = r.factsForBlurb || {}; // optional caller enrichment
+    const recStr = factsForBlurb.last3Record ? `${factsForBlurb.last3Record.wins}-${factsForBlurb.last3Record.losses}${factsForBlurb.last3Record.ties ? `-${factsForBlurb.last3Record.ties}` : ''} L3` : '—';
+    const streakStr = factsForBlurb.streak && factsForBlurb.streak.length >= 2
+      ? `${factsForBlurb.streak.type}${factsForBlurb.streak.length}`
+      : 'no active streak';
+    lines.push(`#${r.rank} | ${name} | ${trend} | ${recStr} | ${ppg} PPG L3 | ${streakStr} | ${seasonPpg} season PPG`);
+  }
+  lines.push('');
+
+  // ─ Awards (deterministic context) ─
+  lines.push('=== WEEKLY AWARDS (deterministic data — re-voice in Schefter style) ===');
+  for (const [key, card] of Object.entries(issue.awards || {})) {
+    if (!card) continue;
+    const fid = card.franchiseId ?? card.homeId;
+    const teamA = fid ? (teams.get(fid)?.nameMedium ?? fid) : '';
+    const teamB = card.awayId ? (teams.get(card.awayId)?.nameMedium ?? card.awayId) : '';
+    const recipient = teamB ? `${teamA} vs ${teamB}` : teamA;
+    lines.push(`${key}: ${card.title} — ${recipient}`);
+    lines.push(`  raw: ${card.blurb}`);
+    if (card.metric) lines.push(`  metric: ${JSON.stringify(card.metric)}`);
+  }
+  lines.push('');
+
+  // ─ Allowed name tokens (helps the model not invent) ─
+  lines.push('=== ALLOWED FRANCHISE NAME TOKENS ===');
+  for (const [, t] of teams) {
+    const aliases = (t.aliases || []).join(', ');
+    lines.push(`- ${t.name} (also: ${[t.nameMedium, t.nameShort, t.abbrev, aliases].filter(Boolean).join(', ')})`);
+  }
+  lines.push('');
+
+  return lines.join('\n');
+}
+
+// ─── Prompts ───────────────────────────────────────────────────────
+
+const TYPE_SPECIFIC_PROMPT = `
+
+ARTICLE TYPE: Tuesday Power Rankings issue.
+
+Your job: rewrite the issue's HEADLINE, LEDE, and a one-sentence BLURB for each of the 16 franchises in Schefter voice. Re-voice the AWARD blurbs in the same style.
+
+VOICE RULES
+- Schefter: confident, punchy, opinionated. "League sources tell me…", "Boom.", "Money is nice, but championships are better."
+- One blurb per team max. Specific. Reference the team's L3 record, PPG, streak, or trend from the fact sheet.
+- Lede: 2-3 sentences. Frame the week's biggest story (rise to #1, fall, hot streak, blowup).
+- Headline: ≤100 chars, punchy, no period. Bias toward action verbs.
+
+NEVER
+- Invent franchise or player names. Only use names that appear in the ALLOWED FRANCHISE NAME TOKENS list.
+- Use curly/smart quotes — straight ASCII only.
+- Use markdown code fences.
+- Hedge with "I'm an AI", "as a language model", "It appears that", "I hope this helps", "in conclusion".
+
+LENGTH
+- headline: ≤100 chars
+- lede: ≤600 chars
+- each blurb: ≤240 chars`;
+
+export function getSystemPrompt() {
+  return buildCachedSystem(TYPE_SPECIFIC_PROMPT);
+}
+
+export function getUserPrompt(factSheet) {
+  return `Rewrite the power rankings issue using ONLY data from the fact sheet below.
+
+${factSheet}
+
+OUTPUT FORMAT — respond with ONLY valid JSON, no markdown fences:
+{
+  "headline": "Punchy headline (~60 chars)",
+  "lede": "2-3 sentence lede in Schefter's voice.",
+  "blurbs": {
+    "<franchiseId>": "One sentence about that franchise (≤240 chars)",
+    ...
+  },
+  "awardBlurbs": {
+    "statOfWeek": "Schefter rewrite of the stat-of-week blurb (or null to keep raw)",
+    "benchBlunder": "...",
+    "heaterOfWeek": "...",
+    "coolerOfWeek": "...",
+    "matchupOfWeek": "..."
+  }
+}
+
+REQUIREMENTS
+- Provide a blurb for ALL 16 franchiseIds present in the fact sheet rankings table.
+- Each blurb must contain a recognizable token for THAT franchise (e.g., the nameMedium).
+- Do not invent stats or names not present in the fact sheet.`;
+}
+
+// ─── Validation ────────────────────────────────────────────────────
+
+/**
+ * Validate a single blurb. Returns array of error strings (empty = ok).
+ *
+ * @param {string} text
+ * @param {{ franchise?: object, maxLength?: number }} opts
+ *   - franchise: team config; the blurb must mention one of its name tokens.
+ *   - maxLength: override the default cap.
+ */
+export function validateBlurb(text, { franchise = null, maxLength = BLURB_MAX } = {}) {
+  const errors = [];
+  if (!text || typeof text !== 'string') {
+    return ['empty'];
+  }
+  const trimmed = text.trim();
+  if (trimmed.length === 0) return ['empty'];
+  if (trimmed.length > maxLength) errors.push(`too long (${trimmed.length} > ${maxLength})`);
+
+  const lower = trimmed.toLowerCase();
+  for (const phrase of BANNED_PHRASES) {
+    if (lower.includes(phrase)) {
+      errors.push(`banned phrase: "${phrase}"`);
+    }
+  }
+  if (CURLY_QUOTE_RE.test(trimmed)) errors.push('curly quote');
+  if (trimmed.includes('```')) errors.push('markdown fence');
+
+  if (franchise) {
+    const tokens = [
+      franchise.name,
+      franchise.nameMedium,
+      franchise.nameShort,
+      franchise.abbrev,
+      ...(franchise.aliases || []),
+    ].filter(Boolean);
+    const found = tokens.some(tok => tok && trimmed.includes(tok));
+    if (!found) errors.push('does not name this franchise');
+  }
+
+  return errors;
+}
+
+/**
+ * Apply AI output to the issue, falling back per-blurb to the templated
+ * version when validation fails. Returns a new issue object — does not mutate.
+ *
+ * @param {object} issue — pre-AI issue (with templated headline/lede/blurbs).
+ * @param {object} aiOutput — parsed { headline, lede, blurbs, awardBlurbs }.
+ * @param {Map<string, object>} teams — franchiseId → team config.
+ * @returns {{ issue: object, report: object }}
+ */
+export function applyAIVoice(issue, aiOutput, teams) {
+  const report = {
+    headline: 'templated',
+    lede: 'templated',
+    blurbs: { applied: 0, fallback: 0, fails: [] },
+    awardBlurbs: { applied: 0, fallback: 0, fails: [] },
+  };
+  const out = { ...issue };
+
+  // Headline
+  if (aiOutput?.headline) {
+    const errs = validateBlurb(aiOutput.headline, { maxLength: HEADLINE_MAX });
+    if (errs.length === 0) {
+      out.headline = aiOutput.headline.trim();
+      report.headline = 'ai';
+    } else {
+      report.headline = 'fallback';
+      report.headlineFails = errs;
+    }
+  }
+
+  // Lede
+  if (aiOutput?.lede) {
+    const errs = validateBlurb(aiOutput.lede, { maxLength: LEDE_MAX });
+    if (errs.length === 0) {
+      out.lede = aiOutput.lede.trim();
+      report.lede = 'ai';
+    } else {
+      report.lede = 'fallback';
+      report.ledeFails = errs;
+    }
+  }
+
+  // Per-team blurbs
+  out.rankings = (issue.rankings || []).map(r => {
+    const aiBlurb = aiOutput?.blurbs?.[r.franchiseId];
+    if (!aiBlurb) {
+      report.blurbs.fallback++;
+      return r;
+    }
+    const errs = validateBlurb(aiBlurb, { franchise: teams.get(r.franchiseId), maxLength: BLURB_MAX });
+    if (errs.length === 0) {
+      report.blurbs.applied++;
+      return { ...r, blurb: aiBlurb.trim() };
+    }
+    report.blurbs.fallback++;
+    report.blurbs.fails.push({ franchiseId: r.franchiseId, errors: errs });
+    return r;
+  });
+
+  // Award blurbs (no franchise-mention requirement; matchupOfWeek mentions two teams)
+  if (issue.awards) {
+    out.awards = { ...issue.awards };
+    for (const [key, card] of Object.entries(issue.awards)) {
+      if (!card) continue;
+      const aiBlurb = aiOutput?.awardBlurbs?.[key];
+      if (!aiBlurb) {
+        report.awardBlurbs.fallback++;
+        continue;
+      }
+      const errs = validateBlurb(aiBlurb, { maxLength: BLURB_MAX });
+      if (errs.length === 0) {
+        out.awards[key] = { ...card, blurb: aiBlurb.trim() };
+        report.awardBlurbs.applied++;
+      } else {
+        report.awardBlurbs.fallback++;
+        report.awardBlurbs.fails.push({ key, errors: errs });
+      }
+    }
+  }
+
+  return { issue: out, report };
+}

--- a/src/components/theleague/PowerRankingsIssue.astro
+++ b/src/components/theleague/PowerRankingsIssue.astro
@@ -1,0 +1,501 @@
+---
+/**
+ * PowerRankingsIssue — renders a single weekly power-rankings issue.
+ *
+ * Driven entirely by the JSON document at
+ * src/data/theleague/power-rankings/<year>-w<week>.json.
+ * Phase 1 ships templated blurbs; Phase 2 will swap in LLM-generated copy
+ * without changing the data shape this component reads.
+ */
+import leagueConfig from '../../data/theleague.config.json';
+
+export interface RankingRow {
+  rank: number;
+  franchiseId: string;
+  previousRank: number | null;
+  trend: 'up' | 'down' | 'flat';
+  blurb: string;
+  metrics: {
+    composite: number | null;
+    rolling3Ppg: number | null;
+    seasonPpg: number | null;
+    ppgScore: number | null;
+    recordScore: number | null;
+    allPlayScore: number | null;
+  };
+}
+
+export interface AwardCard {
+  franchiseId?: string;
+  homeId?: string;
+  awayId?: string;
+  title: string;
+  blurb: string;
+}
+
+export interface StandingsTeamRow {
+  franchiseId: string;
+  name: string;
+  nameMedium: string;
+  abbrev: string;
+  division: string;
+  wins: number;
+  losses: number;
+  ties: number;
+  pf: number;
+  pa: number;
+  ppg: number;
+  allPlayPct: number;
+  allPlayWLT: string;
+}
+
+export interface PowerRankingsData {
+  year: number;
+  week: number;
+  publishedAt: string;
+  generatedAt: string;
+  voiceMode: string;
+  headline: string;
+  lede: string;
+  rankings: RankingRow[];
+  awards: {
+    statOfWeek: AwardCard | null;
+    benchBlunder: AwardCard | null;
+    tradeOfWeek: AwardCard | null;
+    cutOfShame: AwardCard | null;
+    heaterOfWeek: AwardCard | null;
+    coolerOfWeek: AwardCard | null;
+    matchupOfWeek: AwardCard | null;
+  };
+  standings: {
+    divisions: { name: string; teams: StandingsTeamRow[] }[];
+    allPlay: { franchiseId: string; name: string; nameMedium: string; abbrev: string; division: string; allPlayPct: number; allPlayWLT: string; pf: number }[];
+  };
+}
+
+export interface Props {
+  issue: PowerRankingsData;
+}
+
+const { issue } = Astro.props as Props;
+
+// Build franchise lookup for icons/colors
+const teams = new Map<string, any>();
+for (const t of (leagueConfig as any).teams) {
+  teams.set(t.franchiseId, t);
+}
+
+const trendGlyph = (t: 'up' | 'down' | 'flat') =>
+  t === 'up' ? '▲' : t === 'down' ? '▼' : '–';
+
+const formattedDate = new Date(issue.publishedAt).toLocaleDateString('en-US', {
+  year: 'numeric', month: 'long', day: 'numeric',
+});
+
+const orderedAwards: { key: string; card: AwardCard | null }[] = [
+  { key: 'statOfWeek',     card: issue.awards.statOfWeek },
+  { key: 'benchBlunder',   card: issue.awards.benchBlunder },
+  { key: 'heaterOfWeek',   card: issue.awards.heaterOfWeek },
+  { key: 'coolerOfWeek',   card: issue.awards.coolerOfWeek },
+  { key: 'matchupOfWeek',  card: issue.awards.matchupOfWeek },
+  { key: 'tradeOfWeek',    card: issue.awards.tradeOfWeek },
+  { key: 'cutOfShame',     card: issue.awards.cutOfShame },
+];
+---
+
+<article class="pr-issue">
+  <header class="pr-hero">
+    <div class="pr-hero__eyebrow">
+      <span class="pr-hero__badge">Power Rankings</span>
+      <span class="pr-hero__dot" aria-hidden="true"></span>
+      <span>Week {issue.week} · {issue.year}</span>
+      <span class="pr-hero__dot" aria-hidden="true"></span>
+      <time datetime={issue.publishedAt}>{formattedDate}</time>
+    </div>
+    <h1 class="pr-hero__title">{issue.headline}</h1>
+    <p class="pr-hero__lede">{issue.lede}</p>
+  </header>
+
+  <section class="pr-section" aria-label="Standings snapshot">
+    <h2 class="pr-section__title">Standings</h2>
+    <div class="pr-standings-grid">
+      <div class="pr-divisions">
+        <h3 class="pr-subhead">By Division</h3>
+        <div class="pr-divisions__grid">
+          {issue.standings.divisions.map(div => (
+            <div class="pr-division-card">
+              <div class="pr-division-card__title">{div.name}</div>
+              <table class="pr-table">
+                <thead>
+                  <tr><th class="pr-table__rank">#</th><th>Team</th><th>W-L</th><th>PF</th></tr>
+                </thead>
+                <tbody>
+                  {div.teams.map((t, i) => {
+                    const team = teams.get(t.franchiseId);
+                    return (
+                      <tr>
+                        <td class="pr-table__rank">{i + 1}</td>
+                        <td>
+                          <span class="pr-team-chip">
+                            {team?.icon && <img src={team.icon} alt="" loading="lazy" width="20" height="20" />}
+                            <span>{t.nameMedium}</span>
+                          </span>
+                        </td>
+                        <td>{t.wins}-{t.losses}{t.ties ? `-${t.ties}` : ''}</td>
+                        <td>{t.pf.toFixed(1)}</td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div class="pr-allplay">
+        <h3 class="pr-subhead">All-Play</h3>
+        <table class="pr-table">
+          <thead>
+            <tr><th class="pr-table__rank">#</th><th>Team</th><th>All-Play</th><th>PF</th></tr>
+          </thead>
+          <tbody>
+            {issue.standings.allPlay.map((t, i) => {
+              const team = teams.get(t.franchiseId);
+              return (
+                <tr>
+                  <td class="pr-table__rank">{i + 1}</td>
+                  <td>
+                    <span class="pr-team-chip">
+                      {team?.icon && <img src={team.icon} alt="" loading="lazy" width="20" height="20" />}
+                      <span>{t.nameMedium}</span>
+                    </span>
+                  </td>
+                  <td>{t.allPlayWLT || `${(t.allPlayPct * 100).toFixed(1)}%`}</td>
+                  <td>{t.pf.toFixed(1)}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </section>
+
+  <section class="pr-section" aria-label="Power rankings 1-16">
+    <h2 class="pr-section__title">The Rankings</h2>
+    <ol class="pr-rankings">
+      {issue.rankings.map(row => {
+        const team = teams.get(row.franchiseId);
+        const accent = team?.color || 'var(--color-primary, #2563eb)';
+        return (
+          <li class="pr-card" style={`--pr-accent: ${accent}`}>
+            <div class="pr-card__rank">
+              <div class="pr-card__rank-num">{row.rank}</div>
+              {row.previousRank != null && (
+                <div class={`pr-card__trend pr-card__trend--${row.trend}`} title={`Previous: #${row.previousRank}`}>
+                  {trendGlyph(row.trend)}
+                  {row.trend !== 'flat' && (
+                    <span class="pr-card__trend-delta">{Math.abs(row.previousRank - row.rank)}</span>
+                  )}
+                </div>
+              )}
+            </div>
+            <div class="pr-card__body">
+              <div class="pr-card__heading">
+                {team?.icon && <img class="pr-card__icon" src={team.icon} alt="" loading="lazy" width="32" height="32" />}
+                <h3 class="pr-card__name">
+                  <a href={`/theleague/franchises/${row.franchiseId}`}>{team?.name ?? row.franchiseId}</a>
+                </h3>
+              </div>
+              <p class="pr-card__blurb">{row.blurb}</p>
+              <div class="pr-card__metrics">
+                {row.metrics.rolling3Ppg != null && (
+                  <span class="pr-card__metric"><span>L3 PPG</span><strong>{row.metrics.rolling3Ppg.toFixed(1)}</strong></span>
+                )}
+                {row.metrics.seasonPpg != null && (
+                  <span class="pr-card__metric"><span>Season PPG</span><strong>{row.metrics.seasonPpg.toFixed(1)}</strong></span>
+                )}
+                {row.metrics.composite != null && (
+                  <span class="pr-card__metric"><span>Score</span><strong>{row.metrics.composite.toFixed(1)}</strong></span>
+                )}
+              </div>
+            </div>
+          </li>
+        );
+      })}
+    </ol>
+  </section>
+
+  <section class="pr-section" aria-label="Weekly awards">
+    <h2 class="pr-section__title">Awards</h2>
+    <div class="pr-awards">
+      {orderedAwards.filter(a => a.card).map(({ card }) => {
+        const fid = card!.franchiseId ?? card!.homeId;
+        const team = fid ? teams.get(fid) : null;
+        const second = card!.awayId ? teams.get(card!.awayId) : null;
+        const accent = team?.color ?? 'var(--color-primary, #2563eb)';
+        return (
+          <div class="pr-award" style={`--pr-accent: ${accent}`}>
+            <div class="pr-award__title">{card!.title}</div>
+            <div class="pr-award__recipient">
+              {team?.icon && <img src={team.icon} alt="" loading="lazy" width="28" height="28" />}
+              <span>{team?.nameMedium ?? fid ?? '—'}</span>
+              {second && (
+                <>
+                  <span class="pr-award__vs">vs</span>
+                  {second?.icon && <img src={second.icon} alt="" loading="lazy" width="28" height="28" />}
+                  <span>{second?.nameMedium}</span>
+                </>
+              )}
+            </div>
+            <p class="pr-award__blurb">{card!.blurb}</p>
+          </div>
+        );
+      })}
+    </div>
+  </section>
+
+  <footer class="pr-footnote">
+    <p>
+      Phase 1 issue — blurbs are templated from on-disk feeds (no LLM voice yet).
+      Composite score: 60% rolling-3wk PPG · 25% H2H record · 15% all-play %.
+    </p>
+  </footer>
+</article>
+
+<style>
+.pr-issue {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 1.5rem 1rem 4rem;
+}
+.pr-hero {
+  border-bottom: 1px solid var(--color-border, #e5e7eb);
+  padding-bottom: 1.5rem;
+  margin-bottom: 2rem;
+}
+.pr-hero__eyebrow {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-muted, #6b7280);
+  margin-bottom: 0.75rem;
+}
+.pr-hero__badge {
+  background: var(--color-primary, #2563eb);
+  color: #fff;
+  padding: 0.15rem 0.5rem;
+  border-radius: 0.25rem;
+  font-weight: 600;
+}
+.pr-hero__dot {
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: var(--color-text-muted, #6b7280);
+}
+.pr-hero__title {
+  font-size: clamp(1.75rem, 4vw, 2.75rem);
+  line-height: 1.1;
+  margin: 0 0 0.5rem;
+  color: var(--color-text, #111827);
+}
+.pr-hero__lede {
+  font-size: 1.05rem;
+  line-height: 1.6;
+  color: var(--color-text-muted, #4b5563);
+  margin: 0;
+  max-width: 70ch;
+}
+
+.pr-section { margin-bottom: 2.5rem; }
+.pr-section__title {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin: 0 0 1rem;
+  color: var(--color-text, #111827);
+  border-left: 3px solid var(--color-primary, #2563eb);
+  padding-left: 0.6rem;
+}
+.pr-subhead {
+  font-size: 1rem;
+  font-weight: 600;
+  margin: 0 0 0.5rem;
+  color: var(--color-text, #111827);
+}
+
+.pr-standings-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+  gap: 1.5rem;
+}
+.pr-divisions__grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+}
+.pr-division-card {
+  background: var(--color-surface-1, #fff);
+  border: 1px solid var(--color-border, #e5e7eb);
+  border-radius: 0.5rem;
+  padding: 0.75rem;
+}
+.pr-division-card__title {
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+  font-size: 0.95rem;
+}
+.pr-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.875rem;
+}
+.pr-table th, .pr-table td {
+  padding: 0.35rem 0.4rem;
+  text-align: left;
+  border-bottom: 1px solid var(--color-border, #e5e7eb);
+}
+.pr-table th { font-weight: 600; color: var(--color-text-muted, #6b7280); }
+.pr-table__rank { width: 1.6rem; text-align: right; color: var(--color-text-muted, #6b7280); }
+
+.pr-team-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+.pr-team-chip img { border-radius: 0.25rem; }
+
+.pr-rankings {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.6rem;
+}
+.pr-card {
+  display: grid;
+  grid-template-columns: 4.5rem 1fr;
+  gap: 1rem;
+  align-items: center;
+  padding: 0.85rem;
+  border: 1px solid var(--color-border, #e5e7eb);
+  border-left: 4px solid var(--pr-accent);
+  border-radius: 0.5rem;
+  background: var(--color-surface-1, #fff);
+}
+.pr-card__rank {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.15rem;
+}
+.pr-card__rank-num {
+  font-size: 1.75rem;
+  font-weight: 800;
+  line-height: 1;
+  color: var(--pr-accent);
+}
+.pr-card__trend {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.15rem;
+  font-size: 0.7rem;
+  font-weight: 700;
+}
+.pr-card__trend--up { color: #16a34a; }
+.pr-card__trend--down { color: #dc2626; }
+.pr-card__trend--flat { color: var(--color-text-muted, #6b7280); }
+.pr-card__heading {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.25rem;
+}
+.pr-card__icon { border-radius: 0.25rem; }
+.pr-card__name {
+  font-size: 1.05rem;
+  margin: 0;
+  font-weight: 700;
+}
+.pr-card__name a { color: inherit; text-decoration: none; }
+.pr-card__name a:hover { text-decoration: underline; }
+.pr-card__blurb {
+  margin: 0.1rem 0 0.4rem;
+  color: var(--color-text-muted, #4b5563);
+  font-size: 0.95rem;
+  line-height: 1.4;
+}
+.pr-card__metrics {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  font-size: 0.75rem;
+  color: var(--color-text-muted, #6b7280);
+}
+.pr-card__metric {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.25rem;
+}
+.pr-card__metric strong {
+  color: var(--color-text, #111827);
+  font-weight: 700;
+}
+
+.pr-awards {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 0.75rem;
+}
+.pr-award {
+  background: var(--color-surface-1, #fff);
+  border: 1px solid var(--color-border, #e5e7eb);
+  border-top: 3px solid var(--pr-accent);
+  border-radius: 0.5rem;
+  padding: 0.85rem;
+}
+.pr-award__title {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-muted, #6b7280);
+  font-weight: 600;
+  margin-bottom: 0.4rem;
+}
+.pr-award__recipient {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-weight: 700;
+  font-size: 0.95rem;
+  margin-bottom: 0.35rem;
+}
+.pr-award__vs {
+  font-weight: 400;
+  color: var(--color-text-muted, #6b7280);
+}
+.pr-award__blurb {
+  margin: 0;
+  font-size: 0.85rem;
+  line-height: 1.4;
+  color: var(--color-text-muted, #4b5563);
+}
+
+.pr-footnote {
+  margin-top: 2rem;
+  padding-top: 1rem;
+  border-top: 1px dashed var(--color-border, #e5e7eb);
+  font-size: 0.8rem;
+  color: var(--color-text-muted, #6b7280);
+}
+.pr-footnote p { margin: 0; }
+
+@media (max-width: 720px) {
+  .pr-standings-grid { grid-template-columns: 1fr; }
+  .pr-divisions__grid { grid-template-columns: 1fr; }
+}
+</style>

--- a/src/components/theleague/PowerRankingsIssue.astro
+++ b/src/components/theleague/PowerRankingsIssue.astro
@@ -127,7 +127,7 @@ const orderedAwards: { key: string; card: AwardCard | null }[] = [
         height="36"
         loading="lazy"
       />
-      <span>Rankings</span>
+      <span>Power Rankings</span>
     </h2>
     <ol class="pr-rankings">
       {issue.rankings.map(row => {

--- a/src/components/theleague/PowerRankingsIssue.astro
+++ b/src/components/theleague/PowerRankingsIssue.astro
@@ -116,74 +116,19 @@ const orderedAwards: { key: string; card: AwardCard | null }[] = [
     <p class="pr-hero__lede">{issue.lede}</p>
   </header>
 
-  <section class="pr-section" aria-label="Standings snapshot">
-    <h2 class="pr-section__title">Standings</h2>
-    <div class="pr-standings-grid">
-      <div class="pr-divisions">
-        <h3 class="pr-subhead">By Division</h3>
-        <div class="pr-divisions__grid">
-          {issue.standings.divisions.map(div => (
-            <div class="pr-division-card">
-              <div class="pr-division-card__title">{div.name}</div>
-              <table class="pr-table">
-                <thead>
-                  <tr><th class="pr-table__rank">#</th><th>Team</th><th>W-L</th><th>PF</th></tr>
-                </thead>
-                <tbody>
-                  {div.teams.map((t, i) => {
-                    const team = teams.get(t.franchiseId);
-                    return (
-                      <tr>
-                        <td class="pr-table__rank">{i + 1}</td>
-                        <td>
-                          <span class="pr-team-chip">
-                            {team?.icon && <img src={team.icon} alt="" loading="lazy" width="20" height="20" />}
-                            <span>{t.nameMedium}</span>
-                          </span>
-                        </td>
-                        <td>{t.wins}-{t.losses}{t.ties ? `-${t.ties}` : ''}</td>
-                        <td>{t.pf.toFixed(1)}</td>
-                      </tr>
-                    );
-                  })}
-                </tbody>
-              </table>
-            </div>
-          ))}
-        </div>
-      </div>
-
-      <div class="pr-allplay">
-        <h3 class="pr-subhead">All-Play</h3>
-        <table class="pr-table">
-          <thead>
-            <tr><th class="pr-table__rank">#</th><th>Team</th><th>All-Play</th><th>PF</th></tr>
-          </thead>
-          <tbody>
-            {issue.standings.allPlay.map((t, i) => {
-              const team = teams.get(t.franchiseId);
-              return (
-                <tr>
-                  <td class="pr-table__rank">{i + 1}</td>
-                  <td>
-                    <span class="pr-team-chip">
-                      {team?.icon && <img src={team.icon} alt="" loading="lazy" width="20" height="20" />}
-                      <span>{t.nameMedium}</span>
-                    </span>
-                  </td>
-                  <td>{t.allPlayWLT || `${(t.allPlayPct * 100).toFixed(1)}%`}</td>
-                  <td>{t.pf.toFixed(1)}</td>
-                </tr>
-              );
-            })}
-          </tbody>
-        </table>
-      </div>
-    </div>
-  </section>
-
   <section class="pr-section" aria-label="Power rankings 1-16">
-    <h2 class="pr-section__title">The Rankings</h2>
+    <h2 class="pr-section__title pr-section__title--brand">
+      <img
+        class="pr-section__avatar"
+        src="/assets/claude-schefter-avatar.webp"
+        alt=""
+        aria-hidden="true"
+        width="36"
+        height="36"
+        loading="lazy"
+      />
+      <span>Rankings</span>
+    </h2>
     <ol class="pr-rankings">
       {issue.rankings.map(row => {
         const team = teams.get(row.franchiseId);
@@ -321,53 +266,23 @@ const orderedAwards: { key: string; card: AwardCard | null }[] = [
   border-left: 3px solid var(--color-primary, #2563eb);
   padding-left: 0.6rem;
 }
-.pr-subhead {
-  font-size: 1rem;
-  font-weight: 600;
-  margin: 0 0 0.5rem;
-  color: var(--color-text, #111827);
-}
-
-.pr-standings-grid {
-  display: grid;
-  grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
-  gap: 1.5rem;
-}
-.pr-divisions__grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 1rem;
-}
-.pr-division-card {
-  background: var(--color-surface-1, #fff);
-  border: 1px solid var(--color-border, #e5e7eb);
-  border-radius: 0.5rem;
-  padding: 0.75rem;
-}
-.pr-division-card__title {
-  font-weight: 600;
-  margin-bottom: 0.5rem;
-  font-size: 0.95rem;
-}
-.pr-table {
-  width: 100%;
-  border-collapse: collapse;
-  font-size: 0.875rem;
-}
-.pr-table th, .pr-table td {
-  padding: 0.35rem 0.4rem;
-  text-align: left;
-  border-bottom: 1px solid var(--color-border, #e5e7eb);
-}
-.pr-table th { font-weight: 600; color: var(--color-text-muted, #6b7280); }
-.pr-table__rank { width: 1.6rem; text-align: right; color: var(--color-text-muted, #6b7280); }
-
-.pr-team-chip {
+.pr-section__title--brand {
   display: inline-flex;
   align-items: center;
-  gap: 0.35rem;
+  gap: 0.6rem;
+  border-left: none;
+  padding-left: 0;
+  font-size: 1.75rem;
 }
-.pr-team-chip img { border-radius: 0.25rem; }
+.pr-section__avatar {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  object-fit: cover;
+  flex-shrink: 0;
+  border: 2px solid var(--color-border, #e5e7eb);
+  background: var(--color-surface-2, #f3f4f6);
+}
 
 .pr-rankings {
   list-style: none;
@@ -495,7 +410,7 @@ const orderedAwards: { key: string; card: AwardCard | null }[] = [
 .pr-footnote p { margin: 0; }
 
 @media (max-width: 720px) {
-  .pr-standings-grid { grid-template-columns: 1fr; }
-  .pr-divisions__grid { grid-template-columns: 1fr; }
+  .pr-section__title--brand { font-size: 1.5rem; }
+  .pr-section__avatar { width: 32px; height: 32px; }
 }
 </style>

--- a/src/data/theleague/power-rankings/2025-w13.json
+++ b/src/data/theleague/power-rankings/2025-w13.json
@@ -1,0 +1,725 @@
+{
+  "year": 2025,
+  "week": 13,
+  "publishedAt": "2026-05-07T23:40:47.403Z",
+  "generatedAt": "2026-05-07T23:40:47.403Z",
+  "voiceMode": "templated",
+  "headline": "CPU Jocks hold #1 entering Week 14",
+  "lede": "Through Week 13, Computer Jocks sit atop the rankings. Computer Jocks dropped 137.13 — the highest score in the league this week.",
+  "rankings": [
+    {
+      "rank": 1,
+      "franchiseId": "0010",
+      "previousRank": null,
+      "trend": "flat",
+      "metrics": {
+        "composite": 86.87,
+        "rolling3Ppg": 135.71,
+        "seasonPpg": 110.1,
+        "ppgScore": 100,
+        "recordScore": 72.2,
+        "allPlayScore": 58.8
+      },
+      "blurb": "2-1 over their last 3 at 135.7 PPG."
+    },
+    {
+      "rank": 2,
+      "franchiseId": "0002",
+      "previousRank": null,
+      "trend": "flat",
+      "metrics": {
+        "composite": 71.56,
+        "rolling3Ppg": 116.3,
+        "seasonPpg": 117.2,
+        "ppgScore": 71.44,
+        "recordScore": 72.2,
+        "allPlayScore": 71
+      },
+      "blurb": "2-1 over their last 3 at 116.3 PPG."
+    },
+    {
+      "rank": 3,
+      "franchiseId": "0015",
+      "previousRank": null,
+      "trend": "flat",
+      "metrics": {
+        "composite": 65.31,
+        "rolling3Ppg": 108.23,
+        "seasonPpg": 115.4,
+        "ppgScore": 59.57,
+        "recordScore": 77.8,
+        "allPlayScore": 67.5
+      },
+      "blurb": "2-1 over their last 3 at 108.2 PPG."
+    },
+    {
+      "rank": 4,
+      "franchiseId": "0012",
+      "previousRank": null,
+      "trend": "flat",
+      "metrics": {
+        "composite": 62.77,
+        "rolling3Ppg": 108.1,
+        "seasonPpg": 114.9,
+        "ppgScore": 59.37,
+        "recordScore": 66.7,
+        "allPlayScore": 69.8
+      },
+      "blurb": "2-1 over their last 3 at 108.1 PPG. Riding a 3-game win streak."
+    },
+    {
+      "rank": 5,
+      "franchiseId": "0008",
+      "previousRank": null,
+      "trend": "flat",
+      "metrics": {
+        "composite": 60.83,
+        "rolling3Ppg": 108.89,
+        "seasonPpg": 111.5,
+        "ppgScore": 60.53,
+        "recordScore": 61.1,
+        "allPlayScore": 61.6
+      },
+      "blurb": "3-0 over their last 3 at 108.9 PPG. Riding a 4-game win streak."
+    },
+    {
+      "rank": 6,
+      "franchiseId": "0009",
+      "previousRank": null,
+      "trend": "flat",
+      "metrics": {
+        "composite": 56.44,
+        "rolling3Ppg": 96.9,
+        "seasonPpg": 117.6,
+        "ppgScore": 42.89,
+        "recordScore": 83.3,
+        "allPlayScore": 65.9
+      },
+      "blurb": "3-0 over their last 3 at 96.9 PPG."
+    },
+    {
+      "rank": 7,
+      "franchiseId": "0013",
+      "previousRank": null,
+      "trend": "flat",
+      "metrics": {
+        "composite": 52.82,
+        "rolling3Ppg": 101.99,
+        "seasonPpg": 108.6,
+        "ppgScore": 50.37,
+        "recordScore": 55.6,
+        "allPlayScore": 58
+      },
+      "blurb": "2-1 over their last 3 at 102.0 PPG. Riding a 3-game win streak."
+    },
+    {
+      "rank": 8,
+      "franchiseId": "0016",
+      "previousRank": null,
+      "trend": "flat",
+      "metrics": {
+        "composite": 48.58,
+        "rolling3Ppg": 104.95,
+        "seasonPpg": 102.8,
+        "ppgScore": 54.74,
+        "recordScore": 33.3,
+        "allPlayScore": 49.4
+      },
+      "blurb": "0-3 over their last 3 at 105.0 PPG."
+    },
+    {
+      "rank": 9,
+      "franchiseId": "0005",
+      "previousRank": null,
+      "trend": "flat",
+      "metrics": {
+        "composite": 42.3,
+        "rolling3Ppg": 94.64,
+        "seasonPpg": 103.1,
+        "ppgScore": 39.56,
+        "recordScore": 44.4,
+        "allPlayScore": 49.8
+      },
+      "blurb": "2-1 over their last 3 at 94.6 PPG. Riding a 3-game win streak."
+    },
+    {
+      "rank": 10,
+      "franchiseId": "0011",
+      "previousRank": null,
+      "trend": "flat",
+      "metrics": {
+        "composite": 33.25,
+        "rolling3Ppg": 83.39,
+        "seasonPpg": 98,
+        "ppgScore": 23,
+        "recordScore": 50,
+        "allPlayScore": 46.3
+      },
+      "blurb": "1-2 over their last 3 at 83.4 PPG."
+    },
+    {
+      "rank": 11,
+      "franchiseId": "0014",
+      "previousRank": null,
+      "trend": "flat",
+      "metrics": {
+        "composite": 32.44,
+        "rolling3Ppg": 90.9,
+        "seasonPpg": 90.8,
+        "ppgScore": 34.05,
+        "recordScore": 27.8,
+        "allPlayScore": 33.7
+      },
+      "blurb": "1-2 over their last 3 at 90.9 PPG. Riding a 3-game skid."
+    },
+    {
+      "rank": 12,
+      "franchiseId": "0003",
+      "previousRank": null,
+      "trend": "flat",
+      "metrics": {
+        "composite": 24.15,
+        "rolling3Ppg": 81.31,
+        "seasonPpg": 92.5,
+        "ppgScore": 19.94,
+        "recordScore": 27.8,
+        "allPlayScore": 34.9
+      },
+      "blurb": "1-2 over their last 3 at 81.3 PPG."
+    },
+    {
+      "rank": 13,
+      "franchiseId": "0001",
+      "previousRank": null,
+      "trend": "flat",
+      "metrics": {
+        "composite": 22.05,
+        "rolling3Ppg": 68.11,
+        "seasonPpg": 94.9,
+        "ppgScore": 0.52,
+        "recordScore": 61.1,
+        "allPlayScore": 43.1
+      },
+      "blurb": "1-2 over their last 3 at 68.1 PPG."
+    },
+    {
+      "rank": 14,
+      "franchiseId": "0006",
+      "previousRank": null,
+      "trend": "flat",
+      "metrics": {
+        "composite": 21.85,
+        "rolling3Ppg": 78.71,
+        "seasonPpg": 89.8,
+        "ppgScore": 16.11,
+        "recordScore": 27.8,
+        "allPlayScore": 34.9
+      },
+      "blurb": "1-2 over their last 3 at 78.7 PPG. Riding a 2-game skid."
+    },
+    {
+      "rank": 15,
+      "franchiseId": "0004",
+      "previousRank": null,
+      "trend": "flat",
+      "metrics": {
+        "composite": 16.59,
+        "rolling3Ppg": 73.82,
+        "seasonPpg": 88.4,
+        "ppgScore": 8.92,
+        "recordScore": 27.8,
+        "allPlayScore": 28.6
+      },
+      "blurb": "1-2 over their last 3 at 73.8 PPG. Riding a 3-game skid."
+    },
+    {
+      "rank": 16,
+      "franchiseId": "0007",
+      "previousRank": null,
+      "trend": "flat",
+      "metrics": {
+        "composite": 6.78,
+        "rolling3Ppg": 67.76,
+        "seasonPpg": 85.5,
+        "ppgScore": 0,
+        "recordScore": 11.1,
+        "allPlayScore": 26.7
+      },
+      "blurb": "0-3 over their last 3 at 67.8 PPG. Riding a 7-game skid."
+    }
+  ],
+  "awards": {
+    "statOfWeek": {
+      "franchiseId": "0010",
+      "title": "Stat of the Week",
+      "blurb": "Computer Jocks dropped 137.13 — the highest score in the league this week.",
+      "metric": {
+        "score": 137.13
+      }
+    },
+    "benchBlunder": {
+      "franchiseId": "0003",
+      "title": "Bench Blunder of the Week",
+      "blurb": "Mavericks left 55.00 on the bench (76.41 actual vs 131.41 optimal).",
+      "metric": {
+        "actual": 76.41,
+        "optimal": 131.41,
+        "gap": 55
+      }
+    },
+    "tradeOfWeek": null,
+    "cutOfShame": null,
+    "heaterOfWeek": {
+      "franchiseId": "0008",
+      "title": "Heater of the Week",
+      "blurb": "Bring The Pain have won 4 straight — longest active win streak in the league.",
+      "metric": {
+        "streak": 4
+      }
+    },
+    "coolerOfWeek": {
+      "franchiseId": "0007",
+      "title": "Cooler of the Week",
+      "blurb": "Fire Ready have dropped 7 in a row — the longest active losing streak in the league.",
+      "metric": {
+        "streak": 7
+      }
+    },
+    "matchupOfWeek": {
+      "title": "Matchup of the Week",
+      "homeId": "0010",
+      "awayId": "0012",
+      "blurb": "Week 14: #4 Vitside at #1 Computer Jocks. Highest-ranked clash on the slate.",
+      "metric": {
+        "homeRank": 1,
+        "awayRank": 4
+      }
+    }
+  },
+  "standings": {
+    "divisions": [
+      {
+        "name": "Northwest",
+        "teams": [
+          {
+            "franchiseId": "0002",
+            "name": "Da Dangsters",
+            "nameMedium": "Da Dangsters",
+            "abbrev": "DANG",
+            "division": "Northwest",
+            "wins": 13,
+            "losses": 5,
+            "ties": 0,
+            "pf": 1992.84,
+            "pa": 1791.48,
+            "ppg": 117.2,
+            "allPlayPct": 0.71,
+            "allPlayWLT": "181-74-0"
+          },
+          {
+            "franchiseId": "0010",
+            "name": "Computer Jocks",
+            "nameMedium": "Computer Jocks",
+            "abbrev": "JOCKS",
+            "division": "Northwest",
+            "wins": 13,
+            "losses": 5,
+            "ties": 0,
+            "pf": 1871.19,
+            "pa": 1730.5,
+            "ppg": 110.1,
+            "allPlayPct": 0.588,
+            "allPlayWLT": "150-105-0"
+          },
+          {
+            "franchiseId": "0012",
+            "name": "Vitside Mafia",
+            "nameMedium": "Vitside",
+            "abbrev": "VIT",
+            "division": "Northwest",
+            "wins": 12,
+            "losses": 6,
+            "ties": 0,
+            "pf": 1953.88,
+            "pa": 1742.4,
+            "ppg": 114.9,
+            "allPlayPct": 0.698,
+            "allPlayWLT": "178-77-0"
+          },
+          {
+            "franchiseId": "0001",
+            "name": "Pacific Pigskins",
+            "nameMedium": "Pigskins",
+            "abbrev": "SKINS",
+            "division": "Northwest",
+            "wins": 11,
+            "losses": 7,
+            "ties": 0,
+            "pf": 1613.3,
+            "pa": 1737.24,
+            "ppg": 94.9,
+            "allPlayPct": 0.431,
+            "allPlayWLT": "110-145-0"
+          }
+        ]
+      },
+      {
+        "name": "Southwest",
+        "teams": [
+          {
+            "franchiseId": "0013",
+            "name": "Gridiron Geeks",
+            "nameMedium": "Gridiron Geeks",
+            "abbrev": "GEEKS",
+            "division": "Southwest",
+            "wins": 10,
+            "losses": 8,
+            "ties": 0,
+            "pf": 1845.58,
+            "pa": 1880.64,
+            "ppg": 108.6,
+            "allPlayPct": 0.58,
+            "allPlayWLT": "148-107-0"
+          },
+          {
+            "franchiseId": "0011",
+            "name": "Midwestside Connection",
+            "nameMedium": "Midwestside",
+            "abbrev": "MWS",
+            "division": "Southwest",
+            "wins": 9,
+            "losses": 9,
+            "ties": 0,
+            "pf": 1665.88,
+            "pa": 1662.33,
+            "ppg": 98,
+            "allPlayPct": 0.463,
+            "allPlayWLT": "118-137-0"
+          },
+          {
+            "franchiseId": "0006",
+            "name": "Music City Mafia",
+            "nameMedium": "Music City",
+            "abbrev": "MUSIC",
+            "division": "Southwest",
+            "wins": 5,
+            "losses": 13,
+            "ties": 0,
+            "pf": 1526.25,
+            "pa": 1936.22,
+            "ppg": 89.8,
+            "allPlayPct": 0.349,
+            "allPlayWLT": "89-166-0"
+          },
+          {
+            "franchiseId": "0004",
+            "name": "Dead Cap Walking",
+            "nameMedium": "Dead Cap",
+            "abbrev": "DEAD",
+            "division": "Southwest",
+            "wins": 5,
+            "losses": 13,
+            "ties": 0,
+            "pf": 1503.05,
+            "pa": 1804.5,
+            "ppg": 88.4,
+            "allPlayPct": 0.286,
+            "allPlayWLT": "73-182-0"
+          }
+        ]
+      },
+      {
+        "name": "Central",
+        "teams": [
+          {
+            "franchiseId": "0008",
+            "name": "Bring The Pain",
+            "nameMedium": "Bring The Pain",
+            "abbrev": "PAIN",
+            "division": "Central",
+            "wins": 11,
+            "losses": 7,
+            "ties": 0,
+            "pf": 1895.27,
+            "pa": 1911.02,
+            "ppg": 111.5,
+            "allPlayPct": 0.616,
+            "allPlayWLT": "157-98-0"
+          },
+          {
+            "franchiseId": "0005",
+            "name": "The Mariachi Ninjas",
+            "nameMedium": "Mariachi Ninjas",
+            "abbrev": "NINJA",
+            "division": "Central",
+            "wins": 8,
+            "losses": 10,
+            "ties": 0,
+            "pf": 1751.97,
+            "pa": 1758.39,
+            "ppg": 103.1,
+            "allPlayPct": 0.498,
+            "allPlayWLT": "127-128-0"
+          },
+          {
+            "franchiseId": "0003",
+            "name": "Maverick",
+            "nameMedium": "Mavericks",
+            "abbrev": "MAVS",
+            "division": "Central",
+            "wins": 5,
+            "losses": 13,
+            "ties": 0,
+            "pf": 1571.94,
+            "pa": 1973.8,
+            "ppg": 92.5,
+            "allPlayPct": 0.349,
+            "allPlayWLT": "89-166-0"
+          },
+          {
+            "franchiseId": "0014",
+            "name": "Cowboy Up",
+            "nameMedium": "Cowboy Up",
+            "abbrev": "CBOY",
+            "division": "Central",
+            "wins": 5,
+            "losses": 13,
+            "ties": 0,
+            "pf": 1544.42,
+            "pa": 2001.75,
+            "ppg": 90.8,
+            "allPlayPct": 0.337,
+            "allPlayWLT": "86-169-0"
+          }
+        ]
+      },
+      {
+        "name": "East",
+        "teams": [
+          {
+            "franchiseId": "0009",
+            "name": "Wascawy Wabbits",
+            "nameMedium": "Wascawy Wabbits",
+            "abbrev": "WABS",
+            "division": "East",
+            "wins": 15,
+            "losses": 3,
+            "ties": 0,
+            "pf": 1998.36,
+            "pa": 1592.99,
+            "ppg": 117.6,
+            "allPlayPct": 0.659,
+            "allPlayWLT": "168-87-0"
+          },
+          {
+            "franchiseId": "0015",
+            "name": "Dark Magicians of Chaos",
+            "nameMedium": "Dark Magicians",
+            "abbrev": "DMOC",
+            "division": "East",
+            "wins": 14,
+            "losses": 4,
+            "ties": 0,
+            "pf": 1961.1,
+            "pa": 1754.87,
+            "ppg": 115.4,
+            "allPlayPct": 0.675,
+            "allPlayWLT": "172-83-0"
+          },
+          {
+            "franchiseId": "0016",
+            "name": "Running down the Dream",
+            "nameMedium": "The Dream",
+            "abbrev": "DREAM",
+            "division": "East",
+            "wins": 6,
+            "losses": 12,
+            "ties": 0,
+            "pf": 1746.95,
+            "pa": 1978.11,
+            "ppg": 102.8,
+            "allPlayPct": 0.494,
+            "allPlayWLT": "126-129-0"
+          },
+          {
+            "franchiseId": "0007",
+            "name": "Fire Ready Aim",
+            "nameMedium": "Fire Ready",
+            "abbrev": "FIRE",
+            "division": "East",
+            "wins": 2,
+            "losses": 16,
+            "ties": 0,
+            "pf": 1453.35,
+            "pa": 2073.99,
+            "ppg": 85.5,
+            "allPlayPct": 0.267,
+            "allPlayWLT": "68-187-0"
+          }
+        ]
+      }
+    ],
+    "allPlay": [
+      {
+        "franchiseId": "0002",
+        "name": "Da Dangsters",
+        "nameMedium": "Da Dangsters",
+        "abbrev": "DANG",
+        "division": "Northwest",
+        "allPlayPct": 0.71,
+        "allPlayWLT": "181-74-0",
+        "pf": 1992.84
+      },
+      {
+        "franchiseId": "0012",
+        "name": "Vitside Mafia",
+        "nameMedium": "Vitside",
+        "abbrev": "VIT",
+        "division": "Northwest",
+        "allPlayPct": 0.698,
+        "allPlayWLT": "178-77-0",
+        "pf": 1953.88
+      },
+      {
+        "franchiseId": "0015",
+        "name": "Dark Magicians of Chaos",
+        "nameMedium": "Dark Magicians",
+        "abbrev": "DMOC",
+        "division": "East",
+        "allPlayPct": 0.675,
+        "allPlayWLT": "172-83-0",
+        "pf": 1961.1
+      },
+      {
+        "franchiseId": "0009",
+        "name": "Wascawy Wabbits",
+        "nameMedium": "Wascawy Wabbits",
+        "abbrev": "WABS",
+        "division": "East",
+        "allPlayPct": 0.659,
+        "allPlayWLT": "168-87-0",
+        "pf": 1998.36
+      },
+      {
+        "franchiseId": "0008",
+        "name": "Bring The Pain",
+        "nameMedium": "Bring The Pain",
+        "abbrev": "PAIN",
+        "division": "Central",
+        "allPlayPct": 0.616,
+        "allPlayWLT": "157-98-0",
+        "pf": 1895.27
+      },
+      {
+        "franchiseId": "0010",
+        "name": "Computer Jocks",
+        "nameMedium": "Computer Jocks",
+        "abbrev": "JOCKS",
+        "division": "Northwest",
+        "allPlayPct": 0.588,
+        "allPlayWLT": "150-105-0",
+        "pf": 1871.19
+      },
+      {
+        "franchiseId": "0013",
+        "name": "Gridiron Geeks",
+        "nameMedium": "Gridiron Geeks",
+        "abbrev": "GEEKS",
+        "division": "Southwest",
+        "allPlayPct": 0.58,
+        "allPlayWLT": "148-107-0",
+        "pf": 1845.58
+      },
+      {
+        "franchiseId": "0005",
+        "name": "The Mariachi Ninjas",
+        "nameMedium": "Mariachi Ninjas",
+        "abbrev": "NINJA",
+        "division": "Central",
+        "allPlayPct": 0.498,
+        "allPlayWLT": "127-128-0",
+        "pf": 1751.97
+      },
+      {
+        "franchiseId": "0016",
+        "name": "Running down the Dream",
+        "nameMedium": "The Dream",
+        "abbrev": "DREAM",
+        "division": "East",
+        "allPlayPct": 0.494,
+        "allPlayWLT": "126-129-0",
+        "pf": 1746.95
+      },
+      {
+        "franchiseId": "0011",
+        "name": "Midwestside Connection",
+        "nameMedium": "Midwestside",
+        "abbrev": "MWS",
+        "division": "Southwest",
+        "allPlayPct": 0.463,
+        "allPlayWLT": "118-137-0",
+        "pf": 1665.88
+      },
+      {
+        "franchiseId": "0001",
+        "name": "Pacific Pigskins",
+        "nameMedium": "Pigskins",
+        "abbrev": "SKINS",
+        "division": "Northwest",
+        "allPlayPct": 0.431,
+        "allPlayWLT": "110-145-0",
+        "pf": 1613.3
+      },
+      {
+        "franchiseId": "0006",
+        "name": "Music City Mafia",
+        "nameMedium": "Music City",
+        "abbrev": "MUSIC",
+        "division": "Southwest",
+        "allPlayPct": 0.349,
+        "allPlayWLT": "89-166-0",
+        "pf": 1526.25
+      },
+      {
+        "franchiseId": "0003",
+        "name": "Maverick",
+        "nameMedium": "Mavericks",
+        "abbrev": "MAVS",
+        "division": "Central",
+        "allPlayPct": 0.349,
+        "allPlayWLT": "89-166-0",
+        "pf": 1571.94
+      },
+      {
+        "franchiseId": "0014",
+        "name": "Cowboy Up",
+        "nameMedium": "Cowboy Up",
+        "abbrev": "CBOY",
+        "division": "Central",
+        "allPlayPct": 0.337,
+        "allPlayWLT": "86-169-0",
+        "pf": 1544.42
+      },
+      {
+        "franchiseId": "0004",
+        "name": "Dead Cap Walking",
+        "nameMedium": "Dead Cap",
+        "abbrev": "DEAD",
+        "division": "Southwest",
+        "allPlayPct": 0.286,
+        "allPlayWLT": "73-182-0",
+        "pf": 1503.05
+      },
+      {
+        "franchiseId": "0007",
+        "name": "Fire Ready Aim",
+        "nameMedium": "Fire Ready",
+        "abbrev": "FIRE",
+        "division": "East",
+        "allPlayPct": 0.267,
+        "allPlayWLT": "68-187-0",
+        "pf": 1453.35
+      }
+    ]
+  }
+}

--- a/src/data/theleague/power-rankings/2025-w14.json
+++ b/src/data/theleague/power-rankings/2025-w14.json
@@ -1,8 +1,8 @@
 {
   "year": 2025,
   "week": 14,
-  "publishedAt": "2026-05-07T23:40:47.555Z",
-  "generatedAt": "2026-05-07T23:40:47.555Z",
+  "publishedAt": "2026-05-08T00:26:30.746Z",
+  "generatedAt": "2026-05-08T00:26:30.746Z",
   "voiceMode": "templated",
   "headline": "Pain surges to #1",
   "lede": "Through Week 14, Bring The Pain sit atop the rankings. Midwestside dropped 144.74 — the highest score in the league this week. Bring The Pain jump 4 spots to #1. Da Dangsters slide 6 to #8.",

--- a/src/data/theleague/power-rankings/2025-w14.json
+++ b/src/data/theleague/power-rankings/2025-w14.json
@@ -1,0 +1,725 @@
+{
+  "year": 2025,
+  "week": 14,
+  "publishedAt": "2026-05-07T23:40:47.555Z",
+  "generatedAt": "2026-05-07T23:40:47.555Z",
+  "voiceMode": "templated",
+  "headline": "Pain surges to #1",
+  "lede": "Through Week 14, Bring The Pain sit atop the rankings. Midwestside dropped 144.74 — the highest score in the league this week. Bring The Pain jump 4 spots to #1. Da Dangsters slide 6 to #8.",
+  "rankings": [
+    {
+      "rank": 1,
+      "franchiseId": "0008",
+      "previousRank": 5,
+      "trend": "up",
+      "metrics": {
+        "composite": 84.52,
+        "rolling3Ppg": 127.75,
+        "seasonPpg": 111.5,
+        "ppgScore": 100,
+        "recordScore": 61.1,
+        "allPlayScore": 61.6
+      },
+      "blurb": "3-0 over their last 3 at 127.8 PPG. Riding a 4-game win streak. Rankings: up 4 from #5."
+    },
+    {
+      "rank": 2,
+      "franchiseId": "0009",
+      "previousRank": 6,
+      "trend": "up",
+      "metrics": {
+        "composite": 75.57,
+        "rolling3Ppg": 113.09,
+        "seasonPpg": 117.6,
+        "ppgScore": 74.77,
+        "recordScore": 83.3,
+        "allPlayScore": 65.9
+      },
+      "blurb": "2-1 over their last 3 at 113.1 PPG. Rankings: up 4 from #6."
+    },
+    {
+      "rank": 3,
+      "franchiseId": "0015",
+      "previousRank": 3,
+      "trend": "flat",
+      "metrics": {
+        "composite": 74.94,
+        "rolling3Ppg": 113.57,
+        "seasonPpg": 115.4,
+        "ppgScore": 75.61,
+        "recordScore": 77.8,
+        "allPlayScore": 67.5
+      },
+      "blurb": "2-1 over their last 3 at 113.6 PPG. Rankings: holding steady."
+    },
+    {
+      "rank": 4,
+      "franchiseId": "0010",
+      "previousRank": 1,
+      "trend": "down",
+      "metrics": {
+        "composite": 71.48,
+        "rolling3Ppg": 112.84,
+        "seasonPpg": 110.1,
+        "ppgScore": 74.34,
+        "recordScore": 72.2,
+        "allPlayScore": 58.8
+      },
+      "blurb": "2-1 over their last 3 at 112.8 PPG. Rankings: down 3 from #1."
+    },
+    {
+      "rank": 5,
+      "franchiseId": "0012",
+      "previousRank": 4,
+      "trend": "down",
+      "metrics": {
+        "composite": 67.13,
+        "rolling3Ppg": 108.36,
+        "seasonPpg": 114.9,
+        "ppgScore": 66.64,
+        "recordScore": 66.7,
+        "allPlayScore": 69.8
+      },
+      "blurb": "3-0 over their last 3 at 108.4 PPG. Riding a 3-game win streak. Rankings: down 1 from #4."
+    },
+    {
+      "rank": 6,
+      "franchiseId": "0005",
+      "previousRank": 9,
+      "trend": "up",
+      "metrics": {
+        "composite": 65.82,
+        "rolling3Ppg": 115.4,
+        "seasonPpg": 103.1,
+        "ppgScore": 78.75,
+        "recordScore": 44.4,
+        "allPlayScore": 49.8
+      },
+      "blurb": "3-0 over their last 3 at 115.4 PPG. Riding a 3-game win streak. Rankings: up 3 from #9."
+    },
+    {
+      "rank": 7,
+      "franchiseId": "0011",
+      "previousRank": 10,
+      "trend": "up",
+      "metrics": {
+        "composite": 64.75,
+        "rolling3Ppg": 113.51,
+        "seasonPpg": 98,
+        "ppgScore": 75.51,
+        "recordScore": 50,
+        "allPlayScore": 46.3
+      },
+      "blurb": "1-2 over their last 3 at 113.5 PPG. Rankings: up 3 from #10."
+    },
+    {
+      "rank": 8,
+      "franchiseId": "0002",
+      "previousRank": 2,
+      "trend": "down",
+      "metrics": {
+        "composite": 56.88,
+        "rolling3Ppg": 96.93,
+        "seasonPpg": 117.2,
+        "ppgScore": 46.97,
+        "recordScore": 72.2,
+        "allPlayScore": 71
+      },
+      "blurb": "1-2 over their last 3 at 96.9 PPG. Rankings: down 6 from #2."
+    },
+    {
+      "rank": 9,
+      "franchiseId": "0013",
+      "previousRank": 7,
+      "trend": "down",
+      "metrics": {
+        "composite": 52.06,
+        "rolling3Ppg": 98.17,
+        "seasonPpg": 108.6,
+        "ppgScore": 49.11,
+        "recordScore": 55.6,
+        "allPlayScore": 58
+      },
+      "blurb": "3-0 over their last 3 at 98.2 PPG. Riding a 3-game win streak. Rankings: down 2 from #7."
+    },
+    {
+      "rank": 10,
+      "franchiseId": "0016",
+      "previousRank": 8,
+      "trend": "down",
+      "metrics": {
+        "composite": 48.24,
+        "rolling3Ppg": 101.11,
+        "seasonPpg": 102.8,
+        "ppgScore": 54.17,
+        "recordScore": 33.3,
+        "allPlayScore": 49.4
+      },
+      "blurb": "1-2 over their last 3 at 101.1 PPG. Rankings: down 2 from #8."
+    },
+    {
+      "rank": 11,
+      "franchiseId": "0014",
+      "previousRank": 11,
+      "trend": "flat",
+      "metrics": {
+        "composite": 36.05,
+        "rolling3Ppg": 92.92,
+        "seasonPpg": 90.8,
+        "ppgScore": 40.08,
+        "recordScore": 27.8,
+        "allPlayScore": 33.7
+      },
+      "blurb": "0-3 over their last 3 at 92.9 PPG. Riding a 3-game skid. Rankings: holding steady."
+    },
+    {
+      "rank": 12,
+      "franchiseId": "0006",
+      "previousRank": 14,
+      "trend": "up",
+      "metrics": {
+        "composite": 32.1,
+        "rolling3Ppg": 88.92,
+        "seasonPpg": 89.8,
+        "ppgScore": 33.19,
+        "recordScore": 27.8,
+        "allPlayScore": 34.9
+      },
+      "blurb": "1-2 over their last 3 at 88.9 PPG. Riding a 2-game skid. Rankings: up 2 from #14."
+    },
+    {
+      "rank": 13,
+      "franchiseId": "0001",
+      "previousRank": 13,
+      "trend": "flat",
+      "metrics": {
+        "composite": 31.98,
+        "rolling3Ppg": 79.55,
+        "seasonPpg": 94.9,
+        "ppgScore": 17.06,
+        "recordScore": 61.1,
+        "allPlayScore": 43.1
+      },
+      "blurb": "1-2 over their last 3 at 79.5 PPG. Rankings: holding steady."
+    },
+    {
+      "rank": 14,
+      "franchiseId": "0004",
+      "previousRank": 15,
+      "trend": "up",
+      "metrics": {
+        "composite": 21.48,
+        "rolling3Ppg": 79.55,
+        "seasonPpg": 88.4,
+        "ppgScore": 17.07,
+        "recordScore": 27.8,
+        "allPlayScore": 28.6
+      },
+      "blurb": "0-3 over their last 3 at 79.5 PPG. Riding a 3-game skid. Rankings: up 1 from #15."
+    },
+    {
+      "rank": 15,
+      "franchiseId": "0003",
+      "previousRank": 12,
+      "trend": "down",
+      "metrics": {
+        "composite": 19.6,
+        "rolling3Ppg": 76.81,
+        "seasonPpg": 92.5,
+        "ppgScore": 12.35,
+        "recordScore": 27.8,
+        "allPlayScore": 34.9
+      },
+      "blurb": "1-2 over their last 3 at 76.8 PPG. Rankings: down 3 from #12."
+    },
+    {
+      "rank": 16,
+      "franchiseId": "0007",
+      "previousRank": 16,
+      "trend": "flat",
+      "metrics": {
+        "composite": 6.78,
+        "rolling3Ppg": 69.63,
+        "seasonPpg": 85.5,
+        "ppgScore": 0,
+        "recordScore": 11.1,
+        "allPlayScore": 26.7
+      },
+      "blurb": "0-3 over their last 3 at 69.6 PPG. Riding a 7-game skid. Rankings: holding steady."
+    }
+  ],
+  "awards": {
+    "statOfWeek": {
+      "franchiseId": "0011",
+      "title": "Stat of the Week",
+      "blurb": "Midwestside dropped 144.74 — the highest score in the league this week.",
+      "metric": {
+        "score": 144.74
+      }
+    },
+    "benchBlunder": {
+      "franchiseId": "0002",
+      "title": "Bench Blunder of the Week",
+      "blurb": "Da Dangsters left 51.99 on the bench (60.66 actual vs 112.65 optimal).",
+      "metric": {
+        "actual": 60.66,
+        "optimal": 112.65,
+        "gap": 51.99000000000001
+      }
+    },
+    "tradeOfWeek": null,
+    "cutOfShame": null,
+    "heaterOfWeek": {
+      "franchiseId": "0008",
+      "title": "Heater of the Week",
+      "blurb": "Bring The Pain have won 4 straight — longest active win streak in the league.",
+      "metric": {
+        "streak": 4
+      }
+    },
+    "coolerOfWeek": {
+      "franchiseId": "0007",
+      "title": "Cooler of the Week",
+      "blurb": "Fire Ready have dropped 7 in a row — the longest active losing streak in the league.",
+      "metric": {
+        "streak": 7
+      }
+    },
+    "matchupOfWeek": {
+      "title": "Matchup of the Week",
+      "homeId": "0008",
+      "awayId": "0010",
+      "blurb": "Week 15: #4 Computer Jocks at #1 Bring The Pain. Highest-ranked clash on the slate.",
+      "metric": {
+        "homeRank": 1,
+        "awayRank": 4
+      }
+    }
+  },
+  "standings": {
+    "divisions": [
+      {
+        "name": "Northwest",
+        "teams": [
+          {
+            "franchiseId": "0002",
+            "name": "Da Dangsters",
+            "nameMedium": "Da Dangsters",
+            "abbrev": "DANG",
+            "division": "Northwest",
+            "wins": 13,
+            "losses": 5,
+            "ties": 0,
+            "pf": 1992.84,
+            "pa": 1791.48,
+            "ppg": 117.2,
+            "allPlayPct": 0.71,
+            "allPlayWLT": "181-74-0"
+          },
+          {
+            "franchiseId": "0010",
+            "name": "Computer Jocks",
+            "nameMedium": "Computer Jocks",
+            "abbrev": "JOCKS",
+            "division": "Northwest",
+            "wins": 13,
+            "losses": 5,
+            "ties": 0,
+            "pf": 1871.19,
+            "pa": 1730.5,
+            "ppg": 110.1,
+            "allPlayPct": 0.588,
+            "allPlayWLT": "150-105-0"
+          },
+          {
+            "franchiseId": "0012",
+            "name": "Vitside Mafia",
+            "nameMedium": "Vitside",
+            "abbrev": "VIT",
+            "division": "Northwest",
+            "wins": 12,
+            "losses": 6,
+            "ties": 0,
+            "pf": 1953.88,
+            "pa": 1742.4,
+            "ppg": 114.9,
+            "allPlayPct": 0.698,
+            "allPlayWLT": "178-77-0"
+          },
+          {
+            "franchiseId": "0001",
+            "name": "Pacific Pigskins",
+            "nameMedium": "Pigskins",
+            "abbrev": "SKINS",
+            "division": "Northwest",
+            "wins": 11,
+            "losses": 7,
+            "ties": 0,
+            "pf": 1613.3,
+            "pa": 1737.24,
+            "ppg": 94.9,
+            "allPlayPct": 0.431,
+            "allPlayWLT": "110-145-0"
+          }
+        ]
+      },
+      {
+        "name": "Southwest",
+        "teams": [
+          {
+            "franchiseId": "0013",
+            "name": "Gridiron Geeks",
+            "nameMedium": "Gridiron Geeks",
+            "abbrev": "GEEKS",
+            "division": "Southwest",
+            "wins": 10,
+            "losses": 8,
+            "ties": 0,
+            "pf": 1845.58,
+            "pa": 1880.64,
+            "ppg": 108.6,
+            "allPlayPct": 0.58,
+            "allPlayWLT": "148-107-0"
+          },
+          {
+            "franchiseId": "0011",
+            "name": "Midwestside Connection",
+            "nameMedium": "Midwestside",
+            "abbrev": "MWS",
+            "division": "Southwest",
+            "wins": 9,
+            "losses": 9,
+            "ties": 0,
+            "pf": 1665.88,
+            "pa": 1662.33,
+            "ppg": 98,
+            "allPlayPct": 0.463,
+            "allPlayWLT": "118-137-0"
+          },
+          {
+            "franchiseId": "0006",
+            "name": "Music City Mafia",
+            "nameMedium": "Music City",
+            "abbrev": "MUSIC",
+            "division": "Southwest",
+            "wins": 5,
+            "losses": 13,
+            "ties": 0,
+            "pf": 1526.25,
+            "pa": 1936.22,
+            "ppg": 89.8,
+            "allPlayPct": 0.349,
+            "allPlayWLT": "89-166-0"
+          },
+          {
+            "franchiseId": "0004",
+            "name": "Dead Cap Walking",
+            "nameMedium": "Dead Cap",
+            "abbrev": "DEAD",
+            "division": "Southwest",
+            "wins": 5,
+            "losses": 13,
+            "ties": 0,
+            "pf": 1503.05,
+            "pa": 1804.5,
+            "ppg": 88.4,
+            "allPlayPct": 0.286,
+            "allPlayWLT": "73-182-0"
+          }
+        ]
+      },
+      {
+        "name": "Central",
+        "teams": [
+          {
+            "franchiseId": "0008",
+            "name": "Bring The Pain",
+            "nameMedium": "Bring The Pain",
+            "abbrev": "PAIN",
+            "division": "Central",
+            "wins": 11,
+            "losses": 7,
+            "ties": 0,
+            "pf": 1895.27,
+            "pa": 1911.02,
+            "ppg": 111.5,
+            "allPlayPct": 0.616,
+            "allPlayWLT": "157-98-0"
+          },
+          {
+            "franchiseId": "0005",
+            "name": "The Mariachi Ninjas",
+            "nameMedium": "Mariachi Ninjas",
+            "abbrev": "NINJA",
+            "division": "Central",
+            "wins": 8,
+            "losses": 10,
+            "ties": 0,
+            "pf": 1751.97,
+            "pa": 1758.39,
+            "ppg": 103.1,
+            "allPlayPct": 0.498,
+            "allPlayWLT": "127-128-0"
+          },
+          {
+            "franchiseId": "0003",
+            "name": "Maverick",
+            "nameMedium": "Mavericks",
+            "abbrev": "MAVS",
+            "division": "Central",
+            "wins": 5,
+            "losses": 13,
+            "ties": 0,
+            "pf": 1571.94,
+            "pa": 1973.8,
+            "ppg": 92.5,
+            "allPlayPct": 0.349,
+            "allPlayWLT": "89-166-0"
+          },
+          {
+            "franchiseId": "0014",
+            "name": "Cowboy Up",
+            "nameMedium": "Cowboy Up",
+            "abbrev": "CBOY",
+            "division": "Central",
+            "wins": 5,
+            "losses": 13,
+            "ties": 0,
+            "pf": 1544.42,
+            "pa": 2001.75,
+            "ppg": 90.8,
+            "allPlayPct": 0.337,
+            "allPlayWLT": "86-169-0"
+          }
+        ]
+      },
+      {
+        "name": "East",
+        "teams": [
+          {
+            "franchiseId": "0009",
+            "name": "Wascawy Wabbits",
+            "nameMedium": "Wascawy Wabbits",
+            "abbrev": "WABS",
+            "division": "East",
+            "wins": 15,
+            "losses": 3,
+            "ties": 0,
+            "pf": 1998.36,
+            "pa": 1592.99,
+            "ppg": 117.6,
+            "allPlayPct": 0.659,
+            "allPlayWLT": "168-87-0"
+          },
+          {
+            "franchiseId": "0015",
+            "name": "Dark Magicians of Chaos",
+            "nameMedium": "Dark Magicians",
+            "abbrev": "DMOC",
+            "division": "East",
+            "wins": 14,
+            "losses": 4,
+            "ties": 0,
+            "pf": 1961.1,
+            "pa": 1754.87,
+            "ppg": 115.4,
+            "allPlayPct": 0.675,
+            "allPlayWLT": "172-83-0"
+          },
+          {
+            "franchiseId": "0016",
+            "name": "Running down the Dream",
+            "nameMedium": "The Dream",
+            "abbrev": "DREAM",
+            "division": "East",
+            "wins": 6,
+            "losses": 12,
+            "ties": 0,
+            "pf": 1746.95,
+            "pa": 1978.11,
+            "ppg": 102.8,
+            "allPlayPct": 0.494,
+            "allPlayWLT": "126-129-0"
+          },
+          {
+            "franchiseId": "0007",
+            "name": "Fire Ready Aim",
+            "nameMedium": "Fire Ready",
+            "abbrev": "FIRE",
+            "division": "East",
+            "wins": 2,
+            "losses": 16,
+            "ties": 0,
+            "pf": 1453.35,
+            "pa": 2073.99,
+            "ppg": 85.5,
+            "allPlayPct": 0.267,
+            "allPlayWLT": "68-187-0"
+          }
+        ]
+      }
+    ],
+    "allPlay": [
+      {
+        "franchiseId": "0002",
+        "name": "Da Dangsters",
+        "nameMedium": "Da Dangsters",
+        "abbrev": "DANG",
+        "division": "Northwest",
+        "allPlayPct": 0.71,
+        "allPlayWLT": "181-74-0",
+        "pf": 1992.84
+      },
+      {
+        "franchiseId": "0012",
+        "name": "Vitside Mafia",
+        "nameMedium": "Vitside",
+        "abbrev": "VIT",
+        "division": "Northwest",
+        "allPlayPct": 0.698,
+        "allPlayWLT": "178-77-0",
+        "pf": 1953.88
+      },
+      {
+        "franchiseId": "0015",
+        "name": "Dark Magicians of Chaos",
+        "nameMedium": "Dark Magicians",
+        "abbrev": "DMOC",
+        "division": "East",
+        "allPlayPct": 0.675,
+        "allPlayWLT": "172-83-0",
+        "pf": 1961.1
+      },
+      {
+        "franchiseId": "0009",
+        "name": "Wascawy Wabbits",
+        "nameMedium": "Wascawy Wabbits",
+        "abbrev": "WABS",
+        "division": "East",
+        "allPlayPct": 0.659,
+        "allPlayWLT": "168-87-0",
+        "pf": 1998.36
+      },
+      {
+        "franchiseId": "0008",
+        "name": "Bring The Pain",
+        "nameMedium": "Bring The Pain",
+        "abbrev": "PAIN",
+        "division": "Central",
+        "allPlayPct": 0.616,
+        "allPlayWLT": "157-98-0",
+        "pf": 1895.27
+      },
+      {
+        "franchiseId": "0010",
+        "name": "Computer Jocks",
+        "nameMedium": "Computer Jocks",
+        "abbrev": "JOCKS",
+        "division": "Northwest",
+        "allPlayPct": 0.588,
+        "allPlayWLT": "150-105-0",
+        "pf": 1871.19
+      },
+      {
+        "franchiseId": "0013",
+        "name": "Gridiron Geeks",
+        "nameMedium": "Gridiron Geeks",
+        "abbrev": "GEEKS",
+        "division": "Southwest",
+        "allPlayPct": 0.58,
+        "allPlayWLT": "148-107-0",
+        "pf": 1845.58
+      },
+      {
+        "franchiseId": "0005",
+        "name": "The Mariachi Ninjas",
+        "nameMedium": "Mariachi Ninjas",
+        "abbrev": "NINJA",
+        "division": "Central",
+        "allPlayPct": 0.498,
+        "allPlayWLT": "127-128-0",
+        "pf": 1751.97
+      },
+      {
+        "franchiseId": "0016",
+        "name": "Running down the Dream",
+        "nameMedium": "The Dream",
+        "abbrev": "DREAM",
+        "division": "East",
+        "allPlayPct": 0.494,
+        "allPlayWLT": "126-129-0",
+        "pf": 1746.95
+      },
+      {
+        "franchiseId": "0011",
+        "name": "Midwestside Connection",
+        "nameMedium": "Midwestside",
+        "abbrev": "MWS",
+        "division": "Southwest",
+        "allPlayPct": 0.463,
+        "allPlayWLT": "118-137-0",
+        "pf": 1665.88
+      },
+      {
+        "franchiseId": "0001",
+        "name": "Pacific Pigskins",
+        "nameMedium": "Pigskins",
+        "abbrev": "SKINS",
+        "division": "Northwest",
+        "allPlayPct": 0.431,
+        "allPlayWLT": "110-145-0",
+        "pf": 1613.3
+      },
+      {
+        "franchiseId": "0006",
+        "name": "Music City Mafia",
+        "nameMedium": "Music City",
+        "abbrev": "MUSIC",
+        "division": "Southwest",
+        "allPlayPct": 0.349,
+        "allPlayWLT": "89-166-0",
+        "pf": 1526.25
+      },
+      {
+        "franchiseId": "0003",
+        "name": "Maverick",
+        "nameMedium": "Mavericks",
+        "abbrev": "MAVS",
+        "division": "Central",
+        "allPlayPct": 0.349,
+        "allPlayWLT": "89-166-0",
+        "pf": 1571.94
+      },
+      {
+        "franchiseId": "0014",
+        "name": "Cowboy Up",
+        "nameMedium": "Cowboy Up",
+        "abbrev": "CBOY",
+        "division": "Central",
+        "allPlayPct": 0.337,
+        "allPlayWLT": "86-169-0",
+        "pf": 1544.42
+      },
+      {
+        "franchiseId": "0004",
+        "name": "Dead Cap Walking",
+        "nameMedium": "Dead Cap",
+        "abbrev": "DEAD",
+        "division": "Southwest",
+        "allPlayPct": 0.286,
+        "allPlayWLT": "73-182-0",
+        "pf": 1503.05
+      },
+      {
+        "franchiseId": "0007",
+        "name": "Fire Ready Aim",
+        "nameMedium": "Fire Ready",
+        "abbrev": "FIRE",
+        "division": "East",
+        "allPlayPct": 0.267,
+        "allPlayWLT": "68-187-0",
+        "pf": 1453.35
+      }
+    ]
+  }
+}

--- a/src/pages/theleague/power-rankings/[year]/[week].astro
+++ b/src/pages/theleague/power-rankings/[year]/[week].astro
@@ -1,0 +1,101 @@
+---
+/**
+ * Power Rankings — historical permalink: /theleague/power-rankings/[year]/[week].
+ *
+ * Pre-rendered via getStaticPaths for every issue we have on disk.
+ */
+export const prerender = true;
+
+import TheLeagueLayout from '../../../../layouts/TheLeagueLayout.astro';
+import Breadcrumbs from '../../../../components/theleague/Breadcrumbs.astro';
+import PowerRankingsIssue, { type PowerRankingsData } from '../../../../components/theleague/PowerRankingsIssue.astro';
+
+const issueFiles = import.meta.glob<PowerRankingsData>(
+  '../../../../data/theleague/power-rankings/*.json',
+  { eager: true, import: 'default' }
+);
+
+interface Entry { year: number; week: number; data: PowerRankingsData }
+
+const allIssues: Entry[] = Object.entries(issueFiles)
+  .map(([file, data]) => {
+    const m = file.match(/(\d{4})-w(\d{1,2})\.json$/);
+    if (!m) return null;
+    return { year: parseInt(m[1], 10), week: parseInt(m[2], 10), data: data as PowerRankingsData };
+  })
+  .filter((x): x is Entry => x !== null)
+  .sort((a, b) => b.year - a.year || b.week - a.week);
+
+export async function getStaticPaths() {
+  const files = import.meta.glob<PowerRankingsData>(
+    '../../../../data/theleague/power-rankings/*.json',
+    { eager: true, import: 'default' }
+  );
+  const issues: Entry[] = Object.entries(files)
+    .map(([file, data]) => {
+      const m = file.match(/(\d{4})-w(\d{1,2})\.json$/);
+      if (!m) return null;
+      return { year: parseInt(m[1], 10), week: parseInt(m[2], 10), data: data as PowerRankingsData };
+    })
+    .filter((x): x is Entry => x !== null);
+
+  return issues.map(({ year, week, data }) => ({
+    params: { year: String(year), week: String(week) },
+    props: { issue: data },
+  }));
+}
+
+const { issue } = Astro.props as { issue: PowerRankingsData };
+
+// Find adjacent issues for footer nav
+const idx = allIssues.findIndex(i => i.year === issue.year && i.week === issue.week);
+const prevIssue = idx >= 0 ? allIssues[idx + 1] : null; // older
+const nextIssue = idx > 0 ? allIssues[idx - 1] : null;  // newer
+---
+
+<TheLeagueLayout title={`${issue.headline} · Week ${issue.week} Power Rankings`}>
+  <main class="pr-page">
+    <Breadcrumbs items={[
+      { label: 'The League', href: '/theleague' },
+      { label: 'Power Rankings', href: '/theleague/power-rankings' },
+      { label: `Week ${issue.week} · ${issue.year}` },
+    ]} />
+
+    <PowerRankingsIssue issue={issue} />
+
+    <nav class="pr-nav" aria-label="Issue navigation">
+      {prevIssue ? (
+        <a class="pr-nav__link pr-nav__link--prev" href={`/theleague/power-rankings/${prevIssue.year}/${prevIssue.week}`}>
+          ← Week {prevIssue.week} · {prevIssue.year}
+        </a>
+      ) : <span></span>}
+      <a class="pr-nav__link pr-nav__link--index" href="/theleague/power-rankings">All issues</a>
+      {nextIssue ? (
+        <a class="pr-nav__link pr-nav__link--next" href={`/theleague/power-rankings/${nextIssue.year}/${nextIssue.week}`}>
+          Week {nextIssue.week} · {nextIssue.year} →
+        </a>
+      ) : <span></span>}
+    </nav>
+  </main>
+</TheLeagueLayout>
+
+<style>
+.pr-page { min-height: 60vh; }
+.pr-nav {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  max-width: 1100px;
+  margin: -2rem auto 3rem;
+  padding: 0 1rem;
+}
+.pr-nav__link {
+  color: var(--color-text, #111827);
+  text-decoration: none;
+  font-size: 0.9rem;
+  font-weight: 500;
+}
+.pr-nav__link:hover { text-decoration: underline; }
+.pr-nav__link--index { color: var(--color-text-muted, #6b7280); }
+</style>

--- a/src/pages/theleague/power-rankings/index.astro
+++ b/src/pages/theleague/power-rankings/index.astro
@@ -1,0 +1,110 @@
+---
+/**
+ * Power Rankings — current week (latest published issue).
+ *
+ * Reads all power-rankings JSON files via Vite glob and picks the highest
+ * (year, week) combination. Permalink to a specific issue lives at
+ * /theleague/power-rankings/[year]/[week].
+ */
+import TheLeagueLayout from '../../../layouts/TheLeagueLayout.astro';
+import Breadcrumbs from '../../../components/theleague/Breadcrumbs.astro';
+import PowerRankingsIssue, { type PowerRankingsData } from '../../../components/theleague/PowerRankingsIssue.astro';
+
+const issueFiles = import.meta.glob<PowerRankingsData>(
+  '../../../data/theleague/power-rankings/*.json',
+  { eager: true, import: 'default' }
+);
+
+const issues = Object.entries(issueFiles)
+  .map(([file, data]) => {
+    const m = file.match(/(\d{4})-w(\d{1,2})\.json$/);
+    if (!m) return null;
+    return {
+      year: parseInt(m[1], 10),
+      week: parseInt(m[2], 10),
+      data: data as PowerRankingsData,
+    };
+  })
+  .filter((x): x is { year: number; week: number; data: PowerRankingsData } => x !== null)
+  .sort((a, b) => b.year - a.year || b.week - a.week);
+
+const latest = issues[0] ?? null;
+
+const olderIssues = issues.slice(1);
+---
+
+<TheLeagueLayout title={latest ? `${latest.data.headline} · Week ${latest.week} Power Rankings` : 'Power Rankings'}>
+  <main class="pr-page">
+    <Breadcrumbs items={[
+      { label: 'The League', href: '/theleague' },
+      { label: 'Power Rankings' },
+    ]} />
+
+    {latest ? (
+      <>
+        <PowerRankingsIssue issue={latest.data} />
+        {olderIssues.length > 0 && (
+          <aside class="pr-archive">
+            <h2 class="pr-archive__title">Past Issues</h2>
+            <ul class="pr-archive__list">
+              {olderIssues.map(i => (
+                <li>
+                  <a href={`/theleague/power-rankings/${i.year}/${i.week}`}>
+                    Week {i.week} · {i.year} — {i.data.headline}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </aside>
+        )}
+      </>
+    ) : (
+      <section class="pr-empty">
+        <h1>Power Rankings — Coming Soon</h1>
+        <p>
+          The first weekly issue publishes Tuesday morning during the season.
+          Run <code>pnpm generate:power-rankings --year YYYY --week N</code> to seed an issue.
+        </p>
+      </section>
+    )}
+  </main>
+</TheLeagueLayout>
+
+<style>
+.pr-page { min-height: 60vh; }
+.pr-archive {
+  max-width: 1100px;
+  margin: 0 auto 3rem;
+  padding: 0 1rem;
+}
+.pr-archive__title {
+  font-size: 1.25rem;
+  font-weight: 700;
+  margin: 0 0 0.75rem;
+}
+.pr-archive__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.4rem;
+}
+.pr-archive__list a {
+  color: var(--color-text, #111827);
+  text-decoration: none;
+}
+.pr-archive__list a:hover { text-decoration: underline; }
+.pr-empty {
+  max-width: 720px;
+  margin: 4rem auto;
+  padding: 0 1rem;
+  text-align: center;
+  color: var(--color-text-muted, #6b7280);
+}
+.pr-empty code {
+  background: var(--color-surface-2, #f3f4f6);
+  padding: 0.15rem 0.35rem;
+  border-radius: 0.25rem;
+  font-size: 0.9em;
+}
+</style>

--- a/tests/power-rankings-ai.test.ts
+++ b/tests/power-rankings-ai.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect } from 'vitest';
+// @ts-expect-error — sibling .mjs module, no .d.ts
+import {
+  validateBlurb,
+  applyAIVoice,
+  buildFactSheet,
+  HEADLINE_MAX,
+  LEDE_MAX,
+  BLURB_MAX,
+// @ts-expect-error — sibling .mjs module, no .d.ts
+} from '../scripts/lib/power-rankings-ai.mjs';
+
+const pigskins = {
+  franchiseId: '0001',
+  name: 'Pacific Pigskins',
+  nameMedium: 'Pigskins',
+  nameShort: 'Pigskins',
+  abbrev: 'SKINS',
+  aliases: ['Skins', 'Pigs'],
+};
+const dangsters = {
+  franchiseId: '0002',
+  name: 'Da Dangsters',
+  nameMedium: 'Da Dangsters',
+  nameShort: 'Dangsters',
+  abbrev: 'DANG',
+};
+
+describe('validateBlurb', () => {
+  it('passes a clean blurb that names the franchise', () => {
+    const errs = validateBlurb('Pigskins riding a 4-game heater into Week 5.', { franchise: pigskins });
+    expect(errs).toEqual([]);
+  });
+
+  it('rejects empty/missing text', () => {
+    expect(validateBlurb('')).toEqual(['empty']);
+    expect(validateBlurb(null as any)).toEqual(['empty']);
+    expect(validateBlurb('   ')).toEqual(['empty']);
+  });
+
+  it('rejects banned phrases (case-insensitive)', () => {
+    const errs = validateBlurb('As an AI, I think the Pigskins look strong.', { franchise: pigskins });
+    expect(errs.some(e => e.includes('banned phrase'))).toBe(true);
+  });
+
+  it('rejects curly quotes', () => {
+    const errs = validateBlurb('Pigskins “rolling” into Week 5.', { franchise: pigskins });
+    expect(errs).toContain('curly quote');
+  });
+
+  it('rejects markdown fences', () => {
+    const errs = validateBlurb('Pigskins ```rolling``` into Week 5.', { franchise: pigskins });
+    expect(errs).toContain('markdown fence');
+  });
+
+  it('rejects when blurb does not name the target franchise', () => {
+    const errs = validateBlurb('Da Dangsters riding a 4-game heater.', { franchise: pigskins });
+    expect(errs).toContain('does not name this franchise');
+  });
+
+  it('accepts an alias as a franchise mention', () => {
+    const errs = validateBlurb('The Pigs are riding a 4-game heater.', { franchise: pigskins });
+    expect(errs).toEqual([]);
+  });
+
+  it('enforces length cap', () => {
+    const long = 'Pigskins ' + 'x'.repeat(BLURB_MAX);
+    const errs = validateBlurb(long, { franchise: pigskins });
+    expect(errs.some(e => e.startsWith('too long'))).toBe(true);
+  });
+
+  it('uses a different cap for headlines', () => {
+    const headline = 'Pigskins surge to #1 entering Week 5'.padEnd(HEADLINE_MAX + 5, '!');
+    const errs = validateBlurb(headline, { maxLength: HEADLINE_MAX });
+    expect(errs.some(e => e.startsWith('too long'))).toBe(true);
+  });
+});
+
+describe('applyAIVoice', () => {
+  const teams = new Map<string, any>([
+    ['0001', pigskins],
+    ['0002', dangsters],
+  ]);
+
+  const issue = {
+    year: 2025,
+    week: 14,
+    headline: 'Pigskins hold #1',
+    lede: 'Templated lede.',
+    rankings: [
+      { rank: 1, franchiseId: '0001', blurb: 'TEMPLATED Pigskins blurb.', metrics: {}, previousRank: 1, trend: 'flat' },
+      { rank: 2, franchiseId: '0002', blurb: 'TEMPLATED Dangsters blurb.', metrics: {}, previousRank: 2, trend: 'flat' },
+    ],
+    awards: {
+      statOfWeek: { franchiseId: '0001', title: 'Stat of the Week', blurb: 'Pigskins dropped 150.', metric: { score: 150 } },
+      benchBlunder: null,
+    },
+  } as any;
+
+  it('applies all valid AI blurbs and reports counts', () => {
+    const aiOutput = {
+      headline: 'Pigskins keep their grip on #1',
+      lede: 'Pigskins are not relinquishing the throne.',
+      blurbs: {
+        '0001': 'Pigskins riding a 4-game heater. Boom.',
+        '0002': 'Da Dangsters need a spark, sources tell me.',
+      },
+      awardBlurbs: {
+        statOfWeek: 'Pigskins crushed the league with a 150 burst.',
+      },
+    };
+    const { issue: out, report } = applyAIVoice(issue, aiOutput, teams);
+    expect(out.headline).toBe('Pigskins keep their grip on #1');
+    expect(out.lede).toBe('Pigskins are not relinquishing the throne.');
+    expect(out.rankings[0].blurb).toBe('Pigskins riding a 4-game heater. Boom.');
+    expect(out.rankings[1].blurb).toBe('Da Dangsters need a spark, sources tell me.');
+    expect(out.awards.statOfWeek.blurb).toBe('Pigskins crushed the league with a 150 burst.');
+    expect(report.headline).toBe('ai');
+    expect(report.lede).toBe('ai');
+    expect(report.blurbs.applied).toBe(2);
+    expect(report.blurbs.fallback).toBe(0);
+    expect(report.awardBlurbs.applied).toBe(1);
+  });
+
+  it('falls back per-blurb when validation fails', () => {
+    const aiOutput = {
+      headline: 'Pigskins hold #1',
+      lede: 'Templated lede.',
+      blurbs: {
+        '0001': 'Random Team Name riding a heater.', // no franchise mention
+        '0002': 'As an AI, I see strength here.',     // banned phrase
+      },
+      awardBlurbs: {},
+    };
+    const { issue: out, report } = applyAIVoice(issue, aiOutput, teams);
+    expect(out.rankings[0].blurb).toBe('TEMPLATED Pigskins blurb.');
+    expect(out.rankings[1].blurb).toBe('TEMPLATED Dangsters blurb.');
+    expect(report.blurbs.applied).toBe(0);
+    expect(report.blurbs.fallback).toBe(2);
+    expect(report.blurbs.fails).toHaveLength(2);
+  });
+
+  it('does not crash when AI returns nothing', () => {
+    const { issue: out, report } = applyAIVoice(issue, {}, teams);
+    expect(out.headline).toBe('Pigskins hold #1');
+    expect(out.rankings[0].blurb).toBe('TEMPLATED Pigskins blurb.');
+    expect(report.blurbs.applied).toBe(0);
+  });
+
+  it('skips null awards in the input issue', () => {
+    const aiOutput = {
+      awardBlurbs: {
+        benchBlunder: 'Should be ignored — issue has null benchBlunder.',
+      },
+    };
+    const { issue: out } = applyAIVoice(issue, aiOutput, teams);
+    expect(out.awards.benchBlunder).toBeNull();
+  });
+});
+
+describe('buildFactSheet', () => {
+  const teams = new Map<string, any>([
+    ['0001', pigskins],
+    ['0002', dangsters],
+  ]);
+  const issue = {
+    year: 2025,
+    week: 14,
+    rankings: [
+      {
+        rank: 1, franchiseId: '0001', previousRank: 5, trend: 'up',
+        metrics: { rolling3Ppg: 132.5, seasonPpg: 118.0 },
+        factsForBlurb: { last3Record: { wins: 3, losses: 0, ties: 0 }, streak: { type: 'W', length: 4 } },
+      },
+      {
+        rank: 2, franchiseId: '0002', previousRank: 1, trend: 'down',
+        metrics: { rolling3Ppg: 110.0, seasonPpg: 117.2 },
+        factsForBlurb: { last3Record: { wins: 1, losses: 2, ties: 0 }, streak: { type: 'L', length: 1 } },
+      },
+    ],
+    awards: {
+      statOfWeek: { franchiseId: '0001', title: 'Stat of the Week', blurb: 'Pigskins dropped 150.', metric: { score: 150 } },
+    },
+  } as any;
+
+  it('includes rankings with trend, record, ppg, and streak', () => {
+    const sheet = buildFactSheet({ issue, teams });
+    expect(sheet).toContain('#1 | Pigskins');
+    expect(sheet).toContain('up 4 (was #5)');
+    expect(sheet).toContain('3-0 L3');
+    expect(sheet).toContain('132.5 PPG L3');
+    expect(sheet).toContain('W4');
+    expect(sheet).toContain('#2 | Da Dangsters');
+    expect(sheet).toContain('down 1 (was #1)');
+  });
+
+  it('includes the allowed franchise tokens block', () => {
+    const sheet = buildFactSheet({ issue, teams });
+    expect(sheet).toContain('ALLOWED FRANCHISE NAME TOKENS');
+    expect(sheet).toContain('Pacific Pigskins');
+    expect(sheet).toContain('Pigskins, Pigskins, SKINS, Skins, Pigs');
+  });
+
+  it('renders awards with their raw blurbs and metrics', () => {
+    const sheet = buildFactSheet({ issue, teams });
+    expect(sheet).toContain('statOfWeek: Stat of the Week — Pigskins');
+    expect(sheet).toContain('raw: Pigskins dropped 150.');
+    expect(sheet).toContain('"score":150');
+  });
+});

--- a/tests/power-rankings.test.ts
+++ b/tests/power-rankings.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+// @ts-expect-error — sibling .mjs module, no .d.ts
+import {
+  parseStreak,
+  rollingAvgPF,
+  computeRankings,
+  attachTrend,
+// @ts-expect-error — sibling .mjs module, no .d.ts
+} from '../scripts/generate-power-rankings.mjs';
+
+describe('parseStreak', () => {
+  it('parses W and L streaks', () => {
+    expect(parseStreak('W3')).toEqual({ type: 'W', length: 3 });
+    expect(parseStreak('L5')).toEqual({ type: 'L', length: 5 });
+  });
+  it('handles empty / malformed strings', () => {
+    expect(parseStreak('')).toEqual({ type: null, length: 0 });
+    expect(parseStreak(undefined as any)).toEqual({ type: null, length: 0 });
+    expect(parseStreak('foo')).toEqual({ type: null, length: 0 });
+  });
+});
+
+describe('rollingAvgPF', () => {
+  const weekly = {
+    weeks: [
+      { week: 1, scores: { '0001': 100, '0002': 80 } },
+      { week: 2, scores: { '0001': 110, '0002': 90 } },
+      { week: 3, scores: { '0001': 120, '0002': 70 } },
+      { week: 4, scores: { '0001': 90,  '0002': 60 } },
+      { week: 5, scores: { '0001': 130, '0002': 100 } },
+    ],
+  };
+
+  it('averages the last 3 completed weeks', () => {
+    // Through week 5: 90 + 130 = (120+90+130)/3 = 113.33
+    expect(rollingAvgPF(weekly, '0001', 5, 3)).toBeCloseTo(113.33, 1);
+  });
+  it('respects the throughWeek cap', () => {
+    // Through week 3: weeks 1+2+3 → (100+110+120)/3 = 110
+    expect(rollingAvgPF(weekly, '0001', 3, 3)).toBeCloseTo(110, 5);
+  });
+  it('returns null with no completed weeks', () => {
+    expect(rollingAvgPF(weekly, '0099', 5, 3)).toBeNull();
+  });
+});
+
+describe('computeRankings', () => {
+  // Synthetic two-team league
+  const teams = new Map<string, any>([
+    ['0001', { franchiseId: '0001', name: 'Alpha', division: 'A' }],
+    ['0002', { franchiseId: '0002', name: 'Beta',  division: 'A' }],
+  ]);
+  const standingsByFid = new Map<string, any>([
+    ['0001', { id: '0001', h2hpct: '.800', all_play_pct: '.700', avgpf: '120.0' }],
+    ['0002', { id: '0002', h2hpct: '.200', all_play_pct: '.300', avgpf: '95.0' }],
+  ]);
+  const weeklyResults = {
+    weeks: [
+      { week: 1, scores: { '0001': 130, '0002': 90 } },
+      { week: 2, scores: { '0001': 110, '0002': 95 } },
+      { week: 3, scores: { '0001': 125, '0002': 80 } },
+    ],
+  };
+  const schedule = { schedule: { weeklySchedule: [] } };
+
+  it('ranks the better team #1', () => {
+    const ranked = computeRankings({ teams, standingsByFid, weeklyResults, schedule, week: 3 });
+    expect(ranked[0].fid).toBe('0001');
+    expect(ranked[1].fid).toBe('0002');
+    expect(ranked[0].rank).toBe(1);
+    expect(ranked[1].rank).toBe(2);
+  });
+
+  it('uses rolling-3wk PPG, record %, and all-play % in the composite', () => {
+    const ranked = computeRankings({ teams, standingsByFid, weeklyResults, schedule, week: 3 });
+    // Top team should have a substantially higher composite score
+    expect(ranked[0].composite).toBeGreaterThan(ranked[1].composite);
+    // The rolling-3wk PPG should match (130+110+125)/3 = 121.67 for top team
+    expect(ranked[0].rolling3Ppg).toBeCloseTo(121.67, 1);
+  });
+});
+
+describe('attachTrend', () => {
+  const current = [
+    { rank: 1, fid: '0001' },
+    { rank: 2, fid: '0002' },
+    { rank: 3, fid: '0003' },
+  ];
+  it('returns flat trends when there is no previous issue', () => {
+    const out = attachTrend(current, null);
+    expect(out.every((r: any) => r.trend === 'flat' && r.previousRank == null)).toBe(true);
+  });
+
+  it('marks risers, fallers, and steady', () => {
+    const previous = {
+      week: 4,
+      rankings: [
+        { rank: 1, franchiseId: '0002' },
+        { rank: 2, franchiseId: '0001' },
+        { rank: 3, franchiseId: '0003' },
+      ],
+    };
+    const out = attachTrend(current, previous);
+    expect(out[0]).toMatchObject({ fid: '0001', previousRank: 2, trend: 'up' });   // 2→1
+    expect(out[1]).toMatchObject({ fid: '0002', previousRank: 1, trend: 'down' }); // 1→2
+    expect(out[2]).toMatchObject({ fid: '0003', previousRank: 3, trend: 'flat' });
+  });
+});


### PR DESCRIPTION
Adds the Tuesday weekly power-rankings article from
docs/plans/tuesday-power-rankings.md (Phase 1 scope: generation script
+ JSON output + page renderer with templated blurbs; LLM voice deferred
to Phase 2).

- scripts/generate-power-rankings.mjs — composite ranking algorithm
  (60% rolling-3wk PPG / 25% H2H record / 15% all-play %), deterministic
  award detection (statOfWeek / benchBlunder / heater / cooler /
  matchupOfWeek), and templated blurb generation.
- src/components/theleague/PowerRankingsIssue.astro — single rendering
  component shared by current-week and permalink pages.
- /theleague/power-rankings — current week (latest published).
- /theleague/power-rankings/[year]/[week] — prerendered permalinks.
- src/data/theleague/power-rankings/<year>-w<week>.json — issue store.
- tests/power-rankings.test.ts — 9 tests covering composite ranking,
  rolling PPG, streak parsing, and trend computation.
- pnpm generate:power-rankings --year YYYY --week N [--regenerate].

Cap-health weight from the design doc is folded into Phase 2 along with
LLM blurbs and trade/cut-of-shame awards (which need transactions
parsing). Sample issues seeded for 2025 weeks 13 and 14.