### PR TITLE
chore(power-rankings): reweight composite to 50/30/20

### DIFF
--- a/scripts/generate-power-rankings.mjs
+++ b/scripts/generate-power-rankings.mjs
@@ -34,14 +34,14 @@ import {
 const projectRoot = path.resolve(fileURLToPath(new URL('..', import.meta.url)));
 
 // ─── Algorithm weights (composite ranking score) ───────────────────
-//   60% — rolling-3wk PPG (form)
-//   25% — head-to-head record (results)
-//   15% — all-play % (luck-adjusted strength)
+//   50% — rolling-3wk PPG (form)
+//   30% — head-to-head record (results)
+//   20% — all-play % (luck-adjusted strength)
 // Cap-health weight from the design doc is deferred to Phase 2 (needs salary
 // pipeline plumbed in). Total still sums to 1.0 by upweighting form.
-const W_FORM = 0.60;
-const W_RECORD = 0.25;
-const W_ALL_PLAY = 0.15;
+const W_FORM = 0.50;
+const W_RECORD = 0.30;
+const W_ALL_PLAY = 0.20;
 
 // ─── CLI ───────────────────────────────────────────────────────────
 

--- a/src/components/theleague/PowerRankingsIssue.astro
+++ b/src/components/theleague/PowerRankingsIssue.astro
@@ -204,7 +204,7 @@ const orderedAwards: { key: string; card: AwardCard | null }[] = [
   <footer class="pr-footnote">
     <p>
       Phase 1 issue — blurbs are templated from on-disk feeds (no LLM voice yet).
-      Composite score: 60% rolling-3wk PPG · 25% H2H record · 15% all-play %.
+      Composite score: 50% rolling-3wk PPG · 30% H2H record · 20% all-play %.
     </p>
   </footer>
 </article>

--- a/src/data/theleague/power-rankings/2025-w13.json
+++ b/src/data/theleague/power-rankings/2025-w13.json
@@ -1,8 +1,8 @@
 {
   "year": 2025,
   "week": 13,
-  "publishedAt": "2026-05-07T23:40:47.403Z",
-  "generatedAt": "2026-05-07T23:40:47.403Z",
+  "publishedAt": "2026-05-08T01:17:53.835Z",
+  "generatedAt": "2026-05-08T01:17:53.835Z",
   "voiceMode": "templated",
   "headline": "CPU Jocks hold #1 entering Week 14",
   "lede": "Through Week 13, Computer Jocks sit atop the rankings. Computer Jocks dropped 137.13 — the highest score in the league this week.",
@@ -13,7 +13,7 @@
       "previousRank": null,
       "trend": "flat",
       "metrics": {
-        "composite": 86.87,
+        "composite": 83.42,
         "rolling3Ppg": 135.71,
         "seasonPpg": 110.1,
         "ppgScore": 100,
@@ -28,7 +28,7 @@
       "previousRank": null,
       "trend": "flat",
       "metrics": {
-        "composite": 71.56,
+        "composite": 71.58,
         "rolling3Ppg": 116.3,
         "seasonPpg": 117.2,
         "ppgScore": 71.44,
@@ -43,7 +43,7 @@
       "previousRank": null,
       "trend": "flat",
       "metrics": {
-        "composite": 65.31,
+        "composite": 66.62,
         "rolling3Ppg": 108.23,
         "seasonPpg": 115.4,
         "ppgScore": 59.57,
@@ -58,7 +58,7 @@
       "previousRank": null,
       "trend": "flat",
       "metrics": {
-        "composite": 62.77,
+        "composite": 63.66,
         "rolling3Ppg": 108.1,
         "seasonPpg": 114.9,
         "ppgScore": 59.37,
@@ -73,7 +73,7 @@
       "previousRank": null,
       "trend": "flat",
       "metrics": {
-        "composite": 60.83,
+        "composite": 60.92,
         "rolling3Ppg": 108.89,
         "seasonPpg": 111.5,
         "ppgScore": 60.53,
@@ -88,7 +88,7 @@
       "previousRank": null,
       "trend": "flat",
       "metrics": {
-        "composite": 56.44,
+        "composite": 59.61,
         "rolling3Ppg": 96.9,
         "seasonPpg": 117.6,
         "ppgScore": 42.89,
@@ -103,7 +103,7 @@
       "previousRank": null,
       "trend": "flat",
       "metrics": {
-        "composite": 52.82,
+        "composite": 53.47,
         "rolling3Ppg": 101.99,
         "seasonPpg": 108.6,
         "ppgScore": 50.37,
@@ -118,7 +118,7 @@
       "previousRank": null,
       "trend": "flat",
       "metrics": {
-        "composite": 48.58,
+        "composite": 47.24,
         "rolling3Ppg": 104.95,
         "seasonPpg": 102.8,
         "ppgScore": 54.74,
@@ -133,7 +133,7 @@
       "previousRank": null,
       "trend": "flat",
       "metrics": {
-        "composite": 42.3,
+        "composite": 43.06,
         "rolling3Ppg": 94.64,
         "seasonPpg": 103.1,
         "ppgScore": 39.56,
@@ -148,7 +148,7 @@
       "previousRank": null,
       "trend": "flat",
       "metrics": {
-        "composite": 33.25,
+        "composite": 35.76,
         "rolling3Ppg": 83.39,
         "seasonPpg": 98,
         "ppgScore": 23,
@@ -163,7 +163,7 @@
       "previousRank": null,
       "trend": "flat",
       "metrics": {
-        "composite": 32.44,
+        "composite": 32.11,
         "rolling3Ppg": 90.9,
         "seasonPpg": 90.8,
         "ppgScore": 34.05,
@@ -174,26 +174,11 @@
     },
     {
       "rank": 12,
-      "franchiseId": "0003",
-      "previousRank": null,
-      "trend": "flat",
-      "metrics": {
-        "composite": 24.15,
-        "rolling3Ppg": 81.31,
-        "seasonPpg": 92.5,
-        "ppgScore": 19.94,
-        "recordScore": 27.8,
-        "allPlayScore": 34.9
-      },
-      "blurb": "1-2 over their last 3 at 81.3 PPG."
-    },
-    {
-      "rank": 13,
       "franchiseId": "0001",
       "previousRank": null,
       "trend": "flat",
       "metrics": {
-        "composite": 22.05,
+        "composite": 27.21,
         "rolling3Ppg": 68.11,
         "seasonPpg": 94.9,
         "ppgScore": 0.52,
@@ -203,12 +188,27 @@
       "blurb": "1-2 over their last 3 at 68.1 PPG."
     },
     {
+      "rank": 13,
+      "franchiseId": "0003",
+      "previousRank": null,
+      "trend": "flat",
+      "metrics": {
+        "composite": 25.29,
+        "rolling3Ppg": 81.31,
+        "seasonPpg": 92.5,
+        "ppgScore": 19.94,
+        "recordScore": 27.8,
+        "allPlayScore": 34.9
+      },
+      "blurb": "1-2 over their last 3 at 81.3 PPG."
+    },
+    {
       "rank": 14,
       "franchiseId": "0006",
       "previousRank": null,
       "trend": "flat",
       "metrics": {
-        "composite": 21.85,
+        "composite": 23.38,
         "rolling3Ppg": 78.71,
         "seasonPpg": 89.8,
         "ppgScore": 16.11,
@@ -223,7 +223,7 @@
       "previousRank": null,
       "trend": "flat",
       "metrics": {
-        "composite": 16.59,
+        "composite": 18.52,
         "rolling3Ppg": 73.82,
         "seasonPpg": 88.4,
         "ppgScore": 8.92,
@@ -238,7 +238,7 @@
       "previousRank": null,
       "trend": "flat",
       "metrics": {
-        "composite": 6.78,
+        "composite": 8.67,
         "rolling3Ppg": 67.76,
         "seasonPpg": 85.5,
         "ppgScore": 0,

--- a/src/data/theleague/power-rankings/2025-w14.json
+++ b/src/data/theleague/power-rankings/2025-w14.json
@@ -1,8 +1,8 @@
 {
   "year": 2025,
   "week": 14,
-  "publishedAt": "2026-05-08T00:26:30.746Z",
-  "generatedAt": "2026-05-08T00:26:30.746Z",
+  "publishedAt": "2026-05-08T01:17:53.939Z",
+  "generatedAt": "2026-05-08T01:17:53.939Z",
   "voiceMode": "templated",
   "headline": "Pain surges to #1",
   "lede": "Through Week 14, Bring The Pain sit atop the rankings. Midwestside dropped 144.74 — the highest score in the league this week. Bring The Pain jump 4 spots to #1. Da Dangsters slide 6 to #8.",
@@ -13,7 +13,7 @@
       "previousRank": 5,
       "trend": "up",
       "metrics": {
-        "composite": 84.52,
+        "composite": 80.65,
         "rolling3Ppg": 127.75,
         "seasonPpg": 111.5,
         "ppgScore": 100,
@@ -28,7 +28,7 @@
       "previousRank": 6,
       "trend": "up",
       "metrics": {
-        "composite": 75.57,
+        "composite": 75.56,
         "rolling3Ppg": 113.09,
         "seasonPpg": 117.6,
         "ppgScore": 74.77,
@@ -43,7 +43,7 @@
       "previousRank": 3,
       "trend": "flat",
       "metrics": {
-        "composite": 74.94,
+        "composite": 74.64,
         "rolling3Ppg": 113.57,
         "seasonPpg": 115.4,
         "ppgScore": 75.61,
@@ -58,7 +58,7 @@
       "previousRank": 1,
       "trend": "down",
       "metrics": {
-        "composite": 71.48,
+        "composite": 70.59,
         "rolling3Ppg": 112.84,
         "seasonPpg": 110.1,
         "ppgScore": 74.34,
@@ -73,7 +73,7 @@
       "previousRank": 4,
       "trend": "down",
       "metrics": {
-        "composite": 67.13,
+        "composite": 67.29,
         "rolling3Ppg": 108.36,
         "seasonPpg": 114.9,
         "ppgScore": 66.64,
@@ -88,7 +88,7 @@
       "previousRank": 9,
       "trend": "up",
       "metrics": {
-        "composite": 65.82,
+        "composite": 62.65,
         "rolling3Ppg": 115.4,
         "seasonPpg": 103.1,
         "ppgScore": 78.75,
@@ -103,7 +103,7 @@
       "previousRank": 10,
       "trend": "up",
       "metrics": {
-        "composite": 64.75,
+        "composite": 62.01,
         "rolling3Ppg": 113.51,
         "seasonPpg": 98,
         "ppgScore": 75.51,
@@ -118,7 +118,7 @@
       "previousRank": 2,
       "trend": "down",
       "metrics": {
-        "composite": 56.88,
+        "composite": 59.34,
         "rolling3Ppg": 96.93,
         "seasonPpg": 117.2,
         "ppgScore": 46.97,
@@ -133,7 +133,7 @@
       "previousRank": 7,
       "trend": "down",
       "metrics": {
-        "composite": 52.06,
+        "composite": 52.83,
         "rolling3Ppg": 98.17,
         "seasonPpg": 108.6,
         "ppgScore": 49.11,
@@ -148,7 +148,7 @@
       "previousRank": 8,
       "trend": "down",
       "metrics": {
-        "composite": 48.24,
+        "composite": 46.96,
         "rolling3Ppg": 101.11,
         "seasonPpg": 102.8,
         "ppgScore": 54.17,
@@ -159,48 +159,48 @@
     },
     {
       "rank": 11,
-      "franchiseId": "0014",
-      "previousRank": 11,
-      "trend": "flat",
-      "metrics": {
-        "composite": 36.05,
-        "rolling3Ppg": 92.92,
-        "seasonPpg": 90.8,
-        "ppgScore": 40.08,
-        "recordScore": 27.8,
-        "allPlayScore": 33.7
-      },
-      "blurb": "0-3 over their last 3 at 92.9 PPG. Riding a 3-game skid. Rankings: holding steady."
-    },
-    {
-      "rank": 12,
-      "franchiseId": "0006",
-      "previousRank": 14,
+      "franchiseId": "0001",
+      "previousRank": 12,
       "trend": "up",
       "metrics": {
-        "composite": 32.1,
-        "rolling3Ppg": 88.92,
-        "seasonPpg": 89.8,
-        "ppgScore": 33.19,
-        "recordScore": 27.8,
-        "allPlayScore": 34.9
-      },
-      "blurb": "1-2 over their last 3 at 88.9 PPG. Riding a 2-game skid. Rankings: up 2 from #14."
-    },
-    {
-      "rank": 13,
-      "franchiseId": "0001",
-      "previousRank": 13,
-      "trend": "flat",
-      "metrics": {
-        "composite": 31.98,
+        "composite": 35.48,
         "rolling3Ppg": 79.55,
         "seasonPpg": 94.9,
         "ppgScore": 17.06,
         "recordScore": 61.1,
         "allPlayScore": 43.1
       },
-      "blurb": "1-2 over their last 3 at 79.5 PPG. Rankings: holding steady."
+      "blurb": "1-2 over their last 3 at 79.5 PPG. Rankings: up 1 from #12."
+    },
+    {
+      "rank": 12,
+      "franchiseId": "0014",
+      "previousRank": 11,
+      "trend": "down",
+      "metrics": {
+        "composite": 35.12,
+        "rolling3Ppg": 92.92,
+        "seasonPpg": 90.8,
+        "ppgScore": 40.08,
+        "recordScore": 27.8,
+        "allPlayScore": 33.7
+      },
+      "blurb": "0-3 over their last 3 at 92.9 PPG. Riding a 3-game skid. Rankings: down 1 from #11."
+    },
+    {
+      "rank": 13,
+      "franchiseId": "0006",
+      "previousRank": 14,
+      "trend": "up",
+      "metrics": {
+        "composite": 31.92,
+        "rolling3Ppg": 88.92,
+        "seasonPpg": 89.8,
+        "ppgScore": 33.19,
+        "recordScore": 27.8,
+        "allPlayScore": 34.9
+      },
+      "blurb": "1-2 over their last 3 at 88.9 PPG. Riding a 2-game skid. Rankings: up 1 from #14."
     },
     {
       "rank": 14,
@@ -208,7 +208,7 @@
       "previousRank": 15,
       "trend": "up",
       "metrics": {
-        "composite": 21.48,
+        "composite": 22.59,
         "rolling3Ppg": 79.55,
         "seasonPpg": 88.4,
         "ppgScore": 17.07,
@@ -220,17 +220,17 @@
     {
       "rank": 15,
       "franchiseId": "0003",
-      "previousRank": 12,
+      "previousRank": 13,
       "trend": "down",
       "metrics": {
-        "composite": 19.6,
+        "composite": 21.5,
         "rolling3Ppg": 76.81,
         "seasonPpg": 92.5,
         "ppgScore": 12.35,
         "recordScore": 27.8,
         "allPlayScore": 34.9
       },
-      "blurb": "1-2 over their last 3 at 76.8 PPG. Rankings: down 3 from #12."
+      "blurb": "1-2 over their last 3 at 76.8 PPG. Rankings: down 2 from #13."
     },
     {
       "rank": 16,
@@ -238,7 +238,7 @@
       "previousRank": 16,
       "trend": "flat",
       "metrics": {
-        "composite": 6.78,
+        "composite": 8.67,
         "rolling3Ppg": 69.63,
         "seasonPpg": 85.5,
         "ppgScore": 0,


### PR DESCRIPTION
Tunes the power-rankings composite formula. Same three components, slightly less weight on raw form so a hot 3-week stretch can't fully mask a sub-.500 record or unlucky scoring.

| Component | Before | After |
|---|---|---|
| Rolling-3wk PPG | 60% | **50%** |
| H2H record | 25% | **30%** |
| All-play % | 15% | **20%** |

Sample issues for 2025 W13/W14 regenerated to reflect the new weights; renderer footnote updated.

(Phase 1 + 2 of the Tuesday Power Rankings plan already shipped in #187 — this branch was originally meant to stack on top, but main got there first. Rebased + reset; only the reweight remains.)

## Test plan
- [x] `pnpm vitest run tests/power-rankings.test.ts tests/power-rankings-ai.test.ts` — 25 tests pass.
- [x] `pnpm generate:power-rankings --year 2025 --week 14 --no-ai --regenerate` — sample regeneration confirms top-3 unchanged for W14 (Pain still #1) but mid-pack tightens around teams with strong records.