### PR TITLE
feat: franchise history Phase 4 — trade ledger on franchise pages

### DIFF
--- a/data/theleague/derived/franchise-history.json
+++ b/data/theleague/derived/franchise-history.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-08T02:32:50.405Z",
+  "generatedAt": "2026-05-08T03:19:33.305Z",
   "yearsCovered": [
     2007,
     2008,
@@ -6274,6 +6274,1425 @@
           "bothAttributed": true
         }
       ],
+      "draftPicks": [
+        {
+          "year": 2008,
+          "round": 2,
+          "pick": 16,
+          "playerId": "9057",
+          "viaTrade": false,
+          "comments": "Pick made based on Pre-Draft List",
+          "timestamp": 1209944543,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2009,
+          "round": 1,
+          "pick": 16,
+          "playerId": "9460",
+          "viaTrade": false,
+          "comments": "Pick made based on Pre-Draft List",
+          "timestamp": 1241376350,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2009,
+          "round": 3,
+          "pick": 16,
+          "playerId": "9605",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1241673909,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2011,
+          "round": 2,
+          "pick": 12,
+          "playerId": "10347",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1305045687,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2011,
+          "round": 2,
+          "pick": 15,
+          "playerId": "10309",
+          "viaTrade": false,
+          "comments": "Pick made based on Pre-Draft List",
+          "timestamp": 1305057144,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2011,
+          "round": 3,
+          "pick": 4,
+          "playerId": "10333",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1305125093,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "round": 3,
+          "pick": 2,
+          "playerId": "10730",
+          "viaTrade": false,
+          "comments": "Here's to hoping that he can be that true #2 opposite Andre Johnson (Comments Added Tue May 8 9:14:51 p.m. PT 2012)",
+          "timestamp": 1336536335,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2013,
+          "round": 3,
+          "pick": 10,
+          "playerId": "11257",
+          "viaTrade": false,
+          "comments": "Pick made based on Pre-Draft List",
+          "timestamp": 1368244557,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2013,
+          "round": 3,
+          "pick": 11,
+          "playerId": "11217",
+          "viaTrade": false,
+          "comments": "Pick made based on Pre-Draft List",
+          "timestamp": 1368244557,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "round": 3,
+          "pick": 1,
+          "playerId": "11686",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1400616520,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "round": 3,
+          "pick": 10,
+          "playerId": "11645",
+          "viaTrade": false,
+          "comments": "Pick made based on Pre-Draft List",
+          "timestamp": 1400725308,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "round": 3,
+          "pick": 13,
+          "playerId": "11785",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1400729586,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "round": 2,
+          "pick": 17,
+          "playerId": "12721",
+          "viaTrade": false,
+          "comments": "Just because it is 2.17.  I have my Connor Barth replacement - Woo Hoo!!!",
+          "timestamp": 1462940277,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "round": 3,
+          "pick": 6,
+          "playerId": "12785",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1462984535,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "round": 1,
+          "pick": 11,
+          "playerId": "13113",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1494173442,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "round": 3,
+          "pick": 11,
+          "playerId": "13280",
+          "viaTrade": false,
+          "comments": "Pick made based on Pre-Draft List",
+          "timestamp": 1494359454,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "round": 1,
+          "pick": 4,
+          "playerId": "13606",
+          "viaTrade": false,
+          "comments": "[Pick made based on Pre-Draft List]",
+          "timestamp": 1525538988,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "round": 1,
+          "pick": 7,
+          "playerId": "13610",
+          "viaTrade": true,
+          "comments": "[Pick made based on Pre-Draft List] Pick traded from Maverick.",
+          "timestamp": 1525545201,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "round": 1,
+          "pick": 12,
+          "playerId": "13672",
+          "viaTrade": true,
+          "comments": "Pick traded from Bring the Pain.",
+          "timestamp": 1525620858,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "round": 2,
+          "pick": 3,
+          "playerId": "13639",
+          "viaTrade": true,
+          "comments": "[Pick traded from Bring the Pain.] Pick traded from Computer Jocks.",
+          "timestamp": 1525640100,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "round": 2,
+          "pick": 4,
+          "playerId": "13674",
+          "viaTrade": true,
+          "comments": "[Pick traded from Bring the Pain.] Pick traded from Dark Magicians of Chaos.",
+          "timestamp": 1525645298,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "round": 3,
+          "pick": 4,
+          "playerId": "13649",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1525732912,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "round": 3,
+          "pick": 12,
+          "playerId": "13678",
+          "viaTrade": true,
+          "comments": "Pick traded from Bring the Pain.",
+          "timestamp": 1525788653,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "round": 1,
+          "pick": 4,
+          "playerId": "14104",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1557029257,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "round": 1,
+          "pick": 17,
+          "playerId": "14140",
+          "viaTrade": false,
+          "comments": "[Pick added by commissioner.\nPick made based on Pre-Draft List]",
+          "timestamp": 1557097550,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "round": 2,
+          "pick": 4,
+          "playerId": "14080",
+          "viaTrade": false,
+          "comments": "[Pick made based on Pre-Draft List]",
+          "timestamp": 1557099895,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "round": 3,
+          "pick": 4,
+          "playerId": "14109",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1557238422,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "round": 1,
+          "pick": 7,
+          "playerId": "14799",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1588475906,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "round": 1,
+          "pick": 17,
+          "playerId": "14835",
+          "viaTrade": false,
+          "comments": "[Pick added by commissioner.\nPick made from Pre-Draft List]",
+          "timestamp": 1588560191,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "round": 2,
+          "pick": 7,
+          "playerId": "14841",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1588614394,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "round": 3,
+          "pick": 7,
+          "playerId": "14868",
+          "viaTrade": false,
+          "comments": "[Pick made from Pre-Draft List]",
+          "timestamp": 1588739413,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "round": 1,
+          "pick": 12,
+          "playerId": "15239",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1620522605,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "round": 3,
+          "pick": 12,
+          "playerId": "15333",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1620872481,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "round": 1,
+          "pick": 8,
+          "playerId": "15754",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1652061658,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "round": 1,
+          "pick": 12,
+          "playerId": "15717",
+          "viaTrade": true,
+          "comments": "[Pick traded from Vitside Mafia.]",
+          "timestamp": 1652136761,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "round": 3,
+          "pick": 8,
+          "playerId": "15901",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1652407187,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "round": 2,
+          "pick": 6,
+          "playerId": "16189",
+          "viaTrade": true,
+          "comments": "[Pick traded from Bring the Pain.\nPick made from Pre-Draft List]",
+          "timestamp": 1683520069,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "round": 2,
+          "pick": 16,
+          "playerId": "16204",
+          "viaTrade": true,
+          "comments": "[Pick traded from Vitside Mafia.]",
+          "timestamp": 1683567549,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "round": 3,
+          "pick": 15,
+          "playerId": "16211",
+          "viaTrade": false,
+          "comments": "[Pick made from Pre-Draft List]",
+          "timestamp": 1683646899,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "round": 1,
+          "pick": 4,
+          "playerId": "16616",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1714834846,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "round": 1,
+          "pick": 7,
+          "playerId": "16581",
+          "viaTrade": true,
+          "comments": "[Pick traded from Cowboy Up.]",
+          "timestamp": 1714883282,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "round": 2,
+          "pick": 4,
+          "playerId": "16626",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1714953886,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "round": 2,
+          "pick": 6,
+          "playerId": "16644",
+          "viaTrade": true,
+          "comments": "[Pick traded from Bring the Pain.]",
+          "timestamp": 1714964482,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "round": 3,
+          "pick": 7,
+          "playerId": "16623",
+          "viaTrade": true,
+          "comments": "[Pick traded from Cowboy Up.]",
+          "timestamp": 1715110435,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "round": 2,
+          "pick": 3,
+          "playerId": "17106",
+          "viaTrade": true,
+          "comments": "[Pick traded from Heavy Chevy.\nPick traded from Bring the Pain.]",
+          "timestamp": 1746588693,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "round": 3,
+          "pick": 10,
+          "playerId": "17105",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1746759933,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "round": 1,
+          "pick": 11,
+          "playerId": "17500",
+          "viaTrade": true,
+          "comments": "[Pick traded from Bring the Pain.]",
+          "timestamp": 1777845918,
+          "sourceFranchiseId": null
+        }
+      ],
+      "auctionWins": [
+        {
+          "year": 2009,
+          "playerId": "4092",
+          "winningBid": 500000,
+          "timestamp": 1238337732,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2009,
+          "playerId": "7877",
+          "winningBid": 8000000,
+          "timestamp": 1238349911,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2009,
+          "playerId": "0520",
+          "winningBid": 475000,
+          "timestamp": 1238350146,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2009,
+          "playerId": "5172",
+          "winningBid": 425000,
+          "timestamp": 1238480057,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2009,
+          "playerId": "7405",
+          "winningBid": 900000,
+          "timestamp": 1238530638,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2009,
+          "playerId": "2665",
+          "winningBid": 425000,
+          "timestamp": 1238531119,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2009,
+          "playerId": "7813",
+          "winningBid": 725000,
+          "timestamp": 1238777190,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2009,
+          "playerId": "1756",
+          "winningBid": 1950000,
+          "timestamp": 1238818255,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "playerId": "4974",
+          "winningBid": 6500000,
+          "timestamp": 1269385983,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "playerId": "7239",
+          "winningBid": 425000,
+          "timestamp": 1269395934,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "playerId": "9308",
+          "winningBid": 425000,
+          "timestamp": 1269465504,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "playerId": "7647",
+          "winningBid": 425000,
+          "timestamp": 1269465852,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "playerId": "5027",
+          "winningBid": 425000,
+          "timestamp": 1269761665,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "playerId": "8350",
+          "winningBid": 425000,
+          "timestamp": 1271208389,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "playerId": "6541",
+          "winningBid": 500000,
+          "timestamp": 1271641317,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2011,
+          "playerId": "9122",
+          "winningBid": 6500000,
+          "timestamp": 1300813516,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2011,
+          "playerId": "5656",
+          "winningBid": 950000,
+          "timestamp": 1300848533,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2011,
+          "playerId": "0530",
+          "winningBid": 500000,
+          "timestamp": 1300888735,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2011,
+          "playerId": "3445",
+          "winningBid": 750000,
+          "timestamp": 1300921787,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2011,
+          "playerId": "8153",
+          "winningBid": 450000,
+          "timestamp": 1300943318,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2011,
+          "playerId": "8117",
+          "winningBid": 425000,
+          "timestamp": 1301021365,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2011,
+          "playerId": "6522",
+          "winningBid": 825000,
+          "timestamp": 1301023454,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2011,
+          "playerId": "5657",
+          "winningBid": 800000,
+          "timestamp": 1311880344,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "playerId": "0528",
+          "winningBid": 500000,
+          "timestamp": 1331831120,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "playerId": "3291",
+          "winningBid": 6150000,
+          "timestamp": 1331849779,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "playerId": "8493",
+          "winningBid": 6275000,
+          "timestamp": 1331879922,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "playerId": "9770",
+          "winningBid": 500000,
+          "timestamp": 1331921800,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "playerId": "8758",
+          "winningBid": 3275000,
+          "timestamp": 1332116469,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "playerId": "8700",
+          "winningBid": 425000,
+          "timestamp": 1332196149,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "playerId": "10701",
+          "winningBid": 425000,
+          "timestamp": 1336785146,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "playerId": "9638",
+          "winningBid": 425000,
+          "timestamp": 1342821971,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2013,
+          "playerId": "9073",
+          "winningBid": 425000,
+          "timestamp": 1363268031,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2013,
+          "playerId": "8685",
+          "winningBid": 1000000,
+          "timestamp": 1363268082,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2013,
+          "playerId": "10976",
+          "winningBid": 700000,
+          "timestamp": 1363268128,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2013,
+          "playerId": "4923",
+          "winningBid": 6250000,
+          "timestamp": 1363268175,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2013,
+          "playerId": "0508",
+          "winningBid": 425000,
+          "timestamp": 1363272571,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2013,
+          "playerId": "9278",
+          "winningBid": 425000,
+          "timestamp": 1363995897,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2013,
+          "playerId": "8350",
+          "winningBid": 425000,
+          "timestamp": 1364595209,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2013,
+          "playerId": "9964",
+          "winningBid": 425000,
+          "timestamp": 1375032217,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "6789",
+          "winningBid": 450000,
+          "timestamp": 1394764756,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "8371",
+          "winningBid": 425000,
+          "timestamp": 1394854848,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "8042",
+          "winningBid": 425000,
+          "timestamp": 1394892801,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "8062",
+          "winningBid": 425000,
+          "timestamp": 1394892912,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "8269",
+          "winningBid": 525000,
+          "timestamp": 1395030498,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "10716",
+          "winningBid": 425000,
+          "timestamp": 1395892781,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "11436",
+          "winningBid": 425000,
+          "timestamp": 1396365402,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "11756",
+          "winningBid": 425000,
+          "timestamp": 1402083878,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "10080",
+          "winningBid": 5000000,
+          "timestamp": 1426776887,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "6997",
+          "winningBid": 2500000,
+          "timestamp": 1426776965,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "9802",
+          "winningBid": 425000,
+          "timestamp": 1426777004,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "11342",
+          "winningBid": 425000,
+          "timestamp": 1426777032,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "8917",
+          "winningBid": 425000,
+          "timestamp": 1426777071,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "10698",
+          "winningBid": 425000,
+          "timestamp": 1426777172,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "8322",
+          "winningBid": 425000,
+          "timestamp": 1426777198,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "11945",
+          "winningBid": 425000,
+          "timestamp": 1426777261,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "8735",
+          "winningBid": 425000,
+          "timestamp": 1426777514,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "9176",
+          "winningBid": 425000,
+          "timestamp": 1426778520,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "0505",
+          "winningBid": 625000,
+          "timestamp": 1426824127,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "8934",
+          "winningBid": 1200000,
+          "timestamp": 1426908256,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "9250",
+          "winningBid": 3000000,
+          "timestamp": 1426908273,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "9078",
+          "winningBid": 425000,
+          "timestamp": 1426975852,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "10302",
+          "winningBid": 5000000,
+          "timestamp": 1458231067,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "11754",
+          "winningBid": 1125000,
+          "timestamp": 1458231207,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "9706",
+          "winningBid": 825000,
+          "timestamp": 1458231368,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "10976",
+          "winningBid": 450000,
+          "timestamp": 1458254211,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "7873",
+          "winningBid": 2500000,
+          "timestamp": 1458364127,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "9307",
+          "winningBid": 425000,
+          "timestamp": 1458364277,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "10736",
+          "winningBid": 575000,
+          "timestamp": 1458516528,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "10903",
+          "winningBid": 925000,
+          "timestamp": 1458516573,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "12869",
+          "winningBid": 425000,
+          "timestamp": 1463111462,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "12680",
+          "winningBid": 425000,
+          "timestamp": 1467222639,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "9714",
+          "winningBid": 1200000,
+          "timestamp": 1489676956,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "9838",
+          "winningBid": 500000,
+          "timestamp": 1489678309,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "0503",
+          "winningBid": 475000,
+          "timestamp": 1489678426,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "7813",
+          "winningBid": 2000000,
+          "timestamp": 1489693796,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "6589",
+          "winningBid": 425000,
+          "timestamp": 1489772884,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "7942",
+          "winningBid": 1500000,
+          "timestamp": 1489867398,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "11904",
+          "winningBid": 950000,
+          "timestamp": 1489955584,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "9087",
+          "winningBid": 425000,
+          "timestamp": 1490637107,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "13303",
+          "winningBid": 425000,
+          "timestamp": 1494889368,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "13315",
+          "winningBid": 425000,
+          "timestamp": 1495030309,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "10080",
+          "winningBid": 425000,
+          "timestamp": 1495741066,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "8252",
+          "winningBid": 2925000,
+          "timestamp": 1502080727,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "9250",
+          "winningBid": 800000,
+          "timestamp": 1521199968,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "9075",
+          "winningBid": 625000,
+          "timestamp": 1521336203,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "10389",
+          "winningBid": 5025000,
+          "timestamp": 1521336381,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "10709",
+          "winningBid": 700000,
+          "timestamp": 1521336423,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "12655",
+          "winningBid": 425000,
+          "timestamp": 1521336496,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "9436",
+          "winningBid": 425000,
+          "timestamp": 1521336546,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "10722",
+          "winningBid": 8250000,
+          "timestamp": 1521342416,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "7877",
+          "winningBid": 425000,
+          "timestamp": 1521388832,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "9099",
+          "winningBid": 4025000,
+          "timestamp": 1521483439,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "13679",
+          "winningBid": 425000,
+          "timestamp": 1525807982,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "13673",
+          "winningBid": 425000,
+          "timestamp": 1525808002,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "11660",
+          "winningBid": 5000000,
+          "timestamp": 1553178884,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "9988",
+          "winningBid": 9500000,
+          "timestamp": 1553178931,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "6789",
+          "winningBid": 425000,
+          "timestamp": 1553358333,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "13303",
+          "winningBid": 425000,
+          "timestamp": 1584630184,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "0519",
+          "winningBid": 425000,
+          "timestamp": 1584630236,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "0521",
+          "winningBid": 1225000,
+          "timestamp": 1584738805,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "12186",
+          "winningBid": 10775000,
+          "timestamp": 1584759320,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "12181",
+          "winningBid": 425000,
+          "timestamp": 1585331853,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "10413",
+          "winningBid": 925000,
+          "timestamp": 1616717116,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "7813",
+          "winningBid": 425000,
+          "timestamp": 1617819181,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "12676",
+          "winningBid": 2500000,
+          "timestamp": 1647529505,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "14121",
+          "winningBid": 425000,
+          "timestamp": 1647529607,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "12677",
+          "winningBid": 800000,
+          "timestamp": 1647659579,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "13382",
+          "winningBid": 425000,
+          "timestamp": 1647659614,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "12206",
+          "winningBid": 425000,
+          "timestamp": 1647659763,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "13277",
+          "winningBid": 425000,
+          "timestamp": 1647704611,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "0524",
+          "winningBid": 775000,
+          "timestamp": 1647753603,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "15713",
+          "winningBid": 425000,
+          "timestamp": 1652538756,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "13630",
+          "winningBid": 2500000,
+          "timestamp": 1678980184,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "13598",
+          "winningBid": 425000,
+          "timestamp": 1678980225,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "11760",
+          "winningBid": 1225000,
+          "timestamp": 1679012963,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "13172",
+          "winningBid": 425000,
+          "timestamp": 1679341356,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "13289",
+          "winningBid": 425000,
+          "timestamp": 1679341377,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "13132",
+          "winningBid": 5000000,
+          "timestamp": 1711035934,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "13674",
+          "winningBid": 6500000,
+          "timestamp": 1711035962,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "8851",
+          "winningBid": 425000,
+          "timestamp": 1711036020,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "0520",
+          "winningBid": 425000,
+          "timestamp": 1711071618,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "16624",
+          "winningBid": 425000,
+          "timestamp": 1715476341,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "14109",
+          "winningBid": 4675000,
+          "timestamp": 1742482635,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "12437",
+          "winningBid": 425000,
+          "timestamp": 1742482742,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "0504",
+          "winningBid": 900000,
+          "timestamp": 1742482817,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "14095",
+          "winningBid": 425000,
+          "timestamp": 1742570722,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "16444",
+          "winningBid": 425000,
+          "timestamp": 1742570832,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "15319",
+          "winningBid": 800000,
+          "timestamp": 1742660403,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "13138",
+          "winningBid": 1525000,
+          "timestamp": 1742790193,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "15804",
+          "winningBid": 425000,
+          "timestamp": 1743518764,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "17234",
+          "winningBid": 425000,
+          "timestamp": 1753455457,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "13671",
+          "winningBid": 4000000,
+          "timestamp": 1774019862,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "12141",
+          "winningBid": 525000,
+          "timestamp": 1774065889,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "15716",
+          "winningBid": 800000,
+          "timestamp": 1774150824,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "12620",
+          "winningBid": 3525000,
+          "timestamp": 1774151286,
+          "sourceFranchiseId": null
+        }
+      ],
       "currentName": "Dark Magicians of Chaos",
       "currentNameMedium": "Dark Magicians",
       "currentNameShort": "Magicians",
@@ -12406,6 +13825,1898 @@
           "sourceFranchiseId": null,
           "partnerSourceId": null,
           "bothAttributed": true
+        }
+      ],
+      "draftPicks": [
+        {
+          "year": 2008,
+          "round": 1,
+          "pick": 13,
+          "playerId": "9081",
+          "viaTrade": false,
+          "comments": "Pick made based on Pre-Draft List",
+          "timestamp": 1209827979,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2008,
+          "round": 2,
+          "pick": 9,
+          "playerId": "9052",
+          "viaTrade": false,
+          "comments": "Pick made based on Pre-Draft List",
+          "timestamp": 1209941225,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2009,
+          "round": 1,
+          "pick": 10,
+          "playerId": "9450",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1241331509,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2009,
+          "round": 2,
+          "pick": 15,
+          "playerId": "9515",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1241486068,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2009,
+          "round": 3,
+          "pick": 7,
+          "playerId": "9525",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1241549531,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2009,
+          "round": 3,
+          "pick": 9,
+          "playerId": "9526",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1241571175,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2009,
+          "round": 3,
+          "pick": 11,
+          "playerId": "9545",
+          "viaTrade": false,
+          "comments": "Pick made based on Pre-Draft List",
+          "timestamp": 1241614804,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "round": 1,
+          "pick": 12,
+          "playerId": "5848",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1283123309,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "round": 2,
+          "pick": 1,
+          "playerId": "7393",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1283123318,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "round": 3,
+          "pick": 12,
+          "playerId": "8932",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1283125701,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "round": 4,
+          "pick": 1,
+          "playerId": "9054",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1283125754,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "round": 5,
+          "pick": 12,
+          "playerId": "2705",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1283126696,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "round": 6,
+          "pick": 1,
+          "playerId": "0505",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1283126713,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "round": 7,
+          "pick": 12,
+          "playerId": "6522",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1283127458,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "round": 8,
+          "pick": 1,
+          "playerId": "8359",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1283127476,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "round": 9,
+          "pick": 12,
+          "playerId": "4895",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1283129074,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "round": 10,
+          "pick": 1,
+          "playerId": "5116",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1283129138,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "round": 11,
+          "pick": 12,
+          "playerId": "9087",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1283130236,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "round": 12,
+          "pick": 1,
+          "playerId": "7397",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1283130265,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "round": 13,
+          "pick": 12,
+          "playerId": "8930",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1283131215,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "round": 14,
+          "pick": 1,
+          "playerId": "3445",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1283131247,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "round": 15,
+          "pick": 12,
+          "playerId": "8302",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1283132176,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "round": 16,
+          "pick": 1,
+          "playerId": "0513",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1283132188,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2011,
+          "round": 2,
+          "pick": 3,
+          "playerId": "10302",
+          "viaTrade": false,
+          "comments": "Pick made based on Pre-Draft List",
+          "timestamp": 1304964302,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2011,
+          "round": 2,
+          "pick": 5,
+          "playerId": "10300",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1304994157,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2011,
+          "round": 3,
+          "pick": 7,
+          "playerId": "10310",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1305153209,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "round": 2,
+          "pick": 1,
+          "playerId": "10698",
+          "viaTrade": false,
+          "comments": "I really wish I could have gone in another direction but having 3 staring QB's this year was too tempting given my Peyton Manning experience last year. (Comments Added Mon May 7 1:07:52 p.m. PT 2012)",
+          "timestamp": 1336418132,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "round": 2,
+          "pick": 2,
+          "playerId": "10742",
+          "viaTrade": false,
+          "comments": "Hopefully one of the other guys I'm targeting will fall to me at 2.09.",
+          "timestamp": 1336421418,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "round": 2,
+          "pick": 9,
+          "playerId": "10738",
+          "viaTrade": false,
+          "comments": "Since Devil Dogs stole my pick I'll take a chance on Jones.",
+          "timestamp": 1336453655,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "round": 3,
+          "pick": 9,
+          "playerId": "10747",
+          "viaTrade": false,
+          "comments": "Pick made based on Pre-Draft List Happy he fell to me here, between him and Dwayne Allen I'm hoping to have a nice TE of the future.   (Comments Added Wed May 9 11:40:41 a.m. PT 2012)",
+          "timestamp": 1336586344,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "round": 3,
+          "pick": 10,
+          "playerId": "10881",
+          "viaTrade": false,
+          "comments": "Pick made based on Pre-Draft List The Bengal's don't really have a great RB, sorry BJGE. I think he'll have a great chance to earn some playing time early on.\r\n\r\nHopefully one of these 3rd round picks will be my next Mike Wallace! (Comments Added Wed May 9 11:40:56 a.m. PT 2012)",
+          "timestamp": 1336586344,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2013,
+          "round": 1,
+          "pick": 11,
+          "playerId": "11222",
+          "viaTrade": false,
+          "comments": "I was hoping that Eifert would to me here but he went a lot earlier that I expected.  After that it was going to be BPA.  I considered Kelce here but I think Allen has too much talent, the fact that he's in a great situation sealed it for me. (Comments Added Mon May 6 1:34:12 p.m. PT 2013)",
+          "timestamp": 1367819396,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2013,
+          "round": 2,
+          "pick": 11,
+          "playerId": "11231",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1368068502,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "round": 1,
+          "pick": 12,
+          "playerId": "11681",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1400461873,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "round": 3,
+          "pick": 12,
+          "playerId": "11798",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1400726783,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "round": 2,
+          "pick": 13,
+          "playerId": "13168",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1494298689,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "round": 3,
+          "pick": 16,
+          "playerId": "13244",
+          "viaTrade": true,
+          "comments": "Pick traded from LBer-DeCleaters.",
+          "timestamp": 1494369281,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "round": 1,
+          "pick": 1,
+          "playerId": "13604",
+          "viaTrade": false,
+          "comments": "[Pick made based on Pre-Draft List]",
+          "timestamp": 1525525229,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "round": 2,
+          "pick": 8,
+          "playerId": "13634",
+          "viaTrade": true,
+          "comments": "[Pick traded from The Mariachi Ninjas.]",
+          "timestamp": 1525662416,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "round": 2,
+          "pick": 18,
+          "playerId": "13636",
+          "viaTrade": true,
+          "comments": "[Pick traded from The Mariachi Ninjas.]",
+          "timestamp": 1525722960,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "round": 3,
+          "pick": 15,
+          "playerId": "13595",
+          "viaTrade": true,
+          "comments": "[Pick made based on Pre-Draft List] Pick traded from LBer-DeCleaters.",
+          "timestamp": 1525806451,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "round": 1,
+          "pick": 12,
+          "playerId": "14141",
+          "viaTrade": true,
+          "comments": "[Pick traded from Bring the Pain.\nPick traded from Computer Jocks.]",
+          "timestamp": 1557088161,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "round": 2,
+          "pick": 5,
+          "playerId": "14125",
+          "viaTrade": true,
+          "comments": "[Pick traded from Computer Jocks.]",
+          "timestamp": 1557106250,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "round": 2,
+          "pick": 12,
+          "playerId": "14223",
+          "viaTrade": true,
+          "comments": "[Pick traded from Bring the Pain.\nPick traded from Computer Jocks.]",
+          "timestamp": 1557177375,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "round": 3,
+          "pick": 7,
+          "playerId": "14062",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1557248551,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "round": 1,
+          "pick": 12,
+          "playerId": "14836",
+          "viaTrade": false,
+          "comments": "[Pick made from Pre-Draft List]",
+          "timestamp": 1588527903,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "round": 2,
+          "pick": 12,
+          "playerId": "14807",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1588618626,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "round": 1,
+          "pick": 7,
+          "playerId": "15284",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1620508007,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "round": 2,
+          "pick": 3,
+          "playerId": "15241",
+          "viaTrade": true,
+          "comments": "[Pick traded from Cowboy Up.\nPick traded from Vitside Mafia.]",
+          "timestamp": 1620673345,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "round": 2,
+          "pick": 10,
+          "playerId": "15297",
+          "viaTrade": true,
+          "comments": "[Pick traded from Midwestside Connection.\nPick made from Pre-Draft List]",
+          "timestamp": 1620771725,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "round": 2,
+          "pick": 11,
+          "playerId": "15272",
+          "viaTrade": true,
+          "comments": "[Pick traded from The Mariachi Ninjas.]",
+          "timestamp": 1620771843,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "round": 2,
+          "pick": 18,
+          "playerId": "15271",
+          "viaTrade": false,
+          "comments": "[Pick added by commissioner.]",
+          "timestamp": 1620801944,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "round": 2,
+          "pick": 12,
+          "playerId": "15757",
+          "viaTrade": true,
+          "comments": "[Pick traded from Vitside Mafia.]",
+          "timestamp": 1652247991,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "round": 2,
+          "pick": 14,
+          "playerId": "15697",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1652294863,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "round": 3,
+          "pick": 14,
+          "playerId": "15734",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1652460795,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "round": 3,
+          "pick": 5,
+          "playerId": "16163",
+          "viaTrade": true,
+          "comments": "[Pick traded from Cowboy Up.]",
+          "timestamp": 1683579379,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "round": 3,
+          "pick": 14,
+          "playerId": "16377",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1683646899,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "round": 1,
+          "pick": 11,
+          "playerId": "16617",
+          "viaTrade": false,
+          "comments": "[Pick made from Pre-Draft List]",
+          "timestamp": 1714922492,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "round": 1,
+          "pick": 17,
+          "playerId": "16632",
+          "viaTrade": true,
+          "comments": "[Pick added by commissioner.\nPick traded from Bring the Pain.\nPick traded from The Music City Mafia.]",
+          "timestamp": 1714948802,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "round": 2,
+          "pick": 11,
+          "playerId": "16610",
+          "viaTrade": true,
+          "comments": "[Pick traded from Pacific Pigskins.\nPick traded from The Music City Mafia.\nPick made from Pre-Draft List]",
+          "timestamp": 1714971223,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "round": 3,
+          "pick": 1,
+          "playerId": "16642",
+          "viaTrade": true,
+          "comments": "[Pick traded from The Music City Mafia.\nPick made from Pre-Draft List]",
+          "timestamp": 1715045745,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "round": 1,
+          "pick": 9,
+          "playerId": "17104",
+          "viaTrade": false,
+          "comments": "[Pick made from Pre-Draft List]",
+          "timestamp": 1746401800,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "round": 2,
+          "pick": 9,
+          "playerId": "17033",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1746650812,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "round": 2,
+          "pick": 18,
+          "playerId": "17096",
+          "viaTrade": false,
+          "comments": "[Pick added by commissioner.]",
+          "timestamp": 1746713799,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "round": 1,
+          "pick": 10,
+          "playerId": "17512",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1777836417,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "round": 2,
+          "pick": 10,
+          "playerId": "17482",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1778036153,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "round": 3,
+          "pick": 10,
+          "playerId": "17549",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1778124269,
+          "sourceFranchiseId": null
+        }
+      ],
+      "auctionWins": [
+        {
+          "year": 2009,
+          "playerId": "9120",
+          "winningBid": 4800000,
+          "timestamp": 1238350115,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2009,
+          "playerId": "8076",
+          "winningBid": 425000,
+          "timestamp": 1238358427,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2009,
+          "playerId": "5657",
+          "winningBid": 1000000,
+          "timestamp": 1238358652,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2009,
+          "playerId": "8344",
+          "winningBid": 425000,
+          "timestamp": 1238359103,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2009,
+          "playerId": "5817",
+          "winningBid": 1025000,
+          "timestamp": 1238390151,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2009,
+          "playerId": "0515",
+          "winningBid": 425000,
+          "timestamp": 1238441017,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2009,
+          "playerId": "7847",
+          "winningBid": 450000,
+          "timestamp": 1238506564,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2009,
+          "playerId": "9069",
+          "winningBid": 825000,
+          "timestamp": 1238511832,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2009,
+          "playerId": "7922",
+          "winningBid": 7850000,
+          "timestamp": 1238543484,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2009,
+          "playerId": "4077",
+          "winningBid": 2025000,
+          "timestamp": 1238575394,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2009,
+          "playerId": "6929",
+          "winningBid": 3875000,
+          "timestamp": 1238649175,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2009,
+          "playerId": "7433",
+          "winningBid": 1525000,
+          "timestamp": 1238706347,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2009,
+          "playerId": "9299",
+          "winningBid": 425000,
+          "timestamp": 1238828265,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "playerId": "8930",
+          "winningBid": 450000,
+          "timestamp": 1269386474,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "playerId": "3141",
+          "winningBid": 425000,
+          "timestamp": 1269386474,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "playerId": "7942",
+          "winningBid": 3500000,
+          "timestamp": 1269387251,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "playerId": "9315",
+          "winningBid": 425000,
+          "timestamp": 1269387280,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "playerId": "7024",
+          "winningBid": 425000,
+          "timestamp": 1269398011,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "playerId": "8435",
+          "winningBid": 425000,
+          "timestamp": 1269412383,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "playerId": "1756",
+          "winningBid": 425000,
+          "timestamp": 1269412658,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "playerId": "9087",
+          "winningBid": 4000000,
+          "timestamp": 1269449040,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "playerId": "4077",
+          "winningBid": 2275000,
+          "timestamp": 1269572752,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "playerId": "7816",
+          "winningBid": 7875000,
+          "timestamp": 1269573869,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "playerId": "8042",
+          "winningBid": 3200000,
+          "timestamp": 1269635515,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "playerId": "8656",
+          "winningBid": 625000,
+          "timestamp": 1269678811,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "playerId": "7991",
+          "winningBid": 425000,
+          "timestamp": 1269679387,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "playerId": "5817",
+          "winningBid": 425000,
+          "timestamp": 1269758010,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "playerId": "0501",
+          "winningBid": 675000,
+          "timestamp": 1269818494,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "playerId": "0509",
+          "winningBid": 425000,
+          "timestamp": 1269818494,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "playerId": "7496",
+          "winningBid": 425000,
+          "timestamp": 1273917962,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2011,
+          "playerId": "3291",
+          "winningBid": 8000000,
+          "timestamp": 1300809707,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2011,
+          "playerId": "8851",
+          "winningBid": 450000,
+          "timestamp": 1300811294,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2011,
+          "playerId": "0516",
+          "winningBid": 575000,
+          "timestamp": 1300926631,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2011,
+          "playerId": "9693",
+          "winningBid": 2500000,
+          "timestamp": 1300973871,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2011,
+          "playerId": "5817",
+          "winningBid": 450000,
+          "timestamp": 1301249137,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2011,
+          "playerId": "3866",
+          "winningBid": 3325000,
+          "timestamp": 1301283692,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2011,
+          "playerId": "9069",
+          "winningBid": 425000,
+          "timestamp": 1306644036,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2011,
+          "playerId": "8160",
+          "winningBid": 425000,
+          "timestamp": 1312710710,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2011,
+          "playerId": "7814",
+          "winningBid": 425000,
+          "timestamp": 1313437815,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "playerId": "5848",
+          "winningBid": 12000000,
+          "timestamp": 1331845236,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "playerId": "7653",
+          "winningBid": 9000000,
+          "timestamp": 1331845441,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "playerId": "0501",
+          "winningBid": 800000,
+          "timestamp": 1331933767,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "playerId": "7455",
+          "winningBid": 500000,
+          "timestamp": 1331942794,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "playerId": "10496",
+          "winningBid": 425000,
+          "timestamp": 1336815270,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "playerId": "9526",
+          "winningBid": 425000,
+          "timestamp": 1346288262,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2013,
+          "playerId": "1275",
+          "winningBid": 475000,
+          "timestamp": 1363272495,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2013,
+          "playerId": "9690",
+          "winningBid": 13775000,
+          "timestamp": 1363294951,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2013,
+          "playerId": "9064",
+          "winningBid": 3025000,
+          "timestamp": 1363324263,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2013,
+          "playerId": "4891",
+          "winningBid": 1275000,
+          "timestamp": 1363324263,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2013,
+          "playerId": "2842",
+          "winningBid": 425000,
+          "timestamp": 1363324635,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2013,
+          "playerId": "0518",
+          "winningBid": 425000,
+          "timestamp": 1363324955,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2013,
+          "playerId": "4974",
+          "winningBid": 5000000,
+          "timestamp": 1363541294,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2013,
+          "playerId": "8934",
+          "winningBid": 2850000,
+          "timestamp": 1363672189,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2013,
+          "playerId": "11399",
+          "winningBid": 425000,
+          "timestamp": 1368594335,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "4925",
+          "winningBid": 9000000,
+          "timestamp": 1394717203,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "2842",
+          "winningBid": 425000,
+          "timestamp": 1394717258,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "0509",
+          "winningBid": 500000,
+          "timestamp": 1394717339,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "8934",
+          "winningBid": 1750000,
+          "timestamp": 1394717392,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "10276",
+          "winningBid": 2000000,
+          "timestamp": 1394717526,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "9450",
+          "winningBid": 4500000,
+          "timestamp": 1394757113,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "9347",
+          "winningBid": 750000,
+          "timestamp": 1394757541,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "10506",
+          "winningBid": 550000,
+          "timestamp": 1394758027,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "5848",
+          "winningBid": 6000000,
+          "timestamp": 1394758079,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "9427",
+          "winningBid": 8025000,
+          "timestamp": 1395030183,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "11689",
+          "winningBid": 600000,
+          "timestamp": 1400816504,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "10961",
+          "winningBid": 425000,
+          "timestamp": 1402077779,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "9918",
+          "winningBid": 9100000,
+          "timestamp": 1426772624,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "7942",
+          "winningBid": 1000000,
+          "timestamp": 1426818406,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "7859",
+          "winningBid": 425000,
+          "timestamp": 1426958053,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "0526",
+          "winningBid": 625000,
+          "timestamp": 1426994361,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "12409",
+          "winningBid": 425000,
+          "timestamp": 1431582410,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "9525",
+          "winningBid": 1025000,
+          "timestamp": 1458223295,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "10303",
+          "winningBid": 850000,
+          "timestamp": 1458260104,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "10297",
+          "winningBid": 2000000,
+          "timestamp": 1458260354,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "5666",
+          "winningBid": 425000,
+          "timestamp": 1458274332,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "9680",
+          "winningBid": 1500000,
+          "timestamp": 1458278618,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "7942",
+          "winningBid": 1200000,
+          "timestamp": 1458484639,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "11257",
+          "winningBid": 2000000,
+          "timestamp": 1458488692,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "6589",
+          "winningBid": 450000,
+          "timestamp": 1458618623,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "8247",
+          "winningBid": 1000000,
+          "timestamp": 1458773946,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "10500",
+          "winningBid": 425000,
+          "timestamp": 1471216132,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "7260",
+          "winningBid": 2500000,
+          "timestamp": 1489679275,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "9427",
+          "winningBid": 4950000,
+          "timestamp": 1489679275,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "7401",
+          "winningBid": 4000000,
+          "timestamp": 1489679302,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "9884",
+          "winningBid": 6000000,
+          "timestamp": 1489679507,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "9101",
+          "winningBid": 1025000,
+          "timestamp": 1489706348,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "0529",
+          "winningBid": 425000,
+          "timestamp": 1489782171,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "10389",
+          "winningBid": 2525000,
+          "timestamp": 1489813124,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "10872",
+          "winningBid": 425000,
+          "timestamp": 1489855813,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "9189",
+          "winningBid": 1200000,
+          "timestamp": 1489898181,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "10487",
+          "winningBid": 425000,
+          "timestamp": 1489912300,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "10862",
+          "winningBid": 425000,
+          "timestamp": 1489991840,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "9196",
+          "winningBid": 450000,
+          "timestamp": 1490049478,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "0501",
+          "winningBid": 425000,
+          "timestamp": 1490078471,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "11257",
+          "winningBid": 950000,
+          "timestamp": 1521171969,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "6997",
+          "winningBid": 800000,
+          "timestamp": 1521171969,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "9918",
+          "winningBid": 3000000,
+          "timestamp": 1521181891,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "9925",
+          "winningBid": 10500000,
+          "timestamp": 1521302296,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "2842",
+          "winningBid": 425000,
+          "timestamp": 1526223609,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "12680",
+          "winningBid": 425000,
+          "timestamp": 1553177350,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "11668",
+          "winningBid": 425000,
+          "timestamp": 1553177932,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "10738",
+          "winningBid": 4000000,
+          "timestamp": 1553178188,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "7391",
+          "winningBid": 650000,
+          "timestamp": 1553184301,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "7813",
+          "winningBid": 425000,
+          "timestamp": 1553184338,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "5848",
+          "winningBid": 5000000,
+          "timestamp": 1553220225,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "8062",
+          "winningBid": 3000000,
+          "timestamp": 1553221019,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "12437",
+          "winningBid": 600000,
+          "timestamp": 1553277389,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "8359",
+          "winningBid": 700000,
+          "timestamp": 1553277389,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "11761",
+          "winningBid": 3500000,
+          "timestamp": 1553315335,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "13254",
+          "winningBid": 500000,
+          "timestamp": 1553315541,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "11454",
+          "winningBid": 2525000,
+          "timestamp": 1553494359,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "9448",
+          "winningBid": 5000000,
+          "timestamp": 1553572013,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "9884",
+          "winningBid": 575000,
+          "timestamp": 1555465684,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "11247",
+          "winningBid": 10250000,
+          "timestamp": 1584627695,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "12447",
+          "winningBid": 3225000,
+          "timestamp": 1584629586,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "10487",
+          "winningBid": 425000,
+          "timestamp": 1584629688,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "0506",
+          "winningBid": 425000,
+          "timestamp": 1584758114,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "0527",
+          "winningBid": 425000,
+          "timestamp": 1584758133,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "11760",
+          "winningBid": 2525000,
+          "timestamp": 1584820755,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "14866",
+          "winningBid": 425000,
+          "timestamp": 1588894337,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "11674",
+          "winningBid": 5000000,
+          "timestamp": 1616076144,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "8062",
+          "winningBid": 800000,
+          "timestamp": 1616076331,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "12647",
+          "winningBid": 5000000,
+          "timestamp": 1616076428,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "13303",
+          "winningBid": 475000,
+          "timestamp": 1616208073,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "13188",
+          "winningBid": 2550000,
+          "timestamp": 1616517997,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "9474",
+          "winningBid": 1900000,
+          "timestamp": 1616517997,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "11244",
+          "winningBid": 13500000,
+          "timestamp": 1647525648,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "12930",
+          "winningBid": 450000,
+          "timestamp": 1647655345,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "12610",
+          "winningBid": 2000000,
+          "timestamp": 1647677379,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "13115",
+          "winningBid": 1625000,
+          "timestamp": 1647677762,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "12164",
+          "winningBid": 425000,
+          "timestamp": 1647813044,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "14977",
+          "winningBid": 950000,
+          "timestamp": 1678975511,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "12476",
+          "winningBid": 425000,
+          "timestamp": 1678975687,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "12678",
+          "winningBid": 3000000,
+          "timestamp": 1678976286,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "12801",
+          "winningBid": 9000000,
+          "timestamp": 1678976328,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "16080",
+          "winningBid": 425000,
+          "timestamp": 1678994635,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "0512",
+          "winningBid": 725000,
+          "timestamp": 1679019465,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "11225",
+          "winningBid": 2000000,
+          "timestamp": 1679067903,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "13633",
+          "winningBid": 4250000,
+          "timestamp": 1679106761,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "14803",
+          "winningBid": 1150000,
+          "timestamp": 1679281714,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "13176",
+          "winningBid": 1725000,
+          "timestamp": 1679282120,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "14067",
+          "winningBid": 2000000,
+          "timestamp": 1711029633,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "12625",
+          "winningBid": 725000,
+          "timestamp": 1711029849,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "13424",
+          "winningBid": 625000,
+          "timestamp": 1711040575,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "16221",
+          "winningBid": 700000,
+          "timestamp": 1711174052,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "15723",
+          "winningBid": 425000,
+          "timestamp": 1711174160,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "12616",
+          "winningBid": 425000,
+          "timestamp": 1711174731,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "14800",
+          "winningBid": 450000,
+          "timestamp": 1711224780,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "12678",
+          "winningBid": 1500000,
+          "timestamp": 1711268616,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "14057",
+          "winningBid": 700000,
+          "timestamp": 1711307838,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "14059",
+          "winningBid": 2000000,
+          "timestamp": 1711347127,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "14871",
+          "winningBid": 475000,
+          "timestamp": 1711681930,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "13674",
+          "winningBid": 2500000,
+          "timestamp": 1742479419,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "11936",
+          "winningBid": 550000,
+          "timestamp": 1742479641,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "0507",
+          "winningBid": 600000,
+          "timestamp": 1742479696,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "14974",
+          "winningBid": 525000,
+          "timestamp": 1742480933,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "12447",
+          "winningBid": 525000,
+          "timestamp": 1742480981,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "13592",
+          "winningBid": 7525000,
+          "timestamp": 1742610735,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "0513",
+          "winningBid": 1200000,
+          "timestamp": 1742655084,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "11232",
+          "winningBid": 1025000,
+          "timestamp": 1742795689,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "15693",
+          "winningBid": 425000,
+          "timestamp": 1743051522,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "13595",
+          "winningBid": 475000,
+          "timestamp": 1743436485,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "0516",
+          "winningBid": 700000,
+          "timestamp": 1773929167,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "0513",
+          "winningBid": 625000,
+          "timestamp": 1773929285,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "13635",
+          "winningBid": 3250000,
+          "timestamp": 1773929583,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "15742",
+          "winningBid": 1200000,
+          "timestamp": 1773929632,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "11675",
+          "winningBid": 3125000,
+          "timestamp": 1773929853,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "16192",
+          "winningBid": 2000000,
+          "timestamp": 1773930235,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "14138",
+          "winningBid": 2500000,
+          "timestamp": 1773930369,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "13592",
+          "winningBid": 3250000,
+          "timestamp": 1773930520,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "14823",
+          "winningBid": 2125000,
+          "timestamp": 1773955259,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "12611",
+          "winningBid": 3400000,
+          "timestamp": 1773955321,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "13593",
+          "winningBid": 5000000,
+          "timestamp": 1774100456,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "15284",
+          "winningBid": 5575000,
+          "timestamp": 1774156070,
+          "sourceFranchiseId": null
         }
       ],
       "currentName": "Pacific Pigskins",
@@ -19458,6 +22769,1531 @@
           "bothAttributed": true
         }
       ],
+      "draftPicks": [
+        {
+          "year": 2008,
+          "round": 1,
+          "pick": 8,
+          "playerId": "9099",
+          "viaTrade": false,
+          "comments": "Pick made based on Pre-Draft List",
+          "timestamp": 1209816950,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2008,
+          "round": 1,
+          "pick": 11,
+          "playerId": "9078",
+          "viaTrade": false,
+          "comments": "I REALLY like his value @ 1.11.",
+          "timestamp": 1209823663,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2009,
+          "round": 1,
+          "pick": 6,
+          "playerId": "9448",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1241309114,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2009,
+          "round": 1,
+          "pick": 17,
+          "playerId": "9474",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1241392165,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2009,
+          "round": 3,
+          "pick": 3,
+          "playerId": "9575",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1241492351,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "round": 1,
+          "pick": 4,
+          "playerId": "9094",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1283123083,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "round": 2,
+          "pick": 9,
+          "playerId": "9089",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1283125142,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "round": 3,
+          "pick": 4,
+          "playerId": "7839",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1283125425,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "round": 4,
+          "pick": 9,
+          "playerId": "9250",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1283126116,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "round": 5,
+          "pick": 4,
+          "playerId": "9150",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1283126357,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "round": 6,
+          "pick": 9,
+          "playerId": "0518",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1283126953,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "round": 7,
+          "pick": 4,
+          "playerId": "9099",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1283127170,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "round": 8,
+          "pick": 9,
+          "playerId": "9456",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1283128449,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "round": 9,
+          "pick": 4,
+          "playerId": "8680",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1283128832,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "round": 10,
+          "pick": 9,
+          "playerId": "5656",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1283129437,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "round": 11,
+          "pick": 4,
+          "playerId": "8474",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1283129896,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "round": 12,
+          "pick": 9,
+          "playerId": "7837",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1283130544,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "round": 13,
+          "pick": 4,
+          "playerId": "0520",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1283130904,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "round": 14,
+          "pick": 9,
+          "playerId": "9838",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1283131496,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "round": 15,
+          "pick": 4,
+          "playerId": "2840",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1283131849,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "round": 16,
+          "pick": 9,
+          "playerId": "6887",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1283132461,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2011,
+          "round": 1,
+          "pick": 12,
+          "playerId": "10262",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1304905998,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2011,
+          "round": 3,
+          "pick": 13,
+          "playerId": "10365",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1305231541,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "round": 1,
+          "pick": 13,
+          "playerId": "10800",
+          "viaTrade": false,
+          "comments": "Had him @ 8 on my draft list",
+          "timestamp": 1336349935,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "round": 2,
+          "pick": 3,
+          "playerId": "10723",
+          "viaTrade": false,
+          "comments": "Love his potential.  Hoping he can become the Boldin to A.J. Green's Fitzgerald.",
+          "timestamp": 1336426864,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2013,
+          "round": 1,
+          "pick": 5,
+          "playerId": "11225",
+          "viaTrade": false,
+          "comments": "Never thought he'd slip to me at 1.05 (Comments Added Sun May 5 8:49:32 p.m. ET 2013)",
+          "timestamp": 1367779300,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2013,
+          "round": 1,
+          "pick": 14,
+          "playerId": "11244",
+          "viaTrade": false,
+          "comments": "Thought about Wheaton, but I Need a TE badly and I love the opportunities for Kelce in Andy Reid's offense.   (Comments Added Mon May 6 5:24:26 p.m. ET 2013)",
+          "timestamp": 1367836124,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2013,
+          "round": 2,
+          "pick": 1,
+          "playerId": "11247",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1367897522,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2013,
+          "round": 3,
+          "pick": 1,
+          "playerId": "11248",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1368165745,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "round": 1,
+          "pick": 7,
+          "playerId": "11679",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1400404112,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "round": 2,
+          "pick": 3,
+          "playerId": "11640",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1400524594,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "round": 2,
+          "pick": 17,
+          "playerId": "11680",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1400610127,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "round": 3,
+          "pick": 3,
+          "playerId": "11663",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1400643069,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "round": 3,
+          "pick": 1,
+          "playerId": "12656",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1462947755,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "round": 3,
+          "pick": 12,
+          "playerId": "12617",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1463070206,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "round": 2,
+          "pick": 11,
+          "playerId": "13164",
+          "viaTrade": true,
+          "comments": "Pick traded from Dark Magicians of Chaos.",
+          "timestamp": 1494294632,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "round": 1,
+          "pick": 14,
+          "playerId": "13633",
+          "viaTrade": true,
+          "comments": "[Pick traded from Dark Magicians of Chaos.] Pick traded from Devil Dogs.",
+          "timestamp": 1525633279,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "round": 2,
+          "pick": 6,
+          "playerId": "13593",
+          "viaTrade": true,
+          "comments": "[Pick traded from Wascawy Wabbits.\nPick traded from Computer Jocks.]",
+          "timestamp": 1525658942,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "round": 2,
+          "pick": 7,
+          "playerId": "13592",
+          "viaTrade": true,
+          "comments": "Pick traded from Maverick.",
+          "timestamp": 1525658984,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "round": 2,
+          "pick": 15,
+          "playerId": "13622",
+          "viaTrade": true,
+          "comments": "[Pick traded from Maverick.] Pick traded from LBer-DeCleaters.",
+          "timestamp": 1525718564,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "round": 2,
+          "pick": 16,
+          "playerId": "13662",
+          "viaTrade": true,
+          "comments": "[Pick traded from Dark Magicians of Chaos.] Pick traded from Fire Ready Aim.",
+          "timestamp": 1525719494,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "round": 2,
+          "pick": 6,
+          "playerId": "14105",
+          "viaTrade": true,
+          "comments": "[Pick traded from Gridiron Geeks.] I have no idea how he slipped all the way to me at pick 23.  (Comments Added Thu May 9 9:38:09 p.m. ET 2019)",
+          "timestamp": 1557106682,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "round": 1,
+          "pick": 16,
+          "playerId": "14846",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1588560191,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "round": 2,
+          "pick": 5,
+          "playerId": "14870",
+          "viaTrade": true,
+          "comments": "[Pick traded from Drunk Indians.]",
+          "timestamp": 1588613434,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "round": 3,
+          "pick": 12,
+          "playerId": "14850",
+          "viaTrade": true,
+          "comments": "[Pick traded from Pacific Pigskins.]",
+          "timestamp": 1588822328,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "round": 3,
+          "pick": 14,
+          "playerId": "14939",
+          "viaTrade": true,
+          "comments": "[Pick traded from The Music City Mafia.\nPick traded from Cowboy Up.]",
+          "timestamp": 1588822477,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "round": 2,
+          "pick": 4,
+          "playerId": "15283",
+          "viaTrade": true,
+          "comments": "[Pick traded from Heavy Chevy.\nPick traded from Vitside Mafia.] Boiler Up!",
+          "timestamp": 1620677090,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "round": 2,
+          "pick": 12,
+          "playerId": "15255",
+          "viaTrade": true,
+          "comments": "[Pick traded from Dark Magicians of Chaos.]",
+          "timestamp": 1620781704,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "round": 3,
+          "pick": 3,
+          "playerId": "15301",
+          "viaTrade": true,
+          "comments": "[Pick traded from Cowboy Up.]",
+          "timestamp": 1620837886,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "round": 2,
+          "pick": 2,
+          "playerId": "15788",
+          "viaTrade": true,
+          "comments": "[Pick traded from Heavy Chevy.]",
+          "timestamp": 1652206100,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "round": 2,
+          "pick": 5,
+          "playerId": "15714",
+          "viaTrade": true,
+          "comments": "[Pick traded from Maverick.\nPick traded from Wascawy Wabbits.\nPick traded from Heavy Chevy.]",
+          "timestamp": 1652235730,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "round": 3,
+          "pick": 2,
+          "playerId": "15782",
+          "viaTrade": true,
+          "comments": "[Pick traded from Heavy Chevy.]",
+          "timestamp": 1652371364,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "round": 1,
+          "pick": 2,
+          "playerId": "16162",
+          "viaTrade": true,
+          "comments": "[Pick traded from Midwestside Connection.]",
+          "timestamp": 1683389873,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "round": 1,
+          "pick": 14,
+          "playerId": "16214",
+          "viaTrade": true,
+          "comments": "[Pick traded from Pacific Pigskins.]",
+          "timestamp": 1683488180,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "round": 3,
+          "pick": 2,
+          "playerId": "16206",
+          "viaTrade": true,
+          "comments": "[Pick traded from Midwestside Connection.] Pick going to Cowboy Up",
+          "timestamp": 1683568803,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "round": 3,
+          "pick": 4,
+          "playerId": "16153",
+          "viaTrade": true,
+          "comments": "[Pick traded from Heavy Chevy.] Pick going to Cowboy Up",
+          "timestamp": 1683570726,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "round": 1,
+          "pick": 6,
+          "playerId": "16620",
+          "viaTrade": false,
+          "comments": "Pick traded to Dream",
+          "timestamp": 1714879817,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "round": 1,
+          "pick": 8,
+          "playerId": "16618",
+          "viaTrade": true,
+          "comments": "[Pick traded from  Running Down The Dream.]",
+          "timestamp": 1714896511,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "round": 2,
+          "pick": 12,
+          "playerId": "16629",
+          "viaTrade": true,
+          "comments": "[Pick traded from Gridiron Geeks.\nPick traded from Cowboy Up.]",
+          "timestamp": 1714971792,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "round": 2,
+          "pick": 17,
+          "playerId": "16628",
+          "viaTrade": true,
+          "comments": "[Pick added by commissioner.\nPick traded from Cowboy Up.\nPick made from Pre-Draft List]",
+          "timestamp": 1715021172,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "round": 1,
+          "pick": 10,
+          "playerId": "17081",
+          "viaTrade": true,
+          "comments": "[Pick traded from Dark Magicians of Chaos.]",
+          "timestamp": 1746404946,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "round": 1,
+          "pick": 17,
+          "playerId": "17078",
+          "viaTrade": false,
+          "comments": "[Pick added by commissioner.]",
+          "timestamp": 1746545734,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "round": 2,
+          "pick": 7,
+          "playerId": "17107",
+          "viaTrade": true,
+          "comments": "[Pick traded from Maverick.]",
+          "timestamp": 1746628298,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "round": 3,
+          "pick": 8,
+          "playerId": "17053",
+          "viaTrade": true,
+          "comments": "[Pick traded from The Music City Mafia.]",
+          "timestamp": 1746744942,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "round": 2,
+          "pick": 4,
+          "playerId": "17520",
+          "viaTrade": true,
+          "comments": "[Pick traded from The Music City Mafia.]",
+          "timestamp": 1778021229,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "round": 2,
+          "pick": 11,
+          "playerId": "17567",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1778043201,
+          "sourceFranchiseId": null
+        }
+      ],
+      "auctionWins": [
+        {
+          "year": 2009,
+          "playerId": "5429",
+          "winningBid": 425000,
+          "timestamp": 1238475543,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2009,
+          "playerId": "3933",
+          "winningBid": 450000,
+          "timestamp": 1238505879,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2009,
+          "playerId": "6935",
+          "winningBid": 425000,
+          "timestamp": 1238523926,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2009,
+          "playerId": "7653",
+          "winningBid": 6725000,
+          "timestamp": 1238554610,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2009,
+          "playerId": "9663",
+          "winningBid": 425000,
+          "timestamp": 1241730630,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "playerId": "7544",
+          "winningBid": 8800000,
+          "timestamp": 1269375594,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "playerId": "6475",
+          "winningBid": 425000,
+          "timestamp": 1269379636,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "playerId": "6509",
+          "winningBid": 425000,
+          "timestamp": 1269457754,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "playerId": "7847",
+          "winningBid": 425000,
+          "timestamp": 1269490609,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "playerId": "0515",
+          "winningBid": 425000,
+          "timestamp": 1269545294,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "playerId": "6950",
+          "winningBid": 450000,
+          "timestamp": 1269641583,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "playerId": "7498",
+          "winningBid": 3025000,
+          "timestamp": 1269671526,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "playerId": "0528",
+          "winningBid": 425000,
+          "timestamp": 1270149244,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "playerId": "8671",
+          "winningBid": 425000,
+          "timestamp": 1273073894,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "playerId": "2842",
+          "winningBid": 425000,
+          "timestamp": 1281400977,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "playerId": "9144",
+          "winningBid": 425000,
+          "timestamp": 1282259978,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "playerId": "9044",
+          "winningBid": 425000,
+          "timestamp": 1283019533,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2011,
+          "playerId": "3143",
+          "winningBid": 450000,
+          "timestamp": 1300940131,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2011,
+          "playerId": "8657",
+          "winningBid": 9100000,
+          "timestamp": 1300940453,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2011,
+          "playerId": "7403",
+          "winningBid": 600000,
+          "timestamp": 1300973131,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2011,
+          "playerId": "3869",
+          "winningBid": 425000,
+          "timestamp": 1300978238,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2011,
+          "playerId": "6599",
+          "winningBid": 425000,
+          "timestamp": 1300978351,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2011,
+          "playerId": "6929",
+          "winningBid": 2775000,
+          "timestamp": 1301071236,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2011,
+          "playerId": "8687",
+          "winningBid": 1125000,
+          "timestamp": 1301147880,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2011,
+          "playerId": "8760",
+          "winningBid": 425000,
+          "timestamp": 1304195737,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2011,
+          "playerId": "8680",
+          "winningBid": 525000,
+          "timestamp": 1304941081,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2011,
+          "playerId": "6950",
+          "winningBid": 425000,
+          "timestamp": 1314065082,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "playerId": "8301",
+          "winningBid": 9000000,
+          "timestamp": 1331827313,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "playerId": "9054",
+          "winningBid": 10000000,
+          "timestamp": 1331957162,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "playerId": "9271",
+          "winningBid": 425000,
+          "timestamp": 1331997946,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "playerId": "8271",
+          "winningBid": 425000,
+          "timestamp": 1331997991,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "playerId": "9639",
+          "winningBid": 1275000,
+          "timestamp": 1332087212,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "playerId": "8830",
+          "winningBid": 425000,
+          "timestamp": 1332116676,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2013,
+          "playerId": "7653",
+          "winningBid": 8000000,
+          "timestamp": 1363266100,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2013,
+          "playerId": "8294",
+          "winningBid": 425000,
+          "timestamp": 1363405341,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "0522",
+          "winningBid": 425000,
+          "timestamp": 1394735728,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "10262",
+          "winningBid": 425000,
+          "timestamp": 1394735882,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "10870",
+          "winningBid": 7500000,
+          "timestamp": 1394740423,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "9714",
+          "winningBid": 500000,
+          "timestamp": 1394764413,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "7498",
+          "winningBid": 475000,
+          "timestamp": 1395162992,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "4923",
+          "winningBid": 425000,
+          "timestamp": 1426945493,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "10601",
+          "winningBid": 425000,
+          "timestamp": 1426955351,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "0532",
+          "winningBid": 1000000,
+          "timestamp": 1458228574,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "9822",
+          "winningBid": 425000,
+          "timestamp": 1458229171,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "10268",
+          "winningBid": 425000,
+          "timestamp": 1458229440,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "0509",
+          "winningBid": 425000,
+          "timestamp": 1458230234,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "10262",
+          "winningBid": 475000,
+          "timestamp": 1458323822,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "8776",
+          "winningBid": 425000,
+          "timestamp": 1458543099,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "9308",
+          "winningBid": 425000,
+          "timestamp": 1459716808,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "12613",
+          "winningBid": 425000,
+          "timestamp": 1463105238,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "12681",
+          "winningBid": 425000,
+          "timestamp": 1463105356,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "12664",
+          "winningBid": 525000,
+          "timestamp": 1463249434,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "10723",
+          "winningBid": 525000,
+          "timestamp": 1489807620,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "10720",
+          "winningBid": 425000,
+          "timestamp": 1489866146,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "0507",
+          "winningBid": 425000,
+          "timestamp": 1490504055,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "13120",
+          "winningBid": 425000,
+          "timestamp": 1494602708,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "13119",
+          "winningBid": 425000,
+          "timestamp": 1494602810,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "12212",
+          "winningBid": 425000,
+          "timestamp": 1521255437,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "11387",
+          "winningBid": 450000,
+          "timestamp": 1521315639,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "9662",
+          "winningBid": 6525000,
+          "timestamp": 1521353717,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "10372",
+          "winningBid": 425000,
+          "timestamp": 1522170751,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "12934",
+          "winningBid": 425000,
+          "timestamp": 1523493018,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "13718",
+          "winningBid": 425000,
+          "timestamp": 1525852911,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "13601",
+          "winningBid": 425000,
+          "timestamp": 1526370583,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "8062",
+          "winningBid": 425000,
+          "timestamp": 1529620013,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "11213",
+          "winningBid": 425000,
+          "timestamp": 1533672502,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "13980",
+          "winningBid": 475000,
+          "timestamp": 1553191322,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "12785",
+          "winningBid": 575000,
+          "timestamp": 1553366606,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "12773",
+          "winningBid": 425000,
+          "timestamp": 1553379039,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "11188",
+          "winningBid": 425000,
+          "timestamp": 1553415739,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "0523",
+          "winningBid": 425000,
+          "timestamp": 1553481269,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "12912",
+          "winningBid": 1325000,
+          "timestamp": 1553486656,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "12378",
+          "winningBid": 525000,
+          "timestamp": 1553492827,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "13871",
+          "winningBid": 425000,
+          "timestamp": 1565307977,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "13240",
+          "winningBid": 425000,
+          "timestamp": 1584645135,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "12157",
+          "winningBid": 700000,
+          "timestamp": 1584784544,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "13378",
+          "winningBid": 2500000,
+          "timestamp": 1585057236,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "14972",
+          "winningBid": 425000,
+          "timestamp": 1588976226,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "12171",
+          "winningBid": 5250000,
+          "timestamp": 1616188922,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "13418",
+          "winningBid": 425000,
+          "timestamp": 1616279084,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "8930",
+          "winningBid": 425000,
+          "timestamp": 1616351473,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "14810",
+          "winningBid": 1150000,
+          "timestamp": 1616460033,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "13880",
+          "winningBid": 1125000,
+          "timestamp": 1616592651,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "12955",
+          "winningBid": 425000,
+          "timestamp": 1616813800,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "15321",
+          "winningBid": 425000,
+          "timestamp": 1620922983,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "12175",
+          "winningBid": 7250000,
+          "timestamp": 1647529143,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "10297",
+          "winningBid": 425000,
+          "timestamp": 1647613345,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "12616",
+          "winningBid": 425000,
+          "timestamp": 1647723989,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "14592",
+          "winningBid": 425000,
+          "timestamp": 1647891302,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "13645",
+          "winningBid": 425000,
+          "timestamp": 1648594127,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "15882",
+          "winningBid": 550000,
+          "timestamp": 1652716633,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "10312",
+          "winningBid": 425000,
+          "timestamp": 1656605873,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "15786",
+          "winningBid": 425000,
+          "timestamp": 1658686126,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "15900",
+          "winningBid": 425000,
+          "timestamp": 1659630756,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "12616",
+          "winningBid": 425000,
+          "timestamp": 1678975866,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "11228",
+          "winningBid": 425000,
+          "timestamp": 1678975919,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "15242",
+          "winningBid": 425000,
+          "timestamp": 1678977235,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "15873",
+          "winningBid": 750000,
+          "timestamp": 1678979786,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "13134",
+          "winningBid": 2950000,
+          "timestamp": 1679104793,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "15257",
+          "winningBid": 425000,
+          "timestamp": 1680128696,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "16292",
+          "winningBid": 425000,
+          "timestamp": 1683648606,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "9899",
+          "winningBid": 425000,
+          "timestamp": 1684104640,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "15301",
+          "winningBid": 425000,
+          "timestamp": 1690227891,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "14073",
+          "winningBid": 9025000,
+          "timestamp": 1711035220,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "14852",
+          "winningBid": 1025000,
+          "timestamp": 1711517774,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "13168",
+          "winningBid": 425000,
+          "timestamp": 1711577248,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "16683",
+          "winningBid": 425000,
+          "timestamp": 1712251772,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "14063",
+          "winningBid": 425000,
+          "timestamp": 1712838287,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "12785",
+          "winningBid": 425000,
+          "timestamp": 1723160337,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "14104",
+          "winningBid": 7600000,
+          "timestamp": 1742503304,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "16585",
+          "winningBid": 550000,
+          "timestamp": 1742615700,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "11644",
+          "winningBid": 3550000,
+          "timestamp": 1742634025,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "0512",
+          "winningBid": 1200000,
+          "timestamp": 1742765008,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "13404",
+          "winningBid": 975000,
+          "timestamp": 1742902134,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "17037",
+          "winningBid": 450000,
+          "timestamp": 1746917851,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "17034",
+          "winningBid": 425000,
+          "timestamp": 1747675398,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "16640",
+          "winningBid": 425000,
+          "timestamp": 1754207543,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "9064",
+          "winningBid": 525000,
+          "timestamp": 1754411696,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "17076",
+          "winningBid": 425000,
+          "timestamp": 1755234575,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "13604",
+          "winningBid": 7200000,
+          "timestamp": 1773929516,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "15786",
+          "winningBid": 725000,
+          "timestamp": 1773931246,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "0529",
+          "winningBid": 1225000,
+          "timestamp": 1774280331,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "0511",
+          "winningBid": 2525000,
+          "timestamp": 1774539245,
+          "sourceFranchiseId": null
+        }
+      ],
       "currentName": "Bring The Pain",
       "currentNameMedium": "Bring The Pain",
       "currentNameShort": "Pain",
@@ -24224,6 +29060,1356 @@
           "sourceFranchiseId": null,
           "partnerSourceId": null,
           "bothAttributed": true
+        }
+      ],
+      "draftPicks": [
+        {
+          "year": 2010,
+          "round": 1,
+          "pick": 2,
+          "playerId": "8658",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1283123036,
+          "sourceFranchiseId": "0010"
+        },
+        {
+          "year": 2010,
+          "round": 2,
+          "pick": 11,
+          "playerId": "7394",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1283125195,
+          "sourceFranchiseId": "0010"
+        },
+        {
+          "year": 2010,
+          "round": 3,
+          "pick": 2,
+          "playerId": "8493",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1283125308,
+          "sourceFranchiseId": "0010"
+        },
+        {
+          "year": 2010,
+          "round": 4,
+          "pick": 11,
+          "playerId": "7814",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1283126166,
+          "sourceFranchiseId": "0010"
+        },
+        {
+          "year": 2010,
+          "round": 5,
+          "pick": 2,
+          "playerId": "3367",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1283126312,
+          "sourceFranchiseId": "0010"
+        },
+        {
+          "year": 2010,
+          "round": 6,
+          "pick": 11,
+          "playerId": "0530",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1283126990,
+          "sourceFranchiseId": "0010"
+        },
+        {
+          "year": 2010,
+          "round": 7,
+          "pick": 2,
+          "playerId": "7873",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1283127141,
+          "sourceFranchiseId": "0010"
+        },
+        {
+          "year": 2010,
+          "round": 8,
+          "pick": 11,
+          "playerId": "3866",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1283128507,
+          "sourceFranchiseId": "0010"
+        },
+        {
+          "year": 2010,
+          "round": 9,
+          "pick": 2,
+          "playerId": "7471",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1283128714,
+          "sourceFranchiseId": "0010"
+        },
+        {
+          "year": 2010,
+          "round": 10,
+          "pick": 11,
+          "playerId": "7942",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1283129550,
+          "sourceFranchiseId": "0010"
+        },
+        {
+          "year": 2010,
+          "round": 11,
+          "pick": 2,
+          "playerId": "8074",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1283129746,
+          "sourceFranchiseId": "0010"
+        },
+        {
+          "year": 2010,
+          "round": 12,
+          "pick": 11,
+          "playerId": "0514",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1283130666,
+          "sourceFranchiseId": "0010"
+        },
+        {
+          "year": 2010,
+          "round": 13,
+          "pick": 2,
+          "playerId": "4924",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1283130827,
+          "sourceFranchiseId": "0010"
+        },
+        {
+          "year": 2010,
+          "round": 14,
+          "pick": 11,
+          "playerId": "9120",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1283131552,
+          "sourceFranchiseId": "0010"
+        },
+        {
+          "year": 2010,
+          "round": 15,
+          "pick": 2,
+          "playerId": "6715",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1283131752,
+          "sourceFranchiseId": "0010"
+        },
+        {
+          "year": 2010,
+          "round": 16,
+          "pick": 11,
+          "playerId": "9686",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1283132554,
+          "sourceFranchiseId": "0010"
+        },
+        {
+          "year": 2011,
+          "round": 1,
+          "pick": 5,
+          "playerId": "10298",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1304796626,
+          "sourceFranchiseId": "0010"
+        },
+        {
+          "year": 2011,
+          "round": 1,
+          "pick": 13,
+          "playerId": "10303",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1304906132,
+          "sourceFranchiseId": "0010"
+        },
+        {
+          "year": 2011,
+          "round": 2,
+          "pick": 18,
+          "playerId": "10388",
+          "viaTrade": false,
+          "comments": "Was hoping Kendricks would fall on more pick so I could grab him.",
+          "timestamp": 1305091721,
+          "sourceFranchiseId": "0010"
+        },
+        {
+          "year": 2011,
+          "round": 3,
+          "pick": 1,
+          "playerId": "10352",
+          "viaTrade": false,
+          "comments": "The ultimate low-floor, high-ceiling pick.",
+          "timestamp": 1305092928,
+          "sourceFranchiseId": "0010"
+        },
+        {
+          "year": 2012,
+          "round": 1,
+          "pick": 3,
+          "playerId": "10695",
+          "viaTrade": false,
+          "comments": "Vit, you traded for an expensive Vick contract then draft Griffin instead of a WR, and you expect me to take you seriously?",
+          "timestamp": 1336254350,
+          "sourceFranchiseId": "0010"
+        },
+        {
+          "year": 2012,
+          "round": 1,
+          "pick": 9,
+          "playerId": "10720",
+          "viaTrade": false,
+          "comments": "Damn, was really expecting Fleener to be there at 9.",
+          "timestamp": 1336332740,
+          "sourceFranchiseId": "0010"
+        },
+        {
+          "year": 2012,
+          "round": 3,
+          "pick": 5,
+          "playerId": "10712",
+          "viaTrade": false,
+          "comments": "Pick made based on Pre-Draft List At this point we're just taking shots in the dark at RB, but I admit I was hoping Polk would fall to me. Nice snag, Wascawy. (Comments Added Tue May 8 9:57:48 p.m. PT 2012)",
+          "timestamp": 1336536336,
+          "sourceFranchiseId": "0010"
+        },
+        {
+          "year": 2013,
+          "round": 1,
+          "pick": 6,
+          "playerId": "11232",
+          "viaTrade": false,
+          "comments": "Pick made based on Pre-Draft List I was surprised that Patterson slipped so far, and was really hoping he'd keep dropping. That said, DeAndre Hopkins seems ready to drop right into the Houston offense. (Comments Added Mon May 6 4:23:56 p.m. PT 2013)",
+          "timestamp": 1367779301,
+          "sourceFranchiseId": "0010"
+        },
+        {
+          "year": 2013,
+          "round": 1,
+          "pick": 17,
+          "playerId": "11154",
+          "viaTrade": false,
+          "comments": "Pick made based on Pre-Draft List Hoping he turns into my long-term backup for Andrew Luck so I don't have to play QB roulette on my bench. (Comments Added Mon May 6 4:25:36 p.m. PT 2013)",
+          "timestamp": 1367879890,
+          "sourceFranchiseId": "0010"
+        },
+        {
+          "year": 2013,
+          "round": 2,
+          "pick": 5,
+          "playerId": "11223",
+          "viaTrade": false,
+          "comments": "Pick made based on Pre-Draft List As much trash as I talked at Vit, I was hoping Christine Michael would fall to me. :P (Comments Added Sat May 11 9:55:28 a.m. PT 2013)",
+          "timestamp": 1367967543,
+          "sourceFranchiseId": "0010"
+        },
+        {
+          "year": 2013,
+          "round": 3,
+          "pick": 6,
+          "playerId": "11210",
+          "viaTrade": false,
+          "comments": "He's been getting some good press lately, and we're in the sleeper round, so I grabbed him. (Comments Added Sat May 11 9:55:50 a.m. PT 2013)",
+          "timestamp": 1368235893,
+          "sourceFranchiseId": "0010"
+        },
+        {
+          "year": 2013,
+          "round": 3,
+          "pick": 16,
+          "playerId": "11176",
+          "viaTrade": false,
+          "comments": "Pick made based on Pre-Draft List I had Davis, Taylor, and Swope on my list in that order for the last three picks, so on my board I came in 2nd out of 3 over the last three picks. That said, Taylor is only on my list because I already have Ryan Williams, with whom Taylor will be competing for the 2nd string job. (Comments Added Sat May 11 7:15:13 p.m. PT 2013)",
+          "timestamp": 1368304235,
+          "sourceFranchiseId": "0010"
+        },
+        {
+          "year": 2014,
+          "round": 1,
+          "pick": 6,
+          "playerId": "11676",
+          "viaTrade": false,
+          "comments": "I was camping, had no internet, and hadn't planned my draft, so this pick was a total shot from the hip. That said, I'm pretty happy with this pick. (Comments Added Sun May 18 6:46:03 p.m. PT 2014)",
+          "timestamp": 1400401640,
+          "sourceFranchiseId": "0010"
+        },
+        {
+          "year": 2014,
+          "round": 2,
+          "pick": 6,
+          "playerId": "11696",
+          "viaTrade": false,
+          "comments": "Pick made based on Pre-Draft List Shoring up my depth at TE. (Comments Added Mon May 19 5:04:42 p.m. PT 2014)",
+          "timestamp": 1400542537,
+          "sourceFranchiseId": "0010"
+        },
+        {
+          "year": 2014,
+          "round": 3,
+          "pick": 6,
+          "playerId": "11684",
+          "viaTrade": false,
+          "comments": "Pick made based on Pre-Draft List Meh. I'm not excited about the pick, but I like having both of Philly's rookie WR's. (Comments Added Wed May 21 9:54:38 p.m. PT 2014)",
+          "timestamp": 1400676126,
+          "sourceFranchiseId": "0010"
+        },
+        {
+          "year": 2014,
+          "round": 3,
+          "pick": 16,
+          "playerId": "11761",
+          "viaTrade": false,
+          "comments": "Mister Irrelevant: McKinnon was slated to be a decent fantasy rookie prospect until he was drafted by the Vikings and destined to ride the bench behind Purple Jesus. He's the perfect long-term gamble for the last pick in the draft. (Comments Added Wed May 21 9:53:51 p.m. PT 2014)",
+          "timestamp": 1400734325,
+          "sourceFranchiseId": "0010"
+        },
+        {
+          "year": 2019,
+          "round": 1,
+          "pick": 16,
+          "playerId": "14106",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1557097550,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "round": 2,
+          "pick": 16,
+          "playerId": "14086",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1557186830,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "round": 3,
+          "pick": 16,
+          "playerId": "14139",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1557275705,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "round": 3,
+          "pick": 5,
+          "playerId": "14873",
+          "viaTrade": true,
+          "comments": "[Pick traded from Drunk Indians.\nPick made based on FantasySharks.com Player Ranks\nPick cleared by Commissioner.\nReplacement pick made by Commissioner.]",
+          "timestamp": 1588746973,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "round": 3,
+          "pick": 15,
+          "playerId": "14965",
+          "viaTrade": false,
+          "comments": "[Pick made from Pre-Draft List]",
+          "timestamp": 1588822477,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "round": 1,
+          "pick": 10,
+          "playerId": "15282",
+          "viaTrade": false,
+          "comments": "[Pick made from Pre-Draft List]",
+          "timestamp": 1620518974,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "round": 1,
+          "pick": 16,
+          "playerId": "15293",
+          "viaTrade": true,
+          "comments": "[Pick traded from Bring the Pain.\nPick made from Pre-Draft List]",
+          "timestamp": 1620574016,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "round": 2,
+          "pick": 16,
+          "playerId": "15334",
+          "viaTrade": true,
+          "comments": "[Pick traded from Bring the Pain.\nPick made from Pre-Draft List]",
+          "timestamp": 1620788288,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "round": 3,
+          "pick": 10,
+          "playerId": "15252",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1620870698,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "round": 3,
+          "pick": 16,
+          "playerId": "15265",
+          "viaTrade": true,
+          "comments": "[Pick traded from Bring the Pain.]",
+          "timestamp": 1620879098,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "round": 1,
+          "pick": 16,
+          "playerId": "15755",
+          "viaTrade": false,
+          "comments": "[Pick made from Pre-Draft List]",
+          "timestamp": 1652196069,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "round": 2,
+          "pick": 16,
+          "playerId": "15787",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1652322989,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "round": 3,
+          "pick": 16,
+          "playerId": "15777",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1652493008,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "round": 1,
+          "pick": 6,
+          "playerId": "16169",
+          "viaTrade": true,
+          "comments": "[Pick traded from Bring the Pain.]",
+          "timestamp": 1683430487,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "round": 2,
+          "pick": 2,
+          "playerId": "16164",
+          "viaTrade": false,
+          "comments": "[Pick made from Pre-Draft List]",
+          "timestamp": 1683502391,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "round": 2,
+          "pick": 18,
+          "playerId": "16168",
+          "viaTrade": false,
+          "comments": "[Pick added by commissioner.]",
+          "timestamp": 1683567987,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "round": 3,
+          "pick": 1,
+          "playerId": "16222",
+          "viaTrade": true,
+          "comments": "[Pick traded from Computer Jocks.]",
+          "timestamp": 1683567999,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "round": 1,
+          "pick": 10,
+          "playerId": "16597",
+          "viaTrade": false,
+          "comments": "[Pick made from Pre-Draft List]",
+          "timestamp": 1714922492,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "round": 2,
+          "pick": 10,
+          "playerId": "16604",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1714971223,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "round": 3,
+          "pick": 10,
+          "playerId": "16649",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1715142070,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "round": 1,
+          "pick": 2,
+          "playerId": "17044",
+          "viaTrade": false,
+          "comments": "[Pick made from Pre-Draft List]",
+          "timestamp": 1746291403,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "round": 2,
+          "pick": 14,
+          "playerId": "17103",
+          "viaTrade": true,
+          "comments": "[Pick traded from The Mariachi Ninjas.\nPick made from Pre-Draft List]",
+          "timestamp": 1746667856,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "round": 3,
+          "pick": 2,
+          "playerId": "17073",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1746724492,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "round": 3,
+          "pick": 9,
+          "playerId": "17036",
+          "viaTrade": true,
+          "comments": "[Pick traded from Pacific Pigskins.] Meh.",
+          "timestamp": 1746746191,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "round": 1,
+          "pick": 8,
+          "playerId": "17544",
+          "viaTrade": false,
+          "comments": "[Pick made from Pre-Draft List]",
+          "timestamp": 1777815710,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "round": 2,
+          "pick": 2,
+          "playerId": "17506",
+          "viaTrade": true,
+          "comments": "[Pick traded from Dead Cap Walking .\nPick made from Pre-Draft List]",
+          "timestamp": 1777981387,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "round": 2,
+          "pick": 7,
+          "playerId": "17507",
+          "viaTrade": true,
+          "comments": "[Pick traded from The Mariachi Ninjas.\nPick made from Pre-Draft List]",
+          "timestamp": 1778034413,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "round": 2,
+          "pick": 8,
+          "playerId": "17474",
+          "viaTrade": false,
+          "comments": "[Pick made from Pre-Draft List]",
+          "timestamp": 1778034413,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "round": 2,
+          "pick": 14,
+          "playerId": "17505",
+          "viaTrade": true,
+          "comments": "[Pick traded from Dark Magicians of Chaos.\nPick made from Pre-Draft List]",
+          "timestamp": 1778085117,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "round": 2,
+          "pick": 18,
+          "playerId": "17468",
+          "viaTrade": false,
+          "comments": "[Pick added by commissioner.\nPick made from Pre-Draft List]",
+          "timestamp": 1778098792,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "round": 3,
+          "pick": 7,
+          "playerId": "17652",
+          "viaTrade": true,
+          "comments": "[Pick traded from The Mariachi Ninjas.\nPick made from Pre-Draft List]",
+          "timestamp": 1778111860,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "round": 3,
+          "pick": 8,
+          "playerId": "17599",
+          "viaTrade": false,
+          "comments": "[Pick made from Pre-Draft List]",
+          "timestamp": 1778111860,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "round": 3,
+          "pick": 15,
+          "playerId": "17486",
+          "viaTrade": true,
+          "comments": "[Pick traded from Wascawy Wabbits.\nPick made from Pre-Draft List]",
+          "timestamp": 1778196342,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "round": 3,
+          "pick": 16,
+          "playerId": "17526",
+          "viaTrade": true,
+          "comments": "[Pick traded from Computer Jocks.\nPick made from Pre-Draft List]",
+          "timestamp": 1778196342,
+          "sourceFranchiseId": null
+        }
+      ],
+      "auctionWins": [
+        {
+          "year": 2010,
+          "playerId": "3866",
+          "winningBid": 4500000,
+          "timestamp": 1269405528,
+          "sourceFranchiseId": "0010"
+        },
+        {
+          "year": 2010,
+          "playerId": "6951",
+          "winningBid": 550000,
+          "timestamp": 1269471589,
+          "sourceFranchiseId": "0010"
+        },
+        {
+          "year": 2010,
+          "playerId": "8742",
+          "winningBid": 775000,
+          "timestamp": 1269563525,
+          "sourceFranchiseId": "0010"
+        },
+        {
+          "year": 2010,
+          "playerId": "7859",
+          "winningBid": 425000,
+          "timestamp": 1272205524,
+          "sourceFranchiseId": "0010"
+        },
+        {
+          "year": 2010,
+          "playerId": "3870",
+          "winningBid": 425000,
+          "timestamp": 1272990007,
+          "sourceFranchiseId": "0010"
+        },
+        {
+          "year": 2011,
+          "playerId": "8243",
+          "winningBid": 2025000,
+          "timestamp": 1300826500,
+          "sourceFranchiseId": "0010"
+        },
+        {
+          "year": 2011,
+          "playerId": "3579",
+          "winningBid": 450000,
+          "timestamp": 1300826982,
+          "sourceFranchiseId": "0010"
+        },
+        {
+          "year": 2011,
+          "playerId": "8062",
+          "winningBid": 1275000,
+          "timestamp": 1300828705,
+          "sourceFranchiseId": "0010"
+        },
+        {
+          "year": 2011,
+          "playerId": "7842",
+          "winningBid": 1525000,
+          "timestamp": 1300828755,
+          "sourceFranchiseId": "0010"
+        },
+        {
+          "year": 2011,
+          "playerId": "8010",
+          "winningBid": 425000,
+          "timestamp": 1300998758,
+          "sourceFranchiseId": "0010"
+        },
+        {
+          "year": 2011,
+          "playerId": "7918",
+          "winningBid": 1300000,
+          "timestamp": 1300998942,
+          "sourceFranchiseId": "0010"
+        },
+        {
+          "year": 2011,
+          "playerId": "0513",
+          "winningBid": 750000,
+          "timestamp": 1301000122,
+          "sourceFranchiseId": "0010"
+        },
+        {
+          "year": 2011,
+          "playerId": "9874",
+          "winningBid": 3300000,
+          "timestamp": 1301170913,
+          "sourceFranchiseId": "0010"
+        },
+        {
+          "year": 2011,
+          "playerId": "8767",
+          "winningBid": 1225000,
+          "timestamp": 1301171134,
+          "sourceFranchiseId": "0010"
+        },
+        {
+          "year": 2011,
+          "playerId": "10500",
+          "winningBid": 425000,
+          "timestamp": 1314044410,
+          "sourceFranchiseId": "0010"
+        },
+        {
+          "year": 2012,
+          "playerId": "0505",
+          "winningBid": 775000,
+          "timestamp": 1331828274,
+          "sourceFranchiseId": "0010"
+        },
+        {
+          "year": 2012,
+          "playerId": "0509",
+          "winningBid": 425000,
+          "timestamp": 1331828763,
+          "sourceFranchiseId": "0010"
+        },
+        {
+          "year": 2012,
+          "playerId": "0511",
+          "winningBid": 800000,
+          "timestamp": 1331829421,
+          "sourceFranchiseId": "0010"
+        },
+        {
+          "year": 2012,
+          "playerId": "9085",
+          "winningBid": 1500000,
+          "timestamp": 1331830030,
+          "sourceFranchiseId": "0010"
+        },
+        {
+          "year": 2012,
+          "playerId": "1383",
+          "winningBid": 525000,
+          "timestamp": 1331830227,
+          "sourceFranchiseId": "0010"
+        },
+        {
+          "year": 2012,
+          "playerId": "9908",
+          "winningBid": 800000,
+          "timestamp": 1331831031,
+          "sourceFranchiseId": "0010"
+        },
+        {
+          "year": 2013,
+          "playerId": "9686",
+          "winningBid": 425000,
+          "timestamp": 1363296831,
+          "sourceFranchiseId": "0010"
+        },
+        {
+          "year": 2013,
+          "playerId": "0514",
+          "winningBid": 425000,
+          "timestamp": 1363296942,
+          "sourceFranchiseId": "0010"
+        },
+        {
+          "year": 2013,
+          "playerId": "0529",
+          "winningBid": 625000,
+          "timestamp": 1363304300,
+          "sourceFranchiseId": "0010"
+        },
+        {
+          "year": 2013,
+          "playerId": "8062",
+          "winningBid": 425000,
+          "timestamp": 1363461480,
+          "sourceFranchiseId": "0010"
+        },
+        {
+          "year": 2013,
+          "playerId": "8930",
+          "winningBid": 650000,
+          "timestamp": 1363464814,
+          "sourceFranchiseId": "0010"
+        },
+        {
+          "year": 2013,
+          "playerId": "2918",
+          "winningBid": 9225000,
+          "timestamp": 1363540163,
+          "sourceFranchiseId": "0010"
+        },
+        {
+          "year": 2013,
+          "playerId": "8758",
+          "winningBid": 800000,
+          "timestamp": 1364858114,
+          "sourceFranchiseId": "0010"
+        },
+        {
+          "year": 2014,
+          "playerId": "7873",
+          "winningBid": 7500000,
+          "timestamp": 1394830309,
+          "sourceFranchiseId": "0010"
+        },
+        {
+          "year": 2014,
+          "playerId": "9094",
+          "winningBid": 4575000,
+          "timestamp": 1394830422,
+          "sourceFranchiseId": "0010"
+        },
+        {
+          "year": 2014,
+          "playerId": "8679",
+          "winningBid": 625000,
+          "timestamp": 1394835307,
+          "sourceFranchiseId": "0010"
+        },
+        {
+          "year": 2014,
+          "playerId": "10334",
+          "winningBid": 4000000,
+          "timestamp": 1394838967,
+          "sourceFranchiseId": "0010"
+        },
+        {
+          "year": 2014,
+          "playerId": "0504",
+          "winningBid": 1025000,
+          "timestamp": 1394915170,
+          "sourceFranchiseId": "0010"
+        },
+        {
+          "year": 2014,
+          "playerId": "11647",
+          "winningBid": 450000,
+          "timestamp": 1400775537,
+          "sourceFranchiseId": "0010"
+        },
+        {
+          "year": 2015,
+          "playerId": "9278",
+          "winningBid": 6000000,
+          "timestamp": 1426792374,
+          "sourceFranchiseId": "0010"
+        },
+        {
+          "year": 2015,
+          "playerId": "6931",
+          "winningBid": 8000000,
+          "timestamp": 1426792454,
+          "sourceFranchiseId": "0010"
+        },
+        {
+          "year": 2015,
+          "playerId": "0531",
+          "winningBid": 525000,
+          "timestamp": 1426792512,
+          "sourceFranchiseId": "0010"
+        },
+        {
+          "year": 2015,
+          "playerId": "0523",
+          "winningBid": 1025000,
+          "timestamp": 1426794129,
+          "sourceFranchiseId": "0010"
+        },
+        {
+          "year": 2015,
+          "playerId": "10334",
+          "winningBid": 550000,
+          "timestamp": 1432100704,
+          "sourceFranchiseId": "0010"
+        },
+        {
+          "year": 2019,
+          "playerId": "7836",
+          "winningBid": 7125000,
+          "timestamp": 1553292742,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "12212",
+          "winningBid": 1175000,
+          "timestamp": 1553428848,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "12678",
+          "winningBid": 450000,
+          "timestamp": 1553458470,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "12417",
+          "winningBid": 425000,
+          "timestamp": 1584644499,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "0529",
+          "winningBid": 775000,
+          "timestamp": 1616078149,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "10868",
+          "winningBid": 800000,
+          "timestamp": 1616078563,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "10976",
+          "winningBid": 800000,
+          "timestamp": 1616078563,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "12164",
+          "winningBid": 600000,
+          "timestamp": 1616091880,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "0506",
+          "winningBid": 425000,
+          "timestamp": 1616093376,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "13135",
+          "winningBid": 575000,
+          "timestamp": 1616096953,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "11760",
+          "winningBid": 675000,
+          "timestamp": 1616194448,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "10313",
+          "winningBid": 925000,
+          "timestamp": 1616255428,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "12630",
+          "winningBid": 4075000,
+          "timestamp": 1616319179,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "10973",
+          "winningBid": 3050000,
+          "timestamp": 1616456198,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "13236",
+          "winningBid": 550000,
+          "timestamp": 1647525719,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "0529",
+          "winningBid": 800000,
+          "timestamp": 1647525733,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "0508",
+          "winningBid": 1000000,
+          "timestamp": 1647525747,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "13354",
+          "winningBid": 600000,
+          "timestamp": 1647525763,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "11387",
+          "winningBid": 425000,
+          "timestamp": 1647526723,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "14717",
+          "winningBid": 425000,
+          "timestamp": 1647539080,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "5848",
+          "winningBid": 5025000,
+          "timestamp": 1647554515,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "9474",
+          "winningBid": 500000,
+          "timestamp": 1647555057,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "13809",
+          "winningBid": 1000000,
+          "timestamp": 1647558347,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "10738",
+          "winningBid": 525000,
+          "timestamp": 1647558384,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "11938",
+          "winningBid": 5000000,
+          "timestamp": 1647656362,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "13129",
+          "winningBid": 7625000,
+          "timestamp": 1647702186,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "12151",
+          "winningBid": 4250000,
+          "timestamp": 1647805723,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "13138",
+          "winningBid": 5275000,
+          "timestamp": 1647835789,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "11760",
+          "winningBid": 3675000,
+          "timestamp": 1647968810,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "15693",
+          "winningBid": 475000,
+          "timestamp": 1652593363,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "10700",
+          "winningBid": 3500000,
+          "timestamp": 1678975221,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "12625",
+          "winningBid": 2500000,
+          "timestamp": 1678975239,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "11222",
+          "winningBid": 4000000,
+          "timestamp": 1678975296,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "13980",
+          "winningBid": 425000,
+          "timestamp": 1678975365,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "14600",
+          "winningBid": 425000,
+          "timestamp": 1678975379,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "12676",
+          "winningBid": 500000,
+          "timestamp": 1678976419,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "13139",
+          "winningBid": 4000000,
+          "timestamp": 1678976498,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "0502",
+          "winningBid": 800000,
+          "timestamp": 1679005125,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "0519",
+          "winningBid": 425000,
+          "timestamp": 1679022855,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "13164",
+          "winningBid": 8025000,
+          "timestamp": 1679106402,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "12676",
+          "winningBid": 1200000,
+          "timestamp": 1711029700,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "0525",
+          "winningBid": 600000,
+          "timestamp": 1711029720,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "0517",
+          "winningBid": 425000,
+          "timestamp": 1711029732,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "15979",
+          "winningBid": 1000000,
+          "timestamp": 1711029744,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "11945",
+          "winningBid": 500000,
+          "timestamp": 1711029755,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "7836",
+          "winningBid": 4200000,
+          "timestamp": 1711152698,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "14085",
+          "winningBid": 4000000,
+          "timestamp": 1711159544,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "11150",
+          "winningBid": 4800000,
+          "timestamp": 1711249482,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "11150",
+          "winningBid": 6000000,
+          "timestamp": 1742479270,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "16775",
+          "winningBid": 450000,
+          "timestamp": 1742479368,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "12676",
+          "winningBid": 825000,
+          "timestamp": 1742483207,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "14056",
+          "winningBid": 7525000,
+          "timestamp": 1742505247,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "14085",
+          "winningBid": 4000000,
+          "timestamp": 1742609280,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "13630",
+          "winningBid": 4500000,
+          "timestamp": 1742609523,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "11244",
+          "winningBid": 5750000,
+          "timestamp": 1742654345,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "15287",
+          "winningBid": 10000000,
+          "timestamp": 1773928818,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "14779",
+          "winningBid": 5250000,
+          "timestamp": 1773928828,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "16846",
+          "winningBid": 575000,
+          "timestamp": 1773928848,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "13138",
+          "winningBid": 750000,
+          "timestamp": 1774226329,
+          "sourceFranchiseId": null
         }
       ],
       "currentName": "Midwestside Connection",
@@ -29297,6 +35483,1465 @@
           "bothAttributed": true
         }
       ],
+      "draftPicks": [
+        {
+          "year": 2010,
+          "round": 1,
+          "pick": 3,
+          "playerId": "8301",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1283123058,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "round": 2,
+          "pick": 10,
+          "playerId": "6929",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1283125170,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "round": 3,
+          "pick": 3,
+          "playerId": "6982",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1283125326,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "round": 4,
+          "pick": 10,
+          "playerId": "9448",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1283126124,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "round": 5,
+          "pick": 3,
+          "playerId": "6997",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1283126321,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "round": 6,
+          "pick": 10,
+          "playerId": "0523",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1283126975,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "round": 7,
+          "pick": 3,
+          "playerId": "9441",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1283127155,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "round": 8,
+          "pick": 10,
+          "playerId": "9822",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1283128487,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "round": 9,
+          "pick": 3,
+          "playerId": "1600",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1283128792,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "round": 10,
+          "pick": 10,
+          "playerId": "8386",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1283129477,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "round": 11,
+          "pick": 3,
+          "playerId": "8042",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1283129821,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "round": 12,
+          "pick": 10,
+          "playerId": "0517",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1283130642,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "round": 13,
+          "pick": 3,
+          "playerId": "8153",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1283130882,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "round": 14,
+          "pick": 10,
+          "playerId": "7815",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1283131521,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "round": 15,
+          "pick": 3,
+          "playerId": "7991",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1283131824,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "round": 16,
+          "pick": 10,
+          "playerId": "1275",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1283132508,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2011,
+          "round": 1,
+          "pick": 16,
+          "playerId": "10359",
+          "viaTrade": false,
+          "comments": "Pick made based on Pre-Draft List",
+          "timestamp": 1304952850,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2011,
+          "round": 2,
+          "pick": 16,
+          "playerId": "10445",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1305086462,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2011,
+          "round": 3,
+          "pick": 16,
+          "playerId": "10394",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1305245349,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "round": 2,
+          "pick": 10,
+          "playerId": "10731",
+          "viaTrade": false,
+          "comments": "Pick made based on Pre-Draft List Hope he is as good as his 'old man' and lands in a good offense....    (Comments Added Tue May 8 11:21:51 a.m. ET 2012)",
+          "timestamp": 1336453656,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "round": 2,
+          "pick": 14,
+          "playerId": "10744",
+          "viaTrade": false,
+          "comments": "Taking a flyer that he is the heir apparent to Gates!",
+          "timestamp": 1336490696,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "round": 3,
+          "pick": 14,
+          "playerId": "10702",
+          "viaTrade": false,
+          "comments": "Pick made based on Pre-Draft List",
+          "timestamp": 1336615539,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2013,
+          "round": 1,
+          "pick": 12,
+          "playerId": "11198",
+          "viaTrade": false,
+          "comments": "Pick made based on Pre-Draft List Rolling the dice that he is as good as touted (prior to injury) and that in 2+ years becomes the heir apparent to Frank Gore (Comments Added Thu May 9 10:45:24 a.m. ET 2013)",
+          "timestamp": 1367819397,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2013,
+          "round": 2,
+          "pick": 15,
+          "playerId": "11249",
+          "viaTrade": false,
+          "comments": "Taking a flyer on a HOMER pick - GO DOLPHINS!",
+          "timestamp": 1368148639,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "round": 2,
+          "pick": 5,
+          "playerId": "11642",
+          "viaTrade": false,
+          "comments": "Best available i think - but a Jacksonville QB - hope he can take them to the next level! (Comments Added Mon May 19 7:39:55 p.m. ET 2014)",
+          "timestamp": 1400542536,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "round": 1,
+          "pick": 12,
+          "playerId": "12610",
+          "viaTrade": false,
+          "comments": "Wanted Goff but looks like i will have to wait a bit more for Wentz (Comments Added Sun May 8 8:29:34 p.m. ET 2016)",
+          "timestamp": 1462753731,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "round": 2,
+          "pick": 6,
+          "playerId": "12663",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1462838467,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "round": 2,
+          "pick": 9,
+          "playerId": "12630",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1462850731,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "round": 3,
+          "pick": 3,
+          "playerId": "12809",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1462983963,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "round": 2,
+          "pick": 9,
+          "playerId": "13114",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1494273390,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "round": 3,
+          "pick": 9,
+          "playerId": "13167",
+          "viaTrade": false,
+          "comments": "Taking Dan's Player before he does!",
+          "timestamp": 1494359454,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "round": 1,
+          "pick": 6,
+          "playerId": "13607",
+          "viaTrade": true,
+          "comments": "Pick traded from Wascawy Wabbits.",
+          "timestamp": 1525545201,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "round": 1,
+          "pick": 10,
+          "playerId": "13635",
+          "viaTrade": true,
+          "comments": "Pick traded from Da Dangsters.",
+          "timestamp": 1525579602,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "round": 1,
+          "pick": 8,
+          "playerId": "14113",
+          "viaTrade": false,
+          "comments": "Rolling the dice - if Hill is out that is big and having Mahomes to throw to him is not a bad thing...\r\n (Comments Added Sun May 5 1:06:14 p.m. ET 2019)",
+          "timestamp": 1557075925,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "round": 2,
+          "pick": 8,
+          "playerId": "14208",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1557155383,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "round": 3,
+          "pick": 5,
+          "playerId": "14093",
+          "viaTrade": true,
+          "comments": "[Pick traded from Computer Jocks.]",
+          "timestamp": 1557241416,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "round": 3,
+          "pick": 8,
+          "playerId": "14068",
+          "viaTrade": false,
+          "comments": "[Pick made based on Pre-Draft List]",
+          "timestamp": 1557248551,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "round": 1,
+          "pick": 14,
+          "playerId": "14778",
+          "viaTrade": true,
+          "comments": "[Pick traded from The Music City Mafia.\nPick made from Pre-Draft List]",
+          "timestamp": 1588552761,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "round": 2,
+          "pick": 10,
+          "playerId": "14858",
+          "viaTrade": true,
+          "comments": "[Pick traded from Wascawy Wabbits.\nPick traded from The Music City Mafia.]",
+          "timestamp": 1588617770,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "round": 2,
+          "pick": 11,
+          "playerId": "14847",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1588618015,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "round": 3,
+          "pick": 11,
+          "playerId": "14875",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1588781736,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "round": 1,
+          "pick": 1,
+          "playerId": "15329",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1620484278,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "round": 1,
+          "pick": 15,
+          "playerId": "15287",
+          "viaTrade": true,
+          "comments": "[Pick traded from Wascawy Wabbits.]",
+          "timestamp": 1620574016,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "round": 3,
+          "pick": 1,
+          "playerId": "15243",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1620834826,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "round": 1,
+          "pick": 4,
+          "playerId": "15751",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1652014316,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "round": 1,
+          "pick": 10,
+          "playerId": "15789",
+          "viaTrade": true,
+          "comments": "[Pick traded from The Music City Mafia.]",
+          "timestamp": 1652107591,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "round": 1,
+          "pick": 15,
+          "playerId": "15721",
+          "viaTrade": true,
+          "comments": "[Pick traded from Wascawy Wabbits.]",
+          "timestamp": 1652196069,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "round": 2,
+          "pick": 4,
+          "playerId": "15716",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1652234154,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "round": 2,
+          "pick": 13,
+          "playerId": "15691",
+          "viaTrade": true,
+          "comments": "[Pick traded from Bring the Pain.]",
+          "timestamp": 1652280800,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "round": 2,
+          "pick": 17,
+          "playerId": "15797",
+          "viaTrade": false,
+          "comments": "[Pick added by commissioner.\nPick made from Pre-Draft List]",
+          "timestamp": 1652322989,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "round": 3,
+          "pick": 4,
+          "playerId": "15803",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1652392108,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "round": 1,
+          "pick": 4,
+          "playerId": "16186",
+          "viaTrade": true,
+          "comments": "[Pick traded from Heavy Chevy.\nPick traded from Wascawy Wabbits.]",
+          "timestamp": 1683423587,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "round": 1,
+          "pick": 10,
+          "playerId": "16148",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1683468921,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "round": 3,
+          "pick": 10,
+          "playerId": "16333",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1683642501,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "round": 2,
+          "pick": 16,
+          "playerId": "16648",
+          "viaTrade": false,
+          "comments": "[Pick made from Pre-Draft List]",
+          "timestamp": 1715021172,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "round": 3,
+          "pick": 16,
+          "playerId": "16778",
+          "viaTrade": false,
+          "comments": "And with the LAST pick of the 2024 The League Rookie Draft - Here is Mr Irrelevant",
+          "timestamp": 1715202977,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "round": 2,
+          "pick": 5,
+          "playerId": "17052",
+          "viaTrade": true,
+          "comments": "[Pick traded from Bring the Pain.\nPick traded from  Running Down The Dream.\nPick traded from Fire Ready Aim.]",
+          "timestamp": 1746617147,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "round": 2,
+          "pick": 6,
+          "playerId": "17157",
+          "viaTrade": true,
+          "comments": "[Pick traded from  Running Down The Dream.\nPick traded from Fire Ready Aim.]",
+          "timestamp": 1746617167,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "round": 2,
+          "pick": 12,
+          "playerId": "17039",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1746661414,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "round": 3,
+          "pick": 12,
+          "playerId": "17055",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1746797604,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "round": 1,
+          "pick": 1,
+          "playerId": "17472",
+          "viaTrade": false,
+          "comments": "Hope he lives up to the hype/billing and AZ finds an offense :)",
+          "timestamp": 1777756190,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "round": 1,
+          "pick": 14,
+          "playerId": "17509",
+          "viaTrade": true,
+          "comments": "[Pick traded from Dark Magicians of Chaos.]",
+          "timestamp": 1777923576,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "round": 2,
+          "pick": 1,
+          "playerId": "17511",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1777981387,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "round": 2,
+          "pick": 16,
+          "playerId": "17510",
+          "viaTrade": true,
+          "comments": "[Pick traded from Computer Jocks.]",
+          "timestamp": 1778097726,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "round": 3,
+          "pick": 1,
+          "playerId": "17481",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1778099918,
+          "sourceFranchiseId": null
+        }
+      ],
+      "auctionWins": [
+        {
+          "year": 2010,
+          "playerId": "2840",
+          "winningBid": 425000,
+          "timestamp": 1269406371,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "playerId": "8178",
+          "winningBid": 425000,
+          "timestamp": 1269406520,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "playerId": "8559",
+          "winningBid": 425000,
+          "timestamp": 1269476450,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "playerId": "0532",
+          "winningBid": 425000,
+          "timestamp": 1269528981,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "playerId": "0527",
+          "winningBid": 500000,
+          "timestamp": 1269670979,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "playerId": "2986",
+          "winningBid": 1425000,
+          "timestamp": 1269671182,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2010,
+          "playerId": "9706",
+          "winningBid": 425000,
+          "timestamp": 1269902658,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2011,
+          "playerId": "5168",
+          "winningBid": 425000,
+          "timestamp": 1300821866,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2011,
+          "playerId": "4929",
+          "winningBid": 1200000,
+          "timestamp": 1300822092,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2011,
+          "playerId": "7816",
+          "winningBid": 3250000,
+          "timestamp": 1300822183,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2011,
+          "playerId": "6616",
+          "winningBid": 1000000,
+          "timestamp": 1300822507,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2011,
+          "playerId": "7922",
+          "winningBid": 900000,
+          "timestamp": 1300822826,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2011,
+          "playerId": "10164",
+          "winningBid": 600000,
+          "timestamp": 1300915796,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2011,
+          "playerId": "4924",
+          "winningBid": 500000,
+          "timestamp": 1300916619,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2011,
+          "playerId": "6999",
+          "winningBid": 1150000,
+          "timestamp": 1300917216,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2011,
+          "playerId": "0522",
+          "winningBid": 450000,
+          "timestamp": 1300979772,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2011,
+          "playerId": "6887",
+          "winningBid": 425000,
+          "timestamp": 1301199104,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2011,
+          "playerId": "7653",
+          "winningBid": 10300000,
+          "timestamp": 1301350009,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "playerId": "8667",
+          "winningBid": 6000000,
+          "timestamp": 1331834758,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "playerId": "8339",
+          "winningBid": 2000000,
+          "timestamp": 1331834904,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "playerId": "9299",
+          "winningBid": 425000,
+          "timestamp": 1331834985,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "playerId": "9061",
+          "winningBid": 450000,
+          "timestamp": 1331835347,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "playerId": "8042",
+          "winningBid": 2525000,
+          "timestamp": 1331862026,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "playerId": "9120",
+          "winningBid": 425000,
+          "timestamp": 1331900411,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "playerId": "7814",
+          "winningBid": 425000,
+          "timestamp": 1332108433,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "playerId": "4907",
+          "winningBid": 3500000,
+          "timestamp": 1332108583,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2013,
+          "playerId": "0517",
+          "winningBid": 750000,
+          "timestamp": 1363267125,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2013,
+          "playerId": "9625",
+          "winningBid": 425000,
+          "timestamp": 1363270017,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2013,
+          "playerId": "7414",
+          "winningBid": 7750000,
+          "timestamp": 1363296287,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2013,
+          "playerId": "6951",
+          "winningBid": 1750000,
+          "timestamp": 1363297363,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2013,
+          "playerId": "11384",
+          "winningBid": 425000,
+          "timestamp": 1371132446,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2013,
+          "playerId": "8931",
+          "winningBid": 1475000,
+          "timestamp": 1377556040,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "0506",
+          "winningBid": 775000,
+          "timestamp": 1394717448,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "8144",
+          "winningBid": 500000,
+          "timestamp": 1394717693,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "7653",
+          "winningBid": 8000000,
+          "timestamp": 1394729381,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "9545",
+          "winningBid": 3000000,
+          "timestamp": 1394894788,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "2842",
+          "winningBid": 500000,
+          "timestamp": 1426774055,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "11960",
+          "winningBid": 450000,
+          "timestamp": 1426774124,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "6982",
+          "winningBid": 3000000,
+          "timestamp": 1426774478,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "9269",
+          "winningBid": 1000000,
+          "timestamp": 1426779991,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "10048",
+          "winningBid": 3500000,
+          "timestamp": 1426893279,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "10998",
+          "winningBid": 1200000,
+          "timestamp": 1426893585,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "9545",
+          "winningBid": 600000,
+          "timestamp": 1426914058,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "11076",
+          "winningBid": 1000000,
+          "timestamp": 1426914155,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "7422",
+          "winningBid": 425000,
+          "timestamp": 1426995454,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "9936",
+          "winningBid": 600000,
+          "timestamp": 1426997117,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "0503",
+          "winningBid": 1075000,
+          "timestamp": 1427129554,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "7422",
+          "winningBid": 1000000,
+          "timestamp": 1458248568,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "0524",
+          "winningBid": 850000,
+          "timestamp": 1458273888,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "8360",
+          "winningBid": 9125000,
+          "timestamp": 1458274481,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "8252",
+          "winningBid": 3325000,
+          "timestamp": 1458490035,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "12465",
+          "winningBid": 3000000,
+          "timestamp": 1489702868,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "9881",
+          "winningBid": 2000000,
+          "timestamp": 1489702960,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "11938",
+          "winningBid": 2750000,
+          "timestamp": 1489703476,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "0519",
+          "winningBid": 625000,
+          "timestamp": 1489703672,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "8247",
+          "winningBid": 475000,
+          "timestamp": 1490032758,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "8944",
+          "winningBid": 425000,
+          "timestamp": 1491076722,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "13162",
+          "winningBid": 425000,
+          "timestamp": 1494540142,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "8944",
+          "winningBid": 425000,
+          "timestamp": 1501773145,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "10699",
+          "winningBid": 425000,
+          "timestamp": 1521122719,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "10312",
+          "winningBid": 4525000,
+          "timestamp": 1521172190,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "10948",
+          "winningBid": 2000000,
+          "timestamp": 1521172475,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "11705",
+          "winningBid": 3025000,
+          "timestamp": 1521240539,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "9308",
+          "winningBid": 425000,
+          "timestamp": 1521429640,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "9319",
+          "winningBid": 425000,
+          "timestamp": 1521477755,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "9843",
+          "winningBid": 425000,
+          "timestamp": 1521478291,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "7236",
+          "winningBid": 500000,
+          "timestamp": 1527096154,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "8742",
+          "winningBid": 700000,
+          "timestamp": 1553272905,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "0508",
+          "winningBid": 700000,
+          "timestamp": 1553272988,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "9918",
+          "winningBid": 4225000,
+          "timestamp": 1553273300,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "10308",
+          "winningBid": 1500000,
+          "timestamp": 1553273408,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "8658",
+          "winningBid": 1500000,
+          "timestamp": 1553273508,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "12208",
+          "winningBid": 450000,
+          "timestamp": 1553273614,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "11186",
+          "winningBid": 1700000,
+          "timestamp": 1553454829,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "10506",
+          "winningBid": 450000,
+          "timestamp": 1584650771,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "0532",
+          "winningBid": 425000,
+          "timestamp": 1584650843,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "11399",
+          "winningBid": 500000,
+          "timestamp": 1584896147,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "13108",
+          "winningBid": 2000000,
+          "timestamp": 1616089866,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "9925",
+          "winningBid": 525000,
+          "timestamp": 1616090036,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "11232",
+          "winningBid": 11525000,
+          "timestamp": 1616090200,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "0524",
+          "winningBid": 600000,
+          "timestamp": 1616091628,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "12620",
+          "winningBid": 5025000,
+          "timestamp": 1647528978,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "0523",
+          "winningBid": 600000,
+          "timestamp": 1647529209,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "8153",
+          "winningBid": 425000,
+          "timestamp": 1647529629,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "8742",
+          "winningBid": 425000,
+          "timestamp": 1647529726,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "11228",
+          "winningBid": 1500000,
+          "timestamp": 1647530155,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "13319",
+          "winningBid": 8600000,
+          "timestamp": 1647661704,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "13632",
+          "winningBid": 3500000,
+          "timestamp": 1647881456,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "14331",
+          "winningBid": 1200000,
+          "timestamp": 1647881552,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "14849",
+          "winningBid": 425000,
+          "timestamp": 1678981574,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "0529",
+          "winningBid": 575000,
+          "timestamp": 1678981602,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "13124",
+          "winningBid": 425000,
+          "timestamp": 1679419458,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "8930",
+          "winningBid": 425000,
+          "timestamp": 1691427539,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "14870",
+          "winningBid": 1275000,
+          "timestamp": 1692104610,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "13772",
+          "winningBid": 6500000,
+          "timestamp": 1711114362,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "13193",
+          "winningBid": 750000,
+          "timestamp": 1711114437,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "11947",
+          "winningBid": 425000,
+          "timestamp": 1711196003,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "13980",
+          "winningBid": 675000,
+          "timestamp": 1711196081,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "13131",
+          "winningBid": 5325000,
+          "timestamp": 1711247410,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "14108",
+          "winningBid": 425000,
+          "timestamp": 1711395053,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "11938",
+          "winningBid": 2825000,
+          "timestamp": 1711548462,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "16792",
+          "winningBid": 425000,
+          "timestamp": 1715203237,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "16625",
+          "winningBid": 725000,
+          "timestamp": 1715203269,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "13718",
+          "winningBid": 425000,
+          "timestamp": 1722518402,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "16339",
+          "winningBid": 425000,
+          "timestamp": 1722518427,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "13641",
+          "winningBid": 425000,
+          "timestamp": 1723161298,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "15109",
+          "winningBid": 425000,
+          "timestamp": 1742562661,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "16680",
+          "winningBid": 425000,
+          "timestamp": 1742732312,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "0523",
+          "winningBid": 1375000,
+          "timestamp": 1742868242,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "17059",
+          "winningBid": 450000,
+          "timestamp": 1747054503,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "14861",
+          "winningBid": 1525000,
+          "timestamp": 1773929030,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "0509",
+          "winningBid": 875000,
+          "timestamp": 1773929189,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "11671",
+          "winningBid": 4000000,
+          "timestamp": 1774038262,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "14860",
+          "winningBid": 3000000,
+          "timestamp": 1774184129,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "15331",
+          "winningBid": 2000000,
+          "timestamp": 1774314444,
+          "sourceFranchiseId": null
+        }
+      ],
       "currentName": "Fire Ready Aim",
       "currentNameMedium": "Fire Ready",
       "currentNameShort": "Fire",
@@ -34207,6 +41852,1660 @@
           "sourceFranchiseId": null,
           "partnerSourceId": null,
           "bothAttributed": true
+        }
+      ],
+      "draftPicks": [
+        {
+          "year": 2011,
+          "round": 1,
+          "pick": 2,
+          "playerId": "10271",
+          "viaTrade": false,
+          "comments": "Replacement pick made by Commissioner",
+          "timestamp": 1304786114,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "round": 1,
+          "pick": 2,
+          "playerId": "10696",
+          "viaTrade": false,
+          "comments": "Nate you can have 2 years to suck with Luck. (Comments Added Sat May 5 3:35:08 p.m. CT 2012)",
+          "timestamp": 1336250023,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "round": 2,
+          "pick": 7,
+          "playerId": "10714",
+          "viaTrade": false,
+          "comments": "The most logical choice for me and fills a need and sure up my Hawk's running game.  Gotta rely on an Cable's awesome zone blocking scheme.",
+          "timestamp": 1336451379,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "round": 3,
+          "pick": 13,
+          "playerId": "10739",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1336615538,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "round": 3,
+          "pick": 15,
+          "playerId": "10726",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1336627878,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2013,
+          "round": 2,
+          "pick": 2,
+          "playerId": "11179",
+          "viaTrade": false,
+          "comments": "Obvious choice here!  (Comments Added Wed May 8 12:09:27 a.m. CT 2013)",
+          "timestamp": 1367951331,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2013,
+          "round": 2,
+          "pick": 18,
+          "playerId": "11218",
+          "viaTrade": false,
+          "comments": "Pick made based on Pre-Draft List",
+          "timestamp": 1368161061,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2013,
+          "round": 3,
+          "pick": 14,
+          "playerId": "11234",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1368304234,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "round": 1,
+          "pick": 10,
+          "playerId": "11673",
+          "viaTrade": false,
+          "comments": "6'5'' 240lb former basketball player?  a clutch man at the BCS championnship!  Yeah, I'll take that.",
+          "timestamp": 1400452992,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "round": 2,
+          "pick": 11,
+          "playerId": "11704",
+          "viaTrade": false,
+          "comments": "Too much upside to walk away from.  I'll roll the dice with Colt.  Hoping the only snow he blows in Greenbay is the stuff coming down from the sky during winter.",
+          "timestamp": 1400559078,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "round": 3,
+          "pick": 7,
+          "playerId": "11754",
+          "viaTrade": false,
+          "comments": "Last minute flyer cuz my pre-draft selection was drafted.  I figure I'd give this kid a shot. (Comments Added Wed May 21 6:24:16 p.m. CT 2014)",
+          "timestamp": 1400710171,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "round": 1,
+          "pick": 11,
+          "playerId": "12611",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1462733230,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "round": 2,
+          "pick": 11,
+          "playerId": "12678",
+          "viaTrade": false,
+          "comments": "Not the first time I drafted a guy with character issues.   (Comments Added Tue May 10 6:45:21 a.m. CT 2016)",
+          "timestamp": 1462880468,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "round": 3,
+          "pick": 11,
+          "playerId": "12640",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1463033843,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "round": 1,
+          "pick": 9,
+          "playerId": "13189",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1494146226,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "round": 1,
+          "pick": 12,
+          "playerId": "13155",
+          "viaTrade": false,
+          "comments": "Hoping this an immediate impact pick",
+          "timestamp": 1494196526,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "round": 2,
+          "pick": 18,
+          "playerId": "13191",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1494344633,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "round": 3,
+          "pick": 3,
+          "playerId": "13121",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1494348424,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "round": 1,
+          "pick": 9,
+          "playerId": "13612",
+          "viaTrade": false,
+          "comments": "Last of the top Tier RBs.  I thought it was going to be Penny but Comp Jocks was that high on him.  Just hoping that Johnson is not another Detriot high pick RB bust.",
+          "timestamp": 1525575744,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "round": 2,
+          "pick": 9,
+          "playerId": "13589",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1525669339,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "round": 3,
+          "pick": 9,
+          "playerId": "13657",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1525750926,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "round": 1,
+          "pick": 3,
+          "playerId": "14073",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1557028075,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "round": 2,
+          "pick": 3,
+          "playerId": "14121",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1557099895,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "round": 2,
+          "pick": 17,
+          "playerId": "14195",
+          "viaTrade": false,
+          "comments": "[Pick added by commissioner.]",
+          "timestamp": 1557190724,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "round": 3,
+          "pick": 3,
+          "playerId": "14096",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1557198789,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "round": 1,
+          "pick": 13,
+          "playerId": "14842",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1588552761,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "round": 2,
+          "pick": 13,
+          "playerId": "14844",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1588626669,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "round": 3,
+          "pick": 13,
+          "playerId": "14864",
+          "viaTrade": false,
+          "comments": "[Pick made from Pre-Draft List]",
+          "timestamp": 1588822328,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "round": 3,
+          "pick": 16,
+          "playerId": "14869",
+          "viaTrade": true,
+          "comments": "[Pick traded from Bring the Pain.] Let's hope the apple don't fall too far from the tree!",
+          "timestamp": 1588876561,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "round": 1,
+          "pick": 3,
+          "playerId": "15254",
+          "viaTrade": true,
+          "comments": "[Pick traded from Cowboy Up.]",
+          "timestamp": 1620502448,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "round": 1,
+          "pick": 17,
+          "playerId": "15331",
+          "viaTrade": false,
+          "comments": "[Pick added by commissioner.]",
+          "timestamp": 1620608173,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "round": 2,
+          "pick": 1,
+          "playerId": "15302",
+          "viaTrade": true,
+          "comments": "[Pick traded from Fire Ready Aim.]",
+          "timestamp": 1620655861,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "round": 2,
+          "pick": 2,
+          "playerId": "15319",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1620672611,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "round": 2,
+          "pick": 7,
+          "playerId": "15259",
+          "viaTrade": true,
+          "comments": "[Pick traded from Pacific Pigskins.]",
+          "timestamp": 1620740523,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "round": 1,
+          "pick": 13,
+          "playerId": "15712",
+          "viaTrade": true,
+          "comments": "[Pick traded from Bring the Pain.]",
+          "timestamp": 1652142440,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "round": 1,
+          "pick": 14,
+          "playerId": "15762",
+          "viaTrade": true,
+          "comments": "[Pick traded from Pacific Pigskins.]",
+          "timestamp": 1652142549,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "round": 3,
+          "pick": 12,
+          "playerId": "15710",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1652426173,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "round": 3,
+          "pick": 16,
+          "playerId": "16201",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1683648070,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "round": 1,
+          "pick": 13,
+          "playerId": "16584",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1714942978,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "round": 2,
+          "pick": 13,
+          "playerId": "16603",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1714996944,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "round": 3,
+          "pick": 13,
+          "playerId": "16801",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1715170622,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "round": 1,
+          "pick": 13,
+          "playerId": "17075",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1746492293,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "round": 3,
+          "pick": 13,
+          "playerId": "17046",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1746837052,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "round": 1,
+          "pick": 12,
+          "playerId": "17502",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1777863002,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "round": 2,
+          "pick": 12,
+          "playerId": "17517",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1778083721,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "round": 3,
+          "pick": 12,
+          "playerId": "17528",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1778190763,
+          "sourceFranchiseId": null
+        }
+      ],
+      "auctionWins": [
+        {
+          "year": 2011,
+          "playerId": "7052",
+          "winningBid": 1500000,
+          "timestamp": 1300818723,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2011,
+          "playerId": "8252",
+          "winningBid": 5250000,
+          "timestamp": 1300857292,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2011,
+          "playerId": "8776",
+          "winningBid": 2000000,
+          "timestamp": 1300857795,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2011,
+          "playerId": "9176",
+          "winningBid": 1000000,
+          "timestamp": 1300858385,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2011,
+          "playerId": "0518",
+          "winningBid": 700000,
+          "timestamp": 1300859193,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2011,
+          "playerId": "0517",
+          "winningBid": 625000,
+          "timestamp": 1300859291,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2011,
+          "playerId": "8074",
+          "winningBid": 525000,
+          "timestamp": 1300905478,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2011,
+          "playerId": "7837",
+          "winningBid": 3000000,
+          "timestamp": 1300972560,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2011,
+          "playerId": "9132",
+          "winningBid": 500000,
+          "timestamp": 1300986049,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2011,
+          "playerId": "9315",
+          "winningBid": 3025000,
+          "timestamp": 1301065810,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2011,
+          "playerId": "9548",
+          "winningBid": 2050000,
+          "timestamp": 1301066196,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2011,
+          "playerId": "9124",
+          "winningBid": 3000000,
+          "timestamp": 1301066244,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2011,
+          "playerId": "8042",
+          "winningBid": 5550000,
+          "timestamp": 1301243291,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2011,
+          "playerId": "9271",
+          "winningBid": 650000,
+          "timestamp": 1301532405,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2011,
+          "playerId": "10392",
+          "winningBid": 425000,
+          "timestamp": 1312632720,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2011,
+          "playerId": "10316",
+          "winningBid": 425000,
+          "timestamp": 1314715690,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2011,
+          "playerId": "10480",
+          "winningBid": 425000,
+          "timestamp": 1314728018,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2011,
+          "playerId": "8358",
+          "winningBid": 425000,
+          "timestamp": 1314763498,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2011,
+          "playerId": "10442",
+          "winningBid": 425000,
+          "timestamp": 1314802121,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "playerId": "8838",
+          "winningBid": 1550000,
+          "timestamp": 1331829884,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "playerId": "9124",
+          "winningBid": 425000,
+          "timestamp": 1331917668,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "playerId": "0525",
+          "winningBid": 500000,
+          "timestamp": 1331937399,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "playerId": "6776",
+          "winningBid": 425000,
+          "timestamp": 1331937478,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "playerId": "10907",
+          "winningBid": 425000,
+          "timestamp": 1337094087,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "playerId": "8817",
+          "winningBid": 425000,
+          "timestamp": 1337646696,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "playerId": "9680",
+          "winningBid": 575000,
+          "timestamp": 1338246068,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "playerId": "8371",
+          "winningBid": 425000,
+          "timestamp": 1339428102,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "playerId": "10852",
+          "winningBid": 425000,
+          "timestamp": 1341350117,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "playerId": "10960",
+          "winningBid": 1300000,
+          "timestamp": 1341774136,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "playerId": "10048",
+          "winningBid": 575000,
+          "timestamp": 1345476023,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "playerId": "10955",
+          "winningBid": 1450000,
+          "timestamp": 1345740408,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2013,
+          "playerId": "11337",
+          "winningBid": 425000,
+          "timestamp": 1363291098,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2013,
+          "playerId": "9898",
+          "winningBid": 500000,
+          "timestamp": 1363292603,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2013,
+          "playerId": "5657",
+          "winningBid": 425000,
+          "timestamp": 1363303944,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2013,
+          "playerId": "9319",
+          "winningBid": 450000,
+          "timestamp": 1363312046,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2013,
+          "playerId": "8305",
+          "winningBid": 475000,
+          "timestamp": 1363572640,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2013,
+          "playerId": "4907",
+          "winningBid": 1300000,
+          "timestamp": 1363672798,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2013,
+          "playerId": "11343",
+          "winningBid": 450000,
+          "timestamp": 1365414594,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2013,
+          "playerId": "11436",
+          "winningBid": 425000,
+          "timestamp": 1368331220,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2013,
+          "playerId": "11243",
+          "winningBid": 475000,
+          "timestamp": 1368468470,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2013,
+          "playerId": "11381",
+          "winningBid": 700000,
+          "timestamp": 1368577799,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "9964",
+          "winningBid": 3100000,
+          "timestamp": 1394734623,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "9052",
+          "winningBid": 425000,
+          "timestamp": 1394735809,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "8359",
+          "winningBid": 600000,
+          "timestamp": 1394736397,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "0501",
+          "winningBid": 450000,
+          "timestamp": 1394737908,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "6982",
+          "winningBid": 5000000,
+          "timestamp": 1394851747,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "6589",
+          "winningBid": 2000000,
+          "timestamp": 1394851747,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "11893",
+          "winningBid": 500000,
+          "timestamp": 1400754266,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "10737",
+          "winningBid": 425000,
+          "timestamp": 1407980183,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "4974",
+          "winningBid": 1800000,
+          "timestamp": 1426825182,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "10298",
+          "winningBid": 825000,
+          "timestamp": 1426985969,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "11651",
+          "winningBid": 475000,
+          "timestamp": 1426986027,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "0513",
+          "winningBid": 450000,
+          "timestamp": 1426986128,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "9933",
+          "winningBid": 1025000,
+          "timestamp": 1427102988,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "8776",
+          "winningBid": 425000,
+          "timestamp": 1439257970,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "0525",
+          "winningBid": 425000,
+          "timestamp": 1439895744,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "10719",
+          "winningBid": 575000,
+          "timestamp": 1440377026,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "0525",
+          "winningBid": 425000,
+          "timestamp": 1458255395,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "6789",
+          "winningBid": 425000,
+          "timestamp": 1458256081,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "9278",
+          "winningBid": 750000,
+          "timestamp": 1458261862,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "9078",
+          "winningBid": 1100000,
+          "timestamp": 1458407359,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "8117",
+          "winningBid": 425000,
+          "timestamp": 1459907585,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "12875",
+          "winningBid": 425000,
+          "timestamp": 1463387968,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "11337",
+          "winningBid": 425000,
+          "timestamp": 1463388016,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "9933",
+          "winningBid": 725000,
+          "timestamp": 1469009449,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "10742",
+          "winningBid": 4000000,
+          "timestamp": 1489702340,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "12912",
+          "winningBid": 1250000,
+          "timestamp": 1489702452,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "6997",
+          "winningBid": 2000000,
+          "timestamp": 1489702545,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "8658",
+          "winningBid": 3500000,
+          "timestamp": 1489702727,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "10973",
+          "winningBid": 500000,
+          "timestamp": 1489702992,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "10960",
+          "winningBid": 850000,
+          "timestamp": 1489703037,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "12156",
+          "winningBid": 425000,
+          "timestamp": 1489703411,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "10318",
+          "winningBid": 425000,
+          "timestamp": 1489703582,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "8930",
+          "winningBid": 425000,
+          "timestamp": 1489703725,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "10998",
+          "winningBid": 425000,
+          "timestamp": 1489703779,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "10721",
+          "winningBid": 1000000,
+          "timestamp": 1489704486,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "7393",
+          "winningBid": 2000000,
+          "timestamp": 1489714048,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "11182",
+          "winningBid": 2000000,
+          "timestamp": 1489809236,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "8670",
+          "winningBid": 2000000,
+          "timestamp": 1489909721,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "13144",
+          "winningBid": 425000,
+          "timestamp": 1494385838,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "8657",
+          "winningBid": 1650000,
+          "timestamp": 1500535869,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "10389",
+          "winningBid": 1800000,
+          "timestamp": 1502694757,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "10697",
+          "winningBid": 750000,
+          "timestamp": 1503393194,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "0515",
+          "winningBid": 550000,
+          "timestamp": 1521166707,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "6789",
+          "winningBid": 750000,
+          "timestamp": 1521167086,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "9838",
+          "winningBid": 425000,
+          "timestamp": 1521167274,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "10708",
+          "winningBid": 5050000,
+          "timestamp": 1521274816,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "9898",
+          "winningBid": 2000000,
+          "timestamp": 1521274850,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "11225",
+          "winningBid": 425000,
+          "timestamp": 1521432031,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "8360",
+          "winningBid": 425000,
+          "timestamp": 1521546894,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "11381",
+          "winningBid": 550000,
+          "timestamp": 1521684293,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "13793",
+          "winningBid": 500000,
+          "timestamp": 1525817509,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "11232",
+          "winningBid": 12500000,
+          "timestamp": 1553176956,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "0513",
+          "winningBid": 425000,
+          "timestamp": 1553465842,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "11676",
+          "winningBid": 750000,
+          "timestamp": 1553476325,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "7393",
+          "winningBid": 4825000,
+          "timestamp": 1553487961,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "13378",
+          "winningBid": 4000000,
+          "timestamp": 1553488044,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "12263",
+          "winningBid": 525000,
+          "timestamp": 1553748062,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "14316",
+          "winningBid": 425000,
+          "timestamp": 1557291787,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "11947",
+          "winningBid": 425000,
+          "timestamp": 1565909408,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "10271",
+          "winningBid": 12500000,
+          "timestamp": 1584627538,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "10276",
+          "winningBid": 5025000,
+          "timestamp": 1584629380,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "9831",
+          "winningBid": 1600000,
+          "timestamp": 1584629663,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "7393",
+          "winningBid": 625000,
+          "timestamp": 1584629721,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "12857",
+          "winningBid": 425000,
+          "timestamp": 1584629961,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "13632",
+          "winningBid": 625000,
+          "timestamp": 1584630613,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "12110",
+          "winningBid": 775000,
+          "timestamp": 1584679339,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "9448",
+          "winningBid": 425000,
+          "timestamp": 1584679377,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "6997",
+          "winningBid": 1050000,
+          "timestamp": 1584783585,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "13347",
+          "winningBid": 625000,
+          "timestamp": 1584826503,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "10413",
+          "winningBid": 925000,
+          "timestamp": 1584826578,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "4925",
+          "winningBid": 4550000,
+          "timestamp": 1585008679,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "0505",
+          "winningBid": 675000,
+          "timestamp": 1585024516,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "14876",
+          "winningBid": 425000,
+          "timestamp": 1588893758,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "14851",
+          "winningBid": 500000,
+          "timestamp": 1588901864,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "11675",
+          "winningBid": 13000000,
+          "timestamp": 1616076597,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "9431",
+          "winningBid": 3000000,
+          "timestamp": 1616128276,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "13772",
+          "winningBid": 2000000,
+          "timestamp": 1616220252,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "11387",
+          "winningBid": 425000,
+          "timestamp": 1616430925,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "15374",
+          "winningBid": 425000,
+          "timestamp": 1620931934,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "8851",
+          "winningBid": 650000,
+          "timestamp": 1647535207,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "11936",
+          "winningBid": 425000,
+          "timestamp": 1647535326,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "0515",
+          "winningBid": 500000,
+          "timestamp": 1647535359,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "12186",
+          "winningBid": 9125000,
+          "timestamp": 1647539149,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "12628",
+          "winningBid": 425000,
+          "timestamp": 1647539502,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "10308",
+          "winningBid": 425000,
+          "timestamp": 1647741121,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "11678",
+          "winningBid": 7625000,
+          "timestamp": 1647848828,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "0522",
+          "winningBid": 625000,
+          "timestamp": 1647849375,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "13763",
+          "winningBid": 425000,
+          "timestamp": 1647985548,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "10960",
+          "winningBid": 425000,
+          "timestamp": 1648147459,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "13589",
+          "winningBid": 9975000,
+          "timestamp": 1678976710,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "14239",
+          "winningBid": 950000,
+          "timestamp": 1679179767,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "11936",
+          "winningBid": 425000,
+          "timestamp": 1679189097,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "0526",
+          "winningBid": 425000,
+          "timestamp": 1679189185,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "12184",
+          "winningBid": 425000,
+          "timestamp": 1679189261,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "14083",
+          "winningBid": 775000,
+          "timestamp": 1679189302,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "13592",
+          "winningBid": 500000,
+          "timestamp": 1679348612,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "13753",
+          "winningBid": 425000,
+          "timestamp": 1679421464,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "16199",
+          "winningBid": 425000,
+          "timestamp": 1683648760,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "16249",
+          "winningBid": 450000,
+          "timestamp": 1683650313,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "16359",
+          "winningBid": 425000,
+          "timestamp": 1683816060,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "16157",
+          "winningBid": 425000,
+          "timestamp": 1691893998,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "12186",
+          "winningBid": 8000000,
+          "timestamp": 1711031457,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "14137",
+          "winningBid": 1000000,
+          "timestamp": 1711135897,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "0527",
+          "winningBid": 425000,
+          "timestamp": 1711136294,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "13592",
+          "winningBid": 750000,
+          "timestamp": 1711148707,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "10868",
+          "winningBid": 425000,
+          "timestamp": 1711154706,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "12437",
+          "winningBid": 775000,
+          "timestamp": 1711155128,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "14223",
+          "winningBid": 525000,
+          "timestamp": 1711326347,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "13763",
+          "winningBid": 2000000,
+          "timestamp": 1711332389,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "0503",
+          "winningBid": 2075000,
+          "timestamp": 1711589711,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "15626",
+          "winningBid": 425000,
+          "timestamp": 1711819446,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "13617",
+          "winningBid": 425000,
+          "timestamp": 1713383326,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "16788",
+          "winningBid": 425000,
+          "timestamp": 1719549363,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "0515",
+          "winningBid": 700000,
+          "timestamp": 1742481315,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "11247",
+          "winningBid": 1375000,
+          "timestamp": 1742481349,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "13154",
+          "winningBid": 700000,
+          "timestamp": 1742563925,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "12186",
+          "winningBid": 1700000,
+          "timestamp": 1742761118,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "8851",
+          "winningBid": 425000,
+          "timestamp": 1742968250,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "17054",
+          "winningBid": 550000,
+          "timestamp": 1746916303,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "17243",
+          "winningBid": 425000,
+          "timestamp": 1746916501,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "10413",
+          "winningBid": 425000,
+          "timestamp": 1753375887,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "13589",
+          "winningBid": 9000000,
+          "timestamp": 1773932280,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "13772",
+          "winningBid": 1000000,
+          "timestamp": 1773937868,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "16036",
+          "winningBid": 800000,
+          "timestamp": 1774008573,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "15256",
+          "winningBid": 4600000,
+          "timestamp": 1774008626,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "7836",
+          "winningBid": 1250000,
+          "timestamp": 1774027643,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "15979",
+          "winningBid": 900000,
+          "timestamp": 1774058578,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "9431",
+          "winningBid": 3775000,
+          "timestamp": 1774068464,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "13299",
+          "winningBid": 7000000,
+          "timestamp": 1774200820,
+          "sourceFranchiseId": null
         }
       ],
       "currentName": "Vitside Mafia",
@@ -39900,6 +49199,1368 @@
           "bothAttributed": true
         }
       ],
+      "draftPicks": [
+        {
+          "year": 2012,
+          "round": 1,
+          "pick": 1,
+          "playerId": "10706",
+          "viaTrade": false,
+          "comments": "Two Browns on my roster now...  This'll probably be the first season I ever consider watching a Browns game over another game on Sundays!  Welcome to the Wascawy Wabbits TRich!",
+          "timestamp": 1336222935,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "round": 1,
+          "pick": 6,
+          "playerId": "10721",
+          "viaTrade": false,
+          "comments": "Pick made based on Pre-Draft List I was hoping Martin would somehow fall to the #6 spot since I'm a bit light at the RB spot...  Thought about Wilson here, but his severe case of fumble-itis scared me off.  Instead I'll go with the guy who's 6'3, ran a 4.4 at the combine, and is going to be Larry Fitzgerald's understudy!   (Comments Added Sun May 6 5:51:11 a.m. PT 2012)",
+          "timestamp": 1336285318,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "round": 3,
+          "pick": 3,
+          "playerId": "10710",
+          "viaTrade": false,
+          "comments": "Pick made based on Pre-Draft List Polk's fall ends here..  Prior to the draft he was graded as a top 5 RB..  Low risk picking him at this point of the draft.  Had interest in Wylie, but was taken 2 picks earlier (Comments Added Tue May 8 9:15:19 p.m. PT 2012)",
+          "timestamp": 1336536336,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "round": 3,
+          "pick": 4,
+          "playerId": "10717",
+          "viaTrade": false,
+          "comments": "Pick made based on Pre-Draft List Probably won't be a lot of use this season, but could easily be the RB2 on the Chiefs next season which is a valuable spot to be in. (Comments Added Tue May 8 9:24:46 p.m. PT 2012)",
+          "timestamp": 1336536336,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2013,
+          "round": 1,
+          "pick": 4,
+          "playerId": "11250",
+          "viaTrade": false,
+          "comments": "Sorry about that guys. Away this weekend as well as fielding offers. Going with Eifert here. Missing a top TE on my team which I hope he can be",
+          "timestamp": 1367771133,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2013,
+          "round": 2,
+          "pick": 12,
+          "playerId": "11390",
+          "viaTrade": false,
+          "comments": "Gonna swing for the fence with this pick and go Latavius. Possibly the starting RB next season?",
+          "timestamp": 1368072737,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2013,
+          "round": 3,
+          "pick": 9,
+          "playerId": "11235",
+          "viaTrade": false,
+          "comments": "Pick made based on Pre-Draft List Boyce and Charles Johnson were the 2 guys I was really hoping to see slide to this pick, but I'm happy to see Harper join my team. Hopefully he'll carve out a possession type role with the Seahawks and build chemistry with Russ Wilson.  (Comments Added Fri May 10 10:08:15 p.m. PT 2013)",
+          "timestamp": 1368244557,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2013,
+          "round": 3,
+          "pick": 15,
+          "playerId": "11194",
+          "viaTrade": false,
+          "comments": "Pick made based on Pre-Draft List Workout warrior deluxe! Drafted in the 3rd round, talked about as a top pick last season with Lattimore. 2nd last pick in the draft, I'll take a chance on fumble fingers  (Comments Added Sat May 11 3:34:24 p.m. PT 2013)",
+          "timestamp": 1368304235,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "round": 2,
+          "pick": 1,
+          "playerId": "11678",
+          "viaTrade": false,
+          "comments": "Was really hoping for Lee to be staring at me here but DD stopped his fall, but I'll take his draft partner in Robinson.  Great measurables on this guy.",
+          "timestamp": 1400513862,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "round": 2,
+          "pick": 4,
+          "playerId": "11697",
+          "viaTrade": false,
+          "comments": "Pick made based on Pre-Draft List John Mackey Award winners selected in back to back years (Eifert now ASJ) .  It's gonna be pretty tough when TB gets into the RedZone with the towers they've got catching passes.   (Comments Added Mon May 19 9:16:08 p.m. PT 2014)",
+          "timestamp": 1400524595,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "round": 2,
+          "pick": 7,
+          "playerId": "11688",
+          "viaTrade": false,
+          "comments": "Really wanted Amaro to fall one more spot, but I'm happy to welcome Martavis Bryant to my squad.  Should hopefully be battling for a starting spot either right outta the gate or by next year.  Tons of untapped potential in this kid (Comments Added Mon May 19 9:17:16 p.m. PT 2014)",
+          "timestamp": 1400543336,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "round": 2,
+          "pick": 8,
+          "playerId": "11668",
+          "viaTrade": false,
+          "comments": "Going for a boom pick here. Starter next year in Cleveland or outta the league?",
+          "timestamp": 1400543396,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "round": 3,
+          "pick": 14,
+          "playerId": "11783",
+          "viaTrade": false,
+          "comments": "Pick made based on Pre-Draft List I wasn't planning on using this pick initially, but decided to use it and was torn between Brown, McKinnon, and Grice.  Went w/ Brown as a TY Hilton/Tavon Austin clone in Bruce Arians offense.   (Comments Added Thu May 22 7:54:08 a.m. PT 2014)",
+          "timestamp": 1400729587,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "round": 1,
+          "pick": 4,
+          "playerId": "12646",
+          "viaTrade": false,
+          "comments": "CoCo!",
+          "timestamp": 1462639631,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "round": 1,
+          "pick": 14,
+          "playerId": "12677",
+          "viaTrade": false,
+          "comments": "Matt Ryan hasn't had a decent TE since Tony G retired. Huge opportunity to become the #2 target behind Julio given the state of ATLs receiving options. (Comments Added Mon May 9 6:18:37 a.m. PT 2016)",
+          "timestamp": 1462771774,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "round": 2,
+          "pick": 10,
+          "playerId": "12857",
+          "viaTrade": false,
+          "comments": "Pick made based on Pre-Draft List Murray better watch his back!  Washington is here to take that job away! (Comments Added Tue May 10 7:44:55 a.m. PT 2016)",
+          "timestamp": 1462850732,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "round": 2,
+          "pick": 18,
+          "playerId": "12660",
+          "viaTrade": false,
+          "comments": "Someone's gotta catch the passes from Goff",
+          "timestamp": 1462940893,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "round": 1,
+          "pick": 3,
+          "playerId": "13128",
+          "viaTrade": false,
+          "comments": "Metrics be damned",
+          "timestamp": 1494093744,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "round": 1,
+          "pick": 4,
+          "playerId": "13131",
+          "viaTrade": false,
+          "comments": "Gio and Hill gonna get KTFO by Mixon",
+          "timestamp": 1494093840,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "round": 1,
+          "pick": 5,
+          "playerId": "13153",
+          "viaTrade": false,
+          "comments": "Saved some cap getting the 1.01 at 1.05. Davis gonna ball out with Mariota",
+          "timestamp": 1494093949,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "round": 1,
+          "pick": 7,
+          "playerId": "13154",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1494112983,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "round": 1,
+          "pick": 13,
+          "playerId": "13192",
+          "viaTrade": false,
+          "comments": "Coming from TE-U.. Potential of this kid is No-joke-oooo! Was worried Vit might double dip at TE after taking Engram",
+          "timestamp": 1494197911,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "round": 2,
+          "pick": 1,
+          "playerId": "13116",
+          "viaTrade": true,
+          "comments": "Pick traded from Gridiron Geeks.\nAndy Reid when they drafted Mahomes: http://s3.amazonaws.com/br-cdn/temp_images/2013/10/22/andy-reid-kool-aid-2.gif  Shouldn't take too long for him to supplant Alex Smith",
+          "timestamp": 1494255259,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "round": 2,
+          "pick": 4,
+          "playerId": "13237",
+          "viaTrade": false,
+          "comments": "Hyde's a FA next year and the RB whisperer pounded the table for this guy",
+          "timestamp": 1494264613,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "round": 2,
+          "pick": 17,
+          "playerId": "13640",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1525719682,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "round": 3,
+          "pick": 6,
+          "playerId": "13619",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1525733320,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "round": 3,
+          "pick": 16,
+          "playerId": "13789",
+          "viaTrade": true,
+          "comments": "[Pick traded from Computer Jocks.\nPick made based on Pre-Draft List] Pick traded from Fire Ready Aim.\nPick traded from Bring the Pain.",
+          "timestamp": 1525806451,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "round": 2,
+          "pick": 15,
+          "playerId": "14075",
+          "viaTrade": false,
+          "comments": "Trade accepted by Ninjas and I. Drafting Harris on his behalf to keep draft moving",
+          "timestamp": 1557186334,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "round": 3,
+          "pick": 1,
+          "playerId": "14074",
+          "viaTrade": true,
+          "comments": "[Pick traded from Maverick.]",
+          "timestamp": 1557197597,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "round": 3,
+          "pick": 15,
+          "playerId": "14103",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1557264647,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "round": 1,
+          "pick": 2,
+          "playerId": "14802",
+          "viaTrade": true,
+          "comments": "[Pick traded from Cowboy Up.] Let's keep this going. Welcome to the Wabbits JT!",
+          "timestamp": 1588461769,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "round": 1,
+          "pick": 5,
+          "playerId": "14800",
+          "viaTrade": true,
+          "comments": "[Pick traded from Drunk Indians.] RB1 of the leagues deadliest rushing attack",
+          "timestamp": 1588471558,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "round": 1,
+          "pick": 10,
+          "playerId": "14839",
+          "viaTrade": false,
+          "comments": "Gotta go with the Targaryen. PHIs WR1. Gonna beast",
+          "timestamp": 1588475960,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "round": 1,
+          "pick": 15,
+          "playerId": "14777",
+          "viaTrade": true,
+          "comments": "[Pick traded from Midwestside Connection.\nPick traded from The Music City Mafia.] Welcome aboard Joe Exotic. QB position locked in with Mahomes and Burrows leading the charge on cheap contracts",
+          "timestamp": 1588559500,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "round": 2,
+          "pick": 9,
+          "playerId": "14805",
+          "viaTrade": true,
+          "comments": "[Pick traded from The Mariachi Ninjas.] This guy is a wrecking ball. RB2 this year on GB, but he'll be their starter next year when Aaron Jones prices himself out of their price range",
+          "timestamp": 1588616456,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "round": 1,
+          "pick": 6,
+          "playerId": "15256",
+          "viaTrade": true,
+          "comments": "[Pick traded from Computer Jocks.]",
+          "timestamp": 1620507014,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "round": 3,
+          "pick": 2,
+          "playerId": "15292",
+          "viaTrade": true,
+          "comments": "[Pick traded from Vitside Mafia.\nPick traded from Cowboy Up.]",
+          "timestamp": 1620837186,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "round": 3,
+          "pick": 4,
+          "playerId": "15296",
+          "viaTrade": true,
+          "comments": "[Pick traded from Heavy Chevy.]",
+          "timestamp": 1620838216,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "round": 3,
+          "pick": 7,
+          "playerId": "15330",
+          "viaTrade": true,
+          "comments": "[Pick traded from Pacific Pigskins.\nPick traded from Cowboy Up.]",
+          "timestamp": 1620858436,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "round": 1,
+          "pick": 5,
+          "playerId": "15752",
+          "viaTrade": true,
+          "comments": "[Pick traded from Maverick.]",
+          "timestamp": 1652054515,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "round": 2,
+          "pick": 8,
+          "playerId": "15758",
+          "viaTrade": true,
+          "comments": "[Pick traded from Dark Magicians of Chaos.\nPick traded from Bring the Pain.\nPick traded from Heavy Chevy.]",
+          "timestamp": 1652244882,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "round": 2,
+          "pick": 10,
+          "playerId": "15759",
+          "viaTrade": true,
+          "comments": "[Pick traded from The Music City Mafia.\nPick traded from Wascawy Wabbits.\nPick traded from Heavy Chevy.]",
+          "timestamp": 1652245074,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "round": 1,
+          "pick": 9,
+          "playerId": "16213",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1683432693,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "round": 1,
+          "pick": 16,
+          "playerId": "16165",
+          "viaTrade": true,
+          "comments": "[Pick traded from Vitside Mafia.] Picking for music city",
+          "timestamp": 1683489416,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "round": 2,
+          "pick": 1,
+          "playerId": "16197",
+          "viaTrade": true,
+          "comments": "[Pick traded from Computer Jocks.]",
+          "timestamp": 1683502391,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "round": 1,
+          "pick": 1,
+          "playerId": "16614",
+          "viaTrade": true,
+          "comments": "[Pick traded from The Music City Mafia.] The Wabbits welcome Lisan Al Gaib to fulfill the prophecy",
+          "timestamp": 1714828955,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "round": 1,
+          "pick": 5,
+          "playerId": "16641",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1714856466,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "round": 1,
+          "pick": 16,
+          "playerId": "17083",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1746544294,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "round": 2,
+          "pick": 4,
+          "playerId": "17072",
+          "viaTrade": true,
+          "comments": "[Pick traded from Computer Jocks.]",
+          "timestamp": 1746593339,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "round": 2,
+          "pick": 10,
+          "playerId": "17134",
+          "viaTrade": true,
+          "comments": "[Pick traded from Dark Magicians of Chaos.]",
+          "timestamp": 1746651193,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "round": 2,
+          "pick": 16,
+          "playerId": "17069",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1746690626,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "round": 3,
+          "pick": 3,
+          "playerId": "17060",
+          "viaTrade": true,
+          "comments": "[Pick traded from Heavy Chevy.]",
+          "timestamp": 1746727850,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "round": 3,
+          "pick": 16,
+          "playerId": "17256",
+          "viaTrade": false,
+          "comments": "Mr Irrelevant",
+          "timestamp": 1746837844,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "round": 1,
+          "pick": 15,
+          "playerId": "17514",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1777926341,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "round": 3,
+          "pick": 2,
+          "playerId": "17485",
+          "viaTrade": true,
+          "comments": "[Pick traded from Dead Cap Walking .]",
+          "timestamp": 1778101435,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "round": 3,
+          "pick": 4,
+          "playerId": "17529",
+          "viaTrade": true,
+          "comments": "[Pick traded from The Music City Mafia.]",
+          "timestamp": 1778101908,
+          "sourceFranchiseId": null
+        }
+      ],
+      "auctionWins": [
+        {
+          "year": 2012,
+          "playerId": "9931",
+          "winningBid": 475000,
+          "timestamp": 1331828885,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "playerId": "10449",
+          "winningBid": 425000,
+          "timestamp": 1331828981,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "playerId": "8294",
+          "winningBid": 500000,
+          "timestamp": 1331835071,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "playerId": "6982",
+          "winningBid": 800000,
+          "timestamp": 1331835775,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "playerId": "8269",
+          "winningBid": 425000,
+          "timestamp": 1331835994,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "playerId": "9052",
+          "winningBid": 425000,
+          "timestamp": 1331847857,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "playerId": "8252",
+          "winningBid": 3500000,
+          "timestamp": 1331864017,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "playerId": "7150",
+          "winningBid": 425000,
+          "timestamp": 1331924408,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "playerId": "8268",
+          "winningBid": 5000000,
+          "timestamp": 1331957616,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "playerId": "9839",
+          "winningBid": 3800000,
+          "timestamp": 1332001215,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "playerId": "8932",
+          "winningBid": 625000,
+          "timestamp": 1332001215,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "playerId": "9616",
+          "winningBid": 425000,
+          "timestamp": 1332101864,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "playerId": "8944",
+          "winningBid": 425000,
+          "timestamp": 1332101920,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "playerId": "3309",
+          "winningBid": 4025000,
+          "timestamp": 1332132356,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "playerId": "10905",
+          "winningBid": 425000,
+          "timestamp": 1336884495,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "playerId": "10868",
+          "winningBid": 425000,
+          "timestamp": 1337622940,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "playerId": "10508",
+          "winningBid": 425000,
+          "timestamp": 1337739988,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "playerId": "10674",
+          "winningBid": 425000,
+          "timestamp": 1338933838,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "playerId": "10835",
+          "winningBid": 425000,
+          "timestamp": 1344730737,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2012,
+          "playerId": "9315",
+          "winningBid": 425000,
+          "timestamp": 1345493050,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2013,
+          "playerId": "0504",
+          "winningBid": 900000,
+          "timestamp": 1363266075,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2013,
+          "playerId": "9480",
+          "winningBid": 800000,
+          "timestamp": 1363266113,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2013,
+          "playerId": "0507",
+          "winningBid": 500000,
+          "timestamp": 1363266671,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2013,
+          "playerId": "9058",
+          "winningBid": 1400000,
+          "timestamp": 1363273580,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2013,
+          "playerId": "7260",
+          "winningBid": 5500000,
+          "timestamp": 1363294924,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2013,
+          "playerId": "7401",
+          "winningBid": 3000000,
+          "timestamp": 1363324312,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2013,
+          "playerId": "10276",
+          "winningBid": 3250000,
+          "timestamp": 1363441673,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2013,
+          "playerId": "11256",
+          "winningBid": 425000,
+          "timestamp": 1368580955,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2013,
+          "playerId": "11440",
+          "winningBid": 425000,
+          "timestamp": 1375544197,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2013,
+          "playerId": "11259",
+          "winningBid": 425000,
+          "timestamp": 1375635216,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "8252",
+          "winningBid": 2700000,
+          "timestamp": 1394715698,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "8776",
+          "winningBid": 2000000,
+          "timestamp": 1394831773,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "10726",
+          "winningBid": 425000,
+          "timestamp": 1394899105,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "2918",
+          "winningBid": 425000,
+          "timestamp": 1394899225,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "7414",
+          "winningBid": 3750000,
+          "timestamp": 1394972453,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "10719",
+          "winningBid": 650000,
+          "timestamp": 1408197082,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "8667",
+          "winningBid": 1000000,
+          "timestamp": 1426809387,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "7839",
+          "winningBid": 4000000,
+          "timestamp": 1426815748,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "11786",
+          "winningBid": 725000,
+          "timestamp": 1426969288,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "7150",
+          "winningBid": 425000,
+          "timestamp": 1431557606,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "12396",
+          "winningBid": 425000,
+          "timestamp": 1431923211,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "12169",
+          "winningBid": 425000,
+          "timestamp": 1432608218,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "10394",
+          "winningBid": 425000,
+          "timestamp": 1432757181,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "11975",
+          "winningBid": 425000,
+          "timestamp": 1434817923,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "0512",
+          "winningBid": 1000000,
+          "timestamp": 1458219742,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "9823",
+          "winningBid": 11000000,
+          "timestamp": 1458219799,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "7836",
+          "winningBid": 8500000,
+          "timestamp": 1458219942,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "11936",
+          "winningBid": 425000,
+          "timestamp": 1458220033,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "10318",
+          "winningBid": 425000,
+          "timestamp": 1460692903,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "10261",
+          "winningBid": 12000000,
+          "timestamp": 1489673557,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "5848",
+          "winningBid": 7500000,
+          "timestamp": 1489673578,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "8359",
+          "winningBid": 500000,
+          "timestamp": 1489673725,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "13193",
+          "winningBid": 700000,
+          "timestamp": 1494599537,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "9902",
+          "winningBid": 10000000,
+          "timestamp": 1521176402,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "0528",
+          "winningBid": 2250000,
+          "timestamp": 1521182180,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "13611",
+          "winningBid": 425000,
+          "timestamp": 1525807481,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "13814",
+          "winningBid": 425000,
+          "timestamp": 1525816159,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "12632",
+          "winningBid": 425000,
+          "timestamp": 1529346778,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "11890",
+          "winningBid": 425000,
+          "timestamp": 1529346782,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "11399",
+          "winningBid": 425000,
+          "timestamp": 1529346796,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "13722",
+          "winningBid": 425000,
+          "timestamp": 1529346830,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "9925",
+          "winningBid": 3500000,
+          "timestamp": 1553178551,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "0524",
+          "winningBid": 1000000,
+          "timestamp": 1553178607,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "11677",
+          "winningBid": 600000,
+          "timestamp": 1553178728,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "11670",
+          "winningBid": 6000000,
+          "timestamp": 1553351442,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "12646",
+          "winningBid": 425000,
+          "timestamp": 1553446163,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "13776",
+          "winningBid": 475000,
+          "timestamp": 1553447464,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "9823",
+          "winningBid": 425000,
+          "timestamp": 1553523317,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "10409",
+          "winningBid": 450000,
+          "timestamp": 1553523520,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "11689",
+          "winningBid": 425000,
+          "timestamp": 1553658549,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "14315",
+          "winningBid": 425000,
+          "timestamp": 1557277433,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "14126",
+          "winningBid": 425000,
+          "timestamp": 1557283928,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "13863",
+          "winningBid": 425000,
+          "timestamp": 1559404826,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "9474",
+          "winningBid": 4000000,
+          "timestamp": 1584627796,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "10729",
+          "winningBid": 10000000,
+          "timestamp": 1584758922,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "11192",
+          "winningBid": 6800000,
+          "timestamp": 1584759502,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "7394",
+          "winningBid": 2625000,
+          "timestamp": 1584977790,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "10960",
+          "winningBid": 550000,
+          "timestamp": 1584978358,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "13416",
+          "winningBid": 425000,
+          "timestamp": 1585060994,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "9902",
+          "winningBid": 425000,
+          "timestamp": 1586988528,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "14613",
+          "winningBid": 425000,
+          "timestamp": 1591649647,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "10271",
+          "winningBid": 6025000,
+          "timestamp": 1616098075,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "13192",
+          "winningBid": 425000,
+          "timestamp": 1616109162,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "14101",
+          "winningBid": 600000,
+          "timestamp": 1616292080,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "12391",
+          "winningBid": 850000,
+          "timestamp": 1616370671,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "14095",
+          "winningBid": 425000,
+          "timestamp": 1616419520,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "15339",
+          "winningBid": 425000,
+          "timestamp": 1620923306,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "12801",
+          "winningBid": 11725000,
+          "timestamp": 1647534967,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "0514",
+          "winningBid": 1900000,
+          "timestamp": 1647738082,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "12647",
+          "winningBid": 975000,
+          "timestamp": 1647747279,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "14839",
+          "winningBid": 650000,
+          "timestamp": 1647785384,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "13629",
+          "winningBid": 1000000,
+          "timestamp": 1648409040,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "14315",
+          "winningBid": 425000,
+          "timestamp": 1660022087,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "11244",
+          "winningBid": 15525000,
+          "timestamp": 1678976183,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "13672",
+          "winningBid": 950000,
+          "timestamp": 1678976665,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "13163",
+          "winningBid": 3250000,
+          "timestamp": 1678980374,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "10697",
+          "winningBid": 425000,
+          "timestamp": 1678988537,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "16380",
+          "winningBid": 425000,
+          "timestamp": 1690225478,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "14798",
+          "winningBid": 425000,
+          "timestamp": 1690294726,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "14071",
+          "winningBid": 5425000,
+          "timestamp": 1711150568,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "0528",
+          "winningBid": 500000,
+          "timestamp": 1711382866,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "16180",
+          "winningBid": 425000,
+          "timestamp": 1711637992,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "14123",
+          "winningBid": 425000,
+          "timestamp": 1711639471,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "16681",
+          "winningBid": 425000,
+          "timestamp": 1715262387,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "16633",
+          "winningBid": 425000,
+          "timestamp": 1723816929,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "0524",
+          "winningBid": 1100000,
+          "timestamp": 1742479495,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "14208",
+          "winningBid": 425000,
+          "timestamp": 1742866002,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "14835",
+          "winningBid": 7750000,
+          "timestamp": 1746506076,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "14358",
+          "winningBid": 425000,
+          "timestamp": 1746887106,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "12676",
+          "winningBid": 1500000,
+          "timestamp": 1773929168,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "14836",
+          "winningBid": 9800000,
+          "timestamp": 1773968920,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "14102",
+          "winningBid": 2050000,
+          "timestamp": 1773984196,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "15237",
+          "winningBid": 4200000,
+          "timestamp": 1774147625,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "10700",
+          "winningBid": 425000,
+          "timestamp": 1774285943,
+          "sourceFranchiseId": null
+        }
+      ],
       "currentName": "Wascawy Wabbits",
       "currentNameMedium": "Wascawy Wabbits",
       "currentNameShort": "Wabbits",
@@ -43740,6 +54401,1152 @@
           "bothAttributed": true
         }
       ],
+      "draftPicks": [
+        {
+          "year": 2014,
+          "round": 1,
+          "pick": 4,
+          "playerId": "11695",
+          "viaTrade": false,
+          "comments": "Pick made based on Pre-Draft List",
+          "timestamp": 1400366334,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "round": 2,
+          "pick": 14,
+          "playerId": "11651",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1400596463,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "round": 3,
+          "pick": 4,
+          "playerId": "11664",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1400676125,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "round": 3,
+          "pick": 8,
+          "playerId": "11809",
+          "viaTrade": false,
+          "comments": "Pick made based on Pre-Draft List",
+          "timestamp": 1400710172,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "round": 3,
+          "pick": 9,
+          "playerId": "11870",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1400725307,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "round": 1,
+          "pick": 8,
+          "playerId": "12655",
+          "viaTrade": false,
+          "comments": "Pick made based on Pre-Draft List",
+          "timestamp": 1462686668,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "round": 2,
+          "pick": 8,
+          "playerId": "12635",
+          "viaTrade": false,
+          "comments": "Pick made based on Pre-Draft List",
+          "timestamp": 1462843077,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "round": 3,
+          "pick": 8,
+          "playerId": "12620",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1463011514,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "round": 2,
+          "pick": 7,
+          "playerId": "13146",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1494267582,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "round": 2,
+          "pick": 17,
+          "playerId": "13125",
+          "viaTrade": false,
+          "comments": "Pick made based on Pre-Draft List",
+          "timestamp": 1494314137,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "round": 3,
+          "pick": 7,
+          "playerId": "13354",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1494355500,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "round": 1,
+          "pick": 5,
+          "playerId": "13629",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1525541822,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "round": 1,
+          "pick": 16,
+          "playerId": "13590",
+          "viaTrade": true,
+          "comments": "[Pick made based on Pre-Draft List] Pick traded from Fire Ready Aim.",
+          "timestamp": 1525638824,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "round": 2,
+          "pick": 5,
+          "playerId": "13621",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1525645457,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "round": 1,
+          "pick": 9,
+          "playerId": "14137",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1557076158,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "round": 2,
+          "pick": 9,
+          "playerId": "14116",
+          "viaTrade": false,
+          "comments": "[Pick made based on Pre-Draft List]",
+          "timestamp": 1557155383,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "round": 1,
+          "pick": 6,
+          "playerId": "14797",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1588471663,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "round": 2,
+          "pick": 6,
+          "playerId": "14867",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1588614280,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "round": 3,
+          "pick": 6,
+          "playerId": "14969",
+          "viaTrade": false,
+          "comments": "[Pick made from Pre-Draft List]",
+          "timestamp": 1588739413,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "round": 1,
+          "pick": 13,
+          "playerId": "15258",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1620523468,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "round": 2,
+          "pick": 13,
+          "playerId": "15407",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1620782051,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "round": 3,
+          "pick": 13,
+          "playerId": "15291",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1620873294,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "round": 1,
+          "pick": 7,
+          "playerId": "15753",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1652054799,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "round": 1,
+          "pick": 17,
+          "playerId": "15768",
+          "viaTrade": false,
+          "comments": "[Pick added by commissioner.]",
+          "timestamp": 1652196984,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "round": 2,
+          "pick": 3,
+          "playerId": "15692",
+          "viaTrade": true,
+          "comments": "[Pick traded from Gridiron Geeks.]",
+          "timestamp": 1652207873,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "round": 2,
+          "pick": 7,
+          "playerId": "15840",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1652236427,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "round": 3,
+          "pick": 7,
+          "playerId": "15718",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1652400860,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "round": 1,
+          "pick": 3,
+          "playerId": "16185",
+          "viaTrade": false,
+          "comments": "[Pick made from Pre-Draft List]",
+          "timestamp": 1683389873,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "round": 1,
+          "pick": 11,
+          "playerId": "16171",
+          "viaTrade": true,
+          "comments": "[Pick traded from Maverick.]",
+          "timestamp": 1683469733,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "round": 2,
+          "pick": 3,
+          "playerId": "16194",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1683504841,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "round": 2,
+          "pick": 9,
+          "playerId": "16149",
+          "viaTrade": true,
+          "comments": "[Pick traded from Wascawy Wabbits.\nPick made from Pre-Draft List]",
+          "timestamp": 1683556421,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "round": 2,
+          "pick": 11,
+          "playerId": "16215",
+          "viaTrade": true,
+          "comments": "[Pick traded from Maverick.\nPick made from Pre-Draft List]",
+          "timestamp": 1683557914,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "round": 2,
+          "pick": 12,
+          "playerId": "16181",
+          "viaTrade": true,
+          "comments": "[Pick traded from Gridiron Geeks.]",
+          "timestamp": 1683560254,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "round": 2,
+          "pick": 15,
+          "playerId": "16216",
+          "viaTrade": true,
+          "comments": "[Pick traded from Dark Magicians of Chaos.]",
+          "timestamp": 1683562152,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "round": 3,
+          "pick": 3,
+          "playerId": "16193",
+          "viaTrade": false,
+          "comments": "Pick going to Wabbits",
+          "timestamp": 1683570480,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "round": 3,
+          "pick": 11,
+          "playerId": "16286",
+          "viaTrade": true,
+          "comments": "[Pick traded from Maverick.\nPick made from Pre-Draft List]",
+          "timestamp": 1683642501,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "round": 3,
+          "pick": 5,
+          "playerId": "16598",
+          "viaTrade": true,
+          "comments": "[Pick traded from Wascawy Wabbits.\nPick made from Pre-Draft List]",
+          "timestamp": 1715099927,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "round": 3,
+          "pick": 8,
+          "playerId": "16688",
+          "viaTrade": false,
+          "comments": "[Pick made from Pre-Draft List]",
+          "timestamp": 1715110435,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "round": 1,
+          "pick": 6,
+          "playerId": "17102",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1746362309,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "round": 1,
+          "pick": 12,
+          "playerId": "17030",
+          "viaTrade": true,
+          "comments": "[Pick traded from Fire Ready Aim.]",
+          "timestamp": 1746459195,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "round": 2,
+          "pick": 17,
+          "playerId": "17047",
+          "viaTrade": false,
+          "comments": "[Pick added by commissioner.]",
+          "timestamp": 1746707038,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "round": 3,
+          "pick": 5,
+          "playerId": "17097",
+          "viaTrade": true,
+          "comments": "[Pick traded from Bring the Pain.\nPick made from Pre-Draft List]",
+          "timestamp": 1746727850,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "round": 3,
+          "pick": 6,
+          "playerId": "17184",
+          "viaTrade": false,
+          "comments": "[Pick made from Pre-Draft List]",
+          "timestamp": 1746727850,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "round": 1,
+          "pick": 6,
+          "playerId": "17499",
+          "viaTrade": false,
+          "comments": "[Pick made from Pre-Draft List]",
+          "timestamp": 1777789516,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "round": 1,
+          "pick": 17,
+          "playerId": "17463",
+          "viaTrade": false,
+          "comments": "[Pick added by commissioner.]",
+          "timestamp": 1777936242,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "round": 2,
+          "pick": 6,
+          "playerId": "17476",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1778034413,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "round": 3,
+          "pick": 6,
+          "playerId": "17566",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1778111860,
+          "sourceFranchiseId": null
+        }
+      ],
+      "auctionWins": [
+        {
+          "year": 2014,
+          "playerId": "0527",
+          "winningBid": 1100000,
+          "timestamp": 1394762689,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "10929",
+          "winningBid": 550000,
+          "timestamp": 1394762974,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "9474",
+          "winningBid": 3025000,
+          "timestamp": 1394763121,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "9843",
+          "winningBid": 425000,
+          "timestamp": 1394764064,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "10391",
+          "winningBid": 425000,
+          "timestamp": 1394764387,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "9058",
+          "winningBid": 425000,
+          "timestamp": 1394764566,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "9080",
+          "winningBid": 425000,
+          "timestamp": 1394764693,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "4883",
+          "winningBid": 425000,
+          "timestamp": 1394765199,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "9441",
+          "winningBid": 7500000,
+          "timestamp": 1394821334,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "7877",
+          "winningBid": 3500000,
+          "timestamp": 1394849032,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "6929",
+          "winningBid": 2500000,
+          "timestamp": 1394894749,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "9960",
+          "winningBid": 425000,
+          "timestamp": 1408227442,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "10881",
+          "winningBid": 1400000,
+          "timestamp": 1426804893,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "9299",
+          "winningBid": 575000,
+          "timestamp": 1426805033,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "6589",
+          "winningBid": 425000,
+          "timestamp": 1426806821,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "7873",
+          "winningBid": 3525000,
+          "timestamp": 1426807342,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "9964",
+          "winningBid": 775000,
+          "timestamp": 1426844008,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "9680",
+          "winningBid": 1250000,
+          "timestamp": 1426844039,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "11665",
+          "winningBid": 425000,
+          "timestamp": 1426969428,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "9862",
+          "winningBid": 425000,
+          "timestamp": 1429667318,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "12319",
+          "winningBid": 425000,
+          "timestamp": 1440282512,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "9452",
+          "winningBid": 425000,
+          "timestamp": 1458262162,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "10948",
+          "winningBid": 425000,
+          "timestamp": 1458262398,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "11186",
+          "winningBid": 425000,
+          "timestamp": 1458262595,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "9118",
+          "winningBid": 9500000,
+          "timestamp": 1458297766,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "10527",
+          "winningBid": 4500000,
+          "timestamp": 1458314783,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "11681",
+          "winningBid": 425000,
+          "timestamp": 1458998328,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "12381",
+          "winningBid": 1000000,
+          "timestamp": 1469028162,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "10709",
+          "winningBid": 700000,
+          "timestamp": 1489674011,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "12887",
+          "winningBid": 4500000,
+          "timestamp": 1489685644,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "0511",
+          "winningBid": 1000000,
+          "timestamp": 1489708634,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "10737",
+          "winningBid": 550000,
+          "timestamp": 1489710014,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "11367",
+          "winningBid": 425000,
+          "timestamp": 1489711166,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "9054",
+          "winningBid": 1550000,
+          "timestamp": 1489794660,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "9429",
+          "winningBid": 425000,
+          "timestamp": 1489807323,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "11239",
+          "winningBid": 625000,
+          "timestamp": 1490150663,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "0530",
+          "winningBid": 425000,
+          "timestamp": 1492917443,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "6589",
+          "winningBid": 850000,
+          "timestamp": 1521333094,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "11670",
+          "winningBid": 7575000,
+          "timestamp": 1521342156,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "11390",
+          "winningBid": 675000,
+          "timestamp": 1521342186,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "0506",
+          "winningBid": 425000,
+          "timestamp": 1521476303,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "12785",
+          "winningBid": 425000,
+          "timestamp": 1526639159,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "0531",
+          "winningBid": 1000000,
+          "timestamp": 1553177572,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "6997",
+          "winningBid": 1200000,
+          "timestamp": 1553192243,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "11222",
+          "winningBid": 10025000,
+          "timestamp": 1553192921,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "11680",
+          "winningBid": 7500000,
+          "timestamp": 1553193021,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "12656",
+          "winningBid": 425000,
+          "timestamp": 1553214347,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "12815",
+          "winningBid": 425000,
+          "timestamp": 1553273038,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "9118",
+          "winningBid": 1000000,
+          "timestamp": 1553368667,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "14063",
+          "winningBid": 425000,
+          "timestamp": 1557276149,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "14287",
+          "winningBid": 425000,
+          "timestamp": 1557279665,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "14081",
+          "winningBid": 425000,
+          "timestamp": 1557279688,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "14244",
+          "winningBid": 425000,
+          "timestamp": 1557407038,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "10697",
+          "winningBid": 1600000,
+          "timestamp": 1584629696,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "8062",
+          "winningBid": 425000,
+          "timestamp": 1584630312,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "12188",
+          "winningBid": 425000,
+          "timestamp": 1584760990,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "9925",
+          "winningBid": 750000,
+          "timestamp": 1584794528,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "12912",
+          "winningBid": 425000,
+          "timestamp": 1584798893,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "8269",
+          "winningBid": 425000,
+          "timestamp": 1584892097,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "14845",
+          "winningBid": 425000,
+          "timestamp": 1588893219,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "12677",
+          "winningBid": 800000,
+          "timestamp": 1616076569,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "14244",
+          "winningBid": 475000,
+          "timestamp": 1616077893,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "15220",
+          "winningBid": 425000,
+          "timestamp": 1616088588,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "10738",
+          "winningBid": 3000000,
+          "timestamp": 1616092298,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "14341",
+          "winningBid": 650000,
+          "timestamp": 1616110529,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "12930",
+          "winningBid": 4000000,
+          "timestamp": 1616208824,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "0516",
+          "winningBid": 1200000,
+          "timestamp": 1616394630,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "15434",
+          "winningBid": 425000,
+          "timestamp": 1620923216,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "11675",
+          "winningBid": 12600000,
+          "timestamp": 1647526733,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "0507",
+          "winningBid": 600000,
+          "timestamp": 1647526888,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "13403",
+          "winningBid": 550000,
+          "timestamp": 1647527395,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "11761",
+          "winningBid": 575000,
+          "timestamp": 1647556808,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "12650",
+          "winningBid": 2500000,
+          "timestamp": 1647722091,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "10697",
+          "winningBid": 5525000,
+          "timestamp": 1647919517,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "15873",
+          "winningBid": 425000,
+          "timestamp": 1652530414,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "15698",
+          "winningBid": 2025000,
+          "timestamp": 1678983344,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "13668",
+          "winningBid": 425000,
+          "timestamp": 1679014123,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "0527",
+          "winningBid": 425000,
+          "timestamp": 1679019198,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "11938",
+          "winningBid": 1025000,
+          "timestamp": 1679104101,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "13608",
+          "winningBid": 3600000,
+          "timestamp": 1679104648,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "13377",
+          "winningBid": 650000,
+          "timestamp": 1679105268,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "12447",
+          "winningBid": 6000000,
+          "timestamp": 1711030422,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "14798",
+          "winningBid": 4000000,
+          "timestamp": 1711030492,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "0510",
+          "winningBid": 775000,
+          "timestamp": 1711030531,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "0516",
+          "winningBid": 825000,
+          "timestamp": 1711101808,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "13968",
+          "winningBid": 425000,
+          "timestamp": 1711161115,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "11674",
+          "winningBid": 2525000,
+          "timestamp": 1711386997,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "13675",
+          "winningBid": 2525000,
+          "timestamp": 1711414506,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "12626",
+          "winningBid": 8000000,
+          "timestamp": 1742480369,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "14057",
+          "winningBid": 425000,
+          "timestamp": 1742559743,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "13763",
+          "winningBid": 425000,
+          "timestamp": 1742654761,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "17222",
+          "winningBid": 600000,
+          "timestamp": 1746887070,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "15290",
+          "winningBid": 9000000,
+          "timestamp": 1774032953,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "0531",
+          "winningBid": 1050000,
+          "timestamp": 1774033167,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "13192",
+          "winningBid": 650000,
+          "timestamp": 1774185930,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "15252",
+          "winningBid": 425000,
+          "timestamp": 1774186734,
+          "sourceFranchiseId": null
+        }
+      ],
       "currentName": "Running down the Dream",
       "currentNameMedium": "The Dream",
       "currentNameShort": "The Dream",
@@ -47289,6 +59096,1017 @@
           "bothAttributed": true
         }
       ],
+      "draftPicks": [
+        {
+          "year": 2014,
+          "round": 1,
+          "pick": 2,
+          "playerId": "11653",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1400348777,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "round": 2,
+          "pick": 2,
+          "playerId": "11677",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1400522033,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "round": 3,
+          "pick": 2,
+          "playerId": "11703",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1400641989,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "round": 1,
+          "pick": 3,
+          "playerId": "12648",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1462635016,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "round": 1,
+          "pick": 9,
+          "playerId": "12632",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1462690327,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "round": 3,
+          "pick": 9,
+          "playerId": "12657",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1463015226,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "round": 1,
+          "pick": 1,
+          "playerId": "13129",
+          "viaTrade": false,
+          "comments": "Pick made based on Pre-Draft List",
+          "timestamp": 1494075606,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "round": 1,
+          "pick": 13,
+          "playerId": "13631",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1525621804,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "round": 3,
+          "pick": 13,
+          "playerId": "13666",
+          "viaTrade": false,
+          "comments": "[Pick made based on Pre-Draft List]",
+          "timestamp": 1525788653,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "round": 1,
+          "pick": 6,
+          "playerId": "14138",
+          "viaTrade": false,
+          "comments": "Sorry, east coaster. Passed out waiting for 1.03 to drop. Hoping for Gronk 2.0 here.",
+          "timestamp": 1557053119,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "round": 3,
+          "pick": 2,
+          "playerId": "14059",
+          "viaTrade": true,
+          "comments": "[Pick traded from The Mariachi Ninjas.\nPick made based on Pre-Draft List]",
+          "timestamp": 1557197597,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "round": 3,
+          "pick": 6,
+          "playerId": "14082",
+          "viaTrade": false,
+          "comments": "[Pick made based on Pre-Draft List]",
+          "timestamp": 1557241416,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "round": 2,
+          "pick": 1,
+          "playerId": "14779",
+          "viaTrade": true,
+          "comments": "[Pick traded from Maverick.]",
+          "timestamp": 1588588708,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "round": 3,
+          "pick": 1,
+          "playerId": "14863",
+          "viaTrade": true,
+          "comments": "[Pick traded from Maverick.\nPick made from Pre-Draft List]",
+          "timestamp": 1588694900,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "round": 2,
+          "pick": 5,
+          "playerId": "15308",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1620682993,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "round": 2,
+          "pick": 8,
+          "playerId": "15290",
+          "viaTrade": true,
+          "comments": "[Pick traded from Maverick.]",
+          "timestamp": 1620769396,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "round": 2,
+          "pick": 14,
+          "playerId": "15261",
+          "viaTrade": true,
+          "comments": "[Pick traded from The Music City Mafia.]",
+          "timestamp": 1620782088,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "round": 3,
+          "pick": 5,
+          "playerId": "15425",
+          "viaTrade": false,
+          "comments": "Drafted as a tight end.",
+          "timestamp": 1620853740,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "round": 1,
+          "pick": 3,
+          "playerId": "15711",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1651967125,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "round": 3,
+          "pick": 3,
+          "playerId": "15802",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1652389921,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "round": 3,
+          "pick": 9,
+          "playerId": "15763",
+          "viaTrade": true,
+          "comments": "[Pick traded from The Mariachi Ninjas.]",
+          "timestamp": 1652408237,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "round": 1,
+          "pick": 12,
+          "playerId": "16167",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1683482242,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "round": 3,
+          "pick": 12,
+          "playerId": "16205",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1683642934,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "round": 3,
+          "pick": 12,
+          "playerId": "16595",
+          "viaTrade": false,
+          "comments": "[Pick made from Pre-Draft List] The best pick in the draft in my Estimation! 3.12 Baby!!!!!",
+          "timestamp": 1715160837,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "round": 1,
+          "pick": 11,
+          "playerId": "17048",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1746405240,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "round": 2,
+          "pick": 11,
+          "playerId": "17080",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1746651716,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "round": 3,
+          "pick": 11,
+          "playerId": "17098",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1746760661,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "round": 1,
+          "pick": 9,
+          "playerId": "17501",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1777816573,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "round": 2,
+          "pick": 9,
+          "playerId": "17478",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1778034720,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "round": 3,
+          "pick": 9,
+          "playerId": "17519",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1778116495,
+          "sourceFranchiseId": null
+        }
+      ],
+      "auctionWins": [
+        {
+          "year": 2014,
+          "playerId": "9087",
+          "winningBid": 3775000,
+          "timestamp": 1394780690,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "9436",
+          "winningBid": 3500000,
+          "timestamp": 1394780690,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "9150",
+          "winningBid": 2000000,
+          "timestamp": 1394780690,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "8667",
+          "winningBid": 3500000,
+          "timestamp": 1394780690,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "11481",
+          "winningBid": 500000,
+          "timestamp": 1394817820,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "9690",
+          "winningBid": 6200000,
+          "timestamp": 1394819573,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "9099",
+          "winningBid": 5200000,
+          "timestamp": 1394875839,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "10862",
+          "winningBid": 425000,
+          "timestamp": 1394876871,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "7859",
+          "winningBid": 425000,
+          "timestamp": 1394877100,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "9440",
+          "winningBid": 425000,
+          "timestamp": 1394977792,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "9941",
+          "winningBid": 425000,
+          "timestamp": 1394978117,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "9272",
+          "winningBid": 425000,
+          "timestamp": 1394978265,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "10281",
+          "winningBid": 425000,
+          "timestamp": 1394978688,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "0516",
+          "winningBid": 425000,
+          "timestamp": 1395069333,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "7480",
+          "winningBid": 825000,
+          "timestamp": 1395098406,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "0525",
+          "winningBid": 825000,
+          "timestamp": 1395098518,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "11786",
+          "winningBid": 625000,
+          "timestamp": 1400848926,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "11755",
+          "winningBid": 600000,
+          "timestamp": 1400849122,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "11784",
+          "winningBid": 450000,
+          "timestamp": 1400849316,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2014,
+          "playerId": "11659",
+          "winningBid": 425000,
+          "timestamp": 1400859137,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "10077",
+          "winningBid": 425000,
+          "timestamp": 1426814039,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "0530",
+          "winningBid": 475000,
+          "timestamp": 1426815810,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "9838",
+          "winningBid": 425000,
+          "timestamp": 1426817978,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "9694",
+          "winningBid": 425000,
+          "timestamp": 1426941570,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "11752",
+          "winningBid": 425000,
+          "timestamp": 1427057639,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "10955",
+          "winningBid": 425000,
+          "timestamp": 1427060675,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "11957",
+          "winningBid": 425000,
+          "timestamp": 1427124934,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "10500",
+          "winningBid": 475000,
+          "timestamp": 1438789523,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "12098",
+          "winningBid": 425000,
+          "timestamp": 1440199868,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "0518",
+          "winningBid": 450000,
+          "timestamp": 1458255575,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "0523",
+          "winningBid": 450000,
+          "timestamp": 1458256184,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "11945",
+          "winningBid": 475000,
+          "timestamp": 1458256502,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "10369",
+          "winningBid": 1025000,
+          "timestamp": 1458455873,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "9064",
+          "winningBid": 3850000,
+          "timestamp": 1458525396,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "10289",
+          "winningBid": 2075000,
+          "timestamp": 1458525448,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "8670",
+          "winningBid": 1525000,
+          "timestamp": 1458526224,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "10362",
+          "winningBid": 475000,
+          "timestamp": 1458768435,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "12845",
+          "winningBid": 425000,
+          "timestamp": 1463364557,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "12623",
+          "winningBid": 425000,
+          "timestamp": 1463364833,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "12671",
+          "winningBid": 425000,
+          "timestamp": 1463450682,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "11746",
+          "winningBid": 500000,
+          "timestamp": 1470440327,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "11229",
+          "winningBid": 425000,
+          "timestamp": 1489933677,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "11257",
+          "winningBid": 425000,
+          "timestamp": 1489934482,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "11213",
+          "winningBid": 2275000,
+          "timestamp": 1490135432,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "13136",
+          "winningBid": 425000,
+          "timestamp": 1494462720,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "13240",
+          "winningBid": 425000,
+          "timestamp": 1494462991,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "13141",
+          "winningBid": 425000,
+          "timestamp": 1494463593,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "13289",
+          "winningBid": 425000,
+          "timestamp": 1502724092,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "8930",
+          "winningBid": 425000,
+          "timestamp": 1521165945,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "10302",
+          "winningBid": 500000,
+          "timestamp": 1521171680,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "11227",
+          "winningBid": 650000,
+          "timestamp": 1521224522,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "10313",
+          "winningBid": 2325000,
+          "timestamp": 1521235490,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "10261",
+          "winningBid": 11000000,
+          "timestamp": 1521385330,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "11186",
+          "winningBid": 1500000,
+          "timestamp": 1521473353,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "11454",
+          "winningBid": 3525000,
+          "timestamp": 1521519756,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "12159",
+          "winningBid": 525000,
+          "timestamp": 1521989615,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "7422",
+          "winningBid": 450000,
+          "timestamp": 1521989632,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "12177",
+          "winningBid": 750000,
+          "timestamp": 1522192891,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "13776",
+          "winningBid": 425000,
+          "timestamp": 1526243630,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "11657",
+          "winningBid": 3000000,
+          "timestamp": 1553353386,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "12197",
+          "winningBid": 425000,
+          "timestamp": 1553551878,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "10960",
+          "winningBid": 2525000,
+          "timestamp": 1553648013,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "14127",
+          "winningBid": 550000,
+          "timestamp": 1565648911,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "12176",
+          "winningBid": 5000000,
+          "timestamp": 1584645478,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "9662",
+          "winningBid": 4000000,
+          "timestamp": 1584658276,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "11695",
+          "winningBid": 3350000,
+          "timestamp": 1584754694,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "12658",
+          "winningBid": 2000000,
+          "timestamp": 1584754816,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "11670",
+          "winningBid": 875000,
+          "timestamp": 1584756055,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "8930",
+          "winningBid": 525000,
+          "timestamp": 1584790057,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "11390",
+          "winningBid": 2025000,
+          "timestamp": 1585002522,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "14857",
+          "winningBid": 425000,
+          "timestamp": 1588896731,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "0510",
+          "winningBid": 1625000,
+          "timestamp": 1616184498,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "12150",
+          "winningBid": 2025000,
+          "timestamp": 1616184583,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "10729",
+          "winningBid": 3250000,
+          "timestamp": 1616324029,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "15316",
+          "winningBid": 450000,
+          "timestamp": 1620939389,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "10868",
+          "winningBid": 425000,
+          "timestamp": 1647637102,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "12187",
+          "winningBid": 3500000,
+          "timestamp": 1647708486,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "13154",
+          "winningBid": 5500000,
+          "timestamp": 1647709181,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "13153",
+          "winningBid": 875000,
+          "timestamp": 1647840634,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "13623",
+          "winningBid": 425000,
+          "timestamp": 1648098263,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "13157",
+          "winningBid": 425000,
+          "timestamp": 1648268153,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "16269",
+          "winningBid": 425000,
+          "timestamp": 1683648946,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "14080",
+          "winningBid": 1250000,
+          "timestamp": 1711069831,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "14109",
+          "winningBid": 4500000,
+          "timestamp": 1711200179,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "12263",
+          "winningBid": 1000000,
+          "timestamp": 1711200471,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "11232",
+          "winningBid": 7000000,
+          "timestamp": 1711516680,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "11671",
+          "winningBid": 6500000,
+          "timestamp": 1742530614,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "12801",
+          "winningBid": 7000000,
+          "timestamp": 1742530614,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "12175",
+          "winningBid": 700000,
+          "timestamp": 1742534566,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "14797",
+          "winningBid": 750000,
+          "timestamp": 1742535476,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "13832",
+          "winningBid": 675000,
+          "timestamp": 1742665462,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "11938",
+          "winningBid": 1000000,
+          "timestamp": 1742666219,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "17171",
+          "winningBid": 500000,
+          "timestamp": 1746919773,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "17063",
+          "winningBid": 425000,
+          "timestamp": 1747095677,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "12860",
+          "winningBid": 575000,
+          "timestamp": 1773930769,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "15281",
+          "winningBid": 10000000,
+          "timestamp": 1773947513,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "11244",
+          "winningBid": 4750000,
+          "timestamp": 1774034131,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "0518",
+          "winningBid": 1075000,
+          "timestamp": 1774062048,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "13630",
+          "winningBid": 5000000,
+          "timestamp": 1774077420,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "15789",
+          "winningBid": 4750000,
+          "timestamp": 1774077547,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "14600",
+          "winningBid": 450000,
+          "timestamp": 1774116806,
+          "sourceFranchiseId": null
+        }
+      ],
       "currentName": "Gridiron Geeks",
       "currentNameMedium": "Gridiron Geeks",
       "currentNameShort": "Geeks",
@@ -50526,6 +63344,853 @@
           "bothAttributed": true
         }
       ],
+      "draftPicks": [
+        {
+          "year": 2016,
+          "round": 1,
+          "pick": 5,
+          "playerId": "12652",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1462646293,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "round": 1,
+          "pick": 13,
+          "playerId": "12650",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1462757935,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "round": 2,
+          "pick": 12,
+          "playerId": "12639",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1462895876,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "round": 2,
+          "pick": 14,
+          "playerId": "12628",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1462905602,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "round": 3,
+          "pick": 14,
+          "playerId": "12616",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1463079730,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "round": 1,
+          "pick": 8,
+          "playerId": "13138",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1494113306,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "round": 2,
+          "pick": 8,
+          "playerId": "13143",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1494271735,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "round": 3,
+          "pick": 8,
+          "playerId": "13299",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1494355649,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "round": 2,
+          "pick": 10,
+          "playerId": "13668",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1525673585,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "round": 3,
+          "pick": 10,
+          "playerId": "13615",
+          "viaTrade": false,
+          "comments": "Picking behind Vit sucks",
+          "timestamp": 1525752646,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "round": 1,
+          "pick": 11,
+          "playerId": "14079",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1557080667,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "round": 2,
+          "pick": 11,
+          "playerId": "14191",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1557177069,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "round": 3,
+          "pick": 11,
+          "playerId": "14239",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1557259995,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "round": 1,
+          "pick": 3,
+          "playerId": "14832",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1588464002,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "round": 2,
+          "pick": 3,
+          "playerId": "14936",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1588612891,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "round": 2,
+          "pick": 17,
+          "playerId": "14782",
+          "viaTrade": false,
+          "comments": "[Pick added by commissioner.]",
+          "timestamp": 1588694900,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "round": 3,
+          "pick": 3,
+          "playerId": "14843",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1588696034,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "round": 1,
+          "pick": 9,
+          "playerId": "15240",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1620518974,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "round": 2,
+          "pick": 9,
+          "playerId": "15332",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1620771725,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "round": 3,
+          "pick": 9,
+          "playerId": "15275",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1620858741,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "round": 1,
+          "pick": 1,
+          "playerId": "15708",
+          "viaTrade": false,
+          "comments": "[Pick made from Pre-Draft List]",
+          "timestamp": 1651928412,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "round": 2,
+          "pick": 1,
+          "playerId": "15794",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1652203788,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "round": 3,
+          "pick": 1,
+          "playerId": "15779",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1652332482,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "round": 1,
+          "pick": 8,
+          "playerId": "16152",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1683430624,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "round": 2,
+          "pick": 8,
+          "playerId": "16184",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1683556421,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "round": 2,
+          "pick": 10,
+          "playerId": "16191",
+          "viaTrade": true,
+          "comments": "[Pick traded from Fire Ready Aim.]",
+          "timestamp": 1683557914,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "round": 3,
+          "pick": 8,
+          "playerId": "16166",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1683590293,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "round": 1,
+          "pick": 14,
+          "playerId": "16594",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1714944743,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "round": 2,
+          "pick": 14,
+          "playerId": "16637",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1715002644,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "round": 3,
+          "pick": 14,
+          "playerId": "16596",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1715177926,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "round": 1,
+          "pick": 15,
+          "playerId": "17032",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1746515034,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "round": 2,
+          "pick": 15,
+          "playerId": "17064",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1746683610,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "round": 3,
+          "pick": 15,
+          "playerId": "17099",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1746837523,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "round": 1,
+          "pick": 13,
+          "playerId": "17503",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1777887889,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "round": 2,
+          "pick": 13,
+          "playerId": "17607",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1778085117,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "round": 3,
+          "pick": 13,
+          "playerId": "17467",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1778196342,
+          "sourceFranchiseId": null
+        }
+      ],
+      "auctionWins": [
+        {
+          "year": 2015,
+          "playerId": "7393",
+          "winningBid": 3000000,
+          "timestamp": 1426773070,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "9881",
+          "winningBid": 4000000,
+          "timestamp": 1426773105,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "8742",
+          "winningBid": 550000,
+          "timestamp": 1426773221,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "8160",
+          "winningBid": 500000,
+          "timestamp": 1426773280,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "8293",
+          "winningBid": 525000,
+          "timestamp": 1426856507,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "10318",
+          "winningBid": 425000,
+          "timestamp": 1426857328,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "8243",
+          "winningBid": 1200000,
+          "timestamp": 1426978383,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "11258",
+          "winningBid": 2175000,
+          "timestamp": 1426978771,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2015,
+          "playerId": "7813",
+          "winningBid": 3500000,
+          "timestamp": 1427030716,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "7391",
+          "winningBid": 3000000,
+          "timestamp": 1458250130,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "10983",
+          "winningBid": 1250000,
+          "timestamp": 1458250953,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "11747",
+          "winningBid": 825000,
+          "timestamp": 1458251255,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "9044",
+          "winningBid": 4000000,
+          "timestamp": 1458262837,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "10868",
+          "winningBid": 425000,
+          "timestamp": 1458276356,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "11387",
+          "winningBid": 425000,
+          "timestamp": 1458276780,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "9838",
+          "winningBid": 425000,
+          "timestamp": 1458586301,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "12878",
+          "winningBid": 425000,
+          "timestamp": 1466846640,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "12665",
+          "winningBid": 750000,
+          "timestamp": 1489784267,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "10300",
+          "winningBid": 450000,
+          "timestamp": 1489804728,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "6929",
+          "winningBid": 4025000,
+          "timestamp": 1490112722,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "13159",
+          "winningBid": 425000,
+          "timestamp": 1494525554,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "10273",
+          "winningBid": 5225000,
+          "timestamp": 1553219783,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "10297",
+          "winningBid": 425000,
+          "timestamp": 1553220014,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "0526",
+          "winningBid": 425000,
+          "timestamp": 1553355403,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "9831",
+          "winningBid": 4900000,
+          "timestamp": 1553355807,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "11644",
+          "winningBid": 5275000,
+          "timestamp": 1553356774,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "0522",
+          "winningBid": 425000,
+          "timestamp": 1553369919,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "13890",
+          "winningBid": 475000,
+          "timestamp": 1553447968,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "12596",
+          "winningBid": 625000,
+          "timestamp": 1553475743,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "15024",
+          "winningBid": 425000,
+          "timestamp": 1589236237,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "14871",
+          "winningBid": 425000,
+          "timestamp": 1589236348,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "15368",
+          "winningBid": 425000,
+          "timestamp": 1620924463,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "12176",
+          "winningBid": 800000,
+          "timestamp": 1647549158,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "12634",
+          "winningBid": 425000,
+          "timestamp": 1647549216,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "11680",
+          "winningBid": 750000,
+          "timestamp": 1647549589,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "14789",
+          "winningBid": 425000,
+          "timestamp": 1647902394,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "10313",
+          "winningBid": 425000,
+          "timestamp": 1647902425,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "13139",
+          "winningBid": 425000,
+          "timestamp": 1647902609,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "14810",
+          "winningBid": 425000,
+          "timestamp": 1647902744,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "13134",
+          "winningBid": 425000,
+          "timestamp": 1647902891,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "12657",
+          "winningBid": 425000,
+          "timestamp": 1647902955,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "13814",
+          "winningBid": 425000,
+          "timestamp": 1648163465,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "13299",
+          "winningBid": 8500000,
+          "timestamp": 1678979017,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "15727",
+          "winningBid": 425000,
+          "timestamp": 1678979443,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "13129",
+          "winningBid": 425000,
+          "timestamp": 1678979937,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "15261",
+          "winningBid": 425000,
+          "timestamp": 1678980154,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "11644",
+          "winningBid": 2400000,
+          "timestamp": 1678981205,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "11671",
+          "winningBid": 4250000,
+          "timestamp": 1679106844,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "12263",
+          "winningBid": 7150000,
+          "timestamp": 1679261723,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "0526",
+          "winningBid": 500000,
+          "timestamp": 1711048876,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "0532",
+          "winningBid": 800000,
+          "timestamp": 1711048963,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "14823",
+          "winningBid": 625000,
+          "timestamp": 1711049197,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "14079",
+          "winningBid": 425000,
+          "timestamp": 1711049668,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "13134",
+          "winningBid": 425000,
+          "timestamp": 1711136520,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "9064",
+          "winningBid": 425000,
+          "timestamp": 1711137418,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "15332",
+          "winningBid": 425000,
+          "timestamp": 1711300612,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "14136",
+          "winningBid": 3000000,
+          "timestamp": 1742491030,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "16342",
+          "winningBid": 700000,
+          "timestamp": 1742491121,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "14823",
+          "winningBid": 850000,
+          "timestamp": 1742491172,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "14867",
+          "winningBid": 4000000,
+          "timestamp": 1742492587,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "12956",
+          "winningBid": 600000,
+          "timestamp": 1742498576,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "7836",
+          "winningBid": 775000,
+          "timestamp": 1742613058,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "13299",
+          "winningBid": 7000000,
+          "timestamp": 1742754208,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "10703",
+          "winningBid": 1100000,
+          "timestamp": 1742754311,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "14832",
+          "winningBid": 9500000,
+          "timestamp": 1773968072,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "16608",
+          "winningBid": 450000,
+          "timestamp": 1773968698,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "11150",
+          "winningBid": 1225000,
+          "timestamp": 1774071984,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "14085",
+          "winningBid": 2750000,
+          "timestamp": 1774132078,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "14835",
+          "winningBid": 4525000,
+          "timestamp": 1774140785,
+          "sourceFranchiseId": null
+        }
+      ],
       "currentName": "Da Dangsters",
       "currentNameMedium": "Da Dangsters",
       "currentNameShort": "Dangsters",
@@ -53665,6 +67330,1002 @@
           "sourceFranchiseId": null,
           "partnerSourceId": null,
           "bothAttributed": true
+        }
+      ],
+      "draftPicks": [
+        {
+          "year": 2016,
+          "round": 1,
+          "pick": 15,
+          "playerId": "12629",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1462789260,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "round": 2,
+          "pick": 15,
+          "playerId": "12651",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1462927011,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "round": 3,
+          "pick": 15,
+          "playerId": "12672",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1463101119,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "round": 3,
+          "pick": 12,
+          "playerId": "13172",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1494359936,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "round": 1,
+          "pick": 8,
+          "playerId": "13617",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1525546996,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "round": 2,
+          "pick": 1,
+          "playerId": "13591",
+          "viaTrade": true,
+          "comments": "[Pick traded from Pacific Pigskins.]",
+          "timestamp": 1525639541,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "round": 2,
+          "pick": 14,
+          "playerId": "13620",
+          "viaTrade": true,
+          "comments": "[Pick traded from Pacific Pigskins.] Pick traded from Devil Dogs.",
+          "timestamp": 1525714636,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "round": 3,
+          "pick": 8,
+          "playerId": "13807",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1525733833,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "round": 2,
+          "pick": 2,
+          "playerId": "14284",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1557099130,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "round": 3,
+          "pick": 9,
+          "playerId": "14314",
+          "viaTrade": true,
+          "comments": "[Pick traded from  Running Down The Dream.\nPick traded from Wascawy Wabbits.]",
+          "timestamp": 1557252389,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "round": 1,
+          "pick": 9,
+          "playerId": "14810",
+          "viaTrade": false,
+          "comments": "[Pick made from Pre-Draft List]",
+          "timestamp": 1588475906,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "round": 2,
+          "pick": 18,
+          "playerId": "14783",
+          "viaTrade": false,
+          "comments": "[Pick added by commissioner.\nPick made from Pre-Draft List]",
+          "timestamp": 1588694900,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "round": 1,
+          "pick": 11,
+          "playerId": "15257",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1620522002,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "round": 3,
+          "pick": 11,
+          "playerId": "15304",
+          "viaTrade": false,
+          "comments": "[Pick made from Pre-Draft List]",
+          "timestamp": 1620870698,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "round": 1,
+          "pick": 9,
+          "playerId": "15715",
+          "viaTrade": false,
+          "comments": "[Pick made from Pre-Draft List]",
+          "timestamp": 1652061658,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "round": 2,
+          "pick": 9,
+          "playerId": "15761",
+          "viaTrade": false,
+          "comments": "[Pick made from Pre-Draft List]",
+          "timestamp": 1652244882,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "round": 2,
+          "pick": 13,
+          "playerId": "16173",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1683561114,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "round": 1,
+          "pick": 9,
+          "playerId": "16627",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1714922492,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "round": 2,
+          "pick": 9,
+          "playerId": "16757",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1714969086,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "round": 3,
+          "pick": 9,
+          "playerId": "16684",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1715116190,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "round": 1,
+          "pick": 14,
+          "playerId": "17070",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1746492840,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "round": 2,
+          "pick": 2,
+          "playerId": "17086",
+          "viaTrade": true,
+          "comments": "[Pick traded from Midwestside Connection.]",
+          "timestamp": 1746585382,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "round": 3,
+          "pick": 14,
+          "playerId": "17049",
+          "viaTrade": false,
+          "comments": "[Pick made from Pre-Draft List]",
+          "timestamp": 1746837052,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "round": 1,
+          "pick": 7,
+          "playerId": "17462",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1777815710,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "round": 2,
+          "pick": 17,
+          "playerId": "17548",
+          "viaTrade": false,
+          "comments": "[Pick added by commissioner.]",
+          "timestamp": 1778098792,
+          "sourceFranchiseId": null
+        }
+      ],
+      "auctionWins": [
+        {
+          "year": 2016,
+          "playerId": "0517",
+          "winningBid": 500000,
+          "timestamp": 1458268695,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "7401",
+          "winningBid": 7025000,
+          "timestamp": 1458268756,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "9690",
+          "winningBid": 1025000,
+          "timestamp": 1458268889,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "0529",
+          "winningBid": 425000,
+          "timestamp": 1458269275,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "11682",
+          "winningBid": 425000,
+          "timestamp": 1458271035,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "10312",
+          "winningBid": 3950000,
+          "timestamp": 1458476875,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "12637",
+          "winningBid": 425000,
+          "timestamp": 1463183910,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "12867",
+          "winningBid": 425000,
+          "timestamp": 1463183933,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "12807",
+          "winningBid": 425000,
+          "timestamp": 1463183960,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "12874",
+          "winningBid": 425000,
+          "timestamp": 1463183984,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "0527",
+          "winningBid": 800000,
+          "timestamp": 1489707763,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "7877",
+          "winningBid": 1025000,
+          "timestamp": 1489790041,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "7394",
+          "winningBid": 2825000,
+          "timestamp": 1489876058,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "8144",
+          "winningBid": 425000,
+          "timestamp": 1490066908,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "13370",
+          "winningBid": 425000,
+          "timestamp": 1494458288,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "13187",
+          "winningBid": 425000,
+          "timestamp": 1494458452,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "10271",
+          "winningBid": 9500000,
+          "timestamp": 1521126849,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "0527",
+          "winningBid": 500000,
+          "timestamp": 1521153194,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "10276",
+          "winningBid": 8000000,
+          "timestamp": 1521153924,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "11239",
+          "winningBid": 5000000,
+          "timestamp": 1521158847,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "0523",
+          "winningBid": 425000,
+          "timestamp": 1521292537,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "9694",
+          "winningBid": 425000,
+          "timestamp": 1521293579,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "9912",
+          "winningBid": 625000,
+          "timestamp": 1521324888,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "11966",
+          "winningBid": 425000,
+          "timestamp": 1521507885,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "11812",
+          "winningBid": 800000,
+          "timestamp": 1521655412,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "13675",
+          "winningBid": 425000,
+          "timestamp": 1525826148,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "12954",
+          "winningBid": 500000,
+          "timestamp": 1529410581,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "13585",
+          "winningBid": 425000,
+          "timestamp": 1529410698,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "0528",
+          "winningBid": 1000000,
+          "timestamp": 1553217091,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "10389",
+          "winningBid": 825000,
+          "timestamp": 1553218259,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "10708",
+          "winningBid": 4000000,
+          "timestamp": 1553220982,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "11250",
+          "winningBid": 3100000,
+          "timestamp": 1553350824,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "7877",
+          "winningBid": 700000,
+          "timestamp": 1553351067,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "8930",
+          "winningBid": 525000,
+          "timestamp": 1553360872,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "12934",
+          "winningBid": 425000,
+          "timestamp": 1553518660,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "11783",
+          "winningBid": 2500000,
+          "timestamp": 1553529788,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "11399",
+          "winningBid": 425000,
+          "timestamp": 1553624074,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "14267",
+          "winningBid": 425000,
+          "timestamp": 1557281051,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "14231",
+          "winningBid": 425000,
+          "timestamp": 1557282023,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "14313",
+          "winningBid": 425000,
+          "timestamp": 1557282036,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "13819",
+          "winningBid": 425000,
+          "timestamp": 1559399376,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "12398",
+          "winningBid": 425000,
+          "timestamp": 1559447318,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "12175",
+          "winningBid": 9000000,
+          "timestamp": 1584627607,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "12187",
+          "winningBid": 6500000,
+          "timestamp": 1584628512,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "10862",
+          "winningBid": 425000,
+          "timestamp": 1584757910,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "12184",
+          "winningBid": 950000,
+          "timestamp": 1584760885,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "11783",
+          "winningBid": 3025000,
+          "timestamp": 1584761270,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "9308",
+          "winningBid": 425000,
+          "timestamp": 1584762309,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "10722",
+          "winningBid": 1425000,
+          "timestamp": 1584827731,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "10700",
+          "winningBid": 2750000,
+          "timestamp": 1584887331,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "0529",
+          "winningBid": 900000,
+          "timestamp": 1584887498,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "14464",
+          "winningBid": 425000,
+          "timestamp": 1584887892,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "14305",
+          "winningBid": 425000,
+          "timestamp": 1585018356,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "14974",
+          "winningBid": 425000,
+          "timestamp": 1588956660,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "9686",
+          "winningBid": 575000,
+          "timestamp": 1616076556,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "13675",
+          "winningBid": 425000,
+          "timestamp": 1616080457,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "11193",
+          "winningBid": 425000,
+          "timestamp": 1616093680,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "9662",
+          "winningBid": 450000,
+          "timestamp": 1616124737,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "14117",
+          "winningBid": 425000,
+          "timestamp": 1616165819,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "0514",
+          "winningBid": 1300000,
+          "timestamp": 1616170815,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "11222",
+          "winningBid": 7500000,
+          "timestamp": 1616254446,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "12629",
+          "winningBid": 450000,
+          "timestamp": 1616385463,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "15467",
+          "winningBid": 425000,
+          "timestamp": 1620930366,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "0528",
+          "winningBid": 1200000,
+          "timestamp": 1647572338,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "0510",
+          "winningBid": 925000,
+          "timestamp": 1647573545,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "13113",
+          "winningBid": 5000000,
+          "timestamp": 1647662502,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "13156",
+          "winningBid": 5250000,
+          "timestamp": 1647667387,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "13313",
+          "winningBid": 500000,
+          "timestamp": 1647868070,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "12110",
+          "winningBid": 425000,
+          "timestamp": 1647877964,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "13246",
+          "winningBid": 550000,
+          "timestamp": 1647887063,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "15736",
+          "winningBid": 425000,
+          "timestamp": 1652536272,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "13303",
+          "winningBid": 425000,
+          "timestamp": 1678975496,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "15742",
+          "winningBid": 425000,
+          "timestamp": 1678987457,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "12650",
+          "winningBid": 425000,
+          "timestamp": 1679002032,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "13146",
+          "winningBid": 4125000,
+          "timestamp": 1679062913,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "13236",
+          "winningBid": 3000000,
+          "timestamp": 1679264863,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "14876",
+          "winningBid": 425000,
+          "timestamp": 1679265878,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "15239",
+          "winningBid": 425000,
+          "timestamp": 1679323058,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "16203",
+          "winningBid": 425000,
+          "timestamp": 1683654274,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "16379",
+          "winningBid": 425000,
+          "timestamp": 1683988775,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "16159",
+          "winningBid": 425000,
+          "timestamp": 1685632626,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "11244",
+          "winningBid": 9000000,
+          "timestamp": 1711068016,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "0501",
+          "winningBid": 950000,
+          "timestamp": 1711068055,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "12187",
+          "winningBid": 1250000,
+          "timestamp": 1711068399,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "9431",
+          "winningBid": 3200000,
+          "timestamp": 1711068791,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "0518",
+          "winningBid": 1225000,
+          "timestamp": 1711069210,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "14136",
+          "winningBid": 8000000,
+          "timestamp": 1711198566,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "16613",
+          "winningBid": 800000,
+          "timestamp": 1715203443,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "16645",
+          "winningBid": 675000,
+          "timestamp": 1715203519,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "16612",
+          "winningBid": 425000,
+          "timestamp": 1724123541,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "13146",
+          "winningBid": 4000000,
+          "timestamp": 1742479720,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "12678",
+          "winningBid": 1000000,
+          "timestamp": 1742480823,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "13303",
+          "winningBid": 750000,
+          "timestamp": 1742496196,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "16292",
+          "winningBid": 425000,
+          "timestamp": 1742508212,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "14071",
+          "winningBid": 4000000,
+          "timestamp": 1742508676,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "14592",
+          "winningBid": 425000,
+          "timestamp": 1742759055,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "13675",
+          "winningBid": 425000,
+          "timestamp": 1742759220,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "17066",
+          "winningBid": 425000,
+          "timestamp": 1746839641,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "17231",
+          "winningBid": 425000,
+          "timestamp": 1746908750,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "11760",
+          "winningBid": 425000,
+          "timestamp": 1755015043,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "0522",
+          "winningBid": 775000,
+          "timestamp": 1773929186,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "13674",
+          "winningBid": 5000000,
+          "timestamp": 1773941978,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "13303",
+          "winningBid": 425000,
+          "timestamp": 1773953811,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "15337",
+          "winningBid": 1000000,
+          "timestamp": 1774033269,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "17424",
+          "winningBid": 425000,
+          "timestamp": 1774112926,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "14778",
+          "winningBid": 1900000,
+          "timestamp": 1774288368,
+          "sourceFranchiseId": null
         }
       ],
       "currentName": "The Mariachi Ninjas",
@@ -57013,6 +71674,1115 @@
           "bothAttributed": true
         }
       ],
+      "draftPicks": [
+        {
+          "year": 2016,
+          "round": 1,
+          "pick": 2,
+          "playerId": "12645",
+          "viaTrade": false,
+          "comments": "Pick made based on Pre-Draft List",
+          "timestamp": 1462633400,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "round": 1,
+          "pick": 10,
+          "playerId": "12627",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1462710014,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "round": 2,
+          "pick": 2,
+          "playerId": "12669",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1462831583,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "round": 2,
+          "pick": 5,
+          "playerId": "12675",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1462837793,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "round": 2,
+          "pick": 16,
+          "playerId": "12673",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1462928858,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "round": 3,
+          "pick": 2,
+          "playerId": "12726",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1462969187,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "round": 1,
+          "pick": 10,
+          "playerId": "13132",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1494151331,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "round": 2,
+          "pick": 16,
+          "playerId": "13158",
+          "viaTrade": true,
+          "comments": "Pick traded from LBer-DeCleaters.",
+          "timestamp": 1494314137,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "round": 3,
+          "pick": 1,
+          "playerId": "13290",
+          "viaTrade": false,
+          "comments": "Pick made based on Pre-Draft List",
+          "timestamp": 1494344633,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "round": 3,
+          "pick": 10,
+          "playerId": "13166",
+          "viaTrade": false,
+          "comments": "Pick made based on Pre-Draft List",
+          "timestamp": 1494359454,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "round": 3,
+          "pick": 15,
+          "playerId": "13195",
+          "viaTrade": true,
+          "comments": "Pick traded from Devil Dogs.\nPick made based on Pre-Draft List",
+          "timestamp": 1494367357,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "round": 3,
+          "pick": 3,
+          "playerId": "13642",
+          "viaTrade": true,
+          "comments": "[Pick traded from Bring the Pain.\nPick made based on Pre-Draft List] Pick traded from Computer Jocks.",
+          "timestamp": 1525731509,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "round": 3,
+          "pick": 5,
+          "playerId": "13663",
+          "viaTrade": true,
+          "comments": "[Pick traded from Bring the Pain.\nPick made based on Pre-Draft List] Pick traded from  Running Down The Dream.\nPick traded from Computer Jocks.",
+          "timestamp": 1525732912,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "round": 3,
+          "pick": 7,
+          "playerId": "13613",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1525733664,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "round": 1,
+          "pick": 1,
+          "playerId": "14071",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1556999727,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "round": 1,
+          "pick": 2,
+          "playerId": "14101",
+          "viaTrade": true,
+          "comments": "[Pick traded from The Mariachi Ninjas.]",
+          "timestamp": 1557001552,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "round": 1,
+          "pick": 15,
+          "playerId": "14136",
+          "viaTrade": true,
+          "comments": "[Pick traded from Wascawy Wabbits.]",
+          "timestamp": 1557095564,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "round": 2,
+          "pick": 1,
+          "playerId": "14107",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1557098949,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "round": 2,
+          "pick": 10,
+          "playerId": "14057",
+          "viaTrade": true,
+          "comments": "[Pick traded from Cowboy Up.]",
+          "timestamp": 1557176826,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "round": 1,
+          "pick": 1,
+          "playerId": "14803",
+          "viaTrade": false,
+          "comments": "Player to be traded to Gridiron Geeks after trade processed",
+          "timestamp": 1588461466,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "round": 1,
+          "pick": 4,
+          "playerId": "14833",
+          "viaTrade": true,
+          "comments": "[Pick traded from Gridiron Geeks.] My 1.01 at 1.4 nervous times but got here",
+          "timestamp": 1588469730,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "round": 2,
+          "pick": 4,
+          "playerId": "14838",
+          "viaTrade": true,
+          "comments": "[Pick traded from Gridiron Geeks.\nPick made from Pre-Draft List]",
+          "timestamp": 1588612891,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "round": 2,
+          "pick": 16,
+          "playerId": "14804",
+          "viaTrade": true,
+          "comments": "[Pick traded from Bring the Pain.]",
+          "timestamp": 1588671613,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "round": 3,
+          "pick": 4,
+          "playerId": "14837",
+          "viaTrade": true,
+          "comments": "[Pick traded from Gridiron Geeks.\nPick made from Pre-Draft List]",
+          "timestamp": 1588696034,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "round": 1,
+          "pick": 5,
+          "playerId": "15281",
+          "viaTrade": true,
+          "comments": "[Pick traded from Gridiron Geeks.]",
+          "timestamp": 1620506670,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "round": 3,
+          "pick": 8,
+          "playerId": "15462",
+          "viaTrade": false,
+          "comments": "[Pick made from Pre-Draft List]",
+          "timestamp": 1620858436,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "round": 2,
+          "pick": 18,
+          "playerId": "15720",
+          "viaTrade": false,
+          "comments": "[Pick added by commissioner.]",
+          "timestamp": 1652330214,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "round": 3,
+          "pick": 5,
+          "playerId": "15796",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1652394965,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "round": 3,
+          "pick": 6,
+          "playerId": "16179",
+          "viaTrade": true,
+          "comments": "[Pick traded from Bring the Pain.]",
+          "timestamp": 1683580013,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "round": 1,
+          "pick": 15,
+          "playerId": "16639",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1714945309,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "round": 1,
+          "pick": 16,
+          "playerId": "16622",
+          "viaTrade": true,
+          "comments": "[Pick traded from Fire Ready Aim.\nPick traded from Wascawy Wabbits.]",
+          "timestamp": 1714946743,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "round": 2,
+          "pick": 1,
+          "playerId": "16631",
+          "viaTrade": true,
+          "comments": "[Pick traded from The Music City Mafia.\nPick traded from Wascawy Wabbits.] Not gunna Lie my whole Chase trade was about getting Burton and I let it slip",
+          "timestamp": 1714951316,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "round": 2,
+          "pick": 3,
+          "playerId": "16619",
+          "viaTrade": true,
+          "comments": "[Pick traded from Heavy Chevy.\nPick traded from Wascawy Wabbits.]",
+          "timestamp": 1714953162,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "round": 2,
+          "pick": 5,
+          "playerId": "16583",
+          "viaTrade": true,
+          "comments": "[Pick traded from Wascawy Wabbits.]",
+          "timestamp": 1714956754,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "round": 2,
+          "pick": 15,
+          "playerId": "16636",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1715021172,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "round": 3,
+          "pick": 4,
+          "playerId": "16621",
+          "viaTrade": true,
+          "comments": "[Pick traded from Dark Magicians of Chaos.]",
+          "timestamp": 1715099927,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "round": 3,
+          "pick": 15,
+          "playerId": "16746",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1715199559,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "round": 1,
+          "pick": 5,
+          "playerId": "17068",
+          "viaTrade": true,
+          "comments": "[Pick traded from Bring the Pain.]",
+          "timestamp": 1746350302,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "round": 1,
+          "pick": 7,
+          "playerId": "17043",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1746400105,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "round": 1,
+          "pick": 8,
+          "playerId": "17051",
+          "viaTrade": true,
+          "comments": "[Pick traded from The Music City Mafia.]",
+          "timestamp": 1746401800,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "round": 3,
+          "pick": 7,
+          "playerId": "17082",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1746742893,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "round": 1,
+          "pick": 5,
+          "playerId": "17498",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1777789516,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "round": 2,
+          "pick": 5,
+          "playerId": "17547",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1778033661,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "round": 3,
+          "pick": 5,
+          "playerId": "17591",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1778104746,
+          "sourceFranchiseId": null
+        }
+      ],
+      "auctionWins": [
+        {
+          "year": 2016,
+          "playerId": "9448",
+          "winningBid": 5600000,
+          "timestamp": 1458312706,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "9122",
+          "winningBid": 5000000,
+          "timestamp": 1458312839,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "9099",
+          "winningBid": 4700000,
+          "timestamp": 1458407631,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "0504",
+          "winningBid": 1000000,
+          "timestamp": 1458408695,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "8930",
+          "winningBid": 425000,
+          "timestamp": 1458408718,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "12437",
+          "winningBid": 425000,
+          "timestamp": 1458443379,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "10735",
+          "winningBid": 425000,
+          "timestamp": 1458443687,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "8657",
+          "winningBid": 475000,
+          "timestamp": 1458523626,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "9456",
+          "winningBid": 425000,
+          "timestamp": 1458527267,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "8673",
+          "winningBid": 1500000,
+          "timestamp": 1458578212,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "9441",
+          "winningBid": 425000,
+          "timestamp": 1458610890,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "9427",
+          "winningBid": 6550000,
+          "timestamp": 1458761772,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "10432",
+          "winningBid": 500000,
+          "timestamp": 1466040412,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "9319",
+          "winningBid": 425000,
+          "timestamp": 1489702208,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "12353",
+          "winningBid": 425000,
+          "timestamp": 1489712641,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "11957",
+          "winningBid": 425000,
+          "timestamp": 1489723501,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "10929",
+          "winningBid": 425000,
+          "timestamp": 1489927932,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "0505",
+          "winningBid": 425000,
+          "timestamp": 1489928109,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "11936",
+          "winningBid": 425000,
+          "timestamp": 1489928163,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "9120",
+          "winningBid": 425000,
+          "timestamp": 1489943604,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "11399",
+          "winningBid": 1525000,
+          "timestamp": 1489960044,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "8673",
+          "winningBid": 2025000,
+          "timestamp": 1490081485,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "13127",
+          "winningBid": 425000,
+          "timestamp": 1494406433,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "13161",
+          "winningBid": 425000,
+          "timestamp": 1494406547,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "0530",
+          "winningBid": 425000,
+          "timestamp": 1521159142,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "11936",
+          "winningBid": 525000,
+          "timestamp": 1521160518,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "12645",
+          "winningBid": 600000,
+          "timestamp": 1521274076,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "0502",
+          "winningBid": 425000,
+          "timestamp": 1521292973,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "8269",
+          "winningBid": 425000,
+          "timestamp": 1521350129,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "11850",
+          "winningBid": 425000,
+          "timestamp": 1521453893,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "13652",
+          "winningBid": 425000,
+          "timestamp": 1525847508,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "13819",
+          "winningBid": 425000,
+          "timestamp": 1526767417,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "12616",
+          "winningBid": 425000,
+          "timestamp": 1527630499,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "10077",
+          "winningBid": 450000,
+          "timestamp": 1531254959,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "11975",
+          "winningBid": 425000,
+          "timestamp": 1553328970,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "13647",
+          "winningBid": 425000,
+          "timestamp": 1553329101,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "13619",
+          "winningBid": 425000,
+          "timestamp": 1553329150,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "13652",
+          "winningBid": 425000,
+          "timestamp": 1553329437,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "13165",
+          "winningBid": 1600000,
+          "timestamp": 1553542593,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "11678",
+          "winningBid": 7125000,
+          "timestamp": 1553569183,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "13722",
+          "winningBid": 475000,
+          "timestamp": 1553569261,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "14094",
+          "winningBid": 450000,
+          "timestamp": 1557277373,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "14119",
+          "winningBid": 425000,
+          "timestamp": 1557277395,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "14192",
+          "winningBid": 475000,
+          "timestamp": 1557277449,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "14146",
+          "winningBid": 425000,
+          "timestamp": 1557277525,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "14097",
+          "winningBid": 425000,
+          "timestamp": 1557277684,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "14144",
+          "winningBid": 425000,
+          "timestamp": 1563104255,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "12678",
+          "winningBid": 4250000,
+          "timestamp": 1584740455,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "14209",
+          "winningBid": 425000,
+          "timestamp": 1584829880,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "11657",
+          "winningBid": 650000,
+          "timestamp": 1584832927,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "11947",
+          "winningBid": 625000,
+          "timestamp": 1584848910,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "13591",
+          "winningBid": 425000,
+          "timestamp": 1585035896,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "14127",
+          "winningBid": 425000,
+          "timestamp": 1585035925,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "15021",
+          "winningBid": 425000,
+          "timestamp": 1588893203,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "15022",
+          "winningBid": 425000,
+          "timestamp": 1591592238,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "13768",
+          "winningBid": 525000,
+          "timestamp": 1616110320,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "11671",
+          "winningBid": 7500000,
+          "timestamp": 1616237516,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "8851",
+          "winningBid": 425000,
+          "timestamp": 1616979097,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "15295",
+          "winningBid": 425000,
+          "timestamp": 1620935707,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "13163",
+          "winningBid": 6250000,
+          "timestamp": 1647558118,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "10976",
+          "winningBid": 800000,
+          "timestamp": 1647559384,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "13132",
+          "winningBid": 9100000,
+          "timestamp": 1647689008,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "12658",
+          "winningBid": 425000,
+          "timestamp": 1647744789,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "15726",
+          "winningBid": 425000,
+          "timestamp": 1656746060,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "15728",
+          "winningBid": 425000,
+          "timestamp": 1656746073,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "15744",
+          "winningBid": 425000,
+          "timestamp": 1659255914,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "0522",
+          "winningBid": 600000,
+          "timestamp": 1679000501,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "11674",
+          "winningBid": 925000,
+          "timestamp": 1679004125,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "13593",
+          "winningBid": 5250000,
+          "timestamp": 1679101421,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "13590",
+          "winningBid": 3175000,
+          "timestamp": 1679267510,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "16172",
+          "winningBid": 425000,
+          "timestamp": 1683843423,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "16220",
+          "winningBid": 425000,
+          "timestamp": 1683843452,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "16217",
+          "winningBid": 425000,
+          "timestamp": 1683843486,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "16342",
+          "winningBid": 425000,
+          "timestamp": 1686374412,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "14833",
+          "winningBid": 1500000,
+          "timestamp": 1711050035,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "0502",
+          "winningBid": 600000,
+          "timestamp": 1711097055,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "0530",
+          "winningBid": 1200000,
+          "timestamp": 1711191580,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "14105",
+          "winningBid": 4000000,
+          "timestamp": 1711229709,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "13319",
+          "winningBid": 5025000,
+          "timestamp": 1711230093,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "11936",
+          "winningBid": 700000,
+          "timestamp": 1711390516,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "11222",
+          "winningBid": 7475000,
+          "timestamp": 1711508194,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "16751",
+          "winningBid": 525000,
+          "timestamp": 1715210400,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "15789",
+          "winningBid": 600000,
+          "timestamp": 1742498014,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "15979",
+          "winningBid": 575000,
+          "timestamp": 1742498167,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "15972",
+          "winningBid": 3000000,
+          "timestamp": 1742616971,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "15256",
+          "winningBid": 3025000,
+          "timestamp": 1742681081,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "10976",
+          "winningBid": 725000,
+          "timestamp": 1742681113,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "13671",
+          "winningBid": 6750000,
+          "timestamp": 1742681261,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "16414",
+          "winningBid": 1425000,
+          "timestamp": 1773952305,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "15253",
+          "winningBid": 3250000,
+          "timestamp": 1773952441,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "14871",
+          "winningBid": 2775000,
+          "timestamp": 1773981275,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "13590",
+          "winningBid": 3350000,
+          "timestamp": 1774035336,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "13116",
+          "winningBid": 4775000,
+          "timestamp": 1774115224,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "12801",
+          "winningBid": 1650000,
+          "timestamp": 1774293614,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "15759",
+          "winningBid": 425000,
+          "timestamp": 1774295586,
+          "sourceFranchiseId": null
+        }
+      ],
       "currentName": "Maverick",
       "currentNameMedium": "Mavericks",
       "currentNameShort": "Mavericks",
@@ -60198,6 +75968,799 @@
           "bothAttributed": true
         }
       ],
+      "draftPicks": [
+        {
+          "year": 2016,
+          "round": 1,
+          "pick": 16,
+          "playerId": "12647",
+          "viaTrade": false,
+          "comments": "BPA (Comments Added Wed May 11 9:31:17 a.m. PT 2016)",
+          "timestamp": 1462815839,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "round": 3,
+          "pick": 4,
+          "playerId": "12636",
+          "viaTrade": false,
+          "comments": "Pick made based on Pre-Draft List Could get some early playing time since he's behind Mathews and Sproles. (Comments Added Wed May 11 9:30:58 a.m. PT 2016)",
+          "timestamp": 1462983964,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "round": 3,
+          "pick": 5,
+          "playerId": "12614",
+          "viaTrade": false,
+          "comments": "Pick made based on Pre-Draft List No big aspirations here, just hoping he becomes my backup of the future. (Comments Added Wed May 11 9:31:07 a.m. PT 2016)",
+          "timestamp": 1462983964,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "round": 2,
+          "pick": 12,
+          "playerId": "13171",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1494296732,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "round": 3,
+          "pick": 4,
+          "playerId": "13135",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1494352212,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "round": 3,
+          "pick": 5,
+          "playerId": "13137",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1494352350,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "round": 1,
+          "pick": 2,
+          "playerId": "13605",
+          "viaTrade": true,
+          "comments": "[Pick made based on Pre-Draft List] Pick traded from Las Vegas Elite.",
+          "timestamp": 1525525229,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "round": 1,
+          "pick": 3,
+          "playerId": "13608",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1525538988,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "round": 1,
+          "pick": 5,
+          "playerId": "14102",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1557030497,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "round": 1,
+          "pick": 7,
+          "playerId": "14112",
+          "viaTrade": true,
+          "comments": "[Pick traded from Pacific Pigskins.]",
+          "timestamp": 1557073504,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "round": 2,
+          "pick": 7,
+          "playerId": "14058",
+          "viaTrade": true,
+          "comments": "[Pick traded from Pacific Pigskins.]",
+          "timestamp": 1557107385,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "round": 2,
+          "pick": 14,
+          "playerId": "14114",
+          "viaTrade": true,
+          "comments": "[Pick traded from LBer-DeCleaters.]",
+          "timestamp": 1557178753,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "round": 2,
+          "pick": 18,
+          "playerId": "14088",
+          "viaTrade": false,
+          "comments": "[Pick added by commissioner.]",
+          "timestamp": 1557190874,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "round": 3,
+          "pick": 12,
+          "playerId": "14123",
+          "viaTrade": true,
+          "comments": "[Pick traded from Bring the Pain.]",
+          "timestamp": 1557260249,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "round": 3,
+          "pick": 14,
+          "playerId": "14143",
+          "viaTrade": true,
+          "comments": "[Pick traded from LBer-DeCleaters.\nPick traded from Pacific Pigskins.\nPick made based on Pre-Draft List]",
+          "timestamp": 1557264592,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "round": 1,
+          "pick": 8,
+          "playerId": "14834",
+          "viaTrade": false,
+          "comments": "[Pick made from Pre-Draft List]",
+          "timestamp": 1588475906,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "round": 2,
+          "pick": 8,
+          "playerId": "14798",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1588614964,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "round": 3,
+          "pick": 8,
+          "playerId": "14806",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1588744741,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "round": 2,
+          "pick": 6,
+          "playerId": "15289",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1620684119,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "round": 2,
+          "pick": 15,
+          "playerId": "15263",
+          "viaTrade": true,
+          "comments": "[Pick traded from Wascawy Wabbits.]",
+          "timestamp": 1620788288,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "round": 3,
+          "pick": 6,
+          "playerId": "15285",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1620856892,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "round": 1,
+          "pick": 11,
+          "playerId": "15756",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1652108492,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "round": 2,
+          "pick": 11,
+          "playerId": "15746",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1652245498,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "round": 3,
+          "pick": 11,
+          "playerId": "15733",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1652409515,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "round": 1,
+          "pick": 1,
+          "playerId": "16161",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1683386553,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "round": 1,
+          "pick": 13,
+          "playerId": "16175",
+          "viaTrade": true,
+          "comments": "[Pick traded from The Mariachi Ninjas.]",
+          "timestamp": 1683483202,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "round": 1,
+          "pick": 15,
+          "playerId": "16150",
+          "viaTrade": true,
+          "comments": "[Pick traded from Dark Magicians of Chaos.]",
+          "timestamp": 1683488417,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "round": 1,
+          "pick": 17,
+          "playerId": "16212",
+          "viaTrade": false,
+          "comments": "[Pick added by commissioner.]",
+          "timestamp": 1683489747,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "round": 2,
+          "pick": 7,
+          "playerId": "16183",
+          "viaTrade": true,
+          "comments": "[Pick traded from The Music City Mafia.]",
+          "timestamp": 1683521919,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "round": 3,
+          "pick": 13,
+          "playerId": "16196",
+          "viaTrade": true,
+          "comments": "[Pick traded from The Mariachi Ninjas.]",
+          "timestamp": 1683643964,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "round": 1,
+          "pick": 2,
+          "playerId": "16615",
+          "viaTrade": false,
+          "comments": "[Pick made from Pre-Draft List]",
+          "timestamp": 1714828955,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "round": 2,
+          "pick": 2,
+          "playerId": "16580",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1714952897,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "round": 3,
+          "pick": 2,
+          "playerId": "16643",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1715050358,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "round": 3,
+          "pick": 6,
+          "playerId": "16747",
+          "viaTrade": true,
+          "comments": "[Pick traded from Bring the Pain.]",
+          "timestamp": 1715108849,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "round": 1,
+          "pick": 4,
+          "playerId": "17071",
+          "viaTrade": false,
+          "comments": "[Pick made from Pre-Draft List]",
+          "timestamp": 1746330618,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "round": 2,
+          "pick": 8,
+          "playerId": "17108",
+          "viaTrade": true,
+          "comments": "[Pick traded from The Music City Mafia.\nPick traded from Bring the Pain.]",
+          "timestamp": 1746629608,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "round": 3,
+          "pick": 4,
+          "playerId": "17056",
+          "viaTrade": false,
+          "comments": "[Pick made from Pre-Draft List]",
+          "timestamp": 1746727850,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "round": 1,
+          "pick": 16,
+          "playerId": "17477",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1777933713,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "round": 3,
+          "pick": 11,
+          "playerId": "17593",
+          "viaTrade": true,
+          "comments": "[Pick traded from Bring the Pain.]",
+          "timestamp": 1778158780,
+          "sourceFranchiseId": null
+        }
+      ],
+      "auctionWins": [
+        {
+          "year": 2016,
+          "playerId": "0510",
+          "winningBid": 425000,
+          "timestamp": 1458226441,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "0516",
+          "winningBid": 425000,
+          "timestamp": 1458226524,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "0507",
+          "winningBid": 425000,
+          "timestamp": 1458261154,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "7394",
+          "winningBid": 6025000,
+          "timestamp": 1458537876,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "12858",
+          "winningBid": 425000,
+          "timestamp": 1463203569,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "12824",
+          "winningBid": 425000,
+          "timestamp": 1463204040,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2016,
+          "playerId": "12649",
+          "winningBid": 425000,
+          "timestamp": 1463204070,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "10289",
+          "winningBid": 425000,
+          "timestamp": 1489710021,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "12660",
+          "winningBid": 425000,
+          "timestamp": 1489710495,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "12098",
+          "winningBid": 625000,
+          "timestamp": 1489876785,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "10308",
+          "winningBid": 4500000,
+          "timestamp": 1489899274,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "10674",
+          "winningBid": 500000,
+          "timestamp": 1490499540,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2017,
+          "playerId": "13316",
+          "winningBid": 425000,
+          "timestamp": 1494648234,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "11747",
+          "winningBid": 450000,
+          "timestamp": 1521211687,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "9686",
+          "winningBid": 450000,
+          "timestamp": 1521211687,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "12471",
+          "winningBid": 425000,
+          "timestamp": 1522444034,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "13638",
+          "winningBid": 425000,
+          "timestamp": 1525836158,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "13596",
+          "winningBid": 425000,
+          "timestamp": 1526156592,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "10973",
+          "winningBid": 425000,
+          "timestamp": 1533267627,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "13664",
+          "winningBid": 425000,
+          "timestamp": 1533482870,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "11406",
+          "winningBid": 425000,
+          "timestamp": 1533483333,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "11248",
+          "winningBid": 1000000,
+          "timestamp": 1553181915,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "10703",
+          "winningBid": 6525000,
+          "timestamp": 1553268074,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "9902",
+          "winningBid": 6525000,
+          "timestamp": 1553408911,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "11640",
+          "winningBid": 975000,
+          "timestamp": 1553477562,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "14115",
+          "winningBid": 425000,
+          "timestamp": 1557276854,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "13155",
+          "winningBid": 725000,
+          "timestamp": 1584822840,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "14106",
+          "winningBid": 500000,
+          "timestamp": 1584921697,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "11516",
+          "winningBid": 3625000,
+          "timestamp": 1584941357,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "14085",
+          "winningBid": 650000,
+          "timestamp": 1584993571,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "12152",
+          "winningBid": 2850000,
+          "timestamp": 1585056246,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "12437",
+          "winningBid": 425000,
+          "timestamp": 1585060481,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "11761",
+          "winningBid": 575000,
+          "timestamp": 1585060597,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "0509",
+          "winningBid": 775000,
+          "timestamp": 1616320698,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "11886",
+          "winningBid": 500000,
+          "timestamp": 1616465512,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "15262",
+          "winningBid": 425000,
+          "timestamp": 1621529943,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "9099",
+          "winningBid": 2000000,
+          "timestamp": 1647662769,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "12652",
+          "winningBid": 6025000,
+          "timestamp": 1647795219,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "13189",
+          "winningBid": 2600000,
+          "timestamp": 1647795708,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "12630",
+          "winningBid": 1525000,
+          "timestamp": 1647995951,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "15749",
+          "winningBid": 650000,
+          "timestamp": 1660070445,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "15337",
+          "winningBid": 425000,
+          "timestamp": 1661410006,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "13646",
+          "winningBid": 1000000,
+          "timestamp": 1679246995,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "16170",
+          "winningBid": 425000,
+          "timestamp": 1683938645,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "16160",
+          "winningBid": 425000,
+          "timestamp": 1683938815,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "13633",
+          "winningBid": 2000000,
+          "timestamp": 1711045436,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "13404",
+          "winningBid": 4025000,
+          "timestamp": 1711307927,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "16178",
+          "winningBid": 2025000,
+          "timestamp": 1711339546,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "8930",
+          "winningBid": 425000,
+          "timestamp": 1711394537,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "16809",
+          "winningBid": 475000,
+          "timestamp": 1721495359,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "16678",
+          "winningBid": 425000,
+          "timestamp": 1721952658,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "14842",
+          "winningBid": 1525000,
+          "timestamp": 1742532252,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "14127",
+          "winningBid": 2025000,
+          "timestamp": 1742606284,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "16269",
+          "winningBid": 2000000,
+          "timestamp": 1742811797,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "17220",
+          "winningBid": 425000,
+          "timestamp": 1755014371,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "16645",
+          "winningBid": 425000,
+          "timestamp": 1774390118,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "0512",
+          "winningBid": 1875000,
+          "timestamp": 1774457250,
+          "sourceFranchiseId": null
+        }
+      ],
       "currentName": "Computer Jocks",
       "currentNameMedium": "Computer Jocks",
       "currentNameShort": "CPU Jocks",
@@ -62752,6 +79315,852 @@
           "sourceFranchiseId": null,
           "partnerSourceId": null,
           "bothAttributed": true
+        }
+      ],
+      "draftPicks": [
+        {
+          "year": 2018,
+          "round": 3,
+          "pick": 14,
+          "playerId": "13658",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1525806451,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "round": 1,
+          "pick": 10,
+          "playerId": "14087",
+          "viaTrade": false,
+          "comments": "the next starting Rams RB! (Comments Added Mon May 6 7:43:08 p.m. PT 2019)",
+          "timestamp": 1557079338,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "round": 3,
+          "pick": 10,
+          "playerId": "14072",
+          "viaTrade": false,
+          "comments": "[Pick made based on Pre-Draft List]",
+          "timestamp": 1557252389,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "round": 2,
+          "pick": 2,
+          "playerId": "14840",
+          "viaTrade": false,
+          "comments": "god, I hate having to draft a Niner! but best on my draft board!",
+          "timestamp": 1588603006,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "round": 3,
+          "pick": 2,
+          "playerId": "14801",
+          "viaTrade": false,
+          "comments": "[Pick made from Pre-Draft List]",
+          "timestamp": 1588694900,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "round": 1,
+          "pick": 2,
+          "playerId": "15253",
+          "viaTrade": true,
+          "comments": "[Pick traded from Vitside Mafia.]",
+          "timestamp": 1620494881,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "round": 3,
+          "pick": 15,
+          "playerId": "15419",
+          "viaTrade": true,
+          "comments": "[Pick traded from Wascawy Wabbits.\nPick made from Pre-Draft List]",
+          "timestamp": 1620873294,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "round": 1,
+          "pick": 6,
+          "playerId": "15709",
+          "viaTrade": false,
+          "comments": "[Pick made from Pre-Draft List]",
+          "timestamp": 1652054515,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "round": 2,
+          "pick": 6,
+          "playerId": "15694",
+          "viaTrade": false,
+          "comments": "[Pick made from Pre-Draft List]",
+          "timestamp": 1652235730,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "round": 2,
+          "pick": 15,
+          "playerId": "15767",
+          "viaTrade": true,
+          "comments": "[Pick traded from Wascawy Wabbits.\nPick made from Pre-Draft List]",
+          "timestamp": 1652294863,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "round": 3,
+          "pick": 6,
+          "playerId": "15889",
+          "viaTrade": false,
+          "comments": "[Pick made from Pre-Draft List]",
+          "timestamp": 1652394965,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "round": 3,
+          "pick": 13,
+          "playerId": "15795",
+          "viaTrade": true,
+          "comments": "[Pick traded from Bring the Pain.\nPick made from Pre-Draft List]",
+          "timestamp": 1652426173,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "round": 1,
+          "pick": 5,
+          "playerId": "16190",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1683427634,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "round": 2,
+          "pick": 5,
+          "playerId": "16151",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1683520069,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "round": 2,
+          "pick": 14,
+          "playerId": "16187",
+          "viaTrade": true,
+          "comments": "[Pick traded from Pacific Pigskins.] pick going to Bring The Pain",
+          "timestamp": 1683561986,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "round": 2,
+          "pick": 7,
+          "playerId": "16593",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1714967605,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "round": 2,
+          "pick": 8,
+          "playerId": "16601",
+          "viaTrade": true,
+          "comments": "[Pick traded from  Running Down The Dream.\nPick traded from Bring the Pain.]",
+          "timestamp": 1714968225,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "round": 3,
+          "pick": 3,
+          "playerId": "16723",
+          "viaTrade": true,
+          "comments": "[Pick traded from Heavy Chevy.\nPick traded from Bring the Pain.]",
+          "timestamp": 1715098123,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "round": 1,
+          "pick": 1,
+          "playerId": "17042",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1746291403,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "round": 2,
+          "pick": 1,
+          "playerId": "17045",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1746583962,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "round": 3,
+          "pick": 1,
+          "playerId": "17087",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1746717404,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "round": 1,
+          "pick": 3,
+          "playerId": "17497",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1777775999,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "round": 2,
+          "pick": 3,
+          "playerId": "17508",
+          "viaTrade": false,
+          "comments": "",
+          "timestamp": 1778014633,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "round": 3,
+          "pick": 3,
+          "playerId": "17504",
+          "viaTrade": false,
+          "comments": "[Pick made from Pre-Draft List]",
+          "timestamp": 1778101435,
+          "sourceFranchiseId": null
+        }
+      ],
+      "auctionWins": [
+        {
+          "year": 2018,
+          "playerId": "10695",
+          "winningBid": 7000000,
+          "timestamp": 1521131509,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "0516",
+          "winningBid": 425000,
+          "timestamp": 1521234607,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "0513",
+          "winningBid": 425000,
+          "timestamp": 1521234661,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "11248",
+          "winningBid": 8000000,
+          "timestamp": 1521510504,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "9823",
+          "winningBid": 8000000,
+          "timestamp": 1521510566,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "11199",
+          "winningBid": 450000,
+          "timestamp": 1521510728,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "9881",
+          "winningBid": 425000,
+          "timestamp": 1521670691,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2018,
+          "playerId": "11947",
+          "winningBid": 425000,
+          "timestamp": 1521671169,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "8687",
+          "winningBid": 2250000,
+          "timestamp": 1553207392,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "11177",
+          "winningBid": 425000,
+          "timestamp": 1553230667,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "10527",
+          "winningBid": 3525000,
+          "timestamp": 1553282237,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "7401",
+          "winningBid": 4025000,
+          "timestamp": 1553352635,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "9694",
+          "winningBid": 425000,
+          "timestamp": 1553491340,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "0527",
+          "winningBid": 550000,
+          "timestamp": 1553526609,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "0516",
+          "winningBid": 1025000,
+          "timestamp": 1553614397,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "14067",
+          "winningBid": 425000,
+          "timestamp": 1557278651,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "14145",
+          "winningBid": 425000,
+          "timestamp": 1557278776,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "14124",
+          "winningBid": 475000,
+          "timestamp": 1557279095,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "14077",
+          "winningBid": 425000,
+          "timestamp": 1557279296,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "14122",
+          "winningBid": 700000,
+          "timestamp": 1557282141,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "14129",
+          "winningBid": 425000,
+          "timestamp": 1557282731,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "14120",
+          "winningBid": 575000,
+          "timestamp": 1557332116,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "14095",
+          "winningBid": 450000,
+          "timestamp": 1557341503,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "9988",
+          "winningBid": 800000,
+          "timestamp": 1584628885,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "13424",
+          "winningBid": 600000,
+          "timestamp": 1584629610,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "12645",
+          "winningBid": 425000,
+          "timestamp": 1584644087,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "0516",
+          "winningBid": 725000,
+          "timestamp": 1584713361,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "10261",
+          "winningBid": 6025000,
+          "timestamp": 1584713812,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "13615",
+          "winningBid": 550000,
+          "timestamp": 1584766134,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "13241",
+          "winningBid": 425000,
+          "timestamp": 1584846026,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "13880",
+          "winningBid": 425000,
+          "timestamp": 1584846749,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "11936",
+          "winningBid": 625000,
+          "timestamp": 1584846937,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "13168",
+          "winningBid": 425000,
+          "timestamp": 1584897205,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "11674",
+          "winningBid": 6525000,
+          "timestamp": 1584977573,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "14622",
+          "winningBid": 425000,
+          "timestamp": 1585087569,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "12205",
+          "winningBid": 425000,
+          "timestamp": 1585150147,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "14819",
+          "winningBid": 425000,
+          "timestamp": 1588955165,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "11947",
+          "winningBid": 425000,
+          "timestamp": 1616078853,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "13617",
+          "winningBid": 425000,
+          "timestamp": 1616260670,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "11247",
+          "winningBid": 5250000,
+          "timestamp": 1616260758,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "0513",
+          "winningBid": 625000,
+          "timestamp": 1616305292,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "8416",
+          "winningBid": 425000,
+          "timestamp": 1616353218,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "11192",
+          "winningBid": 1525000,
+          "timestamp": 1616434952,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "11936",
+          "winningBid": 425000,
+          "timestamp": 1616473813,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "9075",
+          "winningBid": 450000,
+          "timestamp": 1616539919,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "10271",
+          "winningBid": 600000,
+          "timestamp": 1647536542,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "12171",
+          "winningBid": 425000,
+          "timestamp": 1647548157,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "7836",
+          "winningBid": 6800000,
+          "timestamp": 1647554305,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "0513",
+          "winningBid": 1000000,
+          "timestamp": 1647618656,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "10261",
+          "winningBid": 425000,
+          "timestamp": 1647672901,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "9694",
+          "winningBid": 425000,
+          "timestamp": 1647746498,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "11747",
+          "winningBid": 450000,
+          "timestamp": 1647794414,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "13631",
+          "winningBid": 575000,
+          "timestamp": 1647874375,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "11947",
+          "winningBid": 900000,
+          "timestamp": 1647874398,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "9662",
+          "winningBid": 625000,
+          "timestamp": 1647961413,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "13234",
+          "winningBid": 425000,
+          "timestamp": 1652630373,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "0505",
+          "winningBid": 625000,
+          "timestamp": 1679033173,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "11678",
+          "winningBid": 425000,
+          "timestamp": 1679033267,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "11679",
+          "winningBid": 750000,
+          "timestamp": 1679111042,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "9686",
+          "winningBid": 425000,
+          "timestamp": 1679172048,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "15738",
+          "winningBid": 425000,
+          "timestamp": 1679280922,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "16174",
+          "winningBid": 425000,
+          "timestamp": 1683653125,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "16210",
+          "winningBid": 425000,
+          "timestamp": 1683653309,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "13164",
+          "winningBid": 4500000,
+          "timestamp": 1711124684,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "12652",
+          "winningBid": 425000,
+          "timestamp": 1711124749,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "13909",
+          "winningBid": 425000,
+          "timestamp": 1711260142,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "16808",
+          "winningBid": 425000,
+          "timestamp": 1715203732,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "12181",
+          "winningBid": 425000,
+          "timestamp": 1715203794,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "16680",
+          "winningBid": 425000,
+          "timestamp": 1715475363,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "13718",
+          "winningBid": 425000,
+          "timestamp": 1742498868,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "11222",
+          "winningBid": 625000,
+          "timestamp": 1742583129,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "14817",
+          "winningBid": 525000,
+          "timestamp": 1742693157,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "14258",
+          "winningBid": 425000,
+          "timestamp": 1742693254,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "11674",
+          "winningBid": 425000,
+          "timestamp": 1742693592,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "16432",
+          "winningBid": 425000,
+          "timestamp": 1742775532,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "14079",
+          "winningBid": 425000,
+          "timestamp": 1742831858,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "17101",
+          "winningBid": 425000,
+          "timestamp": 1746943111,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "17058",
+          "winningBid": 825000,
+          "timestamp": 1747673029,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "12263",
+          "winningBid": 450000,
+          "timestamp": 1751430811,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "13719",
+          "winningBid": 550000,
+          "timestamp": 1773982719,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "16219",
+          "winningBid": 425000,
+          "timestamp": 1774069592,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "15238",
+          "winningBid": 675000,
+          "timestamp": 1774111003,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "14073",
+          "winningBid": 4025000,
+          "timestamp": 1774146778,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "14777",
+          "winningBid": 6075000,
+          "timestamp": 1774146792,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "13633",
+          "winningBid": 600000,
+          "timestamp": 1774282851,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "9064",
+          "winningBid": 425000,
+          "timestamp": 1774397299,
+          "sourceFranchiseId": null
         }
       ],
       "currentName": "Cowboy Up",
@@ -65584,6 +82993,535 @@
           "bothAttributed": true
         }
       ],
+      "draftPicks": [
+        {
+          "year": 2019,
+          "round": 1,
+          "pick": 14,
+          "playerId": "14056",
+          "viaTrade": false,
+          "comments": "Kewl",
+          "timestamp": 1557091317,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "round": 1,
+          "pick": 11,
+          "playerId": "14852",
+          "viaTrade": true,
+          "comments": "[Pick traded from Fire Ready Aim.]",
+          "timestamp": 1588527903,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "round": 3,
+          "pick": 9,
+          "playerId": "14808",
+          "viaTrade": true,
+          "comments": "[Pick traded from The Mariachi Ninjas.\nPick traded from Wascawy Wabbits.]",
+          "timestamp": 1588769804,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "round": 3,
+          "pick": 10,
+          "playerId": "14848",
+          "viaTrade": true,
+          "comments": "[Pick traded from Wascawy Wabbits.]",
+          "timestamp": 1588770241,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "round": 1,
+          "pick": 8,
+          "playerId": "15237",
+          "viaTrade": true,
+          "comments": "[Pick traded from Maverick.]",
+          "timestamp": 1620518718,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "round": 1,
+          "pick": 14,
+          "playerId": "15288",
+          "viaTrade": false,
+          "comments": "[Pick made from Pre-Draft List]",
+          "timestamp": 1620523468,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "round": 3,
+          "pick": 14,
+          "playerId": "15268",
+          "viaTrade": false,
+          "comments": "[Pick made from Pre-Draft List]",
+          "timestamp": 1620873294,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "round": 3,
+          "pick": 10,
+          "playerId": "15798",
+          "viaTrade": false,
+          "comments": "[Pick made from Pre-Draft List]",
+          "timestamp": 1652408237,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "round": 1,
+          "pick": 7,
+          "playerId": "16188",
+          "viaTrade": false,
+          "comments": "[Pick made from Pre-Draft List]",
+          "timestamp": 1683430487,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "round": 2,
+          "pick": 17,
+          "playerId": "16176",
+          "viaTrade": false,
+          "comments": "[Pick added by commissioner.\nPick made from Pre-Draft List]",
+          "timestamp": 1683567549,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "round": 1,
+          "pick": 12,
+          "playerId": "16582",
+          "viaTrade": true,
+          "comments": "[Pick traded from Gridiron Geeks.\nPick traded from The Music City Mafia.\nPick traded from Pacific Pigskins.\nPick made from Pre-Draft List]",
+          "timestamp": 1714927503,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "round": 3,
+          "pick": 11,
+          "playerId": "16586",
+          "viaTrade": true,
+          "comments": "[Pick traded from Pacific Pigskins.]",
+          "timestamp": 1715160837,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "round": 1,
+          "pick": 4,
+          "playerId": "17473",
+          "viaTrade": false,
+          "comments": "[Pick made from Pre-Draft List]",
+          "timestamp": 1777775999,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "round": 2,
+          "pick": 15,
+          "playerId": "17466",
+          "viaTrade": true,
+          "comments": "[Pick traded from Wascawy Wabbits.\nPick made from Pre-Draft List]",
+          "timestamp": 1778085117,
+          "sourceFranchiseId": null
+        }
+      ],
+      "auctionWins": [
+        {
+          "year": 2019,
+          "playerId": "12417",
+          "winningBid": 425000,
+          "timestamp": 1553291872,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "10722",
+          "winningBid": 6500000,
+          "timestamp": 1553358665,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "12629",
+          "winningBid": 500000,
+          "timestamp": 1553411470,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "9427",
+          "winningBid": 425000,
+          "timestamp": 1553411590,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "10276",
+          "winningBid": 6225000,
+          "timestamp": 1553575563,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2019,
+          "playerId": "7422",
+          "winningBid": 550000,
+          "timestamp": 1559689428,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "10976",
+          "winningBid": 900000,
+          "timestamp": 1584628007,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "11232",
+          "winningBid": 13525000,
+          "timestamp": 1584757958,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "12171",
+          "winningBid": 6225000,
+          "timestamp": 1584800230,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "10389",
+          "winningBid": 425000,
+          "timestamp": 1584805964,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2020,
+          "playerId": "14912",
+          "winningBid": 425000,
+          "timestamp": 1588897078,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "13919",
+          "winningBid": 425000,
+          "timestamp": 1616077724,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "13639",
+          "winningBid": 425000,
+          "timestamp": 1616089480,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "11966",
+          "winningBid": 425000,
+          "timestamp": 1616171390,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "12151",
+          "winningBid": 9200000,
+          "timestamp": 1616187399,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "12611",
+          "winningBid": 1125000,
+          "timestamp": 1616194661,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "11679",
+          "winningBid": 6000000,
+          "timestamp": 1616245852,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2021,
+          "playerId": "0522",
+          "winningBid": 425000,
+          "timestamp": 1616328415,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "13193",
+          "winningBid": 425000,
+          "timestamp": 1647530877,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "13108",
+          "winningBid": 425000,
+          "timestamp": 1647533289,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "0505",
+          "winningBid": 425000,
+          "timestamp": 1647533371,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "12626",
+          "winningBid": 13050000,
+          "timestamp": 1647702058,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "11695",
+          "winningBid": 425000,
+          "timestamp": 1647790235,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "10862",
+          "winningBid": 425000,
+          "timestamp": 1647790273,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "13378",
+          "winningBid": 425000,
+          "timestamp": 1647893035,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2022,
+          "playerId": "13789",
+          "winningBid": 425000,
+          "timestamp": 1647956262,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "0508",
+          "winningBid": 425000,
+          "timestamp": 1678987094,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "15979",
+          "winningBid": 425000,
+          "timestamp": 1678987140,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "13763",
+          "winningBid": 425000,
+          "timestamp": 1678987204,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "11675",
+          "winningBid": 7000000,
+          "timestamp": 1679061692,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "13793",
+          "winningBid": 650000,
+          "timestamp": 1679106314,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "13133",
+          "winningBid": 1075000,
+          "timestamp": 1679106364,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "14076",
+          "winningBid": 425000,
+          "timestamp": 1679238778,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "13871",
+          "winningBid": 425000,
+          "timestamp": 1679238864,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "13138",
+          "winningBid": 2525000,
+          "timestamp": 1679266173,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "14558",
+          "winningBid": 425000,
+          "timestamp": 1680198906,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "16178",
+          "winningBid": 425000,
+          "timestamp": 1683654853,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2023,
+          "playerId": "15696",
+          "winningBid": 425000,
+          "timestamp": 1684160376,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2024,
+          "playerId": "0508",
+          "winningBid": 500000,
+          "timestamp": 1711240591,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "0508",
+          "winningBid": 425000,
+          "timestamp": 1742490861,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "14223",
+          "winningBid": 425000,
+          "timestamp": 1742501664,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "15981",
+          "winningBid": 550000,
+          "timestamp": 1742563515,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "13319",
+          "winningBid": 5900000,
+          "timestamp": 1742563557,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "14105",
+          "winningBid": 1925000,
+          "timestamp": 1742634344,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "13347",
+          "winningBid": 425000,
+          "timestamp": 1742665928,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "15332",
+          "winningBid": 425000,
+          "timestamp": 1742666045,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "14600",
+          "winningBid": 425000,
+          "timestamp": 1742826409,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "17077",
+          "winningBid": 425000,
+          "timestamp": 1746907024,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2025,
+          "playerId": "15717",
+          "winningBid": 475000,
+          "timestamp": 1755384641,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "12616",
+          "winningBid": 1800000,
+          "timestamp": 1774003314,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "15329",
+          "winningBid": 4500000,
+          "timestamp": 1774004064,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "13832",
+          "winningBid": 425000,
+          "timestamp": 1774008137,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "14056",
+          "winningBid": 4000000,
+          "timestamp": 1774086451,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "15972",
+          "winningBid": 3100000,
+          "timestamp": 1774086562,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "15282",
+          "winningBid": 6525000,
+          "timestamp": 1774258444,
+          "sourceFranchiseId": null
+        }
+      ],
       "currentName": "Music City Mafia",
       "currentNameMedium": "Music City",
       "currentNameShort": "Music City",
@@ -65653,6 +83591,121 @@
       "headToHead": {},
       "matchupHistory": {},
       "trades": [],
+      "draftPicks": [
+        {
+          "year": 2026,
+          "round": 1,
+          "pick": 2,
+          "playerId": "17543",
+          "viaTrade": false,
+          "comments": "[Pick made from Pre-Draft List]",
+          "timestamp": 1777756190,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "round": 3,
+          "pick": 14,
+          "playerId": "17521",
+          "viaTrade": true,
+          "comments": "[Pick traded from Dark Magicians of Chaos.\nPick made from Pre-Draft List]",
+          "timestamp": 1778196342,
+          "sourceFranchiseId": null
+        }
+      ],
+      "auctionWins": [
+        {
+          "year": 2026,
+          "playerId": "16843",
+          "winningBid": 525000,
+          "timestamp": 1773941545,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "15738",
+          "winningBid": 550000,
+          "timestamp": 1773941904,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "16788",
+          "winningBid": 550000,
+          "timestamp": 1773969057,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "13133",
+          "winningBid": 425000,
+          "timestamp": 1773969115,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "16164",
+          "winningBid": 975000,
+          "timestamp": 1774058537,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "16757",
+          "winningBid": 775000,
+          "timestamp": 1774062131,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "14122",
+          "winningBid": 725000,
+          "timestamp": 1774112652,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "14080",
+          "winningBid": 450000,
+          "timestamp": 1774112685,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "15241",
+          "winningBid": 1000000,
+          "timestamp": 1774120451,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "14143",
+          "winningBid": 775000,
+          "timestamp": 1774169801,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "0506",
+          "winningBid": 1000000,
+          "timestamp": 1774213389,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "15259",
+          "winningBid": 1800000,
+          "timestamp": 1774294292,
+          "sourceFranchiseId": null
+        },
+        {
+          "year": 2026,
+          "playerId": "15254",
+          "winningBid": 425000,
+          "timestamp": 1774478641,
+          "sourceFranchiseId": null
+        }
+      ],
       "currentName": "Dead Cap Walking",
       "currentNameMedium": "Dead Cap",
       "currentNameShort": "Dead Cap",
@@ -65666,6 +83719,16 @@
     }
   },
   "playerNames": {
+    "1275": {
+      "name": "Hanson, Jason",
+      "position": "PK",
+      "team": "FA"
+    },
+    "1383": {
+      "name": "Kasay, John",
+      "position": "PK",
+      "team": "FA*"
+    },
     "1600": {
       "name": "Floyd, Malcom",
       "position": "WR",
@@ -65676,10 +83739,50 @@
       "position": "PK",
       "team": "IND"
     },
+    "2918": {
+      "name": "Gonzalez, Tony",
+      "position": "TE",
+      "team": "ATL"
+    },
+    "3143": {
+      "name": "Longwell, Ryan",
+      "position": "PK",
+      "team": "MIN"
+    },
     "3291": {
       "name": "Manning, Peyton",
       "position": "QB",
       "team": "IND"
+    },
+    "3309": {
+      "name": "Moss, Randy",
+      "position": "WR",
+      "team": "SFO"
+    },
+    "3445": {
+      "name": "Hasselbeck, Matt",
+      "position": "QB",
+      "team": "TEN"
+    },
+    "3579": {
+      "name": "Akers, David",
+      "position": "PK",
+      "team": "SFO"
+    },
+    "3866": {
+      "name": "McNabb, Donovan",
+      "position": "QB",
+      "team": "MIN"
+    },
+    "3869": {
+      "name": "Williams, Ricky",
+      "position": "RB",
+      "team": "BAL"
+    },
+    "4883": {
+      "name": "Feely, Jay",
+      "position": "PK",
+      "team": "CHI"
     },
     "4891": {
       "name": "Vick, Michael",
@@ -65691,15 +83794,55 @@
       "position": "WR",
       "team": "WAS"
     },
+    "4923": {
+      "name": "Wayne, Reggie",
+      "position": "WR",
+      "team": "IND"
+    },
+    "4924": {
+      "name": "Heap, Todd",
+      "position": "TE",
+      "team": "ARI"
+    },
     "4925": {
       "name": "Brees, Drew",
       "position": "QB",
       "team": "NOS"
     },
+    "4929": {
+      "name": "Ochocinco, Chad",
+      "position": "WR",
+      "team": "NEP"
+    },
     "4974": {
       "name": "Smith, Steve",
       "position": "WR",
       "team": "CAR"
+    },
+    "5168": {
+      "name": "Tynes, Lawrence",
+      "position": "PK",
+      "team": "NYG"
+    },
+    "5656": {
+      "name": "Jones, Thomas",
+      "position": "RB",
+      "team": "KCC"
+    },
+    "5657": {
+      "name": "Burress, Plaxico",
+      "position": "WR",
+      "team": "NYJ"
+    },
+    "5666": {
+      "name": "Janikowski, Sebastian",
+      "position": "PK",
+      "team": "OAK"
+    },
+    "5817": {
+      "name": "Bulger, Marc",
+      "position": "QB",
+      "team": "FA"
     },
     "5848": {
       "name": "Brady, Tom",
@@ -65711,20 +83854,50 @@
       "position": "QB",
       "team": "NYG"
     },
+    "6522": {
+      "name": "Shockey, Jeremy",
+      "position": "TE",
+      "team": "CAR"
+    },
     "6589": {
       "name": "McCown, Josh",
       "position": "QB",
       "team": "CHI"
+    },
+    "6599": {
+      "name": "Westbrook, Brian",
+      "position": "RB",
+      "team": "FA"
+    },
+    "6616": {
+      "name": "Garrard, David",
+      "position": "QB",
+      "team": "FA"
+    },
+    "6776": {
+      "name": "Cundiff, Billy",
+      "position": "PK",
+      "team": "FA*"
     },
     "6789": {
       "name": "Bryant, Matt",
       "position": "PK",
       "team": "ATL"
     },
+    "6887": {
+      "name": "Reed, Jeff",
+      "position": "PK",
+      "team": "FA*"
+    },
     "6929": {
       "name": "Palmer, Carson",
       "position": "QB",
-      "team": "ARI"
+      "team": "OAK"
+    },
+    "6931": {
+      "name": "Johnson, Andre",
+      "position": "WR",
+      "team": "IND"
     },
     "6950": {
       "name": "Grossman, Rex",
@@ -65744,17 +83917,27 @@
     "6982": {
       "name": "Boldin, Anquan",
       "position": "WR",
-      "team": "SFO"
+      "team": "BAL"
     },
     "6997": {
       "name": "Witten, Jason",
       "position": "TE",
       "team": "DAL"
     },
+    "6999": {
+      "name": "Burleson, Nate",
+      "position": "WR",
+      "team": "DET"
+    },
     "7052": {
       "name": "Lloyd, Brandon",
       "position": "WR",
-      "team": "FA"
+      "team": "STL"
+    },
+    "7150": {
+      "name": "Brown, Josh",
+      "position": "PK",
+      "team": "CIN"
     },
     "7194": {
       "name": "Hill, Shaun",
@@ -65791,10 +83974,30 @@
       "position": "TE",
       "team": "NYJ"
     },
+    "7401": {
+      "name": "Roethlisberger, Ben",
+      "position": "QB",
+      "team": "PIT"
+    },
+    "7403": {
+      "name": "Evans, Lee",
+      "position": "WR",
+      "team": "BAL"
+    },
+    "7414": {
+      "name": "Jackson, Steven",
+      "position": "RB",
+      "team": "ATL"
+    },
     "7422": {
       "name": "Watson, Ben",
       "position": "TE",
       "team": "CLE"
+    },
+    "7455": {
+      "name": "Kaeding, Nate",
+      "position": "PK",
+      "team": "MIA"
     },
     "7480": {
       "name": "Schaub, Matt",
@@ -65814,12 +84017,22 @@
     "7653": {
       "name": "Welker, Wes",
       "position": "WR",
-      "team": "DEN"
+      "team": "NEP"
     },
     "7813": {
       "name": "Smith, Alex",
       "position": "QB",
-      "team": "WAS"
+      "team": "KCC"
+    },
+    "7814": {
+      "name": "Brown, Ronnie",
+      "position": "RB",
+      "team": "PHI"
+    },
+    "7816": {
+      "name": "Benson, Cedric",
+      "position": "RB",
+      "team": "CIN"
     },
     "7822": {
       "name": "Williams, Mike",
@@ -65831,6 +84044,11 @@
       "position": "QB",
       "team": "GBP"
     },
+    "7837": {
+      "name": "Campbell, Jason",
+      "position": "QB",
+      "team": "OAK"
+    },
     "7839": {
       "name": "White, Roddy",
       "position": "WR",
@@ -65841,6 +84059,11 @@
       "position": "TE",
       "team": "PIT"
     },
+    "7859": {
+      "name": "Nugent, Mike",
+      "position": "PK",
+      "team": "CIN"
+    },
     "7873": {
       "name": "Jackson, Vincent",
       "position": "WR",
@@ -65849,12 +84072,27 @@
     "7877": {
       "name": "Gore, Frank",
       "position": "RB",
-      "team": "IND"
+      "team": "SFO"
+    },
+    "7918": {
+      "name": "Orton, Kyle",
+      "position": "QB",
+      "team": "KCC"
+    },
+    "7922": {
+      "name": "Jacobs, Brandon",
+      "position": "RB",
+      "team": "NYG"
+    },
+    "7942": {
+      "name": "Sproles, Darren",
+      "position": "RB",
+      "team": "PHI"
     },
     "8010": {
       "name": "Dreessen, Joel",
       "position": "TE",
-      "team": "DEN"
+      "team": "HOU"
     },
     "8042": {
       "name": "Cassel, Matt",
@@ -65894,7 +84132,7 @@
     "8243": {
       "name": "Bush, Reggie",
       "position": "RB",
-      "team": "DET"
+      "team": "MIA"
     },
     "8247": {
       "name": "Davis, Vernon",
@@ -65926,6 +84164,21 @@
       "position": "RB",
       "team": "FA"
     },
+    "8293": {
+      "name": "Jennings, Greg",
+      "position": "WR",
+      "team": "MIA"
+    },
+    "8294": {
+      "name": "Fasano, Anthony",
+      "position": "TE",
+      "team": "MIA"
+    },
+    "8301": {
+      "name": "Jones-Drew, Maurice",
+      "position": "RB",
+      "team": "JAC"
+    },
     "8305": {
       "name": "Jackson, Tarvaris",
       "position": "QB",
@@ -65934,6 +84187,21 @@
     "8322": {
       "name": "Whitehurst, Charlie",
       "position": "QB",
+      "team": "SEA"
+    },
+    "8339": {
+      "name": "Daniels, Owen",
+      "position": "TE",
+      "team": "HOU"
+    },
+    "8350": {
+      "name": "Avant, Jason",
+      "position": "WR",
+      "team": "PHI"
+    },
+    "8358": {
+      "name": "Washington, Leon",
+      "position": "RB",
       "team": "SEA"
     },
     "8359": {
@@ -65945,6 +84213,11 @@
       "name": "Marshall, Brandon",
       "position": "WR",
       "team": "CHI"
+    },
+    "8371": {
+      "name": "Hixon, Domenik",
+      "position": "WR",
+      "team": "NYG"
     },
     "8416": {
       "name": "Walker, Delanie",
@@ -65991,6 +84264,16 @@
       "position": "WR",
       "team": "SFO"
     },
+    "8679": {
+      "name": "Rice, Sidney",
+      "position": "WR",
+      "team": "FA"
+    },
+    "8680": {
+      "name": "Meachem, Robert",
+      "position": "WR",
+      "team": "NOS"
+    },
     "8683": {
       "name": "Miller, Zach",
       "position": "TE",
@@ -66006,6 +84289,21 @@
       "position": "TE",
       "team": "CAR"
     },
+    "8700": {
+      "name": "Gonzalez, Anthony",
+      "position": "WR",
+      "team": "FA"
+    },
+    "8735": {
+      "name": "Chandler, Scott",
+      "position": "TE",
+      "team": "NEP"
+    },
+    "8742": {
+      "name": "Crosby, Mason",
+      "position": "PK",
+      "team": "GBP"
+    },
     "8758": {
       "name": "Kolb, Kevin",
       "position": "QB",
@@ -66016,6 +84314,11 @@
       "position": "QB",
       "team": "WAS"
     },
+    "8767": {
+      "name": "Jackson, Brandon",
+      "position": "RB",
+      "team": "CLE"
+    },
     "8774": {
       "name": "Robinson, Laurent",
       "position": "WR",
@@ -66024,12 +84327,27 @@
     "8776": {
       "name": "Jones, James",
       "position": "WR",
-      "team": "OAK"
+      "team": "GBP"
+    },
+    "8817": {
+      "name": "McClain, Le'Ron",
+      "position": "RB",
+      "team": "SDC"
+    },
+    "8830": {
+      "name": "Boss, Kevin",
+      "position": "TE",
+      "team": "KCC"
     },
     "8838": {
       "name": "Celek, Brent",
       "position": "TE",
       "team": "PHI"
+    },
+    "8851": {
+      "name": "Folk, Nick",
+      "position": "PK",
+      "team": "NYJ"
     },
     "8917": {
       "name": "Bradshaw, Ahmad",
@@ -66051,6 +84369,16 @@
       "position": "RB",
       "team": "GBP"
     },
+    "8934": {
+      "name": "Jackson, Fred",
+      "position": "RB",
+      "team": "BUF"
+    },
+    "8944": {
+      "name": "Moore, Matt",
+      "position": "QB",
+      "team": "MIA"
+    },
     "9040": {
       "name": "Avery, Donnie",
       "position": "WR",
@@ -66061,10 +84389,45 @@
       "position": "TE",
       "team": "NYG"
     },
+    "9052": {
+      "name": "Carlson, John",
+      "position": "TE",
+      "team": "MIN"
+    },
+    "9054": {
+      "name": "Charles, Jamaal",
+      "position": "RB",
+      "team": "KCC"
+    },
+    "9058": {
+      "name": "Davis, Fred",
+      "position": "TE",
+      "team": "WAS"
+    },
+    "9061": {
+      "name": "Doucet, Early",
+      "position": "WR",
+      "team": "ARI"
+    },
     "9064": {
       "name": "Flacco, Joe",
       "position": "QB",
       "team": "BAL"
+    },
+    "9069": {
+      "name": "Hardy, James",
+      "position": "WR",
+      "team": "FA"
+    },
+    "9073": {
+      "name": "Henne, Chad",
+      "position": "QB",
+      "team": "JAC"
+    },
+    "9075": {
+      "name": "Jackson, DeSean",
+      "position": "WR",
+      "team": "TBB"
     },
     "9078": {
       "name": "Johnson, Chris",
@@ -66075,6 +84438,11 @@
       "name": "Keller, Dustin",
       "position": "TE",
       "team": "NYJ"
+    },
+    "9085": {
+      "name": "Manningham, Mario",
+      "position": "WR",
+      "team": "SFO"
     },
     "9087": {
       "name": "McFadden, Darren",
@@ -66106,6 +84474,21 @@
       "position": "WR",
       "team": "SDC"
     },
+    "9122": {
+      "name": "Forte, Matt",
+      "position": "RB",
+      "team": "CHI"
+    },
+    "9124": {
+      "name": "Simpson, Jerome",
+      "position": "WR",
+      "team": "CIN"
+    },
+    "9132": {
+      "name": "Smith, Kevin",
+      "position": "RB",
+      "team": "DET"
+    },
     "9144": {
       "name": "Douglas, Harry",
       "position": "WR",
@@ -66119,10 +84502,20 @@
     "9176": {
       "name": "Tamme, Jacob",
       "position": "TE",
-      "team": "DEN"
+      "team": "IND"
     },
     "9187": {
       "name": "Torain, Ryan",
+      "position": "RB",
+      "team": "FA"
+    },
+    "9189": {
+      "name": "Barnidge, Gary",
+      "position": "TE",
+      "team": "FA*"
+    },
+    "9196": {
+      "name": "Hightower, Tim",
       "position": "RB",
       "team": "FA"
     },
@@ -66136,15 +84529,35 @@
       "position": "WR",
       "team": "BUF"
     },
+    "9271": {
+      "name": "Schilens, Chaz",
+      "position": "WR",
+      "team": "OAK"
+    },
+    "9272": {
+      "name": "Hillis, Peyton",
+      "position": "RB",
+      "team": "NYG"
+    },
     "9278": {
       "name": "Forsett, Justin",
       "position": "RB",
-      "team": "BAL"
+      "team": "JAC"
     },
     "9282": {
       "name": "Arrington, Adrian",
       "position": "WR",
       "team": "FA"
+    },
+    "9299": {
+      "name": "Carpenter, Dan",
+      "position": "PK",
+      "team": "MIA"
+    },
+    "9307": {
+      "name": "Barth, Connor",
+      "position": "PK",
+      "team": "CHI"
     },
     "9308": {
       "name": "Amendola, Danny",
@@ -66154,17 +84567,32 @@
     "9315": {
       "name": "Tolbert, Mike",
       "position": "RB",
-      "team": "CAR"
+      "team": "SDC"
     },
     "9319": {
       "name": "Hauschka, Steven",
       "position": "PK",
-      "team": "BUF"
+      "team": "SEA"
+    },
+    "9347": {
+      "name": "Green-Ellis, BenJarvus",
+      "position": "RB",
+      "team": "FA*"
     },
     "9360": {
       "name": "Hartley, Garrett",
       "position": "PK",
       "team": "NOS"
+    },
+    "9427": {
+      "name": "Crabtree, Michael",
+      "position": "WR",
+      "team": "SFO"
+    },
+    "9429": {
+      "name": "Sanchez, Mark",
+      "position": "QB",
+      "team": "CHI"
     },
     "9431": {
       "name": "Stafford, Matthew",
@@ -66174,7 +84602,17 @@
     "9436": {
       "name": "Maclin, Jeremy",
       "position": "WR",
-      "team": "KCC"
+      "team": "PHI"
+    },
+    "9440": {
+      "name": "Wells, Beanie",
+      "position": "RB",
+      "team": "FA"
+    },
+    "9441": {
+      "name": "Harvin, Percy",
+      "position": "WR",
+      "team": "NYJ"
     },
     "9444": {
       "name": "Pettigrew, Brandon",
@@ -66196,10 +84634,35 @@
       "position": "WR",
       "team": "OAK"
     },
+    "9456": {
+      "name": "Brown, Donald",
+      "position": "RB",
+      "team": "FA"
+    },
     "9467": {
       "name": "Britt, Kenny",
       "position": "WR",
       "team": "NEP"
+    },
+    "9474": {
+      "name": "Cook, Jared",
+      "position": "TE",
+      "team": "STL"
+    },
+    "9480": {
+      "name": "Casey, James",
+      "position": "TE",
+      "team": "PHI"
+    },
+    "9525": {
+      "name": "Wallace, Mike",
+      "position": "WR",
+      "team": "BAL"
+    },
+    "9526": {
+      "name": "Barden, Ramses",
+      "position": "WR",
+      "team": "NYG"
     },
     "9545": {
       "name": "Hartline, Brian",
@@ -66209,7 +84672,7 @@
     "9548": {
       "name": "Goodson, Mike",
       "position": "RB",
-      "team": "NYJ"
+      "team": "CAR"
     },
     "9575": {
       "name": "Knox, Johnny",
@@ -66221,10 +84684,30 @@
       "position": "RB",
       "team": "TEN"
     },
+    "9616": {
+      "name": "Peerman, Cedric",
+      "position": "RB",
+      "team": "CIN"
+    },
+    "9625": {
+      "name": "Gibson, Brandon",
+      "position": "WR",
+      "team": "MIA"
+    },
     "9632": {
       "name": "Myers, Brandon",
       "position": "TE",
       "team": "NYG"
+    },
+    "9638": {
+      "name": "Phillips, John",
+      "position": "TE",
+      "team": "DAL"
+    },
+    "9639": {
+      "name": "Scott, Bernard",
+      "position": "RB",
+      "team": "CIN"
     },
     "9662": {
       "name": "Edelman, Julian",
@@ -66234,7 +84717,12 @@
     "9680": {
       "name": "Jennings, Rashad",
       "position": "RB",
-      "team": "OAK"
+      "team": "JAC"
+    },
+    "9686": {
+      "name": "Succop, Ryan",
+      "position": "PK",
+      "team": "KCC"
     },
     "9690": {
       "name": "Foster, Arian",
@@ -66244,22 +84732,47 @@
     "9693": {
       "name": "Woodhead, Danny",
       "position": "RB",
-      "team": "SDC"
+      "team": "NEP"
+    },
+    "9694": {
+      "name": "Gano, Graham",
+      "position": "PK",
+      "team": "CAR"
     },
     "9705": {
       "name": "Redman, Isaac",
       "position": "RB",
       "team": "PIT"
     },
+    "9706": {
+      "name": "Daniel, Chase",
+      "position": "QB",
+      "team": "PHI"
+    },
     "9714": {
       "name": "Hoyer, Brian",
       "position": "QB",
-      "team": "NEP"
+      "team": "CLE"
+    },
+    "9770": {
+      "name": "Bell, Kahlil",
+      "position": "RB",
+      "team": "CHI"
+    },
+    "9802": {
+      "name": "Reece, Marcel",
+      "position": "RB",
+      "team": "OAK"
     },
     "9817": {
       "name": "Bradford, Sam",
       "position": "QB",
       "team": "STL"
+    },
+    "9822": {
+      "name": "Spiller, C.J.",
+      "position": "RB",
+      "team": "FA"
     },
     "9823": {
       "name": "Bryant, Dez",
@@ -66301,6 +84814,11 @@
       "position": "WR",
       "team": "TEN"
     },
+    "9862": {
+      "name": "Tebow, Tim",
+      "position": "QB",
+      "team": "FA"
+    },
     "9874": {
       "name": "Ford, Jacoby",
       "position": "WR",
@@ -66341,6 +84859,16 @@
       "position": "RB",
       "team": "HOU"
     },
+    "9908": {
+      "name": "Hardesty, Montario",
+      "position": "RB",
+      "team": "CLE"
+    },
+    "9912": {
+      "name": "Dickson, Ed",
+      "position": "TE",
+      "team": "SEA"
+    },
     "9918": {
       "name": "Sanders, Emmanuel",
       "position": "WR",
@@ -66361,6 +84889,16 @@
       "position": "WR",
       "team": "TBB"
     },
+    "9931": {
+      "name": "Easley, Marcus",
+      "position": "WR",
+      "team": "BUF"
+    },
+    "9933": {
+      "name": "Pitta, Dennis",
+      "position": "TE",
+      "team": "BAL"
+    },
     "9936": {
       "name": "Graham, Garrett",
       "position": "TE",
@@ -66371,10 +84909,30 @@
       "position": "TE",
       "team": "JAC"
     },
+    "9960": {
+      "name": "Quarless, Andrew",
+      "position": "TE",
+      "team": "GBP"
+    },
+    "9964": {
+      "name": "Cooper, Riley",
+      "position": "WR",
+      "team": "PHI"
+    },
     "9987": {
       "name": "Starks, James",
       "position": "RB",
       "team": "GBP"
+    },
+    "9988": {
+      "name": "Brown, Antonio",
+      "position": "WR",
+      "team": "FA*"
+    },
+    "10048": {
+      "name": "Bell, Joique",
+      "position": "RB",
+      "team": "DET"
     },
     "10064": {
       "name": "Harrell, Graham",
@@ -66401,6 +84959,11 @@
       "position": "WR",
       "team": "SDC"
     },
+    "10164": {
+      "name": "James, Javarris",
+      "position": "RB",
+      "team": "FA"
+    },
     "10212": {
       "name": "Roosevelt, Naaman",
       "position": "WR",
@@ -66415,6 +84978,11 @@
       "name": "Gabbert, Blaine",
       "position": "QB",
       "team": "JAC"
+    },
+    "10268": {
+      "name": "Mallett, Ryan",
+      "position": "QB",
+      "team": "BAL"
     },
     "10271": {
       "name": "Jones, Julio",
@@ -66431,6 +84999,16 @@
       "position": "RB",
       "team": "NOS"
     },
+    "10281": {
+      "name": "Leshoure, Mikel",
+      "position": "RB",
+      "team": "FA"
+    },
+    "10289": {
+      "name": "Smith, Torrey",
+      "position": "WR",
+      "team": "SFO"
+    },
     "10296": {
       "name": "Ponder, Christian",
       "position": "QB",
@@ -66440,6 +85018,11 @@
       "name": "Kaepernick, Colin",
       "position": "QB",
       "team": "SFO"
+    },
+    "10298": {
+      "name": "Williams, Ryan",
+      "position": "RB",
+      "team": "ARI"
     },
     "10299": {
       "name": "Thomas, Daniel",
@@ -66454,12 +85037,12 @@
     "10302": {
       "name": "Murray, DeMarco",
       "position": "RB",
-      "team": "TEN"
+      "team": "DAL"
     },
     "10303": {
       "name": "Vereen, Shane",
       "position": "RB",
-      "team": "FA"
+      "team": "NEP"
     },
     "10308": {
       "name": "Cobb, Randall",
@@ -66471,6 +85054,11 @@
       "position": "WR",
       "team": "DET"
     },
+    "10310": {
+      "name": "Doss, Tandon",
+      "position": "WR",
+      "team": "BAL"
+    },
     "10312": {
       "name": "Rudolph, Kyle",
       "position": "TE",
@@ -66481,10 +85069,15 @@
       "position": "QB",
       "team": "CIN"
     },
+    "10316": {
+      "name": "Stanzi, Ricky",
+      "position": "QB",
+      "team": "KCC"
+    },
     "10318": {
       "name": "Kendricks, Lance",
       "position": "TE",
-      "team": "RAM"
+      "team": "STL"
     },
     "10327": {
       "name": "Little, Greg",
@@ -66501,6 +85094,16 @@
       "position": "RB",
       "team": "NEP"
     },
+    "10347": {
+      "name": "Green, Alex",
+      "position": "RB",
+      "team": "GBP"
+    },
+    "10352": {
+      "name": "Cameron, Jordan",
+      "position": "TE",
+      "team": "CLE"
+    },
     "10355": {
       "name": "Helu, Roy",
       "position": "RB",
@@ -66511,10 +85114,20 @@
       "position": "WR",
       "team": "DET"
     },
+    "10359": {
+      "name": "Gates, Clyde",
+      "position": "WR",
+      "team": "MIA"
+    },
     "10362": {
       "name": "Shorts, Cecil",
       "position": "WR",
       "team": "JAC"
+    },
+    "10365": {
+      "name": "Henery, Alex",
+      "position": "PK",
+      "team": "PHI"
     },
     "10368": {
       "name": "Jones, Taiwan",
@@ -66531,6 +85144,16 @@
       "position": "TE",
       "team": "DEN"
     },
+    "10388": {
+      "name": "Moore, Denarius",
+      "position": "WR",
+      "team": "OAK"
+    },
+    "10389": {
+      "name": "Lewis, Dion",
+      "position": "RB",
+      "team": "NEP"
+    },
     "10391": {
       "name": "Yates, T.J.",
       "position": "QB",
@@ -66539,7 +85162,12 @@
     "10392": {
       "name": "Kerley, Jeremy",
       "position": "WR",
-      "team": "SFO"
+      "team": "NYJ"
+    },
+    "10394": {
+      "name": "Paul, Niles",
+      "position": "WR",
+      "team": "WAS"
     },
     "10409": {
       "name": "Clay, Charles",
@@ -66556,15 +85184,70 @@
       "position": "QB",
       "team": "BUF"
     },
+    "10432": {
+      "name": "Green, Virgil",
+      "position": "TE",
+      "team": "DEN"
+    },
+    "10442": {
+      "name": "Taylor, Ryan",
+      "position": "TE",
+      "team": "GBP"
+    },
+    "10445": {
+      "name": "Scott, Da'Rel",
+      "position": "RB",
+      "team": "NYG"
+    },
+    "10449": {
+      "name": "Allen, Anthony",
+      "position": "RB",
+      "team": "BAL"
+    },
+    "10480": {
+      "name": "Saunders, Weslye",
+      "position": "TE",
+      "team": "PIT"
+    },
+    "10487": {
+      "name": "Forbath, Kai",
+      "position": "PK",
+      "team": "MIN"
+    },
+    "10496": {
+      "name": "Lockette, Ricardo",
+      "position": "WR",
+      "team": "FA"
+    },
     "10500": {
       "name": "Pryor, Terrelle",
       "position": "QB",
       "team": "OAK"
     },
+    "10506": {
+      "name": "Bailey, Dan",
+      "position": "PK",
+      "team": "DAL"
+    },
+    "10508": {
+      "name": "Jean, Lestar",
+      "position": "WR",
+      "team": "HOU"
+    },
     "10527": {
       "name": "Baldwin, Doug",
       "position": "WR",
       "team": "SEA"
+    },
+    "10601": {
+      "name": "Hawkins, Andrew",
+      "position": "WR",
+      "team": "CLE"
+    },
+    "10674": {
+      "name": "Holmes, Andre",
+      "position": "WR",
+      "team": "NEP"
     },
     "10695": {
       "name": "Luck, Andrew",
@@ -66581,20 +85264,75 @@
       "position": "QB",
       "team": "MIA"
     },
+    "10698": {
+      "name": "Weeden, Brandon",
+      "position": "QB",
+      "team": "CLE"
+    },
+    "10699": {
+      "name": "Foles, Nick",
+      "position": "QB",
+      "team": "PHI"
+    },
     "10700": {
       "name": "Cousins, Kirk",
       "position": "QB",
       "team": "MIN"
+    },
+    "10701": {
+      "name": "Moore, Kellen",
+      "position": "QB",
+      "team": "DET"
+    },
+    "10702": {
+      "name": "Osweiler, Brock",
+      "position": "QB",
+      "team": "DEN"
     },
     "10703": {
       "name": "Wilson, Russell",
       "position": "QB",
       "team": "SEA"
     },
+    "10706": {
+      "name": "Richardson, Trent",
+      "position": "RB",
+      "team": "CLE"
+    },
     "10708": {
       "name": "Miller, Lamar",
       "position": "RB",
       "team": "HOU"
+    },
+    "10709": {
+      "name": "Martin, Doug",
+      "position": "RB",
+      "team": "TBB"
+    },
+    "10710": {
+      "name": "Polk, Chris",
+      "position": "RB",
+      "team": "PHI"
+    },
+    "10712": {
+      "name": "Rainey, Chris",
+      "position": "RB",
+      "team": "FA"
+    },
+    "10714": {
+      "name": "Turbin, Robert",
+      "position": "RB",
+      "team": "SEA"
+    },
+    "10716": {
+      "name": "Demps, Jeff",
+      "position": "RB",
+      "team": "IND"
+    },
+    "10717": {
+      "name": "Gray, Cyrus",
+      "position": "RB",
+      "team": "KCC"
     },
     "10718": {
       "name": "Pead, Isaiah",
@@ -66606,6 +85344,11 @@
       "position": "WR",
       "team": "JAC"
     },
+    "10720": {
+      "name": "Wright, Kendall",
+      "position": "WR",
+      "team": "TEN"
+    },
     "10721": {
       "name": "Floyd, Michael",
       "position": "WR",
@@ -66616,30 +85359,140 @@
       "position": "WR",
       "team": "CHI"
     },
+    "10723": {
+      "name": "Sanu, Mohamed",
+      "position": "WR",
+      "team": "CIN"
+    },
+    "10726": {
+      "name": "McNutt, Marvin",
+      "position": "WR",
+      "team": "PHI"
+    },
     "10729": {
       "name": "Hilton, T.Y.",
       "position": "WR",
       "team": "IND"
+    },
+    "10730": {
+      "name": "Posey, DeVier",
+      "position": "WR",
+      "team": "HOU"
+    },
+    "10731": {
+      "name": "Toon, Nick",
+      "position": "WR",
+      "team": "NOS"
+    },
+    "10735": {
+      "name": "Quick, Brian",
+      "position": "WR",
+      "team": "RAM"
+    },
+    "10736": {
+      "name": "Givens, Chris",
+      "position": "WR",
+      "team": "FA"
+    },
+    "10737": {
+      "name": "Benjamin, Travis",
+      "position": "WR",
+      "team": "CLE"
+    },
+    "10738": {
+      "name": "Jones, Marvin",
+      "position": "WR",
+      "team": "CIN"
+    },
+    "10739": {
+      "name": "Cunningham, B.J.",
+      "position": "WR",
+      "team": "PHI"
     },
     "10742": {
       "name": "Allen, Dwayne",
       "position": "TE",
       "team": "IND"
     },
+    "10744": {
+      "name": "Green, Ladarius",
+      "position": "TE",
+      "team": "SDC"
+    },
+    "10747": {
+      "name": "Charles, Orson",
+      "position": "TE",
+      "team": "CIN"
+    },
+    "10800": {
+      "name": "Hill, Stephen",
+      "position": "WR",
+      "team": "NYJ"
+    },
+    "10835": {
+      "name": "Martin, Keshawn",
+      "position": "WR",
+      "team": "HOU"
+    },
+    "10852": {
+      "name": "Thompson, Taylor",
+      "position": "TE",
+      "team": "TEN"
+    },
+    "10862": {
+      "name": "Bullock, Randy",
+      "position": "PK",
+      "team": "HOU"
+    },
     "10866": {
       "name": "Criner, Juron",
       "position": "WR",
       "team": "OAK"
+    },
+    "10868": {
+      "name": "Zuerlein, Greg",
+      "position": "PK",
+      "team": "STL"
     },
     "10870": {
       "name": "Morris, Alfred",
       "position": "RB",
       "team": "WAS"
     },
+    "10872": {
+      "name": "Walsh, Blair",
+      "position": "PK",
+      "team": "SEA"
+    },
+    "10881": {
+      "name": "Herron, Dan",
+      "position": "RB",
+      "team": "CIN"
+    },
     "10889": {
       "name": "Brazill, LaVon",
       "position": "WR",
       "team": "IND"
+    },
+    "10903": {
+      "name": "Matthews, Rishard",
+      "position": "WR",
+      "team": "TEN"
+    },
+    "10905": {
+      "name": "Brown, Bryce",
+      "position": "RB",
+      "team": "PHI"
+    },
+    "10907": {
+      "name": "Clemons, Toney",
+      "position": "WR",
+      "team": "JAC"
+    },
+    "10929": {
+      "name": "Rainey, Bobby",
+      "position": "RB",
+      "team": "TBB"
     },
     "10948": {
       "name": "Keenum, Case",
@@ -66651,30 +85504,65 @@
       "position": "WR",
       "team": "PHI"
     },
+    "10955": {
+      "name": "Streater, Rod",
+      "position": "WR",
+      "team": "OAK"
+    },
     "10960": {
       "name": "Gordon, Josh",
       "position": "WR",
-      "team": "NEP"
+      "team": "CLE"
+    },
+    "10961": {
+      "name": "Dunbar, Lance",
+      "position": "RB",
+      "team": "DAL"
+    },
+    "10973": {
+      "name": "Beasley, Cole",
+      "position": "WR",
+      "team": "DAL"
     },
     "10976": {
       "name": "Tucker, Justin",
       "position": "PK",
       "team": "BAL"
     },
+    "10983": {
+      "name": "Hogan, Chris",
+      "position": "WR",
+      "team": "NEP"
+    },
     "10998": {
       "name": "Asiata, Matt",
       "position": "RB",
       "team": "MIN"
+    },
+    "11076": {
+      "name": "Kearse, Jermaine",
+      "position": "WR",
+      "team": "SEA"
     },
     "11125": {
       "name": "Bostick, Brandon",
       "position": "TE",
       "team": "GBP"
     },
+    "11150": {
+      "name": "Smith, Geno",
+      "position": "QB",
+      "team": "SEA"
+    },
     "11152": {
       "name": "Glennon, Mike",
       "position": "QB",
       "team": "TBB"
+    },
+    "11154": {
+      "name": "Manuel, E.J.",
+      "position": "QB",
+      "team": "BUF"
     },
     "11156": {
       "name": "Jones, Landry",
@@ -66686,10 +85574,40 @@
       "position": "RB",
       "team": "ARI"
     },
+    "11176": {
+      "name": "Taylor, Stepfan",
+      "position": "RB",
+      "team": "ARI"
+    },
+    "11177": {
+      "name": "Barner, Kenjon",
+      "position": "RB",
+      "team": "ATL"
+    },
+    "11179": {
+      "name": "Michael, Christine",
+      "position": "RB",
+      "team": "SEA"
+    },
     "11180": {
       "name": "Gillislee, Mike",
       "position": "RB",
       "team": "BUF"
+    },
+    "11182": {
+      "name": "Burkhead, Rex",
+      "position": "RB",
+      "team": "NEP"
+    },
+    "11186": {
+      "name": "Thompson, Chris",
+      "position": "RB",
+      "team": "WAS"
+    },
+    "11188": {
+      "name": "Riddick, Theo",
+      "position": "RB",
+      "team": "DEN"
     },
     "11192": {
       "name": "Bell, Le'Veon",
@@ -66701,10 +85619,45 @@
       "position": "RB",
       "team": "CIN"
     },
+    "11194": {
+      "name": "Davis, Knile",
+      "position": "RB",
+      "team": "KCC"
+    },
+    "11198": {
+      "name": "Lattimore, Marcus",
+      "position": "RB",
+      "team": "SFO"
+    },
+    "11199": {
+      "name": "Ware, Spencer",
+      "position": "RB",
+      "team": "KCC"
+    },
+    "11210": {
+      "name": "Robinson, Denard",
+      "position": "RB",
+      "team": "JAC"
+    },
+    "11213": {
+      "name": "Austin, Tavon",
+      "position": "WR",
+      "team": "LAR"
+    },
     "11214": {
       "name": "Dobson, Aaron",
       "position": "WR",
       "team": "NEP"
+    },
+    "11217": {
+      "name": "Mellette, Aaron",
+      "position": "WR",
+      "team": "BAL"
+    },
+    "11218": {
+      "name": "Patton, Quinton",
+      "position": "WR",
+      "team": "SFO"
     },
     "11219": {
       "name": "King, Tavarres",
@@ -66714,22 +85667,62 @@
     "11222": {
       "name": "Allen, Keenan",
       "position": "WR",
-      "team": "LAC"
+      "team": "SDC"
+    },
+    "11223": {
+      "name": "Bailey, Stedman",
+      "position": "WR",
+      "team": "STL"
     },
     "11225": {
       "name": "Patterson, Cordarrelle",
       "position": "WR",
       "team": "MIN"
     },
+    "11227": {
+      "name": "Stills, Kenny",
+      "position": "WR",
+      "team": "MIA"
+    },
     "11228": {
       "name": "Woods, Robert",
       "position": "WR",
       "team": "BUF"
     },
+    "11229": {
+      "name": "Wheaton, Markus",
+      "position": "WR",
+      "team": "CHI"
+    },
+    "11231": {
+      "name": "Wilson, Marquess",
+      "position": "WR",
+      "team": "CHI"
+    },
     "11232": {
       "name": "Hopkins, DeAndre",
       "position": "WR",
       "team": "HOU"
+    },
+    "11234": {
+      "name": "Swope, Ryan",
+      "position": "WR",
+      "team": "ARI"
+    },
+    "11235": {
+      "name": "Harper, Chris",
+      "position": "WR",
+      "team": "GBP"
+    },
+    "11239": {
+      "name": "Goodwin, Marquise",
+      "position": "WR",
+      "team": "SFO"
+    },
+    "11243": {
+      "name": "Fauria, Joseph",
+      "position": "TE",
+      "team": "DET"
     },
     "11244": {
       "name": "Kelce, Travis",
@@ -66746,6 +85739,11 @@
       "position": "TE",
       "team": "WAS"
     },
+    "11249": {
+      "name": "Sims, Dion",
+      "position": "TE",
+      "team": "MIA"
+    },
     "11250": {
       "name": "Eifert, Tyler",
       "position": "TE",
@@ -66756,20 +85754,95 @@
       "position": "TE",
       "team": "ATL"
     },
+    "11256": {
+      "name": "Gragg, Chris",
+      "position": "TE",
+      "team": "BUF"
+    },
+    "11257": {
+      "name": "McDonald, Vance",
+      "position": "TE",
+      "team": "SFO"
+    },
+    "11258": {
+      "name": "Rivera, Mychal",
+      "position": "TE",
+      "team": "OAK"
+    },
+    "11259": {
+      "name": "Sudfeld, Zach",
+      "position": "TE",
+      "team": "NYJ"
+    },
+    "11337": {
+      "name": "Fells, Darren",
+      "position": "TE",
+      "team": "ARI"
+    },
+    "11342": {
+      "name": "Whittaker, Fozzy",
+      "position": "RB",
+      "team": "CAR"
+    },
     "11343": {
       "name": "Momah, Ifeanyi",
       "position": "WR",
       "team": "PHI"
+    },
+    "11367": {
+      "name": "Juszczyk, Kyle",
+      "position": "RB",
+      "team": "SFO"
+    },
+    "11381": {
+      "name": "Willson, Luke",
+      "position": "TE",
+      "team": "SEA"
+    },
+    "11384": {
+      "name": "Sturgis, Caleb",
+      "position": "PK",
+      "team": "MIA"
     },
     "11387": {
       "name": "Hopkins, Dustin",
       "position": "PK",
       "team": "WAS"
     },
+    "11390": {
+      "name": "Murray, Latavius",
+      "position": "RB",
+      "team": "OAK"
+    },
+    "11399": {
+      "name": "Griffin, Ryan",
+      "position": "TE",
+      "team": "HOU"
+    },
+    "11406": {
+      "name": "Butler, Brice",
+      "position": "WR",
+      "team": "MIA"
+    },
     "11426": {
       "name": "Cox, Michael",
       "position": "RB",
       "team": "NYG"
+    },
+    "11436": {
+      "name": "Harrison, Mark",
+      "position": "WR",
+      "team": "NEP"
+    },
+    "11440": {
+      "name": "Thompkins, Kenbrell",
+      "position": "WR",
+      "team": "NEP"
+    },
+    "11454": {
+      "name": "Anderson, C.J.",
+      "position": "RB",
+      "team": "LAR"
     },
     "11456": {
       "name": "Brown, Jaron",
@@ -66780,6 +85853,11 @@
       "name": "Robinson, Khiry",
       "position": "RB",
       "team": "NOS"
+    },
+    "11481": {
+      "name": "Brown, Marlon",
+      "position": "WR",
+      "team": "BAL"
     },
     "11516": {
       "name": "Doyle, Jack",
@@ -66806,15 +85884,30 @@
       "position": "QB",
       "team": "OAK"
     },
+    "11645": {
+      "name": "Mettenberger, Zach",
+      "position": "QB",
+      "team": "TEN"
+    },
     "11647": {
       "name": "Thomas, Logan",
-      "position": "TE",
-      "team": "WAS"
+      "position": "QB",
+      "team": "ARI"
     },
     "11650": {
       "name": "Mason, Tre",
       "position": "RB",
       "team": "STL"
+    },
+    "11651": {
+      "name": "Seastrunk, Lache",
+      "position": "RB",
+      "team": "TEN"
+    },
+    "11653": {
+      "name": "Sankey, Bishop",
+      "position": "RB",
+      "team": "TEN"
     },
     "11656": {
       "name": "Sims, Charles",
@@ -66826,6 +85919,31 @@
       "position": "RB",
       "team": "SFO"
     },
+    "11659": {
+      "name": "Thomas, De'Anthony",
+      "position": "RB",
+      "team": "KCC"
+    },
+    "11660": {
+      "name": "Freeman, Devonta",
+      "position": "RB",
+      "team": "ATL"
+    },
+    "11663": {
+      "name": "Johnson, Storm",
+      "position": "RB",
+      "team": "JAC"
+    },
+    "11664": {
+      "name": "Josey, Henry",
+      "position": "RB",
+      "team": "MIN"
+    },
+    "11665": {
+      "name": "Redd, Silas",
+      "position": "RB",
+      "team": "WAS"
+    },
     "11668": {
       "name": "Crowell, Isaiah",
       "position": "RB",
@@ -66834,7 +85952,7 @@
     "11670": {
       "name": "Watkins, Sammy",
       "position": "WR",
-      "team": "BAL"
+      "team": "KCC"
     },
     "11671": {
       "name": "Evans, Mike",
@@ -66846,6 +85964,11 @@
       "position": "WR",
       "team": "JAC"
     },
+    "11673": {
+      "name": "Benjamin, Kelvin",
+      "position": "WR",
+      "team": "CAR"
+    },
     "11674": {
       "name": "Cooks, Brandin",
       "position": "WR",
@@ -66856,10 +85979,20 @@
       "position": "WR",
       "team": "GBP"
     },
+    "11676": {
+      "name": "Matthews, Jordan",
+      "position": "WR",
+      "team": "PHI"
+    },
+    "11677": {
+      "name": "Moncrief, Donte",
+      "position": "WR",
+      "team": "IND"
+    },
     "11678": {
       "name": "Robinson, Allen",
       "position": "WR",
-      "team": "CHI"
+      "team": "JAC"
     },
     "11679": {
       "name": "Beckham, Odell",
@@ -66871,20 +86004,100 @@
       "position": "WR",
       "team": "MIA"
     },
+    "11681": {
+      "name": "Richardson, Paul",
+      "position": "WR",
+      "team": "SEA"
+    },
+    "11682": {
+      "name": "Abbrederis, Jared",
+      "position": "WR",
+      "team": "DET"
+    },
+    "11684": {
+      "name": "Huff, Josh",
+      "position": "WR",
+      "team": "PHI"
+    },
+    "11686": {
+      "name": "Jones, T.J.",
+      "position": "WR",
+      "team": "DET"
+    },
     "11688": {
       "name": "Bryant, Martavis",
       "position": "WR",
       "team": "PIT"
     },
+    "11689": {
+      "name": "Ellington, Bruce",
+      "position": "WR",
+      "team": "SFO"
+    },
+    "11695": {
+      "name": "Ebron, Eric",
+      "position": "TE",
+      "team": "DET"
+    },
     "11696": {
       "name": "Amaro, Jace",
       "position": "TE",
-      "team": "TEN"
+      "team": "NYJ"
+    },
+    "11697": {
+      "name": "Seferian-Jenkins, Austin",
+      "position": "TE",
+      "team": "TBB"
     },
     "11698": {
       "name": "Fiedorowicz, C.J.",
       "position": "TE",
       "team": "HOU"
+    },
+    "11703": {
+      "name": "Niklas, Troy",
+      "position": "TE",
+      "team": "ARI"
+    },
+    "11704": {
+      "name": "Lyerla, Colt",
+      "position": "TE",
+      "team": "FA"
+    },
+    "11705": {
+      "name": "Burton, Trey",
+      "position": "TE",
+      "team": "CHI"
+    },
+    "11746": {
+      "name": "West, Terrance",
+      "position": "RB",
+      "team": "BAL"
+    },
+    "11747": {
+      "name": "White, James",
+      "position": "RB",
+      "team": "NEP"
+    },
+    "11752": {
+      "name": "Matthews, Chris",
+      "position": "WR",
+      "team": "BAL"
+    },
+    "11754": {
+      "name": "Coleman, Brandon",
+      "position": "WR",
+      "team": "FA"
+    },
+    "11755": {
+      "name": "Herron, Robert",
+      "position": "WR",
+      "team": "TBB"
+    },
+    "11756": {
+      "name": "Dressler, Weston",
+      "position": "WR",
+      "team": "FA"
     },
     "11760": {
       "name": "Garoppolo, Jimmy",
@@ -66894,47 +86107,137 @@
     "11761": {
       "name": "McKinnon, Jerick",
       "position": "RB",
-      "team": "SFO"
+      "team": "MIN"
     },
     "11783": {
       "name": "Brown, John",
       "position": "WR",
+      "team": "ARI"
+    },
+    "11784": {
+      "name": "Archer, Dri",
+      "position": "RB",
+      "team": "PIT"
+    },
+    "11785": {
+      "name": "Rodgers, Richard",
+      "position": "TE",
+      "team": "GBP"
+    },
+    "11786": {
+      "name": "Gillmore, Crockett",
+      "position": "TE",
       "team": "BAL"
+    },
+    "11798": {
+      "name": "Norwood, Kevin",
+      "position": "WR",
+      "team": "SEA"
+    },
+    "11809": {
+      "name": "Taliaferro, Lorenzo",
+      "position": "RB",
+      "team": "BAL"
+    },
+    "11812": {
+      "name": "Grant, Ryan",
+      "position": "WR",
+      "team": "IND"
     },
     "11834": {
       "name": "Blue, Alfred",
       "position": "RB",
       "team": "HOU"
     },
+    "11850": {
+      "name": "Enunwa, Quincy",
+      "position": "WR",
+      "team": "NYJ"
+    },
+    "11870": {
+      "name": "Janis, Jeff",
+      "position": "WR",
+      "team": "GBP"
+    },
     "11874": {
       "name": "Wright, James",
       "position": "WR",
       "team": "CIN"
+    },
+    "11886": {
+      "name": "Williams, Damien",
+      "position": "RB",
+      "team": "CHI"
+    },
+    "11890": {
+      "name": "Wilson, Albert",
+      "position": "WR",
+      "team": "MIA"
+    },
+    "11893": {
+      "name": "Flanders, Tim",
+      "position": "RB",
+      "team": "FA"
+    },
+    "11904": {
+      "name": "Swoope, Erik",
+      "position": "TE",
+      "team": "IND"
     },
     "11925": {
       "name": "Hurns, Allen",
       "position": "WR",
       "team": "JAC"
     },
+    "11936": {
+      "name": "Boswell, Chris",
+      "position": "PK",
+      "team": "PIT"
+    },
     "11938": {
       "name": "Thielen, Adam",
       "position": "WR",
       "team": "MIN"
     },
+    "11945": {
+      "name": "Santos, Cairo",
+      "position": "PK",
+      "team": "KCC"
+    },
+    "11947": {
+      "name": "McManus, Brandon",
+      "position": "PK",
+      "team": "DEN"
+    },
     "11957": {
       "name": "Inman, Dontrelle",
       "position": "WR",
-      "team": "CHI"
+      "team": "SDC"
     },
     "11960": {
       "name": "Catanzaro, Chandler",
       "position": "PK",
-      "team": "NYJ"
+      "team": "ARI"
+    },
+    "11966": {
+      "name": "Parkey, Cody",
+      "position": "PK",
+      "team": "CHI"
     },
     "11972": {
       "name": "Brown, Corey",
       "position": "WR",
       "team": "CAR"
+    },
+    "11975": {
+      "name": "Gabriel, Taylor",
+      "position": "WR",
+      "team": "CLE"
+    },
+    "12098": {
+      "name": "West, Charcandrick",
+      "position": "RB",
+      "team": "KCC"
     },
     "12110": {
       "name": "Brate, Cameron",
@@ -66961,6 +86264,16 @@
       "position": "RB",
       "team": "STL"
     },
+    "12151": {
+      "name": "Gordon, Melvin",
+      "position": "RB",
+      "team": "DEN"
+    },
+    "12152": {
+      "name": "Coleman, Tevin",
+      "position": "RB",
+      "team": "SFO"
+    },
     "12153": {
       "name": "Yeldon, T.J.",
       "position": "RB",
@@ -66971,10 +86284,35 @@
       "position": "RB",
       "team": "DET"
     },
+    "12156": {
+      "name": "Langford, Jeremy",
+      "position": "RB",
+      "team": "NYJ"
+    },
+    "12157": {
+      "name": "Johnson, Duke",
+      "position": "RB",
+      "team": "HOU"
+    },
+    "12159": {
+      "name": "Allen, Javorius",
+      "position": "RB",
+      "team": "BAL"
+    },
     "12160": {
       "name": "Williams, Karlos",
       "position": "RB",
       "team": "BUF"
+    },
+    "12164": {
+      "name": "Davis, Mike",
+      "position": "RB",
+      "team": "ATL"
+    },
+    "12169": {
+      "name": "Rawls, Thomas",
+      "position": "RB",
+      "team": "SEA"
     },
     "12171": {
       "name": "Johnson, David",
@@ -67006,6 +86344,16 @@
       "position": "WR",
       "team": "PHI"
     },
+    "12184": {
+      "name": "Crowder, Jamison",
+      "position": "WR",
+      "team": "NYJ"
+    },
+    "12186": {
+      "name": "Diggs, Stefon",
+      "position": "WR",
+      "team": "BUF"
+    },
     "12187": {
       "name": "Lockett, Tyler",
       "position": "WR",
@@ -67015,6 +86363,11 @@
       "name": "Dorsett, Phillip",
       "position": "WR",
       "team": "IND"
+    },
+    "12197": {
+      "name": "Perriman, Breshad",
+      "position": "WR",
+      "team": "TBB"
     },
     "12205": {
       "name": "Funchess, Devin",
@@ -67026,10 +86379,15 @@
       "position": "TE",
       "team": "BAL"
     },
+    "12208": {
+      "name": "Heuerman, Jeff",
+      "position": "TE",
+      "team": "DEN"
+    },
     "12212": {
       "name": "Kroft, Tyler",
       "position": "TE",
-      "team": "BUF"
+      "team": "CIN"
     },
     "12257": {
       "name": "Conley, Chris",
@@ -67039,17 +86397,32 @@
     "12263": {
       "name": "Waller, Darren",
       "position": "TE",
-      "team": "LVR"
+      "team": "OAK"
     },
     "12317": {
       "name": "Uzomah, C.J.",
       "position": "TE",
       "team": "CIN"
     },
+    "12319": {
+      "name": "Nelson, J.J.",
+      "position": "WR",
+      "team": "ARI"
+    },
     "12353": {
       "name": "Ripkowski, Aaron",
       "position": "RB",
       "team": "GBP"
+    },
+    "12378": {
+      "name": "Swaim, Geoff",
+      "position": "TE",
+      "team": "JAC"
+    },
+    "12381": {
+      "name": "Siemian, Trevor",
+      "position": "QB",
+      "team": "DEN"
     },
     "12386": {
       "name": "Brown, Malcolm",
@@ -67061,25 +86434,90 @@
       "position": "WR",
       "team": "FA"
     },
+    "12396": {
+      "name": "Farmer, George",
+      "position": "WR",
+      "team": "SEA"
+    },
+    "12398": {
+      "name": "Taylor, Jordan",
+      "position": "WR",
+      "team": "FA"
+    },
+    "12409": {
+      "name": "Davis, Darius",
+      "position": "WR",
+      "team": "SFO"
+    },
+    "12417": {
+      "name": "Lambo, Josh",
+      "position": "PK",
+      "team": "JAC"
+    },
+    "12437": {
+      "name": "Myers, Jason",
+      "position": "PK",
+      "team": "JAC"
+    },
+    "12447": {
+      "name": "Mostert, Raheem",
+      "position": "RB",
+      "team": "SFO"
+    },
+    "12465": {
+      "name": "Meredith, Cameron",
+      "position": "WR",
+      "team": "CHI"
+    },
+    "12471": {
+      "name": "Roberts, Seth",
+      "position": "WR",
+      "team": "OAK"
+    },
     "12476": {
       "name": "Heinicke, Taylor",
       "position": "QB",
       "team": "WAS"
     },
+    "12596": {
+      "name": "LaCosse, Matt",
+      "position": "TE",
+      "team": "NEP"
+    },
+    "12610": {
+      "name": "Wentz, Carson",
+      "position": "QB",
+      "team": "PHI"
+    },
     "12611": {
       "name": "Goff, Jared",
       "position": "QB",
-      "team": "DET"
+      "team": "RAM"
     },
     "12612": {
       "name": "Lynch, Paxton",
       "position": "QB",
       "team": "DEN"
     },
+    "12613": {
+      "name": "Cook, Connor",
+      "position": "QB",
+      "team": "OAK"
+    },
+    "12614": {
+      "name": "Hackenberg, Christian",
+      "position": "QB",
+      "team": "NYJ"
+    },
     "12616": {
       "name": "Brissett, Jacoby",
       "position": "QB",
-      "team": "IND"
+      "team": "NEP"
+    },
+    "12617": {
+      "name": "Kessler, Cody",
+      "position": "QB",
+      "team": "CLE"
     },
     "12618": {
       "name": "Hogan, Kevin",
@@ -67091,23 +86529,63 @@
       "position": "QB",
       "team": "DAL"
     },
+    "12623": {
+      "name": "Driskel, Jeff",
+      "position": "QB",
+      "team": "CIN"
+    },
+    "12625": {
+      "name": "Elliott, Ezekiel",
+      "position": "RB",
+      "team": "NEP"
+    },
     "12626": {
       "name": "Henry, Derrick",
       "position": "RB",
       "team": "TEN"
     },
+    "12627": {
+      "name": "Prosise, C.J.",
+      "position": "RB",
+      "team": "SEA"
+    },
+    "12628": {
+      "name": "Collins, Alex",
+      "position": "RB",
+      "team": "SEA"
+    },
+    "12629": {
+      "name": "Booker, Devontae",
+      "position": "RB",
+      "team": "DEN"
+    },
     "12630": {
       "name": "Drake, Kenyan",
       "position": "RB",
-      "team": "ARI"
+      "team": "MIA"
     },
     "12631": {
       "name": "Perkins, Paul",
       "position": "RB",
       "team": "NYG"
     },
+    "12632": {
+      "name": "Dixon, Kenneth",
+      "position": "RB",
+      "team": "BAL"
+    },
     "12634": {
       "name": "Howard, Jordan",
+      "position": "RB",
+      "team": "PHI"
+    },
+    "12635": {
+      "name": "Williams, Jonathan",
+      "position": "RB",
+      "team": "BUF"
+    },
+    "12636": {
+      "name": "Smallwood, Wendell",
       "position": "RB",
       "team": "PHI"
     },
@@ -67116,65 +86594,285 @@
       "position": "RB",
       "team": "TBB"
     },
+    "12639": {
+      "name": "Ervin, Tyler",
+      "position": "RB",
+      "team": "HOU"
+    },
+    "12640": {
+      "name": "Ferguson, Josh",
+      "position": "RB",
+      "team": "IND"
+    },
+    "12645": {
+      "name": "Treadwell, Laquon",
+      "position": "WR",
+      "team": "MIN"
+    },
     "12646": {
       "name": "Coleman, Corey",
       "position": "WR",
-      "team": "NYG"
+      "team": "CLE"
     },
     "12647": {
       "name": "Fuller, Will",
       "position": "WR",
       "team": "HOU"
     },
+    "12648": {
+      "name": "Doctson, Josh",
+      "position": "WR",
+      "team": "WAS"
+    },
+    "12649": {
+      "name": "Lewis, Roger",
+      "position": "WR",
+      "team": "NYG"
+    },
+    "12650": {
+      "name": "Boyd, Tyler",
+      "position": "WR",
+      "team": "CIN"
+    },
+    "12651": {
+      "name": "Miller, Braxton",
+      "position": "WR",
+      "team": "HOU"
+    },
+    "12652": {
+      "name": "Thomas, Michael",
+      "position": "WR",
+      "team": "NOS"
+    },
+    "12655": {
+      "name": "Carroo, Leonte",
+      "position": "WR",
+      "team": "MIA"
+    },
+    "12656": {
+      "name": "Higgins, Rashard",
+      "position": "WR",
+      "team": "CLE"
+    },
+    "12657": {
+      "name": "Sharpe, Tajae",
+      "position": "WR",
+      "team": "TEN"
+    },
     "12658": {
       "name": "Shepard, Sterling",
       "position": "WR",
       "team": "NYG"
+    },
+    "12660": {
+      "name": "Cooper, Pharoh",
+      "position": "WR",
+      "team": "RAM"
+    },
+    "12663": {
+      "name": "Payton, Jordan",
+      "position": "WR",
+      "team": "CLE"
+    },
+    "12664": {
+      "name": "Duarte, Thomas",
+      "position": "TE",
+      "team": "MIA"
+    },
+    "12665": {
+      "name": "Allison, Geronimo",
+      "position": "WR",
+      "team": "GBP"
+    },
+    "12669": {
+      "name": "Mitchell, Malcolm",
+      "position": "WR",
+      "team": "NEP"
+    },
+    "12671": {
+      "name": "Listenbee, Kolby",
+      "position": "WR",
+      "team": "BUF"
+    },
+    "12672": {
+      "name": "Braverman, Daniel",
+      "position": "WR",
+      "team": "CHI"
+    },
+    "12673": {
+      "name": "Peake, Charone",
+      "position": "WR",
+      "team": "NYJ"
+    },
+    "12675": {
+      "name": "Thomas, Mike",
+      "position": "WR",
+      "team": "RAM"
     },
     "12676": {
       "name": "Henry, Hunter",
       "position": "TE",
       "team": "SDC"
     },
+    "12677": {
+      "name": "Hooper, Austin",
+      "position": "TE",
+      "team": "ATL"
+    },
     "12678": {
       "name": "Higbee, Tyler",
       "position": "TE",
-      "team": "LAR"
+      "team": "RAM"
+    },
+    "12680": {
+      "name": "Vannett, Nick",
+      "position": "TE",
+      "team": "SEA"
+    },
+    "12681": {
+      "name": "Adams, Jerell",
+      "position": "TE",
+      "team": "NYG"
+    },
+    "12721": {
+      "name": "Aguayo, Roberto",
+      "position": "PK",
+      "team": "TBB"
+    },
+    "12726": {
+      "name": "Garrett, Keyarris",
+      "position": "WR",
+      "team": "CAR"
+    },
+    "12773": {
+      "name": "Moore, Chris",
+      "position": "WR",
+      "team": "BAL"
+    },
+    "12785": {
+      "name": "Robinson, Demarcus",
+      "position": "WR",
+      "team": "KCC"
     },
     "12801": {
       "name": "Hill, Tyreek",
       "position": "WR",
       "team": "KCC"
     },
+    "12807": {
+      "name": "Hemingway, Temarrick",
+      "position": "TE",
+      "team": "RAM"
+    },
+    "12809": {
+      "name": "Boehringer, Moritz",
+      "position": "WR",
+      "team": "FA"
+    },
+    "12815": {
+      "name": "Sudfeld, Nate",
+      "position": "QB",
+      "team": "PHI"
+    },
+    "12824": {
+      "name": "Core, Cody",
+      "position": "WR",
+      "team": "CIN"
+    },
     "12845": {
       "name": "Washington, Dwayne",
       "position": "RB",
       "team": "DET"
+    },
+    "12857": {
+      "name": "Washington, DeAndre",
+      "position": "RB",
+      "team": "OAK"
+    },
+    "12858": {
+      "name": "Coprich, Marshaun",
+      "position": "RB",
+      "team": "FA"
+    },
+    "12860": {
+      "name": "Fairbairn, Ka'imi",
+      "position": "PK",
+      "team": "HOU"
+    },
+    "12867": {
+      "name": "Wilds, Brandon",
+      "position": "RB",
+      "team": "NYJ"
+    },
+    "12869": {
+      "name": "Johnson, Devon",
+      "position": "RB",
+      "team": "FA"
+    },
+    "12874": {
+      "name": "Valles, Hakeem",
+      "position": "TE",
+      "team": "ARI"
+    },
+    "12875": {
+      "name": "Bercovici, Mike",
+      "position": "QB",
+      "team": "FA"
+    },
+    "12878": {
+      "name": "Boykin, Trevone",
+      "position": "QB",
+      "team": "SEA"
     },
     "12887": {
       "name": "Kelley, Rob",
       "position": "RB",
       "team": "WAS"
     },
+    "12912": {
+      "name": "Richard, Jalen",
+      "position": "RB",
+      "team": "OAK"
+    },
     "12930": {
       "name": "Anderson, Robby",
       "position": "WR",
       "team": "CAR"
+    },
+    "12934": {
+      "name": "Rogers, Chester",
+      "position": "WR",
+      "team": "IND"
+    },
+    "12954": {
+      "name": "Bowman, Braedon",
+      "position": "TE",
+      "team": "FA"
+    },
+    "12955": {
+      "name": "Manhertz, Chris",
+      "position": "TE",
+      "team": "JAC"
     },
     "12956": {
       "name": "Lutz, Wil",
       "position": "PK",
       "team": "NOS"
     },
+    "13108": {
+      "name": "McKissic, J.D.",
+      "position": "RB",
+      "team": "WAS"
+    },
     "13113": {
       "name": "Watson, Deshaun",
       "position": "QB",
-      "team": "CLE"
+      "team": "HOU"
     },
     "13114": {
       "name": "Kizer, DeShone",
       "position": "QB",
-      "team": "GBP"
+      "team": "CLE"
     },
     "13115": {
       "name": "Trubisky, Mitchell",
@@ -67186,15 +86884,45 @@
       "position": "QB",
       "team": "KCC"
     },
+    "13119": {
+      "name": "Dobbs, Joshua",
+      "position": "QB",
+      "team": "PIT"
+    },
+    "13120": {
+      "name": "Webb, Davis",
+      "position": "QB",
+      "team": "NYG"
+    },
+    "13121": {
+      "name": "Kelly, Chad",
+      "position": "QB",
+      "team": "DEN"
+    },
     "13124": {
       "name": "Rush, Cooper",
       "position": "QB",
       "team": "DAL"
     },
+    "13125": {
+      "name": "Beathard, C.J.",
+      "position": "QB",
+      "team": "SFO"
+    },
+    "13127": {
+      "name": "Peterman, Nathan",
+      "position": "QB",
+      "team": "BUF"
+    },
     "13128": {
       "name": "Cook, Dalvin",
       "position": "RB",
       "team": "MIN"
+    },
+    "13129": {
+      "name": "Fournette, Leonard",
+      "position": "RB",
+      "team": "JAC"
     },
     "13130": {
       "name": "McCaffrey, Christian",
@@ -67211,10 +86939,60 @@
       "position": "RB",
       "team": "NOS"
     },
+    "13133": {
+      "name": "Perine, Samaje",
+      "position": "RB",
+      "team": "DEN"
+    },
     "13134": {
       "name": "Foreman, D'Onta",
       "position": "RB",
-      "team": "CHI"
+      "team": "CAR"
+    },
+    "13135": {
+      "name": "Gallman, Wayne",
+      "position": "RB",
+      "team": "NYG"
+    },
+    "13136": {
+      "name": "Clement, Corey",
+      "position": "RB",
+      "team": "PHI"
+    },
+    "13137": {
+      "name": "Pumphrey, Donnel",
+      "position": "RB",
+      "team": "PHI"
+    },
+    "13138": {
+      "name": "Hunt, Kareem",
+      "position": "RB",
+      "team": "KCC"
+    },
+    "13139": {
+      "name": "Williams, Jamaal",
+      "position": "RB",
+      "team": "DET"
+    },
+    "13141": {
+      "name": "Hood, Elijah",
+      "position": "RB",
+      "team": "OAK"
+    },
+    "13143": {
+      "name": "McNichols, Jeremy",
+      "position": "RB",
+      "team": "SFO"
+    },
+    "13144": {
+      "name": "McGuire, Elijah",
+      "position": "RB",
+      "team": "NYJ"
+    },
+    "13146": {
+      "name": "Conner, James",
+      "position": "RB",
+      "team": "PIT"
     },
     "13153": {
       "name": "Davis, Corey",
@@ -67226,15 +87004,40 @@
       "position": "WR",
       "team": "LAC"
     },
+    "13155": {
+      "name": "Ross, John",
+      "position": "WR",
+      "team": "CIN"
+    },
     "13156": {
       "name": "Smith-Schuster, JuJu",
       "position": "WR",
       "team": "PIT"
     },
+    "13157": {
+      "name": "Samuel, Curtis",
+      "position": "WR",
+      "team": "WAS"
+    },
     "13158": {
       "name": "Westbrook, Dede",
       "position": "WR",
       "team": "JAC"
+    },
+    "13159": {
+      "name": "Cannon, KD",
+      "position": "WR",
+      "team": "DAL"
+    },
+    "13161": {
+      "name": "Scott, Artavis",
+      "position": "WR",
+      "team": "LAC"
+    },
+    "13162": {
+      "name": "Ford, Isaiah",
+      "position": "WR",
+      "team": "MIA"
     },
     "13163": {
       "name": "Godwin, Chris",
@@ -67246,15 +87049,45 @@
       "position": "WR",
       "team": "LAR"
     },
+    "13165": {
+      "name": "Switzer, Ryan",
+      "position": "WR",
+      "team": "PIT"
+    },
+    "13166": {
+      "name": "Darboh, Amara",
+      "position": "WR",
+      "team": "SEA"
+    },
     "13167": {
       "name": "Taylor, Taywan",
       "position": "WR",
       "team": "TEN"
     },
+    "13168": {
+      "name": "Reynolds, Josh",
+      "position": "WR",
+      "team": "LAR"
+    },
+    "13171": {
+      "name": "Henderson, Carlos",
+      "position": "WR",
+      "team": "DEN"
+    },
+    "13172": {
+      "name": "Brown, Noah",
+      "position": "WR",
+      "team": "DAL"
+    },
     "13176": {
       "name": "Jones, Zay",
       "position": "WR",
-      "team": "ARI"
+      "team": "JAC"
+    },
+    "13187": {
+      "name": "Yancey, DeAngelo",
+      "position": "WR",
+      "team": "GBP"
     },
     "13188": {
       "name": "Howard, O.J.",
@@ -67264,12 +87097,17 @@
     "13189": {
       "name": "Engram, Evan",
       "position": "TE",
-      "team": "DEN"
+      "team": "NYG"
     },
     "13190": {
       "name": "Butt, Jake",
       "position": "TE",
       "team": "DEN"
+    },
+    "13191": {
+      "name": "Hodges, Bucky",
+      "position": "TE",
+      "team": "FA"
     },
     "13192": {
       "name": "Njoku, David",
@@ -67280,6 +87118,11 @@
       "name": "Smith, Jonnu",
       "position": "TE",
       "team": "TEN"
+    },
+    "13195": {
+      "name": "Leggett, Jordan",
+      "position": "TE",
+      "team": "NYJ"
     },
     "13234": {
       "name": "Mack, Marlon",
@@ -67296,20 +87139,85 @@
       "position": "RB",
       "team": "SFO"
     },
+    "13240": {
+      "name": "Hill, Brian",
+      "position": "RB",
+      "team": "CIN"
+    },
+    "13241": {
+      "name": "Rosas, Aldrick",
+      "position": "PK",
+      "team": "JAC"
+    },
+    "13244": {
+      "name": "Zamora, Ishmael",
+      "position": "WR",
+      "team": "FA"
+    },
+    "13246": {
+      "name": "Alie-Cox, Mo",
+      "position": "TE",
+      "team": "IND"
+    },
+    "13254": {
+      "name": "Shaheen, Adam",
+      "position": "TE",
+      "team": "CHI"
+    },
     "13277": {
       "name": "Golladay, Kenny",
       "position": "WR",
       "team": "DET"
+    },
+    "13280": {
+      "name": "Williams, Chad",
+      "position": "WR",
+      "team": "ARI"
+    },
+    "13289": {
+      "name": "Hollins, Mack",
+      "position": "WR",
+      "team": "PHI"
     },
     "13290": {
       "name": "Cohen, Tarik",
       "position": "RB",
       "team": "CHI"
     },
+    "13299": {
+      "name": "Kittle, George",
+      "position": "TE",
+      "team": "SFO"
+    },
+    "13303": {
+      "name": "Elliott, Jake",
+      "position": "PK",
+      "team": "PHI"
+    },
+    "13313": {
+      "name": "McKenzie, Isaiah",
+      "position": "WR",
+      "team": "BUF"
+    },
+    "13315": {
+      "name": "Saubert, Eric",
+      "position": "TE",
+      "team": "ATL"
+    },
+    "13316": {
+      "name": "Taylor, Trent",
+      "position": "WR",
+      "team": "SFO"
+    },
     "13319": {
       "name": "Jones, Aaron",
       "position": "RB",
       "team": "GBP"
+    },
+    "13347": {
+      "name": "Gonzalez, Zane",
+      "position": "PK",
+      "team": "ARI"
     },
     "13354": {
       "name": "Butker, Harrison",
@@ -67321,10 +87229,40 @@
       "position": "RB",
       "team": "SEA"
     },
+    "13370": {
+      "name": "Hogan, Krishawn",
+      "position": "WR",
+      "team": "IND"
+    },
+    "13377": {
+      "name": "Patrick, Tim",
+      "position": "WR",
+      "team": "DEN"
+    },
+    "13378": {
+      "name": "Breida, Matt",
+      "position": "RB",
+      "team": "SFO"
+    },
+    "13382": {
+      "name": "Seals-Jones, Ricky",
+      "position": "TE",
+      "team": "FA"
+    },
+    "13403": {
+      "name": "Koo, Younghoe",
+      "position": "PK",
+      "team": "ATL"
+    },
     "13404": {
       "name": "Ekeler, Austin",
       "position": "RB",
       "team": "LAC"
+    },
+    "13416": {
+      "name": "Walker, P.J.",
+      "position": "QB",
+      "team": "CAR"
     },
     "13418": {
       "name": "Bourne, Kendrick",
@@ -67333,43 +87271,168 @@
     },
     "13424": {
       "name": "Hill, Taysom",
-      "position": "TE",
+      "position": "QB",
       "team": "NOS"
+    },
+    "13585": {
+      "name": "Zylstra, Brandon",
+      "position": "WR",
+      "team": "MIN"
+    },
+    "13589": {
+      "name": "Allen, Josh",
+      "position": "QB",
+      "team": "BUF"
+    },
+    "13590": {
+      "name": "Mayfield, Baker",
+      "position": "QB",
+      "team": "CLE"
+    },
+    "13591": {
+      "name": "Rosen, Josh",
+      "position": "QB",
+      "team": "ARI"
+    },
+    "13592": {
+      "name": "Darnold, Sam",
+      "position": "QB",
+      "team": "NYJ"
     },
     "13593": {
       "name": "Jackson, Lamar",
       "position": "QB",
       "team": "BAL"
     },
+    "13595": {
+      "name": "Rudolph, Mason",
+      "position": "QB",
+      "team": "PIT"
+    },
+    "13596": {
+      "name": "Barrett, J.T.",
+      "position": "QB",
+      "team": "NOS"
+    },
+    "13598": {
+      "name": "White, Mike",
+      "position": "QB",
+      "team": "MIA"
+    },
+    "13601": {
+      "name": "Lauletta, Kyle",
+      "position": "QB",
+      "team": "NYG"
+    },
+    "13604": {
+      "name": "Barkley, Saquon",
+      "position": "RB",
+      "team": "NYG"
+    },
+    "13605": {
+      "name": "Guice, Derrius",
+      "position": "RB",
+      "team": "WAS"
+    },
+    "13606": {
+      "name": "Jones, Ronald",
+      "position": "RB",
+      "team": "TBB"
+    },
+    "13607": {
+      "name": "Michel, Sony",
+      "position": "RB",
+      "team": "NEP"
+    },
+    "13608": {
+      "name": "Penny, Rashaad",
+      "position": "RB",
+      "team": "SEA"
+    },
     "13610": {
       "name": "Chubb, Nick",
       "position": "RB",
       "team": "CLE"
+    },
+    "13611": {
+      "name": "Adams, Josh",
+      "position": "RB",
+      "team": "PHI"
+    },
+    "13612": {
+      "name": "Johnson, Kerryon",
+      "position": "RB",
+      "team": "DET"
+    },
+    "13613": {
+      "name": "Samuels, Jaylen",
+      "position": "RB",
+      "team": "PIT"
     },
     "13614": {
       "name": "Lindsay, Phillip",
       "position": "RB",
       "team": "DEN"
     },
+    "13615": {
+      "name": "Scarbrough, Bo",
+      "position": "RB",
+      "team": "SEA"
+    },
+    "13617": {
+      "name": "Freeman, Royce",
+      "position": "RB",
+      "team": "DEN"
+    },
+    "13619": {
+      "name": "Kelly, John",
+      "position": "RB",
+      "team": "LAR"
+    },
+    "13620": {
+      "name": "Jackson, Justin",
+      "position": "RB",
+      "team": "LAC"
+    },
+    "13621": {
+      "name": "Ballage, Kalen",
+      "position": "RB",
+      "team": "MIA"
+    },
     "13622": {
       "name": "Hines, Nyheim",
       "position": "RB",
       "team": "IND"
     },
+    "13623": {
+      "name": "Williams, Darrel",
+      "position": "RB",
+      "team": "ARI"
+    },
     "13629": {
       "name": "Ridley, Calvin",
       "position": "WR",
-      "team": "JAC"
+      "team": "ATL"
     },
     "13630": {
       "name": "Sutton, Courtland",
       "position": "WR",
       "team": "DEN"
     },
+    "13631": {
+      "name": "Washington, James",
+      "position": "WR",
+      "team": "PIT"
+    },
+    "13632": {
+      "name": "Lazard, Allen",
+      "position": "WR",
+      "team": "GBP"
+    },
     "13633": {
       "name": "Kirk, Christian",
       "position": "WR",
-      "team": "JAC"
+      "team": "ARI"
     },
     "13634": {
       "name": "Pettis, Dante",
@@ -67381,45 +87444,155 @@
       "position": "WR",
       "team": "CAR"
     },
+    "13636": {
+      "name": "Cain, Deon",
+      "position": "WR",
+      "team": "IND"
+    },
     "13637": {
       "name": "St. Brown, Equanimeous",
       "position": "WR",
       "team": "GBP"
+    },
+    "13638": {
+      "name": "Berrios, Braxton",
+      "position": "WR",
+      "team": "NEP"
     },
     "13639": {
       "name": "Miller, Anthony",
       "position": "WR",
       "team": "CHI"
     },
+    "13640": {
+      "name": "Callaway, Antonio",
+      "position": "WR",
+      "team": "CLE"
+    },
+    "13641": {
+      "name": "McCloud, Ray-Ray",
+      "position": "WR",
+      "team": "ATL"
+    },
+    "13642": {
+      "name": "Tate, Auden",
+      "position": "WR",
+      "team": "CIN"
+    },
     "13645": {
       "name": "Smith, Tre'Quan",
       "position": "WR",
       "team": "NOS"
+    },
+    "13646": {
+      "name": "Gallup, Michael",
+      "position": "WR",
+      "team": "DAL"
+    },
+    "13647": {
+      "name": "Ateman, Marcell",
+      "position": "WR",
+      "team": "OAK"
+    },
+    "13649": {
+      "name": "Hamilton, DaeSean",
+      "position": "WR",
+      "team": "DEN"
+    },
+    "13652": {
+      "name": "Wilson, Cedrick",
+      "position": "WR",
+      "team": "DAL"
+    },
+    "13657": {
+      "name": "Moore, J'Mon",
+      "position": "WR",
+      "team": "GBP"
+    },
+    "13658": {
+      "name": "Lasley, Jordan",
+      "position": "WR",
+      "team": "BAL"
+    },
+    "13662": {
+      "name": "Coutee, Keke",
+      "position": "WR",
+      "team": "HOU"
+    },
+    "13663": {
+      "name": "Scott, Jaleel",
+      "position": "WR",
+      "team": "BAL"
+    },
+    "13664": {
+      "name": "Quinn, Trey",
+      "position": "WR",
+      "team": "WAS"
     },
     "13666": {
       "name": "Fountain, Daurice",
       "position": "WR",
       "team": "IND"
     },
+    "13668": {
+      "name": "Chark, D.J.",
+      "position": "WR",
+      "team": "JAC"
+    },
+    "13671": {
+      "name": "Andrews, Mark",
+      "position": "TE",
+      "team": "BAL"
+    },
     "13672": {
       "name": "Gesicki, Mike",
       "position": "TE",
       "team": "MIA"
+    },
+    "13673": {
+      "name": "Fumagalli, Troy",
+      "position": "TE",
+      "team": "DEN"
+    },
+    "13674": {
+      "name": "Goedert, Dallas",
+      "position": "TE",
+      "team": "PHI"
+    },
+    "13675": {
+      "name": "Conklin, Tyler",
+      "position": "TE",
+      "team": "MIN"
     },
     "13678": {
       "name": "Thomas, Ian",
       "position": "TE",
       "team": "CAR"
     },
+    "13679": {
+      "name": "Herndon, Chris",
+      "position": "TE",
+      "team": "NYJ"
+    },
     "13680": {
       "name": "Hurst, Hayden",
       "position": "TE",
       "team": "BAL"
     },
+    "13718": {
+      "name": "Carlson, Daniel",
+      "position": "PK",
+      "team": "OAK"
+    },
     "13719": {
       "name": "Pineiro, Eddy",
       "position": "PK",
       "team": "OAK"
+    },
+    "13722": {
+      "name": "Jarwin, Blake",
+      "position": "TE",
+      "team": "DAL"
     },
     "13726": {
       "name": "Edmonds, Chase",
@@ -67446,6 +87619,56 @@
       "position": "TE",
       "team": "DAL"
     },
+    "13776": {
+      "name": "Watson, Justin",
+      "position": "WR",
+      "team": "TBB"
+    },
+    "13789": {
+      "name": "Wilkins, Jordan",
+      "position": "RB",
+      "team": "IND"
+    },
+    "13793": {
+      "name": "Valdes-Scantling, Marquez",
+      "position": "WR",
+      "team": "GBP"
+    },
+    "13807": {
+      "name": "Cantrell, Dylan",
+      "position": "WR",
+      "team": "LAC"
+    },
+    "13809": {
+      "name": "Gage, Russell",
+      "position": "WR",
+      "team": "TBB"
+    },
+    "13814": {
+      "name": "Scott, Boston",
+      "position": "RB",
+      "team": "PHI"
+    },
+    "13819": {
+      "name": "Thomas, Jordan",
+      "position": "TE",
+      "team": "HOU"
+    },
+    "13832": {
+      "name": "Sanders, Jason",
+      "position": "PK",
+      "team": "MIA"
+    },
+    "13863": {
+      "name": "Pringle, Byron",
+      "position": "WR",
+      "team": "KCC"
+    },
+    "13871": {
+      "name": "Hilliard, Dontrell",
+      "position": "RB",
+      "team": "CLE"
+    },
     "13879": {
       "name": "Allen, Kyle",
       "position": "QB",
@@ -67454,7 +87677,32 @@
     "13880": {
       "name": "Arnold, Dan",
       "position": "TE",
-      "team": "JAC"
+      "team": "ARI"
+    },
+    "13890": {
+      "name": "Croom, Jason",
+      "position": "TE",
+      "team": "BUF"
+    },
+    "13909": {
+      "name": "Maher, Brett",
+      "position": "PK",
+      "team": "FA"
+    },
+    "13919": {
+      "name": "Firkser, Anthony",
+      "position": "TE",
+      "team": "TEN"
+    },
+    "13968": {
+      "name": "Mullens, Nick",
+      "position": "QB",
+      "team": "MIN"
+    },
+    "13980": {
+      "name": "Badgley, Mike",
+      "position": "PK",
+      "team": "LAC"
     },
     "14056": {
       "name": "Murray, Kyler",
@@ -67464,17 +87712,57 @@
     "14057": {
       "name": "Lock, Drew",
       "position": "QB",
-      "team": "SEA"
+      "team": "DEN"
+    },
+    "14058": {
+      "name": "Haskins, Dwayne",
+      "position": "QB",
+      "team": "WAS"
     },
     "14059": {
       "name": "Jones, Daniel",
       "position": "QB",
       "team": "NYG"
     },
+    "14062": {
+      "name": "Grier, Will",
+      "position": "QB",
+      "team": "CAR"
+    },
+    "14063": {
+      "name": "Stidham, Jarrett",
+      "position": "QB",
+      "team": "NEP"
+    },
     "14067": {
       "name": "Minshew, Gardner",
       "position": "QB",
-      "team": "LVR"
+      "team": "JAC"
+    },
+    "14068": {
+      "name": "Finley, Ryan",
+      "position": "QB",
+      "team": "CIN"
+    },
+    "14071": {
+      "name": "Montgomery, David",
+      "position": "RB",
+      "team": "CHI"
+    },
+    "14072": {
+      "name": "Snell, Benny",
+      "position": "RB",
+      "team": "PIT"
+    },
+    "14073": {
+      "name": "Jacobs, Josh",
+      "position": "RB",
+      "team": "OAK"
+    },
+    "14074": {
+      "name": "Williams, Dexter",
+      "position": "RB",
+      "team": "GBP"
     },
     "14075": {
       "name": "Harris, Damien",
@@ -67486,10 +87774,35 @@
       "position": "RB",
       "team": "CIN"
     },
+    "14077": {
+      "name": "Weber, Mike",
+      "position": "RB",
+      "team": "FA"
+    },
+    "14079": {
+      "name": "Sanders, Miles",
+      "position": "RB",
+      "team": "PHI"
+    },
+    "14080": {
+      "name": "Singletary, Devin",
+      "position": "RB",
+      "team": "BUF"
+    },
     "14081": {
       "name": "Gaskin, Myles",
       "position": "RB",
       "team": "MIA"
+    },
+    "14082": {
+      "name": "Love, Bryce",
+      "position": "RB",
+      "team": "WAS"
+    },
+    "14083": {
+      "name": "Homer, Travis",
+      "position": "RB",
+      "team": "CHI"
     },
     "14085": {
       "name": "Pollard, Tony",
@@ -67501,10 +87814,55 @@
       "position": "RB",
       "team": "BAL"
     },
+    "14087": {
+      "name": "Henderson, Darrell",
+      "position": "RB",
+      "team": "LAR"
+    },
+    "14088": {
+      "name": "Anderson, Rodney",
+      "position": "RB",
+      "team": "CIN"
+    },
+    "14093": {
+      "name": "Armstead, Ryquell",
+      "position": "RB",
+      "team": "JAC"
+    },
+    "14094": {
+      "name": "Scarlett, Jordan",
+      "position": "RB",
+      "team": "CAR"
+    },
+    "14095": {
+      "name": "Johnson, Ty",
+      "position": "RB",
+      "team": "DET"
+    },
+    "14096": {
+      "name": "Ozigbo, Devine",
+      "position": "RB",
+      "team": "JAC"
+    },
+    "14097": {
+      "name": "Ollison, Qadree",
+      "position": "RB",
+      "team": "ATL"
+    },
+    "14101": {
+      "name": "Harry, N'Keal",
+      "position": "WR",
+      "team": "NEP"
+    },
     "14102": {
       "name": "Metcalf, DK",
       "position": "WR",
       "team": "SEA"
+    },
+    "14103": {
+      "name": "Ridley, Riley",
+      "position": "WR",
+      "team": "CHI"
     },
     "14104": {
       "name": "Brown, A.J.",
@@ -67514,6 +87872,21 @@
     "14105": {
       "name": "Brown, Marquise",
       "position": "WR",
+      "team": "BAL"
+    },
+    "14106": {
+      "name": "Butler, Hakeem",
+      "position": "WR",
+      "team": "ARI"
+    },
+    "14107": {
+      "name": "Arcega-Whiteside, JJ",
+      "position": "WR",
+      "team": "PHI"
+    },
+    "14108": {
+      "name": "Dortch, Greg",
+      "position": "WR",
       "team": "ARI"
     },
     "14109": {
@@ -67521,10 +87894,50 @@
       "position": "WR",
       "team": "WAS"
     },
+    "14112": {
+      "name": "Campbell, Parris",
+      "position": "WR",
+      "team": "IND"
+    },
     "14113": {
       "name": "Hardman, Mecole",
       "position": "WR",
       "team": "KCC"
+    },
+    "14114": {
+      "name": "Harmon, Kelvin",
+      "position": "WR",
+      "team": "WAS"
+    },
+    "14115": {
+      "name": "Hall, Emanuel",
+      "position": "WR",
+      "team": "WAS"
+    },
+    "14116": {
+      "name": "Hurd, Jalen",
+      "position": "WR",
+      "team": "SFO"
+    },
+    "14117": {
+      "name": "Johnson, Tyron",
+      "position": "WR",
+      "team": "LVR"
+    },
+    "14119": {
+      "name": "Johnson, Anthony",
+      "position": "WR",
+      "team": "PIT"
+    },
+    "14120": {
+      "name": "Jennings, Gary",
+      "position": "WR",
+      "team": "MIA"
+    },
+    "14121": {
+      "name": "Isabella, Andy",
+      "position": "WR",
+      "team": "ARI"
     },
     "14122": {
       "name": "Slayton, Darius",
@@ -67534,42 +87947,127 @@
     "14123": {
       "name": "Renfrow, Hunter",
       "position": "WR",
-      "team": "LVR"
+      "team": "OAK"
+    },
+    "14124": {
+      "name": "Johnson, KeeSean",
+      "position": "WR",
+      "team": "ARI"
+    },
+    "14125": {
+      "name": "Boykin, Miles",
+      "position": "WR",
+      "team": "BAL"
     },
     "14126": {
       "name": "Williams, Preston",
       "position": "WR",
       "team": "MIA"
     },
+    "14127": {
+      "name": "Meyers, Jakobi",
+      "position": "WR",
+      "team": "NEP"
+    },
     "14129": {
       "name": "Mitchell, Dillon",
       "position": "WR",
-      "team": "FA"
+      "team": "MIN"
     },
     "14136": {
       "name": "Samuel, Deebo",
       "position": "WR",
       "team": "SFO"
     },
+    "14137": {
+      "name": "Fant, Noah",
+      "position": "TE",
+      "team": "DEN"
+    },
+    "14138": {
+      "name": "Hockenson, T.J.",
+      "position": "TE",
+      "team": "DET"
+    },
     "14139": {
       "name": "Mack, Alize",
       "position": "TE",
       "team": "KCC"
     },
+    "14140": {
+      "name": "Sternberger, Jace",
+      "position": "TE",
+      "team": "GBP"
+    },
     "14141": {
       "name": "Smith Jr., Irv",
       "position": "TE",
-      "team": "CIN"
+      "team": "MIN"
+    },
+    "14143": {
+      "name": "Knox, Dawson",
+      "position": "TE",
+      "team": "BUF"
+    },
+    "14144": {
+      "name": "Nauta, Isaac",
+      "position": "TE",
+      "team": "DET"
     },
     "14145": {
       "name": "Wilson, Caleb",
       "position": "TE",
-      "team": "PHI"
+      "team": "WAS"
+    },
+    "14146": {
+      "name": "Sample, Drew",
+      "position": "TE",
+      "team": "CIN"
+    },
+    "14191": {
+      "name": "Barnes, Alex",
+      "position": "RB",
+      "team": "FA"
+    },
+    "14192": {
+      "name": "Williams, James",
+      "position": "RB",
+      "team": "FA"
+    },
+    "14195": {
+      "name": "Warring, Kahale",
+      "position": "TE",
+      "team": "HOU"
     },
     "14208": {
       "name": "Johnson, Diontae",
       "position": "WR",
       "team": "PIT"
+    },
+    "14209": {
+      "name": "Oliver, Josh",
+      "position": "TE",
+      "team": "JAC"
+    },
+    "14223": {
+      "name": "Mattison, Alexander",
+      "position": "RB",
+      "team": "MIN"
+    },
+    "14231": {
+      "name": "Wesco, Trevon",
+      "position": "TE",
+      "team": "NYJ"
+    },
+    "14239": {
+      "name": "Moreau, Foster",
+      "position": "TE",
+      "team": "OAK"
+    },
+    "14244": {
+      "name": "Gay, Matt",
+      "position": "PK",
+      "team": "TBB"
     },
     "14258": {
       "name": "Seibert, Austin",
@@ -67581,20 +88079,120 @@
       "position": "WR",
       "team": "PHI"
     },
+    "14267": {
+      "name": "Winfree, Juwann",
+      "position": "WR",
+      "team": "DEN"
+    },
+    "14284": {
+      "name": "Thompson, Darwin",
+      "position": "RB",
+      "team": "KCC"
+    },
+    "14287": {
+      "name": "Gillaspia, Cullen",
+      "position": "RB",
+      "team": "HOU"
+    },
+    "14305": {
+      "name": "Johnson, Olabisi",
+      "position": "WR",
+      "team": "MIN"
+    },
+    "14313": {
+      "name": "Butler, Emmanuel",
+      "position": "WR",
+      "team": "NOS"
+    },
+    "14314": {
+      "name": "Anderson, Bruce",
+      "position": "RB",
+      "team": "IND"
+    },
+    "14315": {
+      "name": "Dulin, Ashton",
+      "position": "WR",
+      "team": "IND"
+    },
+    "14316": {
+      "name": "Hart, Penny",
+      "position": "WR",
+      "team": "SEA"
+    },
+    "14331": {
+      "name": "Johnson, D'Ernest",
+      "position": "RB",
+      "team": "CLE"
+    },
+    "14341": {
+      "name": "Parham, Donald",
+      "position": "TE",
+      "team": "LAC"
+    },
     "14358": {
       "name": "Browning, Jake",
       "position": "QB",
       "team": "CIN"
+    },
+    "14464": {
+      "name": "Graham, Jaeden",
+      "position": "TE",
+      "team": "ATL"
+    },
+    "14558": {
+      "name": "Harty, Deonte",
+      "position": "WR",
+      "team": "BUF"
+    },
+    "14592": {
+      "name": "Zaccheaus, Olamide",
+      "position": "WR",
+      "team": "ATL"
     },
     "14600": {
       "name": "Slye, Joey",
       "position": "PK",
       "team": "WAS"
     },
+    "14613": {
+      "name": "Sims, Steven",
+      "position": "WR",
+      "team": "WAS"
+    },
+    "14622": {
+      "name": "Ta'amu, Jordan",
+      "position": "QB",
+      "team": "KCC"
+    },
+    "14717": {
+      "name": "McLaughlin, Chase",
+      "position": "PK",
+      "team": "IND"
+    },
     "14777": {
       "name": "Burrow, Joe",
       "position": "QB",
       "team": "CIN"
+    },
+    "14778": {
+      "name": "Tagovailoa, Tua",
+      "position": "QB",
+      "team": "MIA"
+    },
+    "14779": {
+      "name": "Herbert, Justin",
+      "position": "QB",
+      "team": "LAC"
+    },
+    "14782": {
+      "name": "Love, Jordan",
+      "position": "QB",
+      "team": "GBP"
+    },
+    "14783": {
+      "name": "Hurts, Jalen",
+      "position": "QB",
+      "team": "PHI"
     },
     "14789": {
       "name": "Huntley, Tyler",
@@ -67609,72 +88207,437 @@
     "14798": {
       "name": "Moss, Zack",
       "position": "RB",
-      "team": "IND"
+      "team": "BUF"
+    },
+    "14799": {
+      "name": "Akers, Cam",
+      "position": "RB",
+      "team": "LAR"
     },
     "14800": {
       "name": "Dobbins, J.K.",
       "position": "RB",
       "team": "BAL"
     },
+    "14801": {
+      "name": "Benjamin, Eno",
+      "position": "RB",
+      "team": "ARI"
+    },
+    "14802": {
+      "name": "Taylor, Jonathan",
+      "position": "RB",
+      "team": "IND"
+    },
     "14803": {
       "name": "Edwards-Helaire, Clyde",
       "position": "RB",
       "team": "KCC"
     },
+    "14804": {
+      "name": "McFarland, Anthony",
+      "position": "RB",
+      "team": "PIT"
+    },
+    "14805": {
+      "name": "Dillon, AJ",
+      "position": "RB",
+      "team": "GBP"
+    },
+    "14806": {
+      "name": "Perine, Lamical",
+      "position": "RB",
+      "team": "NYJ"
+    },
     "14807": {
       "name": "Kelley, Joshua",
       "position": "RB",
+      "team": "LAC"
+    },
+    "14808": {
+      "name": "Evans, Darrynton",
+      "position": "RB",
       "team": "TEN"
+    },
+    "14810": {
+      "name": "Vaughn, Ke'Shawn",
+      "position": "RB",
+      "team": "TBB"
+    },
+    "14817": {
+      "name": "Taylor, Patrick",
+      "position": "RB",
+      "team": "SFO"
+    },
+    "14819": {
+      "name": "Feaster, Tavien",
+      "position": "RB",
+      "team": "FA"
+    },
+    "14823": {
+      "name": "Dowdle, Rico",
+      "position": "RB",
+      "team": "DAL"
+    },
+    "14832": {
+      "name": "Lamb, CeeDee",
+      "position": "WR",
+      "team": "DAL"
+    },
+    "14833": {
+      "name": "Jeudy, Jerry",
+      "position": "WR",
+      "team": "DEN"
+    },
+    "14834": {
+      "name": "Ruggs, Henry",
+      "position": "WR",
+      "team": "LVR"
     },
     "14835": {
       "name": "Higgins, Tee",
       "position": "WR",
       "team": "CIN"
     },
+    "14836": {
+      "name": "Jefferson, Justin",
+      "position": "WR",
+      "team": "MIN"
+    },
     "14837": {
       "name": "Hamler, KJ",
       "position": "WR",
       "team": "DEN"
+    },
+    "14838": {
+      "name": "Shenault, Laviska",
+      "position": "WR",
+      "team": "JAC"
+    },
+    "14839": {
+      "name": "Reagor, Jalen",
+      "position": "WR",
+      "team": "PHI"
+    },
+    "14840": {
+      "name": "Aiyuk, Brandon",
+      "position": "WR",
+      "team": "SFO"
+    },
+    "14841": {
+      "name": "Claypool, Chase",
+      "position": "WR",
+      "team": "PIT"
     },
     "14842": {
       "name": "Pittman, Michael",
       "position": "WR",
       "team": "IND"
     },
+    "14843": {
+      "name": "Bowden, Lynn",
+      "position": "RB",
+      "team": "MIA"
+    },
+    "14844": {
+      "name": "Edwards, Bryan",
+      "position": "WR",
+      "team": "LVR"
+    },
+    "14845": {
+      "name": "Davis, Gabriel",
+      "position": "WR",
+      "team": "BUF"
+    },
+    "14846": {
+      "name": "Mims, Denzel",
+      "position": "WR",
+      "team": "NYJ"
+    },
+    "14847": {
+      "name": "Duvernay, Devin",
+      "position": "WR",
+      "team": "BAL"
+    },
+    "14848": {
+      "name": "Proche, James",
+      "position": "WR",
+      "team": "BAL"
+    },
+    "14849": {
+      "name": "Hodgins, Isaiah",
+      "position": "WR",
+      "team": "NYG"
+    },
+    "14850": {
+      "name": "Cephus, Quintez",
+      "position": "WR",
+      "team": "DET"
+    },
+    "14851": {
+      "name": "Hill, K.J.",
+      "position": "WR",
+      "team": "LAC"
+    },
     "14852": {
       "name": "Gibson, Antonio",
       "position": "RB",
       "team": "WAS"
     },
+    "14857": {
+      "name": "Peoples-Jones, Donovan",
+      "position": "WR",
+      "team": "CLE"
+    },
     "14858": {
       "name": "Jefferson, Van",
       "position": "WR",
-      "team": "ATL"
+      "team": "LAR"
+    },
+    "14860": {
+      "name": "Jennings, Jauan",
+      "position": "WR",
+      "team": "SFO"
     },
     "14861": {
       "name": "Johnson, Juwan",
       "position": "TE",
       "team": "NOS"
     },
+    "14863": {
+      "name": "Gandy-Golden, Antonio",
+      "position": "WR",
+      "team": "WAS"
+    },
+    "14864": {
+      "name": "Johnson, Tyler",
+      "position": "WR",
+      "team": "TBB"
+    },
+    "14866": {
+      "name": "Thomas, Jeff",
+      "position": "WR",
+      "team": "FA"
+    },
     "14867": {
       "name": "Kmet, Cole",
       "position": "TE",
       "team": "CHI"
     },
+    "14868": {
+      "name": "Hopkins, Brycen",
+      "position": "TE",
+      "team": "LAR"
+    },
+    "14869": {
+      "name": "Moss, Thaddeus",
+      "position": "TE",
+      "team": "WAS"
+    },
+    "14870": {
+      "name": "Trautman, Adam",
+      "position": "TE",
+      "team": "NOS"
+    },
+    "14871": {
+      "name": "Parkinson, Colby",
+      "position": "TE",
+      "team": "SEA"
+    },
+    "14873": {
+      "name": "Okwuegbunam, Albert",
+      "position": "TE",
+      "team": "DEN"
+    },
+    "14875": {
+      "name": "Bryant, Harrison",
+      "position": "TE",
+      "team": "CLE"
+    },
+    "14876": {
+      "name": "Deguara, Josiah",
+      "position": "TE",
+      "team": "GBP"
+    },
+    "14912": {
+      "name": "Blankenship, Rodrigo",
+      "position": "PK",
+      "team": "IND"
+    },
+    "14936": {
+      "name": "Asiasi, Devin",
+      "position": "TE",
+      "team": "NEP"
+    },
+    "14939": {
+      "name": "Keene, Dalton",
+      "position": "TE",
+      "team": "NEP"
+    },
     "14965": {
       "name": "Rohrwasser, Justin",
       "position": "PK",
-      "team": "FA"
+      "team": "NEP"
+    },
+    "14969": {
+      "name": "Hightower, John",
+      "position": "WR",
+      "team": "PHI"
+    },
+    "14972": {
+      "name": "Coulter, Isaiah",
+      "position": "WR",
+      "team": "HOU"
+    },
+    "14974": {
+      "name": "Mooney, Darnell",
+      "position": "WR",
+      "team": "CHI"
+    },
+    "14977": {
+      "name": "Osborn, K.J.",
+      "position": "WR",
+      "team": "MIN"
+    },
+    "15021": {
+      "name": "Calais, Raymond",
+      "position": "RB",
+      "team": "LAR"
+    },
+    "15022": {
+      "name": "Perry, Malcolm",
+      "position": "RB",
+      "team": "MIA"
+    },
+    "15024": {
+      "name": "Sloman, Sam",
+      "position": "PK",
+      "team": "TEN"
     },
     "15109": {
       "name": "Westbrook-Ikhine, Nick",
       "position": "WR",
       "team": "TEN"
     },
+    "15220": {
+      "name": "Williams, Antonio",
+      "position": "RB",
+      "team": "NYG"
+    },
+    "15237": {
+      "name": "Lawrence, Trevor",
+      "position": "QB",
+      "team": "JAC"
+    },
+    "15238": {
+      "name": "Fields, Justin",
+      "position": "QB",
+      "team": "KCC"
+    },
+    "15239": {
+      "name": "Wilson, Zach",
+      "position": "QB",
+      "team": "NYJ"
+    },
+    "15240": {
+      "name": "Lance, Trey",
+      "position": "QB",
+      "team": "SFO"
+    },
     "15241": {
       "name": "Jones, Mac",
       "position": "QB",
+      "team": "NEP"
+    },
+    "15242": {
+      "name": "Trask, Kyle",
+      "position": "QB",
+      "team": "TBB"
+    },
+    "15243": {
+      "name": "Mond, Kellen",
+      "position": "QB",
+      "team": "MIN"
+    },
+    "15252": {
+      "name": "Mills, Davis",
+      "position": "QB",
+      "team": "HOU"
+    },
+    "15253": {
+      "name": "Etienne, Travis",
+      "position": "RB",
       "team": "JAC"
+    },
+    "15254": {
+      "name": "Harris, Najee",
+      "position": "RB",
+      "team": "PIT"
+    },
+    "15255": {
+      "name": "Gainwell, Kenneth",
+      "position": "RB",
+      "team": "PHI"
+    },
+    "15256": {
+      "name": "Williams, Javonte",
+      "position": "RB",
+      "team": "DEN"
+    },
+    "15257": {
+      "name": "Sermon, Trey",
+      "position": "RB",
+      "team": "SFO"
+    },
+    "15258": {
+      "name": "Carter, Michael",
+      "position": "RB",
+      "team": "NYJ"
+    },
+    "15259": {
+      "name": "Stevenson, Rhamondre",
+      "position": "RB",
+      "team": "NEP"
+    },
+    "15261": {
+      "name": "Hubbard, Chuba",
+      "position": "RB",
+      "team": "CAR"
+    },
+    "15262": {
+      "name": "Jefferson, Jermar",
+      "position": "RB",
+      "team": "DET"
+    },
+    "15263": {
+      "name": "Mitchell, Elijah",
+      "position": "RB",
+      "team": "SFO"
+    },
+    "15265": {
+      "name": "Hill, Kylin",
+      "position": "RB",
+      "team": "GBP"
+    },
+    "15268": {
+      "name": "Hawkins, Javian",
+      "position": "RB",
+      "team": "FA"
+    },
+    "15271": {
+      "name": "Herbert, Khalil",
+      "position": "RB",
+      "team": "CHI"
+    },
+    "15272": {
+      "name": "Rountree, Larry",
+      "position": "RB",
+      "team": "LAC"
+    },
+    "15275": {
+      "name": "Evans, Chris",
+      "position": "RB",
+      "team": "CIN"
     },
     "15281": {
       "name": "Chase, Ja'Marr",
@@ -67696,15 +88659,95 @@
       "position": "WR",
       "team": "MIA"
     },
+    "15285": {
+      "name": "Wallace, Tylan",
+      "position": "WR",
+      "team": "BAL"
+    },
     "15287": {
       "name": "St. Brown, Amon-Ra",
       "position": "WR",
       "team": "DET"
     },
+    "15288": {
+      "name": "Moore, Elijah",
+      "position": "WR",
+      "team": "NYJ"
+    },
+    "15289": {
+      "name": "Toney, Kadarius",
+      "position": "WR",
+      "team": "NYG"
+    },
+    "15290": {
+      "name": "Collins, Nico",
+      "position": "WR",
+      "team": "HOU"
+    },
+    "15291": {
+      "name": "Newsome, Dazz",
+      "position": "WR",
+      "team": "CHI"
+    },
+    "15292": {
+      "name": "Brown, Dyami",
+      "position": "WR",
+      "team": "WAS"
+    },
+    "15293": {
+      "name": "Bateman, Rashod",
+      "position": "WR",
+      "team": "BAL"
+    },
+    "15295": {
+      "name": "Surratt, Sage",
+      "position": "WR",
+      "team": "FA"
+    },
+    "15296": {
+      "name": "Schwartz, Anthony",
+      "position": "WR",
+      "team": "CLE"
+    },
+    "15297": {
+      "name": "Rodgers, Amari",
+      "position": "WR",
+      "team": "GBP"
+    },
+    "15301": {
+      "name": "Atwell, Tutu",
+      "position": "WR",
+      "team": "LAR"
+    },
     "15302": {
       "name": "Eskridge, D'Wayne",
       "position": "WR",
       "team": "SEA"
+    },
+    "15304": {
+      "name": "Darby, Frank",
+      "position": "WR",
+      "team": "ATL"
+    },
+    "15308": {
+      "name": "Marshall, Terrace",
+      "position": "WR",
+      "team": "CAR"
+    },
+    "15316": {
+      "name": "Powell, Cornell",
+      "position": "WR",
+      "team": "KCC"
+    },
+    "15319": {
+      "name": "Palmer, Josh",
+      "position": "WR",
+      "team": "LAC"
+    },
+    "15321": {
+      "name": "Darden, Jaelon",
+      "position": "WR",
+      "team": "TBB"
     },
     "15329": {
       "name": "Pitts, Kyle",
@@ -67716,15 +88759,145 @@
       "position": "TE",
       "team": "HOU"
     },
+    "15331": {
+      "name": "Freiermuth, Pat",
+      "position": "TE",
+      "team": "PIT"
+    },
+    "15332": {
+      "name": "Tremble, Tommy",
+      "position": "TE",
+      "team": "CAR"
+    },
+    "15333": {
+      "name": "McKitty, Tre'",
+      "position": "TE",
+      "team": "LAC"
+    },
+    "15334": {
+      "name": "Long, Hunter",
+      "position": "TE",
+      "team": "MIA"
+    },
+    "15337": {
+      "name": "Gray, Noah",
+      "position": "TE",
+      "team": "KCC"
+    },
+    "15339": {
+      "name": "Yeboah, Kenny",
+      "position": "TE",
+      "team": "NYJ"
+    },
+    "15368": {
+      "name": "McPherson, Evan",
+      "position": "PK",
+      "team": "CIN"
+    },
+    "15374": {
+      "name": "Reyes, Sammis",
+      "position": "TE",
+      "team": "WAS"
+    },
+    "15407": {
+      "name": "Fitzpatrick, Dez",
+      "position": "WR",
+      "team": "TEN"
+    },
+    "15419": {
+      "name": "Granson, Kylen",
+      "position": "TE",
+      "team": "IND"
+    },
+    "15425": {
+      "name": "Harris, Jacob",
+      "position": "TE",
+      "team": "LAR"
+    },
+    "15434": {
+      "name": "Smith-Marsette, Ihmir",
+      "position": "WR",
+      "team": "MIN"
+    },
+    "15462": {
+      "name": "Brightwell, Gary",
+      "position": "RB",
+      "team": "NYG"
+    },
+    "15467": {
+      "name": "Camp, Jalen",
+      "position": "WR",
+      "team": "HOU"
+    },
+    "15626": {
+      "name": "Wright, Brock",
+      "position": "TE",
+      "team": "DET"
+    },
+    "15691": {
+      "name": "Corral, Matt",
+      "position": "QB",
+      "team": "CAR"
+    },
+    "15692": {
+      "name": "Pickett, Kenny",
+      "position": "QB",
+      "team": "PIT"
+    },
+    "15693": {
+      "name": "Howell, Sam",
+      "position": "QB",
+      "team": "WAS"
+    },
+    "15694": {
+      "name": "Willis, Malik",
+      "position": "QB",
+      "team": "TEN"
+    },
+    "15696": {
+      "name": "Zappe, Bailey",
+      "position": "QB",
+      "team": "NEP"
+    },
     "15697": {
       "name": "Ridder, Desmond",
       "position": "QB",
-      "team": "LVR"
+      "team": "ATL"
+    },
+    "15698": {
+      "name": "Purdy, Brock",
+      "position": "QB",
+      "team": "SFO"
     },
     "15699": {
       "name": "Thompson, Skylar",
       "position": "QB",
       "team": "PIT"
+    },
+    "15708": {
+      "name": "Hall, Breece",
+      "position": "RB",
+      "team": "NYJ"
+    },
+    "15709": {
+      "name": "Spiller, Isaiah",
+      "position": "RB",
+      "team": "LAC"
+    },
+    "15710": {
+      "name": "Williams, Kyren",
+      "position": "RB",
+      "team": "LAR"
+    },
+    "15711": {
+      "name": "Walker III, Kenneth",
+      "position": "RB",
+      "team": "SEA"
+    },
+    "15712": {
+      "name": "Allgeier, Tyler",
+      "position": "RB",
+      "team": "ATL"
     },
     "15713": {
       "name": "Ford, Jerome",
@@ -67736,35 +88909,110 @@
       "position": "RB",
       "team": "LVR"
     },
+    "15715": {
+      "name": "Cook, James",
+      "position": "RB",
+      "team": "BUF"
+    },
     "15716": {
       "name": "Robinson, Brian",
       "position": "RB",
-      "team": "SFO"
+      "team": "WAS"
+    },
+    "15717": {
+      "name": "Pierce, Dameon",
+      "position": "RB",
+      "team": "HOU"
+    },
+    "15718": {
+      "name": "Badie, Tyler",
+      "position": "RB",
+      "team": "DEN"
+    },
+    "15720": {
+      "name": "Haskins, Hassan",
+      "position": "RB",
+      "team": "TEN"
+    },
+    "15721": {
+      "name": "White, Rachaad",
+      "position": "RB",
+      "team": "TBB"
+    },
+    "15723": {
+      "name": "Chandler, Ty",
+      "position": "RB",
+      "team": "MIN"
+    },
+    "15726": {
+      "name": "Rivers, Ronnie",
+      "position": "RB",
+      "team": "LAR"
+    },
+    "15727": {
+      "name": "Knight, Zonovan",
+      "position": "RB",
+      "team": "DET"
     },
     "15728": {
       "name": "Smith, Abram",
       "position": "RB",
       "team": "FA"
     },
+    "15733": {
+      "name": "Strong Jr., Pierre",
+      "position": "RB",
+      "team": "NEP"
+    },
     "15734": {
       "name": "Ingram, Keaontay",
       "position": "RB",
-      "team": "FA"
+      "team": "ARI"
+    },
+    "15736": {
+      "name": "Brooks, Kennedy",
+      "position": "RB",
+      "team": "PHI"
+    },
+    "15738": {
+      "name": "Davis, Malik",
+      "position": "RB",
+      "team": "DAL"
+    },
+    "15742": {
+      "name": "Warren, Jaylen",
+      "position": "RB",
+      "team": "PIT"
     },
     "15744": {
       "name": "Price, D'vonte",
       "position": "RB",
       "team": "IND"
     },
+    "15746": {
+      "name": "Davis-Price, Tyrion",
+      "position": "RB",
+      "team": "SFO"
+    },
     "15749": {
       "name": "Pacheco, Isiah",
       "position": "RB",
-      "team": "DET"
+      "team": "KCC"
+    },
+    "15751": {
+      "name": "London, Drake",
+      "position": "WR",
+      "team": "ATL"
     },
     "15752": {
       "name": "Burks, Treylon",
       "position": "WR",
       "team": "TEN"
+    },
+    "15753": {
+      "name": "Wilson, Garrett",
+      "position": "WR",
+      "team": "NYJ"
     },
     "15754": {
       "name": "Olave, Chris",
@@ -67776,10 +89024,45 @@
       "position": "WR",
       "team": "WAS"
     },
+    "15756": {
+      "name": "Williams, Jameson",
+      "position": "WR",
+      "team": "DET"
+    },
     "15757": {
       "name": "Robinson, Wan'Dale",
       "position": "WR",
       "team": "NYG"
+    },
+    "15758": {
+      "name": "Bell, David",
+      "position": "WR",
+      "team": "CLE"
+    },
+    "15759": {
+      "name": "Metchie, John",
+      "position": "WR",
+      "team": "HOU"
+    },
+    "15761": {
+      "name": "Shakir, Khalil",
+      "position": "WR",
+      "team": "BUF"
+    },
+    "15762": {
+      "name": "Pickens, George",
+      "position": "WR",
+      "team": "PIT"
+    },
+    "15763": {
+      "name": "Ross, Justyn",
+      "position": "WR",
+      "team": "KCC"
+    },
+    "15767": {
+      "name": "Jones, Velus",
+      "position": "WR",
+      "team": "CHI"
     },
     "15768": {
       "name": "Pierce, Alec",
@@ -67791,6 +89074,26 @@
       "position": "WR",
       "team": "PIT"
     },
+    "15779": {
+      "name": "Doubs, Romeo",
+      "position": "WR",
+      "team": "GBP"
+    },
+    "15782": {
+      "name": "Gray, Danny",
+      "position": "WR",
+      "team": "SFO"
+    },
+    "15786": {
+      "name": "Nailor, Jalen",
+      "position": "WR",
+      "team": "MIN"
+    },
+    "15787": {
+      "name": "Thornton, Tyquan",
+      "position": "WR",
+      "team": "NEP"
+    },
     "15788": {
       "name": "Tolbert, Jalen",
       "position": "WR",
@@ -67801,30 +89104,260 @@
       "position": "WR",
       "team": "GBP"
     },
+    "15794": {
+      "name": "McBride, Trey",
+      "position": "TE",
+      "team": "ARI"
+    },
+    "15795": {
+      "name": "Kolar, Charlie",
+      "position": "TE",
+      "team": "BAL"
+    },
+    "15796": {
+      "name": "Ruckert, Jeremy",
+      "position": "TE",
+      "team": "NYJ"
+    },
     "15797": {
       "name": "Dulcich, Greg",
       "position": "TE",
       "team": "DEN"
+    },
+    "15798": {
+      "name": "Likely, Isaiah",
+      "position": "TE",
+      "team": "BAL"
+    },
+    "15802": {
+      "name": "Otton, Cade",
+      "position": "TE",
+      "team": "TBB"
+    },
+    "15803": {
+      "name": "Turner, Cole",
+      "position": "TE",
+      "team": "WAS"
+    },
+    "15804": {
+      "name": "Calcaterra, Grant",
+      "position": "TE",
+      "team": "PHI"
+    },
+    "15840": {
+      "name": "Woods, Jelani",
+      "position": "TE",
+      "team": "IND"
+    },
+    "15873": {
+      "name": "Bellinger, Daniel",
+      "position": "TE",
+      "team": "NYG"
     },
     "15882": {
       "name": "York, Cade",
       "position": "PK",
       "team": "CLE"
     },
+    "15889": {
+      "name": "Okonkwo, Chigoziem",
+      "position": "TE",
+      "team": "TEN"
+    },
+    "15900": {
+      "name": "Washington, Montrell",
+      "position": "WR",
+      "team": "DEN"
+    },
+    "15901": {
+      "name": "Philips, Kyle",
+      "position": "WR",
+      "team": "TEN"
+    },
+    "15972": {
+      "name": "Mason, Jordan",
+      "position": "RB",
+      "team": "MIN"
+    },
+    "15979": {
+      "name": "Dicker, Cameron",
+      "position": "PK",
+      "team": "LAC"
+    },
+    "15981": {
+      "name": "Turpin, KaVontae",
+      "position": "WR",
+      "team": "DAL"
+    },
+    "16036": {
+      "name": "Tonges, Jake",
+      "position": "TE",
+      "team": "SFO"
+    },
+    "16080": {
+      "name": "Shaheed, Rashid",
+      "position": "WR",
+      "team": "NOS"
+    },
+    "16148": {
+      "name": "Young, Bryce",
+      "position": "QB",
+      "team": "CAR"
+    },
     "16149": {
       "name": "Levis, Will",
       "position": "QB",
       "team": "TEN"
+    },
+    "16150": {
+      "name": "Stroud, C.J.",
+      "position": "QB",
+      "team": "HOU"
+    },
+    "16151": {
+      "name": "Hooker, Hendon",
+      "position": "QB",
+      "team": "DET"
+    },
+    "16152": {
+      "name": "Richardson, Anthony",
+      "position": "QB",
+      "team": "IND"
     },
     "16153": {
       "name": "Bennett, Stetson",
       "position": "QB",
       "team": "LAR"
     },
+    "16157": {
+      "name": "Cunningham, Malik",
+      "position": "QB",
+      "team": "BAL"
+    },
+    "16159": {
+      "name": "O'Connell, Aidan",
+      "position": "QB",
+      "team": "LVR"
+    },
+    "16160": {
+      "name": "Tune, Clayton",
+      "position": "QB",
+      "team": "ARI"
+    },
+    "16161": {
+      "name": "Robinson, Bijan",
+      "position": "RB",
+      "team": "ATL"
+    },
+    "16162": {
+      "name": "Gibbs, Jahmyr",
+      "position": "RB",
+      "team": "DET"
+    },
+    "16163": {
+      "name": "Evans, Zach",
+      "position": "RB",
+      "team": "LAR"
+    },
+    "16164": {
+      "name": "Bigsby, Tank",
+      "position": "RB",
+      "team": "JAC"
+    },
     "16165": {
       "name": "Spears, Tyjae",
       "position": "RB",
       "team": "TEN"
+    },
+    "16166": {
+      "name": "Tucker, Sean",
+      "position": "RB",
+      "team": "TBB"
+    },
+    "16167": {
+      "name": "Achane, De'Von",
+      "position": "RB",
+      "team": "MIA"
+    },
+    "16168": {
+      "name": "Abanikanda, Israel",
+      "position": "RB",
+      "team": "NYJ"
+    },
+    "16169": {
+      "name": "Charbonnet, Zach",
+      "position": "RB",
+      "team": "SEA"
+    },
+    "16170": {
+      "name": "McIntosh, Kenny",
+      "position": "RB",
+      "team": "SEA"
+    },
+    "16171": {
+      "name": "Miller, Kendre",
+      "position": "RB",
+      "team": "NOS"
+    },
+    "16172": {
+      "name": "Ibrahim, Mohamed",
+      "position": "RB",
+      "team": "FA"
+    },
+    "16173": {
+      "name": "Gray, Eric",
+      "position": "RB",
+      "team": "NYG"
+    },
+    "16174": {
+      "name": "Rodriguez, Chris",
+      "position": "RB",
+      "team": "WAS"
+    },
+    "16175": {
+      "name": "Johnson, Roschon",
+      "position": "RB",
+      "team": "CHI"
+    },
+    "16176": {
+      "name": "Vaughn, Deuce",
+      "position": "RB",
+      "team": "DAL"
+    },
+    "16178": {
+      "name": "Mitchell, Keaton",
+      "position": "RB",
+      "team": "BAL"
+    },
+    "16179": {
+      "name": "McBride, DeWayne",
+      "position": "RB",
+      "team": "MIN"
+    },
+    "16180": {
+      "name": "Hull, Evan",
+      "position": "RB",
+      "team": "PIT"
+    },
+    "16181": {
+      "name": "Brown, Chase",
+      "position": "RB",
+      "team": "CIN"
+    },
+    "16183": {
+      "name": "Hyatt, Jalin",
+      "position": "WR",
+      "team": "NYG"
+    },
+    "16184": {
+      "name": "Reed, Jayden",
+      "position": "WR",
+      "team": "GBP"
+    },
+    "16185": {
+      "name": "Smith-Njigba, Jaxon",
+      "position": "WR",
+      "team": "SEA"
     },
     "16186": {
       "name": "Addison, Jordan",
@@ -67841,10 +89374,25 @@
       "position": "WR",
       "team": "LAC"
     },
+    "16189": {
+      "name": "Mims, Marvin",
+      "position": "WR",
+      "team": "DEN"
+    },
     "16190": {
       "name": "Flowers, Zay",
       "position": "WR",
       "team": "BAL"
+    },
+    "16191": {
+      "name": "Tillman, Cedric",
+      "position": "WR",
+      "team": "CLE"
+    },
+    "16192": {
+      "name": "Washington, Parker",
+      "position": "WR",
+      "team": "JAC"
     },
     "16193": {
       "name": "Boutte, Kayshon",
@@ -67856,6 +89404,41 @@
       "position": "WR",
       "team": "KCC"
     },
+    "16196": {
+      "name": "Perry, A.T.",
+      "position": "WR",
+      "team": "NOS"
+    },
+    "16197": {
+      "name": "Mingo, Jonathan",
+      "position": "WR",
+      "team": "CAR"
+    },
+    "16199": {
+      "name": "Palmer, Trey",
+      "position": "WR",
+      "team": "TBB"
+    },
+    "16201": {
+      "name": "Hutchinson, Xavier",
+      "position": "WR",
+      "team": "HOU"
+    },
+    "16203": {
+      "name": "Jones, Charlie",
+      "position": "WR",
+      "team": "CIN"
+    },
+    "16204": {
+      "name": "Dell, Tank",
+      "position": "WR",
+      "team": "HOU"
+    },
+    "16205": {
+      "name": "Scott, Tyler",
+      "position": "WR",
+      "team": "CHI"
+    },
     "16206": {
       "name": "Wilson, Michael",
       "position": "WR",
@@ -67866,40 +89449,1075 @@
       "position": "WR",
       "team": "CIN"
     },
+    "16210": {
+      "name": "Shorter, Justin",
+      "position": "WR",
+      "team": "BUF"
+    },
+    "16211": {
+      "name": "Nacua, Puka",
+      "position": "WR",
+      "team": "LAR"
+    },
+    "16212": {
+      "name": "Mayer, Michael",
+      "position": "TE",
+      "team": "LVR"
+    },
+    "16213": {
+      "name": "Kincaid, Dalton",
+      "position": "TE",
+      "team": "BUF"
+    },
+    "16214": {
+      "name": "LaPorta, Sam",
+      "position": "TE",
+      "team": "DET"
+    },
+    "16215": {
+      "name": "Musgrave, Luke",
+      "position": "TE",
+      "team": "GBP"
+    },
+    "16216": {
+      "name": "Washington, Darnell",
+      "position": "TE",
+      "team": "PIT"
+    },
+    "16217": {
+      "name": "Latu, Cameron",
+      "position": "TE",
+      "team": "SFO"
+    },
+    "16219": {
+      "name": "Allen, Davis",
+      "position": "TE",
+      "team": "LAR"
+    },
+    "16220": {
+      "name": "Mallory, Will",
+      "position": "TE",
+      "team": "IND"
+    },
+    "16221": {
+      "name": "Schoonmaker, Luke",
+      "position": "TE",
+      "team": "DAL"
+    },
+    "16222": {
+      "name": "Kraft, Tucker",
+      "position": "TE",
+      "team": "GBP"
+    },
+    "16249": {
+      "name": "Kuntz, Zack",
+      "position": "TE",
+      "team": "NYJ"
+    },
+    "16269": {
+      "name": "Strange, Brenton",
+      "position": "TE",
+      "team": "JAC"
+    },
+    "16286": {
+      "name": "Moody, Jake",
+      "position": "PK",
+      "team": "SFO"
+    },
+    "16292": {
+      "name": "Ryland, Chad",
+      "position": "PK",
+      "team": "NEP"
+    },
+    "16333": {
+      "name": "Higgins, Elijah",
+      "position": "TE",
+      "team": "ARI"
+    },
+    "16339": {
+      "name": "Carlson, Anders",
+      "position": "PK",
+      "team": "NYJ"
+    },
+    "16342": {
+      "name": "Douglas, Demario",
+      "position": "WR",
+      "team": "NEP"
+    },
+    "16359": {
+      "name": "Nichols, Lew",
+      "position": "RB",
+      "team": "PHI"
+    },
+    "16377": {
+      "name": "Evans, Tiyon",
+      "position": "RB",
+      "team": "FA"
+    },
+    "16379": {
+      "name": "Ford-Wheaton, Bryce",
+      "position": "WR",
+      "team": "NYG"
+    },
+    "16380": {
+      "name": "Prince, Deneric",
+      "position": "RB",
+      "team": "KCC"
+    },
+    "16414": {
+      "name": "Aubrey, Brandon",
+      "position": "PK",
+      "team": "DAL"
+    },
+    "16432": {
+      "name": "Wilson, Emanuel",
+      "position": "RB",
+      "team": "GBP"
+    },
+    "16444": {
+      "name": "Grupe, Blake",
+      "position": "PK",
+      "team": "IND"
+    },
+    "16580": {
+      "name": "Maye, Drake",
+      "position": "QB",
+      "team": "NEP"
+    },
+    "16581": {
+      "name": "Daniels, Jayden",
+      "position": "QB",
+      "team": "WAS"
+    },
     "16582": {
       "name": "Nix, Bo",
       "position": "QB",
       "team": "DEN"
+    },
+    "16583": {
+      "name": "Penix Jr., Michael",
+      "position": "QB",
+      "team": "ATL"
+    },
+    "16584": {
+      "name": "McCarthy, J.J.",
+      "position": "QB",
+      "team": "MIN"
+    },
+    "16585": {
+      "name": "Milton, Joe",
+      "position": "QB",
+      "team": "DAL"
+    },
+    "16586": {
+      "name": "Rattler, Spencer",
+      "position": "QB",
+      "team": "NOS"
+    },
+    "16593": {
+      "name": "Corum, Blake",
+      "position": "RB",
+      "team": "LAR"
+    },
+    "16594": {
+      "name": "Benson, Trey",
+      "position": "RB",
+      "team": "ARI"
+    },
+    "16595": {
+      "name": "Estime, Audric",
+      "position": "RB",
+      "team": "DEN"
+    },
+    "16596": {
+      "name": "Allen, Braelon",
+      "position": "RB",
+      "team": "NYJ"
+    },
+    "16597": {
+      "name": "Brooks, Jonathon",
+      "position": "RB",
+      "team": "CAR"
+    },
+    "16598": {
+      "name": "Irving, Bucky",
+      "position": "RB",
+      "team": "TBB"
+    },
+    "16601": {
+      "name": "Shipley, Will",
+      "position": "RB",
+      "team": "PHI"
+    },
+    "16603": {
+      "name": "Davis, Ray",
+      "position": "RB",
+      "team": "BUF"
+    },
+    "16604": {
+      "name": "Lloyd, MarShawn",
+      "position": "RB",
+      "team": "GBP"
+    },
+    "16608": {
+      "name": "Holani, George",
+      "position": "RB",
+      "team": "SEA"
+    },
+    "16610": {
+      "name": "Wright, Jaylen",
+      "position": "RB",
+      "team": "MIA"
+    },
+    "16612": {
+      "name": "Steele, Carson",
+      "position": "RB",
+      "team": "KCC"
+    },
+    "16613": {
+      "name": "Laube, Dylan",
+      "position": "RB",
+      "team": "LVR"
+    },
+    "16614": {
+      "name": "Harrison Jr., Marvin",
+      "position": "WR",
+      "team": "ARI"
+    },
+    "16615": {
+      "name": "Nabers, Malik",
+      "position": "WR",
+      "team": "NYG"
+    },
+    "16616": {
+      "name": "Odunze, Rome",
+      "position": "WR",
+      "team": "CHI"
+    },
+    "16617": {
+      "name": "Coleman, Keon",
+      "position": "WR",
+      "team": "BUF"
     },
     "16618": {
       "name": "Thomas Jr., Brian",
       "position": "WR",
       "team": "JAC"
     },
+    "16619": {
+      "name": "Franklin, Troy",
+      "position": "WR",
+      "team": "DEN"
+    },
     "16620": {
       "name": "Worthy, Xavier",
       "position": "WR",
       "team": "KCC"
+    },
+    "16621": {
+      "name": "Walker, Devontez",
+      "position": "WR",
+      "team": "BAL"
+    },
+    "16622": {
+      "name": "Pearsall, Ricky",
+      "position": "WR",
+      "team": "SFO"
+    },
+    "16623": {
+      "name": "Rice, Brenden",
+      "position": "WR",
+      "team": "LAC"
+    },
+    "16624": {
+      "name": "Thrash, Jamari",
+      "position": "WR",
+      "team": "CLE"
+    },
+    "16625": {
+      "name": "Wilson, Johnny",
+      "position": "WR",
+      "team": "PHI"
+    },
+    "16626": {
+      "name": "Mitchell, Adonai",
+      "position": "WR",
+      "team": "IND"
+    },
+    "16627": {
+      "name": "McConkey, Ladd",
+      "position": "WR",
+      "team": "LAC"
+    },
+    "16628": {
+      "name": "McMillan, Jalen",
+      "position": "WR",
+      "team": "TBB"
+    },
+    "16629": {
+      "name": "Wilson, Roman",
+      "position": "WR",
+      "team": "PIT"
+    },
+    "16631": {
+      "name": "Polk, Ja'Lynn",
+      "position": "WR",
+      "team": "NEP"
+    },
+    "16632": {
+      "name": "Burton, Jermaine",
+      "position": "WR",
+      "team": "CIN"
+    },
+    "16633": {
+      "name": "Whittington, Jordan",
+      "position": "WR",
+      "team": "LAR"
+    },
+    "16636": {
+      "name": "Corley, Malachi",
+      "position": "WR",
+      "team": "NYJ"
+    },
+    "16637": {
+      "name": "Baker, Javon",
+      "position": "WR",
+      "team": "NEP"
+    },
+    "16639": {
+      "name": "Legette, Xavier",
+      "position": "WR",
+      "team": "CAR"
+    },
+    "16640": {
+      "name": "Cowing, Jacob",
+      "position": "WR",
+      "team": "SFO"
+    },
+    "16641": {
+      "name": "Bowers, Brock",
+      "position": "TE",
+      "team": "LVR"
+    },
+    "16642": {
+      "name": "Stover, Cade",
+      "position": "TE",
+      "team": "HOU"
+    },
+    "16643": {
+      "name": "Sanders, Ja'Tavion",
+      "position": "TE",
+      "team": "CAR"
+    },
+    "16644": {
+      "name": "Sinnott, Ben",
+      "position": "TE",
+      "team": "WAS"
+    },
+    "16645": {
+      "name": "All, Erick",
+      "position": "TE",
+      "team": "CIN"
     },
     "16646": {
       "name": "Bell, Jaheim",
       "position": "TE",
       "team": "PHI"
     },
+    "16648": {
+      "name": "Wiley, Jared",
+      "position": "TE",
+      "team": "KCC"
+    },
+    "16649": {
+      "name": "Johnson, Theo",
+      "position": "TE",
+      "team": "NYG"
+    },
+    "16678": {
+      "name": "Vaki, Sione",
+      "position": "RB",
+      "team": "DET"
+    },
+    "16680": {
+      "name": "Little, Cam",
+      "position": "PK",
+      "team": "JAC"
+    },
+    "16681": {
+      "name": "Reichard, Will",
+      "position": "PK",
+      "team": "MIN"
+    },
+    "16683": {
+      "name": "Rees-Zammit, Louis",
+      "position": "RB",
+      "team": "FA"
+    },
+    "16684": {
+      "name": "Washington, Malik",
+      "position": "WR",
+      "team": "MIA"
+    },
+    "16688": {
+      "name": "Guerendo, Isaac",
+      "position": "RB",
+      "team": "SFO"
+    },
+    "16723": {
+      "name": "Barner, AJ",
+      "position": "TE",
+      "team": "SEA"
+    },
+    "16746": {
+      "name": "Ali, Rasheen",
+      "position": "RB",
+      "team": "BAL"
+    },
+    "16747": {
+      "name": "Tracy, Tyrone",
+      "position": "RB",
+      "team": "NYG"
+    },
+    "16751": {
+      "name": "Means, Bub",
+      "position": "WR",
+      "team": "NOS"
+    },
+    "16757": {
+      "name": "Vidal, Kimani",
+      "position": "RB",
+      "team": "LAC"
+    },
+    "16775": {
+      "name": "Karty, Joshua",
+      "position": "PK",
+      "team": "ARI"
+    },
+    "16778": {
+      "name": "Flournoy, Ryan",
+      "position": "WR",
+      "team": "DAL"
+    },
+    "16788": {
+      "name": "Vele, Devaughn",
+      "position": "WR",
+      "team": "DEN"
+    },
+    "16792": {
+      "name": "Washington, Tahj",
+      "position": "WR",
+      "team": "MIA"
+    },
+    "16801": {
+      "name": "Johnson, Cornelius",
+      "position": "WR",
+      "team": "GBP"
+    },
+    "16808": {
+      "name": "Peat, Nathaniel",
+      "position": "RB",
+      "team": "FA"
+    },
+    "16809": {
+      "name": "Coker, Jalen",
+      "position": "WR",
+      "team": "CAR"
+    },
+    "16843": {
+      "name": "Mevis, Harrison",
+      "position": "PK",
+      "team": "LAR"
+    },
     "16846": {
       "name": "Bates, Jake",
       "position": "PK",
       "team": "DET"
+    },
+    "17030": {
+      "name": "Ward, Cam",
+      "position": "QB",
+      "team": "TEN"
+    },
+    "17032": {
+      "name": "Dart, Jaxson",
+      "position": "QB",
+      "team": "NYG"
+    },
+    "17033": {
+      "name": "Milroe, Jalen",
+      "position": "QB",
+      "team": "SEA"
+    },
+    "17034": {
+      "name": "Ewers, Quinn",
+      "position": "QB",
+      "team": "MIA"
+    },
+    "17036": {
+      "name": "Howard, Will",
+      "position": "QB",
+      "team": "PIT"
+    },
+    "17037": {
+      "name": "Gabriel, Dillon",
+      "position": "QB",
+      "team": "CLE"
+    },
+    "17039": {
+      "name": "Shough, Tyler",
+      "position": "QB",
+      "team": "NOS"
+    },
+    "17042": {
+      "name": "Jeanty, Ashton",
+      "position": "RB",
+      "team": "LVR"
+    },
+    "17043": {
+      "name": "Henderson, TreVeyon",
+      "position": "RB",
+      "team": "NEP"
+    },
+    "17044": {
+      "name": "Hampton, Omarion",
+      "position": "RB",
+      "team": "LAC"
+    },
+    "17045": {
+      "name": "Skattebo, Cam",
+      "position": "RB",
+      "team": "NYG"
+    },
+    "17046": {
+      "name": "Neal, Devin",
+      "position": "RB",
+      "team": "NOS"
+    },
+    "17047": {
+      "name": "Sampson, Dylan",
+      "position": "RB",
+      "team": "CLE"
+    },
+    "17048": {
+      "name": "Johnson, Kaleb",
+      "position": "RB",
+      "team": "PIT"
+    },
+    "17049": {
+      "name": "Smith, Brashard",
+      "position": "RB",
+      "team": "KCC"
+    },
+    "17051": {
+      "name": "Judkins, Quinshon",
+      "position": "RB",
+      "team": "CLE"
+    },
+    "17052": {
+      "name": "Tuten, Bhayshul",
+      "position": "RB",
+      "team": "JAC"
+    },
+    "17053": {
+      "name": "Marks, Woody",
+      "position": "RB",
+      "team": "HOU"
+    },
+    "17054": {
+      "name": "Martinez, Damien",
+      "position": "RB",
+      "team": "GBP"
+    },
+    "17055": {
+      "name": "James, Jordan",
+      "position": "RB",
+      "team": "SFO"
+    },
+    "17056": {
+      "name": "Etienne, Trevor",
+      "position": "RB",
+      "team": "CAR"
+    },
+    "17058": {
+      "name": "Brooks, Tahj",
+      "position": "RB",
+      "team": "CIN"
+    },
+    "17059": {
+      "name": "Gordon, Ollie",
+      "position": "RB",
+      "team": "MIA"
+    },
+    "17060": {
+      "name": "Giddens, DJ",
+      "position": "RB",
+      "team": "IND"
+    },
+    "17063": {
+      "name": "Mafah, Phil",
+      "position": "RB",
+      "team": "DAL"
+    },
+    "17064": {
+      "name": "Hunter, Jarquez",
+      "position": "RB",
+      "team": "LAR"
+    },
+    "17066": {
+      "name": "Monangai, Kyle",
+      "position": "RB",
+      "team": "CHI"
+    },
+    "17068": {
+      "name": "Harvey, RJ",
+      "position": "RB",
+      "team": "DEN"
+    },
+    "17069": {
+      "name": "Blue, Jaydon",
+      "position": "RB",
+      "team": "DAL"
+    },
+    "17070": {
+      "name": "Burden, Luther",
+      "position": "WR",
+      "team": "CHI"
+    },
+    "17071": {
+      "name": "McMillan, Tetairoa",
+      "position": "WR",
+      "team": "CAR"
     },
     "17072": {
       "name": "Harris, Tre",
       "position": "WR",
       "team": "LAC"
     },
+    "17073": {
+      "name": "Ayomanor, Elic",
+      "position": "WR",
+      "team": "TEN"
+    },
+    "17075": {
+      "name": "Golden, Matthew",
+      "position": "WR",
+      "team": "GBP"
+    },
+    "17076": {
+      "name": "Bond, Isaiah",
+      "position": "WR",
+      "team": "CLE"
+    },
+    "17077": {
+      "name": "Restrepo, Xavier",
+      "position": "WR",
+      "team": "TEN"
+    },
+    "17078": {
+      "name": "Bech, Jack",
+      "position": "WR",
+      "team": "LVR"
+    },
+    "17080": {
+      "name": "Noel, Jaylin",
+      "position": "WR",
+      "team": "HOU"
+    },
+    "17081": {
+      "name": "Egbuka, Emeka",
+      "position": "WR",
+      "team": "TBB"
+    },
+    "17082": {
+      "name": "Bryant, Pat",
+      "position": "WR",
+      "team": "DEN"
+    },
+    "17083": {
+      "name": "Higgins, Jayden",
+      "position": "WR",
+      "team": "HOU"
+    },
+    "17086": {
+      "name": "Royals, Jalen",
+      "position": "WR",
+      "team": "KCC"
+    },
+    "17087": {
+      "name": "Thornton, Dont'e",
+      "position": "WR",
+      "team": "LVR"
+    },
+    "17096": {
+      "name": "Williams, Savion",
+      "position": "WR",
+      "team": "GBP"
+    },
+    "17097": {
+      "name": "Felton, Tai",
+      "position": "WR",
+      "team": "MIN"
+    },
+    "17098": {
+      "name": "Horton, Tory",
+      "position": "WR",
+      "team": "SEA"
+    },
+    "17099": {
+      "name": "Gadsden, Oronde",
+      "position": "TE",
+      "team": "LAC"
+    },
+    "17101": {
+      "name": "Prather, Kaden",
+      "position": "WR",
+      "team": "FA"
+    },
+    "17102": {
+      "name": "Warren, Tyler",
+      "position": "TE",
+      "team": "IND"
+    },
+    "17103": {
+      "name": "Fannin, Harold",
+      "position": "TE",
+      "team": "CLE"
+    },
+    "17104": {
+      "name": "Loveland, Colston",
+      "position": "TE",
+      "team": "CHI"
+    },
+    "17105": {
+      "name": "Helm, Gunnar",
+      "position": "TE",
+      "team": "TEN"
+    },
+    "17106": {
+      "name": "Taylor, Mason",
+      "position": "TE",
+      "team": "NYJ"
+    },
+    "17107": {
+      "name": "Ferguson, Terrance",
+      "position": "TE",
+      "team": "LAR"
+    },
+    "17108": {
+      "name": "Arroyo, Elijah",
+      "position": "TE",
+      "team": "SEA"
+    },
+    "17134": {
+      "name": "Williams, Kyle",
+      "position": "WR",
+      "team": "NEP"
+    },
+    "17157": {
+      "name": "TeSlaa, Isaac",
+      "position": "WR",
+      "team": "DET"
+    },
+    "17171": {
+      "name": "Dike, Chimere",
+      "position": "WR",
+      "team": "TEN"
+    },
+    "17184": {
+      "name": "Lane, Jaylin",
+      "position": "WR",
+      "team": "WAS"
+    },
+    "17220": {
+      "name": "Borregales, Andres",
+      "position": "PK",
+      "team": "NEP"
+    },
+    "17222": {
+      "name": "Loop, Tyler",
+      "position": "PK",
+      "team": "BAL"
+    },
+    "17231": {
+      "name": "Bartholomew, Gavin",
+      "position": "TE",
+      "team": "MIN"
+    },
+    "17234": {
+      "name": "Horn, Jimmy",
+      "position": "WR",
+      "team": "CAR"
+    },
+    "17243": {
+      "name": "Fidone, Thomas",
+      "position": "TE",
+      "team": "NYG"
+    },
     "17256": {
       "name": "Croskey-Merritt, Jacory",
       "position": "RB",
       "team": "WAS"
+    },
+    "17424": {
+      "name": "Smyth, Charlie",
+      "position": "PK",
+      "team": "NOS"
+    },
+    "17462": {
+      "name": "Mendoza, Fernando",
+      "position": "QB",
+      "team": "LVR"
+    },
+    "17463": {
+      "name": "Simpson, Ty",
+      "position": "QB",
+      "team": "LAR"
+    },
+    "17466": {
+      "name": "Beck, Carson",
+      "position": "QB",
+      "team": "ARI"
+    },
+    "17467": {
+      "name": "Klubnik, Cade",
+      "position": "QB",
+      "team": "NYJ"
+    },
+    "17468": {
+      "name": "Allar, Drew",
+      "position": "QB",
+      "team": "PIT"
+    },
+    "17472": {
+      "name": "Love, Jeremiyah",
+      "position": "RB",
+      "team": "ARI"
+    },
+    "17473": {
+      "name": "Price, Jadarian",
+      "position": "RB",
+      "team": "SEA"
+    },
+    "17474": {
+      "name": "Johnson, Emmett",
+      "position": "RB",
+      "team": "KCC"
+    },
+    "17476": {
+      "name": "Singleton, Nicholas",
+      "position": "RB",
+      "team": "TEN"
+    },
+    "17477": {
+      "name": "Coleman, Jonah",
+      "position": "RB",
+      "team": "DEN"
+    },
+    "17478": {
+      "name": "Allen, Kaytron",
+      "position": "RB",
+      "team": "WAS"
+    },
+    "17481": {
+      "name": "Claiborne, Demond",
+      "position": "RB",
+      "team": "MIN"
+    },
+    "17482": {
+      "name": "Washington Jr., Mike",
+      "position": "RB",
+      "team": "LVR"
+    },
+    "17485": {
+      "name": "Black, Kaelon",
+      "position": "RB",
+      "team": "SFO"
+    },
+    "17486": {
+      "name": "Miller, Jam",
+      "position": "RB",
+      "team": "NEP"
+    },
+    "17497": {
+      "name": "Tate, Carnell",
+      "position": "WR",
+      "team": "TEN"
+    },
+    "17498": {
+      "name": "Tyson, Jordyn",
+      "position": "WR",
+      "team": "NOS"
+    },
+    "17499": {
+      "name": "Lemon, Makai",
+      "position": "WR",
+      "team": "PHI"
+    },
+    "17500": {
+      "name": "Boston, Denzel",
+      "position": "WR",
+      "team": "CLE"
+    },
+    "17501": {
+      "name": "Concepcion, KC",
+      "position": "WR",
+      "team": "CLE"
+    },
+    "17502": {
+      "name": "Cooper Jr., Omar",
+      "position": "WR",
+      "team": "NYJ"
+    },
+    "17503": {
+      "name": "Bernard, Germie",
+      "position": "WR",
+      "team": "PIT"
+    },
+    "17504": {
+      "name": "Daniels, CJ",
+      "position": "WR",
+      "team": "LAR"
+    },
+    "17505": {
+      "name": "Sarratt, Elijah",
+      "position": "WR",
+      "team": "BAL"
+    },
+    "17506": {
+      "name": "Bell, Chris",
+      "position": "WR",
+      "team": "MIA"
+    },
+    "17507": {
+      "name": "Branch, Zachariah",
+      "position": "WR",
+      "team": "ATL"
+    },
+    "17508": {
+      "name": "Bell, Skyler",
+      "position": "WR",
+      "team": "BUF"
+    },
+    "17509": {
+      "name": "Brazzell II, Chris",
+      "position": "WR",
+      "team": "CAR"
+    },
+    "17510": {
+      "name": "Burks, Deion",
+      "position": "WR",
+      "team": "IND"
+    },
+    "17511": {
+      "name": "Fields, Malachi",
+      "position": "WR",
+      "team": "NYG"
+    },
+    "17512": {
+      "name": "Williams, Antonio",
+      "position": "WR",
+      "team": "WAS"
+    },
+    "17514": {
+      "name": "Stribling, De'Zhaun",
+      "position": "WR",
+      "team": "SFO"
+    },
+    "17517": {
+      "name": "Lane, Ja'Kobi",
+      "position": "WR",
+      "team": "BAL"
+    },
+    "17519": {
+      "name": "Lance, Bryce",
+      "position": "WR",
+      "team": "NOS"
+    },
+    "17520": {
+      "name": "Hurst, Ted",
+      "position": "WR",
+      "team": "TBB"
+    },
+    "17521": {
+      "name": "Thomas, Zavion",
+      "position": "WR",
+      "team": "CHI"
+    },
+    "17526": {
+      "name": "Virgil, Reggie",
+      "position": "WR",
+      "team": "ARI"
+    },
+    "17528": {
+      "name": "Coleman, Kevin",
+      "position": "WR",
+      "team": "MIA"
+    },
+    "17529": {
+      "name": "Thompson, Brenen",
+      "position": "WR",
+      "team": "LAC"
+    },
+    "17543": {
+      "name": "Sadiq, Kenyon",
+      "position": "TE",
+      "team": "NYJ"
+    },
+    "17544": {
+      "name": "Stowers, Eli",
+      "position": "TE",
+      "team": "PHI"
+    },
+    "17547": {
+      "name": "Klare, Max",
+      "position": "TE",
+      "team": "LAR"
+    },
+    "17548": {
+      "name": "Joly, Justin",
+      "position": "TE",
+      "team": "DEN"
+    },
+    "17549": {
+      "name": "Roush, Sam",
+      "position": "TE",
+      "team": "CHI"
+    },
+    "17566": {
+      "name": "Royer, Joe",
+      "position": "TE",
+      "team": "CLE"
+    },
+    "17567": {
+      "name": "Delp, Oscar",
+      "position": "TE",
+      "team": "NOS"
+    },
+    "17591": {
+      "name": "Boerkircher, Nate",
+      "position": "TE",
+      "team": "JAC"
+    },
+    "17593": {
+      "name": "Klein, Marlin",
+      "position": "TE",
+      "team": "HOU"
+    },
+    "17599": {
+      "name": "Douglas, Caleb",
+      "position": "WR",
+      "team": "MIA"
+    },
+    "17607": {
+      "name": "Raridon, Eli",
+      "position": "TE",
+      "team": "NEP"
+    },
+    "17652": {
+      "name": "Randall, Adam",
+      "position": "RB",
+      "team": "BAL"
     },
     "0519": {
       "name": "Cardinals, Arizona",
@@ -67925,6 +90543,36 @@
       "name": "Panthers, Carolina",
       "position": "Def",
       "team": "CAR"
+    },
+    "0517": {
+      "name": "Giants, New York",
+      "position": "Def",
+      "team": "NYG"
+    },
+    "0518": {
+      "name": "Eagles, Philadelphia",
+      "position": "Def",
+      "team": "PHI"
+    },
+    "0516": {
+      "name": "Cowboys, Dallas",
+      "position": "Def",
+      "team": "DAL"
+    },
+    "0530": {
+      "name": "49ers, San Francisco",
+      "position": "Def",
+      "team": "SFO"
+    },
+    "0513": {
+      "name": "Raiders, Oakland",
+      "position": "Def",
+      "team": "OAK"
+    },
+    "0522": {
+      "name": "Lions, Detroit",
+      "position": "Def",
+      "team": "DET"
     },
     "0532": {
       "name": "Texans, Houston",
@@ -67956,35 +90604,70 @@
       "position": "Def",
       "team": "SDC"
     },
-    "0518": {
-      "name": "Eagles, Philadelphia",
+    "0505": {
+      "name": "Jets, New York",
       "position": "Def",
-      "team": "PHI"
+      "team": "NYJ"
     },
     "0509": {
       "name": "Jaguars, Jacksonville",
       "position": "Def",
       "team": "JAC"
     },
-    "0513": {
-      "name": "Raiders, Oakland",
+    "0525": {
+      "name": "Buccaneers, Tampa Bay",
       "position": "Def",
-      "team": "OAK"
+      "team": "TBB"
     },
-    "0505": {
-      "name": "Jets, New York",
+    "0507": {
+      "name": "Browns, Cleveland",
       "position": "Def",
-      "team": "NYJ"
+      "team": "CLE"
+    },
+    "0508": {
+      "name": "Titans, Tennessee",
+      "position": "Def",
+      "team": "TEN"
+    },
+    "0529": {
+      "name": "Saints, New Orleans",
+      "position": "Def",
+      "team": "NOS"
+    },
+    "0506": {
+      "name": "Bengals, Cincinnati",
+      "position": "Def",
+      "team": "CIN"
+    },
+    "0523": {
+      "name": "Packers, Green Bay",
+      "position": "Def",
+      "team": "GBP"
+    },
+    "0503": {
+      "name": "Dolphins, Miami",
+      "position": "Def",
+      "team": "MIA"
     },
     "0531": {
       "name": "Ravens, Baltimore",
       "position": "Def",
       "team": "BAL"
     },
-    "0506": {
-      "name": "Bengals, Cincinnati",
+    "0526": {
+      "name": "Falcons, Atlanta",
       "position": "Def",
-      "team": "CIN"
+      "team": "ATL"
+    },
+    "0524": {
+      "name": "Vikings, Minnesota",
+      "position": "Def",
+      "team": "MIN"
+    },
+    "0510": {
+      "name": "Steelers, Pittsburgh",
+      "position": "Def",
+      "team": "PIT"
     },
     "0521": {
       "name": "Bears, Chicago",
@@ -67995,31 +90678,6 @@
       "name": "Redskins, Washington",
       "position": "Def",
       "team": "WAS"
-    },
-    "0525": {
-      "name": "Buccaneers, Tampa Bay",
-      "position": "Def",
-      "team": "TBB"
-    },
-    "0508": {
-      "name": "Titans, Tennessee",
-      "position": "Def",
-      "team": "TEN"
-    },
-    "0507": {
-      "name": "Browns, Cleveland",
-      "position": "Def",
-      "team": "CLE"
-    },
-    "0503": {
-      "name": "Dolphins, Miami",
-      "position": "Def",
-      "team": "MIA"
-    },
-    "0524": {
-      "name": "Vikings, Minnesota",
-      "position": "Def",
-      "team": "MIN"
     }
   }
 }

--- a/docs/plans/franchise-history-phases.md
+++ b/docs/plans/franchise-history-phases.md
@@ -144,10 +144,21 @@ Two new sections on each franchise detail page.
 
 ### Trade ledger
 
-- Walk `data/theleague/mfl-feeds/<year>/transactions.json` for every year, filter `type=TRADE` involving this franchise.
-- Render a chronological list with each trade's date, partner franchise (linked), every asset gained/lost.
-- Group by year; collapsible by default.
-- Aggregation produces `franchises[id].trades[]` for cheap render.
+- [x] Walk `data/theleague/mfl-feeds/<year>/transactions.json` for every year,
+  filter `type=TRADE` involving this franchise. **Already aggregated in
+  Phase 2** as `franchises[id].trades[]` with bidirectional attribution.
+- [x] Render a chronological list with each trade's date, partner franchise
+  (linked → rivalry page), every asset sent/received. Grouped by year with
+  the most recent year auto-expanded; older years collapsed via `<details>`.
+  Lives between "Top Rivals" and "Points by Season" on the franchise detail
+  page.
+- [x] Asset formatter extracted to `src/utils/franchise-trade-asset.ts` and
+  shared with the rivalries page (`formatTradeAsset`).
+- Known data limitation (carried forward): trades from 2007-2010 render
+  unresolved player codes as "Player #NNNN" because MFL's per-year
+  `players.json` isn't available for those years. Fix would require a
+  cross-year fallback to the most recent `players.json` that contains the
+  ID — out of scope for the trade-ledger UI.
 
 ### Draft history
 

--- a/docs/plans/franchise-history-phases.md
+++ b/docs/plans/franchise-history-phases.md
@@ -162,9 +162,21 @@ Two new sections on each franchise detail page.
 
 ### Draft history
 
-- Walk `data/theleague/mfl-feeds/<year>/draftResults.json` and `auctionResults.json` for every year.
-- Render every pick the franchise made: round/pick number, player name, salary (if auction), career arc indicator (current contract status if still rostered).
-- Useful sub-stat: best pick by VORP (cross-reference salary + scoring data we already have).
+- [x] Walk `data/theleague/mfl-feeds/<year>/draftResults.json` and
+  `auctionResults.json` for every year. Aggregator emits
+  `franchises[id].draftPicks[]` and `franchises[id].auctionWins[]` with
+  ownerHistory attribution; player names resolved via the existing per-year
+  `players.json` cache shared with the trade-asset name resolver.
+- [x] Render every pick the franchise made — round/pick number for the
+  rookie draft, winning bid for auctions, player name + position from the
+  shared `playerNames` lookup. "Pick traded from …" comments surface as a
+  small "via trade" pill on the affected draft rows.
+- [x] Year-grouped via `<details>` with the most recent year auto-expanded;
+  same disclosure styling as the trade ledger (`.year-group`).
+- Career-arc indicator (current contract status if still rostered) and
+  "best pick by VORP" highlights are deferred — both require cross-ref to
+  current rosters / season scoring beyond what `franchise-history.json`
+  carries today. Revisit when the per-franchise file split happens.
 
 ## Phase 5: Schefter milestone integration
 

--- a/scripts/compute-franchise-history.mjs
+++ b/scripts/compute-franchise-history.mjs
@@ -487,6 +487,8 @@ const ensureFranchise = (id) => {
       headToHead: {}, // opponentFranchiseId -> { wins, losses, ties }
       matchupHistory: {}, // opponentFranchiseId -> [{year, week, score, opponentScore, isPlayoff, playoffRound, sourceFranchiseId}]
       trades: [], // [{year, timestamp, partnerId, gaveUp[], received[], byCommish, comments, sourceFranchiseId, partnerSourceId}]
+      draftPicks: [], // [{year, round, pick, playerId, viaTrade, comments, timestamp, sourceFranchiseId}]
+      auctionWins: [], // [{year, playerId, winningBid, timestamp, sourceFranchiseId}]
     });
   }
   return franchiseMap.get(id);
@@ -992,6 +994,63 @@ for (const year of years) {
     }
   }
 
+  // Rookie draft results — every pick is per-franchise; "[Pick traded from
+  // <name>]" comments indicate the slot moved between franchises before the
+  // selection was made. We don't try to resolve the prior owner's franchise
+  // ID from the comment text (names rotate); the pill is just informational.
+  const draftResults = readJson(path.join(yearDir, 'draftResults.json'));
+  const draftPicks = toArray(draftResults?.draftResults?.draftUnit?.draftPick);
+  const draftPlayerIds = [];
+  for (const dp of draftPicks) {
+    if (!dp?.franchise || !dp?.player) continue;
+    const target = attributeYear(dp.franchise, year);
+    if (!target) continue;
+    draftPlayerIds.push(dp.player);
+    const comments = dp.comments || '';
+    ensureFranchise(target).draftPicks.push({
+      year,
+      round: parseNum(dp.round),
+      pick: parseNum(dp.pick),
+      playerId: dp.player,
+      viaTrade: /Pick traded from/i.test(comments),
+      comments: comments.trim(),
+      timestamp: parseNum(dp.timestamp),
+      sourceFranchiseId: dp.franchise !== target ? dp.franchise : null,
+    });
+  }
+
+  // Auction wins — `winningBid` is the dollar amount in raw integer form.
+  const auctionResults = readJson(path.join(yearDir, 'auctionResults.json'));
+  const auctionWins = toArray(auctionResults?.auctionResults?.auctionUnit?.auction);
+  const auctionPlayerIds = [];
+  for (const aw of auctionWins) {
+    if (!aw?.franchise || !aw?.player) continue;
+    const target = attributeYear(aw.franchise, year);
+    if (!target) continue;
+    auctionPlayerIds.push(aw.player);
+    ensureFranchise(target).auctionWins.push({
+      year,
+      playerId: aw.player,
+      winningBid: parseNum(aw.winningBid),
+      timestamp: parseNum(aw.lastBidTime || aw.timeStarted),
+      sourceFranchiseId: aw.franchise !== target ? aw.franchise : null,
+    });
+  }
+
+  // Resolve player names for any draft + auction picks that haven't already
+  // been picked up by the trade-asset resolver. Reuses the per-year players
+  // index helper defined above (closes over the same `yearPlayers` cache).
+  const allDraftAuctionIds = [...draftPlayerIds, ...auctionPlayerIds];
+  if (allDraftAuctionIds.some((c) => /^\d+$/.test(c))) {
+    const idx = ensurePlayersIndex();
+    for (const code of allDraftAuctionIds) {
+      if (!/^\d+$/.test(code)) continue;
+      if (playerNameLookup[code]) continue;
+      const p = idx.get(code);
+      if (p) playerNameLookup[code] = p;
+    }
+  }
+
   yearSummaries.push({
     year,
     leagueSize: standingsRows.length,
@@ -1022,6 +1081,10 @@ for (const [id, fr] of franchiseMap) {
   }
   // Trades oldest → newest by timestamp; ties → year asc
   fr.trades.sort((a, b) => a.timestamp - b.timestamp || a.year - b.year);
+  // Draft picks: ascending by year then overall pick order
+  fr.draftPicks.sort((a, b) => a.year - b.year || a.round - b.round || a.pick - b.pick);
+  // Auction wins: ascending by year then bid time
+  fr.auctionWins.sort((a, b) => a.year - b.year || a.timestamp - b.timestamp);
 
   // Pre-2020 playoff enrichment: MFL retired the bracket data for older
   // years so getPlayoffMatchupKeys can't tag those games. The hand-curated

--- a/src/pages/theleague/franchises/[id].astro
+++ b/src/pages/theleague/franchises/[id].astro
@@ -4,6 +4,7 @@ import Breadcrumbs from '../../../components/theleague/Breadcrumbs.astro';
 import { resolveLeaguePath } from '../../../utils/nav-utils';
 import franchiseHistory from '../../../../data/theleague/derived/franchise-history.json';
 import leagueConfig from '../../../data/theleague.config.json';
+import { formatTradeAsset } from '../../../utils/franchise-trade-asset';
 
 export const prerender = false;
 
@@ -316,6 +317,53 @@ const opponentMeta: Record<string, any> = Object.fromEntries(
 
 const canonicalRivalryPair = (a: string, b: string): string =>
   [a, b].sort().join('-vs-');
+
+// Trade ledger — every trade involving this franchise, grouped by year for
+// rendering. Trades are stored in `fr.trades` oldest-first (see
+// scripts/compute-franchise-history.mjs); display newest-first.
+const playerNames = ((franchiseHistory as any).playerNames ?? {}) as Record<
+  string,
+  { name: string; position?: string; team?: string }
+>;
+const franchiseShortName = (fid: string): string => {
+  const meta = opponentMeta[fid];
+  return meta?.nameShort ?? meta?.nameMedium ?? meta?.name ?? fid;
+};
+const formatAsset = (code: string) => formatTradeAsset(code, playerNames, franchiseShortName);
+
+type FranchiseTrade = {
+  year: number;
+  timestamp: number;
+  partnerId: string;
+  gaveUp: string[];
+  received: string[];
+  byCommish: boolean;
+  comments: string;
+  bothAttributed: boolean;
+};
+const allTrades: FranchiseTrade[] = ((fr.trades as FranchiseTrade[]) || []).filter(
+  (t) => t.partnerId !== id
+);
+const tradesByYear = new Map<number, FranchiseTrade[]>();
+for (const t of allTrades) {
+  if (!tradesByYear.has(t.year)) tradesByYear.set(t.year, []);
+  tradesByYear.get(t.year)!.push(t);
+}
+const tradeYearGroups = Array.from(tradesByYear.entries())
+  .map(([year, trades]) => ({
+    year,
+    trades: trades.slice().sort((a, b) => b.timestamp - a.timestamp),
+  }))
+  .sort((a, b) => b.year - a.year);
+
+const tradeDateLabel = (t: FranchiseTrade): string => {
+  if (!t.timestamp) return String(t.year);
+  return new Date(t.timestamp * 1000).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+};
 ---
 
 <TheLeagueLayout title={`${fr.currentName} — Franchise History`}>
@@ -488,6 +536,70 @@ const canonicalRivalryPair = (a: string, b: string): string =>
         <p class="dim small">
           <a href={resolveLeaguePath('/theleague/rivalries', hideLeaguePrefix)}>See full rivalry matrix →</a>
         </p>
+      </section>
+    )}
+
+    {allTrades.length > 0 && (
+      <section class="trades-section">
+        <h2>Trade Ledger ({allTrades.length})</h2>
+        <p class="dim small">
+          Every trade involving the current owner — grouped by year, newest first.
+        </p>
+        {tradeYearGroups.map((group) => (
+          <details class="trade-year" open={group === tradeYearGroups[0]}>
+            <summary>
+              <span class="trade-year-label">{group.year}</span>
+              <span class="dim small">{group.trades.length} trade{group.trades.length === 1 ? '' : 's'}</span>
+            </summary>
+            <ul class="trade-list">
+              {group.trades.map((t) => {
+                const partnerMeta = opponentMeta[t.partnerId];
+                const partnerName =
+                  partnerMeta?.nameShort ?? partnerMeta?.nameMedium ?? partnerMeta?.name ?? t.partnerId;
+                const partnerIcon = partnerMeta?.icon ?? `/assets/theleague/icons/${t.partnerId}.png`;
+                const rivalryHref = resolveLeaguePath(
+                  `/theleague/rivalries/${canonicalRivalryPair(id!, t.partnerId)}`,
+                  hideLeaguePrefix
+                );
+                return (
+                  <li class="trade">
+                    <div class="trade-head">
+                      <a class="trade-partner" href={rivalryHref} title={`Rivalry vs ${partnerName}`}>
+                        <img src={partnerIcon} alt="" class="partner-icon" loading="lazy" />
+                        <span class="partner-name">{partnerName}</span>
+                      </a>
+                      <span class="dim small trade-date">{tradeDateLabel(t)}</span>
+                      {t.byCommish && (
+                        <span class="commish-tag" title="Trade was processed by the commissioner">
+                          commish
+                        </span>
+                      )}
+                    </div>
+                    <div class="trade-cols">
+                      <div class="trade-col">
+                        <div class="t-name">Sent</div>
+                        {t.gaveUp.length > 0 ? (
+                          <ul>{t.gaveUp.map((c) => <li>{formatAsset(c)}</li>)}</ul>
+                        ) : (
+                          <p class="dim small">—</p>
+                        )}
+                      </div>
+                      <div class="trade-col">
+                        <div class="t-name">Received</div>
+                        {t.received.length > 0 ? (
+                          <ul>{t.received.map((c) => <li>{formatAsset(c)}</li>)}</ul>
+                        ) : (
+                          <p class="dim small">—</p>
+                        )}
+                      </div>
+                    </div>
+                    {t.comments && <p class="trade-comments dim small">"{t.comments}"</p>}
+                  </li>
+                );
+              })}
+            </ul>
+          </details>
+        ))}
       </section>
     )}
 
@@ -1196,5 +1308,133 @@ const canonicalRivalryPair = (a: string, b: string): string =>
     text-transform: uppercase;
     letter-spacing: 0.04em;
     margin-top: 0.125rem;
+  }
+
+  /* ============================================
+   * TRADE LEDGER
+   * ============================================ */
+  .trades-section {
+    margin: 2.5rem 0;
+  }
+  .trades-section > p {
+    margin: 0 0 1rem;
+  }
+  .trade-year {
+    margin-bottom: 0.625rem;
+    border: 1px solid var(--border, #e5e5e5);
+    border-radius: 0.625rem;
+    background: #fff;
+    overflow: hidden;
+  }
+  .trade-year > summary {
+    cursor: pointer;
+    padding: 0.625rem 0.875rem;
+    display: flex;
+    align-items: baseline;
+    gap: 0.625rem;
+    font-weight: 600;
+    background: var(--surface-2, #f5f5f5);
+    list-style: none;
+  }
+  .trade-year > summary::-webkit-details-marker { display: none; }
+  .trade-year > summary::before {
+    content: '▸';
+    color: var(--text-tertiary, #888);
+    transition: transform 0.15s ease;
+    display: inline-block;
+  }
+  .trade-year[open] > summary::before { transform: rotate(90deg); }
+  .trade-year-label {
+    font-variant-numeric: tabular-nums;
+    font-size: 1rem;
+  }
+  .trade-list {
+    list-style: none;
+    margin: 0;
+    padding: 0.625rem 0.875rem 0.875rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.625rem;
+  }
+  .trade {
+    background: var(--surface-2, #f7f7f7);
+    border-radius: 0.5rem;
+    padding: 0.75rem 0.875rem;
+  }
+  .trade-head {
+    display: flex;
+    align-items: center;
+    gap: 0.625rem;
+    margin-bottom: 0.5rem;
+  }
+  .trade-partner {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    text-decoration: none;
+    color: inherit;
+    font-weight: 600;
+    background: #fff;
+    padding: 0.25rem 0.5rem 0.25rem 0.375rem;
+    border-radius: 999px;
+    border: 1px solid transparent;
+    transition: border-color 0.15s ease;
+  }
+  .trade-partner:hover { border-color: var(--accent); }
+  .partner-icon {
+    width: 22px;
+    height: 22px;
+    object-fit: contain;
+    flex-shrink: 0;
+  }
+  .partner-name {
+    font-size: 0.875rem;
+  }
+  .trade-date {
+    margin-left: auto;
+    font-variant-numeric: tabular-nums;
+  }
+  .commish-tag {
+    font-size: 0.6875rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    background: var(--surface-3, #ebebeb);
+    padding: 0.125rem 0.375rem;
+    border-radius: 0.25rem;
+    color: var(--text-tertiary, #666);
+  }
+  .trade-cols {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.625rem;
+  }
+  .trade-col {
+    background: #fff;
+    border-radius: 0.375rem;
+    padding: 0.5rem 0.625rem;
+  }
+  .t-name {
+    font-size: 0.6875rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--text-tertiary, #888);
+    font-weight: 700;
+    margin-bottom: 0.25rem;
+  }
+  .trade-col ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    font-size: 0.875rem;
+  }
+  .trade-col li { padding: 0.125rem 0; }
+  .trade-col p { margin: 0; }
+  .trade-comments {
+    margin: 0.5rem 0 0;
+    font-style: italic;
+  }
+  @media (max-width: 600px) {
+    .trade-cols { grid-template-columns: 1fr; gap: 0.5rem; }
+    .trade-date { margin-left: 0; flex-basis: 100%; order: 3; }
   }
 </style>

--- a/src/pages/theleague/franchises/[id].astro
+++ b/src/pages/theleague/franchises/[id].astro
@@ -364,6 +364,61 @@ const tradeDateLabel = (t: FranchiseTrade): string => {
     day: 'numeric',
   });
 };
+
+// Draft + auction history (Phase 4). Both are pre-sorted oldest-first by the
+// aggregator; we display newest year first with the most recent year auto-
+// expanded, matching the trade-ledger layout.
+type FranchiseDraftPick = {
+  year: number;
+  round: number;
+  pick: number;
+  playerId: string;
+  viaTrade: boolean;
+  comments: string;
+  timestamp: number;
+};
+type FranchiseAuctionWin = {
+  year: number;
+  playerId: string;
+  winningBid: number;
+  timestamp: number;
+};
+
+const groupByYearDesc = <T extends { year: number }>(items: T[]): { year: number; items: T[] }[] => {
+  const m = new Map<number, T[]>();
+  for (const it of items) {
+    if (!m.has(it.year)) m.set(it.year, []);
+    m.get(it.year)!.push(it);
+  }
+  return Array.from(m.entries())
+    .map(([year, items]) => ({ year, items }))
+    .sort((a, b) => b.year - a.year);
+};
+
+const draftPicks: FranchiseDraftPick[] = (fr.draftPicks as FranchiseDraftPick[]) || [];
+const draftYearGroups = groupByYearDesc(draftPicks).map((g) => ({
+  year: g.year,
+  items: g.items.slice().sort((a, b) => a.round - b.round || a.pick - b.pick),
+}));
+
+const auctionWins: FranchiseAuctionWin[] = (fr.auctionWins as FranchiseAuctionWin[]) || [];
+const auctionYearGroups = groupByYearDesc(auctionWins).map((g) => ({
+  year: g.year,
+  items: g.items.slice().sort((a, b) => b.winningBid - a.winningBid),
+  totalSpend: g.items.reduce((s, a) => s + a.winningBid, 0),
+}));
+
+const formatPlayerLabel = (playerId: string): string => {
+  const meta = playerNames[playerId];
+  if (meta) return `${meta.name}${meta.position ? ` (${meta.position})` : ''}`;
+  return `Player #${playerId}`;
+};
+
+const formatBid = (n: number): string => {
+  if (n >= 1_000_000) return `$${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `$${(n / 1_000).toFixed(0)}K`;
+  return `$${n}`;
+};
 ---
 
 <TheLeagueLayout title={`${fr.currentName} — Franchise History`}>
@@ -598,6 +653,57 @@ const tradeDateLabel = (t: FranchiseTrade): string => {
                 );
               })}
             </ul>
+          </details>
+        ))}
+      </section>
+    )}
+
+    {draftPicks.length > 0 && (
+      <section class="draft-section">
+        <h2>Draft History ({draftPicks.length})</h2>
+        <p class="dim small">
+          Every rookie draft pick made by the current owner — grouped by year, in draft order.
+        </p>
+        {draftYearGroups.map((group) => (
+          <details class="year-group" open={group === draftYearGroups[0]}>
+            <summary>
+              <span class="year-label">{group.year}</span>
+              <span class="dim small">{group.items.length} pick{group.items.length === 1 ? '' : 's'}</span>
+            </summary>
+            <ol class="pick-list">
+              {group.items.map((p) => (
+                <li class="pick-row">
+                  <span class="pick-slot">{p.round}.{String(p.pick).padStart(2, '0')}</span>
+                  <span class="pick-player">{formatPlayerLabel(p.playerId)}</span>
+                  {p.viaTrade && <span class="pick-tag" title="Pick acquired via trade">via trade</span>}
+                </li>
+              ))}
+            </ol>
+          </details>
+        ))}
+      </section>
+    )}
+
+    {auctionWins.length > 0 && (
+      <section class="auction-section">
+        <h2>Auction History ({auctionWins.length})</h2>
+        <p class="dim small">
+          Every auction win by the current owner — grouped by year, biggest bid first.
+        </p>
+        {auctionYearGroups.map((group) => (
+          <details class="year-group" open={group === auctionYearGroups[0]}>
+            <summary>
+              <span class="year-label">{group.year}</span>
+              <span class="dim small">{group.items.length} win{group.items.length === 1 ? '' : 's'} · {formatBid(group.totalSpend)} spent</span>
+            </summary>
+            <ol class="pick-list">
+              {group.items.map((a) => (
+                <li class="pick-row">
+                  <span class="pick-bid">{formatBid(a.winningBid)}</span>
+                  <span class="pick-player">{formatPlayerLabel(a.playerId)}</span>
+                </li>
+              ))}
+            </ol>
           </details>
         ))}
       </section>
@@ -1436,5 +1542,81 @@ const tradeDateLabel = (t: FranchiseTrade): string => {
   @media (max-width: 600px) {
     .trade-cols { grid-template-columns: 1fr; gap: 0.5rem; }
     .trade-date { margin-left: 0; flex-basis: 100%; order: 3; }
+  }
+
+  /* ============================================
+   * DRAFT + AUCTION HISTORY
+   * (reuses .trade-year disclosure styling via .year-group)
+   * ============================================ */
+  .draft-section, .auction-section {
+    margin: 2.5rem 0;
+  }
+  .draft-section > p, .auction-section > p {
+    margin: 0 0 1rem;
+  }
+  .year-group {
+    margin-bottom: 0.625rem;
+    border: 1px solid var(--border, #e5e5e5);
+    border-radius: 0.625rem;
+    background: #fff;
+    overflow: hidden;
+  }
+  .year-group > summary {
+    cursor: pointer;
+    padding: 0.625rem 0.875rem;
+    display: flex;
+    align-items: baseline;
+    gap: 0.625rem;
+    font-weight: 600;
+    background: var(--surface-2, #f5f5f5);
+    list-style: none;
+  }
+  .year-group > summary::-webkit-details-marker { display: none; }
+  .year-group > summary::before {
+    content: '▸';
+    color: var(--text-tertiary, #888);
+    transition: transform 0.15s ease;
+    display: inline-block;
+  }
+  .year-group[open] > summary::before { transform: rotate(90deg); }
+  .year-label {
+    font-variant-numeric: tabular-nums;
+    font-size: 1rem;
+  }
+  .pick-list {
+    list-style: none;
+    margin: 0;
+    padding: 0.375rem 0.875rem 0.625rem;
+  }
+  .pick-row {
+    display: flex;
+    align-items: baseline;
+    gap: 0.625rem;
+    padding: 0.375rem 0;
+    border-bottom: 1px solid var(--border, #f0f0f0);
+    font-size: 0.875rem;
+  }
+  .pick-row:last-child { border-bottom: none; }
+  .pick-slot, .pick-bid {
+    font-variant-numeric: tabular-nums;
+    font-weight: 700;
+    flex-shrink: 0;
+    min-width: 3.5rem;
+    color: var(--accent);
+  }
+  .pick-bid { color: #1f5d2d; }
+  .pick-player {
+    flex: 1;
+    min-width: 0;
+  }
+  .pick-tag {
+    font-size: 0.6875rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    background: var(--surface-3, #ebebeb);
+    padding: 0.125rem 0.375rem;
+    border-radius: 0.25rem;
+    color: var(--text-tertiary, #666);
+    font-weight: 600;
   }
 </style>

--- a/src/pages/theleague/rivalries/[pair].astro
+++ b/src/pages/theleague/rivalries/[pair].astro
@@ -4,6 +4,7 @@ import Breadcrumbs from '../../../components/theleague/Breadcrumbs.astro';
 import { resolveLeaguePath } from '../../../utils/nav-utils';
 import franchiseHistory from '../../../../data/theleague/derived/franchise-history.json';
 import leagueConfig from '../../../data/theleague.config.json';
+import { formatTradeAsset } from '../../../utils/franchise-trade-asset';
 
 export const prerender = false;
 
@@ -127,32 +128,11 @@ const tradesBetween: Trade[] = ((frA.trades as Trade[]) || [])
   .filter((t) => t.partnerId === bigger && t.bothAttributed)
   .sort((x, y) => x.timestamp - y.timestamp);
 
-// Asset code → human label. Picks come in two flavors:
-// - DP_<round>_<pick>      = current draft pick (round 0-indexed)
-// - FP_<franchiseId>_<year>_<round> = future pick from another franchise's draft
-function franchiseShortName(id: string): string {
-  const t = teamLookup[id];
-  return t?.nameShort ?? t?.nameMedium ?? t?.name ?? id;
+function franchiseShortName(fid: string): string {
+  const t = teamLookup[fid];
+  return t?.nameShort ?? t?.nameMedium ?? t?.name ?? fid;
 }
-
-function formatAsset(code: string): string {
-  if (/^FP_(\d{4})_(\d{4})_(\d+)$/.test(code)) {
-    const [, fid, yr, rnd] = code.match(/^FP_(\d{4})_(\d{4})_(\d+)$/)!;
-    return `${yr} R${rnd} pick (via ${franchiseShortName(fid)})`;
-  }
-  if (/^DP_(\d+)_(\d+)$/.test(code)) {
-    const [, rnd, pick] = code.match(/^DP_(\d+)_(\d+)$/)!;
-    return `Draft pick R${Number(rnd) + 1}.${Number(pick) + 1}`;
-  }
-  if (code === 'CASH') return 'Salary cap cash';
-  if (code.startsWith('BBID')) return `BBID balance`;
-  if (/^\d+$/.test(code)) {
-    const meta = playerNames[code];
-    if (meta) return `${meta.name}${meta.position ? ` (${meta.position})` : ''}`;
-    return `Player #${code}`;
-  }
-  return code;
-}
+const formatAsset = (code: string) => formatTradeAsset(code, playerNames, franchiseShortName);
 
 function tradeDateLabel(t: Trade): string {
   if (!t.timestamp) return String(t.year);

--- a/src/utils/franchise-trade-asset.ts
+++ b/src/utils/franchise-trade-asset.ts
@@ -1,0 +1,41 @@
+/**
+ * Format an MFL asset code (player ID, DP_*, FP_*, CASH, BBID*) into a
+ * human-readable label for franchise-history trade ledgers.
+ *
+ * Used by the rivalries page and the franchise detail page. The shapes here
+ * are intentionally narrower than the trade-builder's parsing utilities:
+ * the franchise-history pages only need a one-shot text label, no asset
+ * type discrimination or reverse lookup.
+ */
+
+export type PlayerNameLookup = Record<
+  string,
+  { name: string; position?: string; team?: string }
+>;
+
+export type FranchiseShortNameLookup = (franchiseId: string) => string;
+
+export function formatTradeAsset(
+  code: string,
+  playerNames: PlayerNameLookup,
+  franchiseShortName: FranchiseShortNameLookup
+): string {
+  const fp = code.match(/^FP_(\d{4})_(\d{4})_(\d+)$/);
+  if (fp) {
+    const [, fid, yr, rnd] = fp;
+    return `${yr} R${rnd} pick (via ${franchiseShortName(fid)})`;
+  }
+  const dp = code.match(/^DP_(\d+)_(\d+)$/);
+  if (dp) {
+    const [, rnd, pick] = dp;
+    return `Draft pick R${Number(rnd) + 1}.${Number(pick) + 1}`;
+  }
+  if (code === 'CASH') return 'Salary cap cash';
+  if (code.startsWith('BBID')) return 'BBID balance';
+  if (/^\d+$/.test(code)) {
+    const meta = playerNames[code];
+    if (meta) return `${meta.name}${meta.position ? ` (${meta.position})` : ''}`;
+    return `Player #${code}`;
+  }
+  return code;
+}


### PR DESCRIPTION
Adds a Trade Ledger section to /theleague/franchises/[id] that lists every
trade involving the current owner, grouped by year (most recent expanded,
older years collapsed via <details>). Each card links the trade partner to
the rivalry page and renders sent/received assets via the same formatter the
rivalry page uses.

Trade data was already aggregated in Phase 2 (franchises[id].trades[]); this
PR is UI-only. The asset formatter is extracted from the rivalries page into
src/utils/franchise-trade-asset.ts so both pages share one implementation.