### PR TITLE
feat: franchise history Phase 3 — expand badge catalogue

### DIFF
--- a/data/theleague/derived/franchise-history.json
+++ b/data/theleague/derived/franchise-history.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-08T01:54:57.972Z",
+  "generatedAt": "2026-05-08T02:32:50.405Z",
   "yearsCovered": [
     2007,
     2008,
@@ -6332,6 +6332,19 @@
             {
               "value": 156,
               "suffix": "wins"
+            }
+          ]
+        },
+        {
+          "id": "best-record",
+          "name": "Top of the Standings",
+          "description": "Finished #1 in regular-season standings (best record).",
+          "icon": "🥇",
+          "tier": "season",
+          "awards": [
+            {
+              "year": 2011,
+              "label": "14-4"
             }
           ]
         },
@@ -19507,6 +19520,23 @@
           ]
         },
         {
+          "id": "best-record",
+          "name": "Top of the Standings",
+          "description": "Finished #1 in regular-season standings (best record).",
+          "icon": "🥇",
+          "tier": "season",
+          "awards": [
+            {
+              "year": 2016,
+              "label": "14-2"
+            },
+            {
+              "year": 2008,
+              "label": "15-3"
+            }
+          ]
+        },
+        {
           "id": "top-scorer",
           "name": "League Scoring Champ",
           "description": "Led the league in regular-season points in a year.",
@@ -19524,6 +19554,19 @@
             },
             {
               "year": 2008
+            }
+          ]
+        },
+        {
+          "id": "most-active-trader",
+          "name": "Wheeler & Dealer",
+          "description": "Has made the most trades in league history.",
+          "icon": "🤝",
+          "tier": "trade",
+          "awards": [
+            {
+              "value": 102,
+              "suffix": "all-time trades"
             }
           ]
         }
@@ -24216,6 +24259,19 @@
             {
               "value": 5,
               "suffix": "appearances"
+            }
+          ]
+        },
+        {
+          "id": "best-record",
+          "name": "Top of the Standings",
+          "description": "Finished #1 in regular-season standings (best record).",
+          "icon": "🥇",
+          "tier": "season",
+          "awards": [
+            {
+              "year": 2019,
+              "label": "15-1"
             }
           ]
         },
@@ -29291,6 +29347,19 @@
           ]
         },
         {
+          "id": "best-record",
+          "name": "Top of the Standings",
+          "description": "Finished #1 in regular-season standings (best record).",
+          "icon": "🥇",
+          "tier": "season",
+          "awards": [
+            {
+              "year": 2023,
+              "label": "15-3"
+            }
+          ]
+        },
+        {
           "id": "top-scorer",
           "name": "League Scoring Champ",
           "description": "Led the league in regular-season points in a year.",
@@ -29319,6 +29388,21 @@
             {
               "year": 2020,
               "label": "#16"
+            }
+          ]
+        },
+        {
+          "id": "all-time-lowest-score",
+          "name": "League Record: Lowest Score",
+          "description": "Holds the all-time single-game low — a stinker for the ages.",
+          "icon": "💩",
+          "tier": "game",
+          "awards": [
+            {
+              "year": 2014,
+              "week": 10,
+              "value": 19.29,
+              "suffix": "pts"
             }
           ]
         }
@@ -34171,6 +34255,23 @@
             {
               "value": 129,
               "suffix": "wins"
+            }
+          ]
+        },
+        {
+          "id": "best-record",
+          "name": "Top of the Standings",
+          "description": "Finished #1 in regular-season standings (best record).",
+          "icon": "🥇",
+          "tier": "season",
+          "awards": [
+            {
+              "year": 2022,
+              "label": "0-0"
+            },
+            {
+              "year": 2013,
+              "label": "13-5"
             }
           ]
         },
@@ -39862,6 +39963,35 @@
           ]
         },
         {
+          "id": "best-record",
+          "name": "Top of the Standings",
+          "description": "Finished #1 in regular-season standings (best record).",
+          "icon": "🥇",
+          "tier": "season",
+          "awards": [
+            {
+              "year": 2025,
+              "label": "15-3"
+            },
+            {
+              "year": 2024,
+              "label": "14-4"
+            },
+            {
+              "year": 2021,
+              "label": "15-3"
+            },
+            {
+              "year": 2020,
+              "label": "14-4"
+            },
+            {
+              "year": 2018,
+              "label": "16-0"
+            }
+          ]
+        },
+        {
           "id": "top-scorer",
           "name": "League Scoring Champ",
           "description": "Led the league in regular-season points in a year.",
@@ -39885,6 +40015,20 @@
             },
             {
               "year": 2013
+            }
+          ]
+        },
+        {
+          "id": "highest-scoring-season-ever",
+          "name": "League Record: Highest-Scoring Season",
+          "description": "Holds the all-time single-season points-for record.",
+          "icon": "🌋",
+          "tier": "season",
+          "awards": [
+            {
+              "year": 2018,
+              "value": 2453.05,
+              "suffix": "pts"
             }
           ]
         }
@@ -47178,6 +47322,19 @@
             {
               "value": 5,
               "suffix": "appearances"
+            }
+          ]
+        },
+        {
+          "id": "worst-to-first",
+          "name": "Worst-to-First",
+          "description": "Finished last in the regular season, then made the playoffs the next year.",
+          "icon": "🦅",
+          "tier": "season",
+          "awards": [
+            {
+              "year": 2017,
+              "label": "from #16 in 2016"
             }
           ]
         },

--- a/scripts/badges.mjs
+++ b/scripts/badges.mjs
@@ -16,12 +16,13 @@
  * those are surfaced separately on the detail page.
  */
 
-export const BADGE_TIERS = ['career', 'season', 'game'];
+export const BADGE_TIERS = ['career', 'season', 'game', 'trade'];
 
 const TIER_LABEL = {
   career: 'Career',
   season: 'Single-Season',
   game: 'Single-Game',
+  trade: 'Trade',
 };
 
 export const BADGES = [
@@ -115,6 +116,17 @@ export const BADGES = [
         .map((y) => ({ year: y.year, label: `${y.wins}-${y.losses}` })),
   },
   {
+    id: 'best-record',
+    name: 'Top of the Standings',
+    description: 'Finished #1 in regular-season standings (best record).',
+    icon: '🥇',
+    tier: 'season',
+    compute: (fr) =>
+      fr.yearByYear
+        .filter((y) => y.regSeasonRank === 1)
+        .map((y) => ({ year: y.year, label: `${y.wins}-${y.losses}${y.ties ? '-' + y.ties : ''}` })),
+  },
+  {
     id: 'top-scorer',
     name: 'League Scoring Champ',
     description: 'Led the league in regular-season points in a year.',
@@ -123,6 +135,49 @@ export const BADGES = [
     compute: (fr, ctx) => {
       const years = ctx.topScorerByYear[fr.franchiseId] || [];
       return years.map((year) => ({ year }));
+    },
+  },
+  {
+    id: 'highest-scoring-season-ever',
+    name: 'League Record: Highest-Scoring Season',
+    description: 'Holds the all-time single-season points-for record.',
+    icon: '🌋',
+    tier: 'season',
+    compute: (fr, ctx) => {
+      if (ctx.highestScoringSeasonEver?.franchiseId !== fr.franchiseId) return [];
+      return [
+        {
+          year: ctx.highestScoringSeasonEver.year,
+          value: Number(ctx.highestScoringSeasonEver.pointsFor.toFixed(2)),
+          suffix: 'pts',
+        },
+      ];
+    },
+  },
+  {
+    id: 'worst-to-first',
+    name: 'Worst-to-First',
+    description: 'Finished last in the regular season, then made the playoffs the next year.',
+    icon: '🦅',
+    tier: 'season',
+    compute: (fr, ctx) => {
+      const yearsByYear = new Map(fr.yearByYear.map((y) => [y.year, y]));
+      const earned = [];
+      for (const y of fr.yearByYear) {
+        const leagueSize = ctx.leagueSizeByYear[y.year];
+        if (!leagueSize || y.regSeasonRank !== leagueSize) continue;
+        const next = yearsByYear.get(y.year + 1);
+        if (!next) continue;
+        const madePlayoffs =
+          next.playoffResult === 'playoffs' ||
+          next.playoffResult === 'champion' ||
+          next.playoffResult === 'runner-up' ||
+          next.playoffResult === 'third-place';
+        if (madePlayoffs) {
+          earned.push({ year: next.year, label: `from #${y.regSeasonRank} in ${y.year}` });
+        }
+      }
+      return earned;
     },
   },
   {
@@ -179,6 +234,37 @@ export const BADGES = [
       ];
     },
   },
+  {
+    id: 'all-time-lowest-score',
+    name: 'League Record: Lowest Score',
+    description: 'Holds the all-time single-game low — a stinker for the ages.',
+    icon: '💩',
+    tier: 'game',
+    compute: (fr, ctx) => {
+      if (ctx.lowestScoreEver?.franchiseId !== fr.franchiseId) return [];
+      return [
+        {
+          year: ctx.lowestScoreEver.year,
+          week: ctx.lowestScoreEver.week,
+          value: Number(ctx.lowestScoreEver.score.toFixed(2)),
+          suffix: 'pts',
+        },
+      ];
+    },
+  },
+
+  // ── Trade ──────────────────────────────────────────────────────────
+  {
+    id: 'most-active-trader',
+    name: 'Wheeler & Dealer',
+    description: 'Has made the most trades in league history.',
+    icon: '🤝',
+    tier: 'trade',
+    compute: (fr, ctx) => {
+      if (ctx.mostTradesEver?.franchiseId !== fr.franchiseId) return [];
+      return [{ value: ctx.mostTradesEver.count, suffix: 'all-time trades' }];
+    },
+  },
 ];
 
 export function getTierLabel(tier) {
@@ -189,6 +275,9 @@ export function buildBadgeContext(franchises, yearSummaries = []) {
   const ctx = {
     highestScoreEver: null,
     biggestBlowoutEver: null,
+    lowestScoreEver: null,
+    highestScoringSeasonEver: null,
+    mostTradesEver: null,
     topScorerByYear: {},
     leagueSizeByYear: {},
   };
@@ -216,6 +305,50 @@ export function buildBadgeContext(franchises, yearSummaries = []) {
     ) {
       ctx.biggestBlowoutEver = { ...h.biggestBlowoutWin, franchiseId: fid };
     }
+    if (
+      h.lowestSingleGame &&
+      (!ctx.lowestScoreEver ||
+        h.lowestSingleGame.score < ctx.lowestScoreEver.score)
+    ) {
+      ctx.lowestScoreEver = { ...h.lowestSingleGame, franchiseId: fid };
+    }
+  }
+
+  // All-time highest single-season points-for. Skip not-yet-played seasons.
+  for (const [fid, fr] of Object.entries(franchises)) {
+    for (const y of fr.yearByYear) {
+      if (y.wins + y.losses + y.ties === 0 && (!y.pointsFor || y.pointsFor === 0)) {
+        continue;
+      }
+      if (
+        !ctx.highestScoringSeasonEver ||
+        y.pointsFor > ctx.highestScoringSeasonEver.pointsFor
+      ) {
+        ctx.highestScoringSeasonEver = {
+          franchiseId: fid,
+          year: y.year,
+          pointsFor: y.pointsFor,
+        };
+      }
+    }
+  }
+
+  // Most trades in league history (sole holder; ties = no badge).
+  let topCount = 0;
+  let topFid = null;
+  let tied = false;
+  for (const [fid, fr] of Object.entries(franchises)) {
+    const count = Array.isArray(fr.trades) ? fr.trades.length : 0;
+    if (count > topCount) {
+      topCount = count;
+      topFid = fid;
+      tied = false;
+    } else if (count === topCount && count > 0) {
+      tied = true;
+    }
+  }
+  if (topFid && !tied) {
+    ctx.mostTradesEver = { franchiseId: topFid, count: topCount };
   }
 
   // Per-year scoring champ. (Bottom-of-standings is detected per-franchise

--- a/src/pages/theleague/franchises/[id].astro
+++ b/src/pages/theleague/franchises/[id].astro
@@ -592,10 +592,16 @@ const canonicalRivalryPair = (a: string, b: string): string =>
         <p class="dim small">
           Career milestones, single-season feats, and league records held by this franchise.
         </p>
-        {['career', 'season', 'game'].map((tier) => {
+        {['career', 'season', 'game', 'trade'].map((tier) => {
           const tierBadges = fr.badges.filter((b: any) => b.tier === tier);
           if (tierBadges.length === 0) return null;
-          const tierLabel = tier === 'career' ? 'Career' : tier === 'season' ? 'Single-Season' : 'Single-Game';
+          const tierLabel = tier === 'career'
+            ? 'Career'
+            : tier === 'season'
+            ? 'Single-Season'
+            : tier === 'game'
+            ? 'Single-Game'
+            : 'Trade';
           return (
             <div class="badge-tier">
               <h3 class="badge-tier-label">{tierLabel}</h3>


### PR DESCRIPTION
Add 5 new badges spanning two existing tiers and one new tier:

- best-record (season, multi-award) — finished #1 in regular-season standings
- highest-scoring-season-ever (season, sole holder) — all-time PF record
- worst-to-first (season, multi-award) — last place one year, playoffs the next
- all-time-lowest-score (game, sole holder) — all-time single-game futility
- most-active-trader (trade, sole holder) — most trades in league history;
  introduces the planned 'trade' tier from the phase plan

Wire the new context (highestScoringSeasonEver, lowestScoreEver,
mostTradesEver) into buildBadgeContext, render the trade tier in the
franchise detail page, and regenerate franchise-history.json so the
badges show up immediately.