### PR TITLE
chore: drop unused commish pill from trade ledger

### DIFF
--- a/data/theleague/derived/franchise-history.json
+++ b/data/theleague/derived/franchise-history.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-08T03:19:33.305Z",
+  "generatedAt": "2026-05-08T04:50:18.242Z",
   "yearsCovered": [
     2007,
     2008,
@@ -5407,7 +5407,6 @@
           "received": [
             "6887"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0013",
@@ -5424,7 +5423,6 @@
           "received": [
             "8293"
           ],
-          "byCommish": false,
           "comments": "Changed my mind on this, will do either of the offers I've sent out...",
           "sourceFranchiseId": null,
           "partnerSourceId": "0014",
@@ -5441,7 +5439,6 @@
             "8775",
             "DP_0_14"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0014",
@@ -5458,7 +5455,6 @@
           "received": [
             "8293"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0014",
@@ -5474,7 +5470,6 @@
           "received": [
             "4092"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0011",
@@ -5490,7 +5485,6 @@
           "received": [
             "9247"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0003",
@@ -5508,7 +5502,6 @@
             "5027",
             "6599"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0007",
@@ -5524,7 +5517,6 @@
           "received": [
             "9081"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -5545,7 +5537,6 @@
             "8247",
             "0518"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0013",
@@ -5562,7 +5553,6 @@
           "received": [
             "7814"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0011",
@@ -5578,7 +5568,6 @@
           "received": [
             "6952"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -5596,7 +5585,6 @@
             "4974",
             "FP_0005_2012_3"
           ],
-          "byCommish": true,
           "comments": "Need to include Clark in order to make the salary cap work.",
           "sourceFranchiseId": null,
           "partnerSourceId": "0005",
@@ -5614,7 +5602,6 @@
           "received": [
             "9078"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -5631,7 +5618,6 @@
             "DP_0_5",
             "DP_1_5"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0016",
@@ -5652,7 +5638,6 @@
             "FP_0009_2013_1",
             "FP_0009_2013_2"
           ],
-          "byCommish": true,
           "comments": "I want to hold on to my 2013 picks so I am re-countering with the trade parameters we discussed in e-mail :-)",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -5672,7 +5657,6 @@
             "9604",
             "8510"
           ],
-          "byCommish": true,
           "comments": "Here is what I would rather do.  BTW - not interested in Cecil Short",
           "sourceFranchiseId": null,
           "partnerSourceId": "0003",
@@ -5688,7 +5672,6 @@
           "received": [
             "0512"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -5707,7 +5690,6 @@
           "received": [
             "8493"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0003",
@@ -5724,7 +5706,6 @@
           "received": [
             "8685"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0005",
@@ -5741,7 +5722,6 @@
             "10262",
             "DP_2_10"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0011",
@@ -5757,7 +5737,6 @@
           "received": [
             "10527"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0011",
@@ -5776,7 +5755,6 @@
             "9632",
             "DP_2_9"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -5792,7 +5770,6 @@
           "received": [
             "8160"
           ],
-          "byCommish": true,
           "comments": "We both have K's on same bye weeks.  Swap our #2 K's?",
           "sourceFranchiseId": null,
           "partnerSourceId": "0016",
@@ -5813,7 +5790,6 @@
             "FP_0004_2014_3",
             "FP_0003_2014_3"
           ],
-          "byCommish": true,
           "comments": "I do not any salary cap room to speak of so I cannot take on more cap than what I give up.  How about this as all have only 1 year contracts?",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -5829,7 +5805,6 @@
           "received": [
             "DP_2_12"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0006",
@@ -5845,7 +5820,6 @@
           "received": [
             "FP_0003_2015_1"
           ],
-          "byCommish": true,
           "comments": "Want to trade first round picks so that you have a Draft pick this year? :-)",
           "sourceFranchiseId": null,
           "partnerSourceId": "0003",
@@ -5862,7 +5836,6 @@
           "received": [
             "8917"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0014",
@@ -5880,7 +5853,6 @@
             "FP_0008_2018_1",
             "FP_0008_2018_3"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -5907,7 +5879,6 @@
             "FP_0003_2018_1",
             "FP_0014_2018_1"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -5923,7 +5894,6 @@
           "received": [
             "11960"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -5941,7 +5911,6 @@
             "FP_0007_2018_1",
             "FP_0007_2018_2"
           ],
-          "byCommish": true,
           "comments": "Dan - looks like no \"conditions\" - let me know if this works",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -5957,7 +5926,6 @@
           "received": [
             "13167"
           ],
-          "byCommish": true,
           "comments": "Oh i know i will regret this at some point.. Taylor will become the next Julio Jones.... but need to get strong for this final push",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -5973,7 +5941,6 @@
           "received": [
             "11516"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -5991,7 +5958,6 @@
             "DP_1_2",
             "DP_1_3"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -6007,7 +5973,6 @@
           "received": [
             "FP_0008_2022_2"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -6024,7 +5989,6 @@
             "14861",
             "FP_0009_2022_1"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -6041,7 +6005,6 @@
           "received": [
             "14208"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -6057,7 +6020,6 @@
           "received": [
             "13116"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -6075,7 +6037,6 @@
             "13164",
             "FP_0008_2023_2"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -6092,7 +6053,6 @@
             "DP_0_11",
             "FP_0012_2023_2"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -6109,7 +6069,6 @@
           "received": [
             "14105"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -6126,7 +6085,6 @@
           "received": [
             "0518"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -6142,7 +6100,6 @@
           "received": [
             "FP_0013_2024_2"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -6163,7 +6120,6 @@
             "FP_0014_2024_1",
             "FP_0014_2024_3"
           ],
-          "byCommish": true,
           "comments": "I get where you are coming from in your counter proposal.  If I move Mahomes now I am basically playing for next season and so I am in the mindset of acquiring draft capital.  If I am going to lose a 2nd, I would like to get the 3rd then as well. Also, I would also be interested in the trade without giving up my 2nd and not acquiring your 3rd.  Let me know.",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -6181,7 +6137,6 @@
             "12611",
             "FP_0008_2024_2"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -6197,7 +6152,6 @@
           "received": [
             "15329"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -6214,7 +6168,6 @@
             "DP_1_2",
             "FP_0008_2026_1"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -6231,7 +6184,6 @@
           "received": [
             "16186"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -6249,7 +6201,6 @@
           "received": [
             "13130"
           ],
-          "byCommish": true,
           "comments": "Per your message I threw in a draft pick for the trade.",
           "sourceFranchiseId": null,
           "partnerSourceId": "0004",
@@ -6267,7 +6218,6 @@
           "received": [
             "15282"
           ],
-          "byCommish": true,
           "comments": "Players included to make the salary cap work.",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -13060,7 +13010,6 @@
             "8266",
             "8302"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0011",
@@ -13077,7 +13026,6 @@
             "4946",
             "4928"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0016",
@@ -13093,7 +13041,6 @@
           "received": [
             "DP_1_11"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0011",
@@ -13110,7 +13057,6 @@
           "received": [
             "DP_1_8"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0003",
@@ -13126,7 +13072,6 @@
           "received": [
             "8774"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0011",
@@ -13142,7 +13087,6 @@
           "received": [
             "FP_0012_2009_2"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0012",
@@ -13160,7 +13104,6 @@
             "FP_0009_2009_2",
             "FP_0012_2009_3"
           ],
-          "byCommish": true,
           "comments": "The 2nd round pick from Rolling Rockers will most likely be the 1st pick in the 2nd round.",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -13179,7 +13122,6 @@
           "received": [
             "DP_1_14"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0013",
@@ -13210,7 +13152,6 @@
             "FP_0011_2010_2",
             "FP_0012_2010_2"
           ],
-          "byCommish": true,
           "comments": "This is very similar to a proposal you made to me earlier and may help with your cap issues.  Just another option.",
           "sourceFranchiseId": null,
           "partnerSourceId": "0011",
@@ -13226,7 +13167,6 @@
           "received": [
             "3494"
           ],
-          "byCommish": true,
           "comments": "my kickers have same bye week.",
           "sourceFranchiseId": null,
           "partnerSourceId": "0013",
@@ -13242,7 +13182,6 @@
           "received": [
             "FP_0015_2010_3"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -13265,7 +13204,6 @@
             "DP_2_0",
             "DP_2_6"
           ],
-          "byCommish": true,
           "comments": "How about this....",
           "sourceFranchiseId": null,
           "partnerSourceId": "0010",
@@ -13282,7 +13220,6 @@
           "received": [
             "DP_1_4"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0010",
@@ -13304,7 +13241,6 @@
             "7842",
             "FP_0010_2012_3"
           ],
-          "byCommish": true,
           "comments": "I believe this would fit under the salary cap.",
           "sourceFranchiseId": null,
           "partnerSourceId": "0010",
@@ -13320,7 +13256,6 @@
           "received": [
             "FP_0008_2012_3"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -13338,7 +13273,6 @@
           "received": [
             "8667"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -13355,7 +13289,6 @@
             "DP_1_0",
             "DP_1_1"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -13371,7 +13304,6 @@
           "received": [
             "9907"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0003",
@@ -13389,7 +13321,6 @@
           "received": [
             "8917"
           ],
-          "byCommish": true,
           "comments": "Same with a 3rd rounder.",
           "sourceFranchiseId": null,
           "partnerSourceId": "0011",
@@ -13409,7 +13340,6 @@
             "5848",
             "9144"
           ],
-          "byCommish": true,
           "comments": "Lets do it. This is your same offer, excluding Carpenter. I have to keep my kicker, because I will have little flexibility to grab one after taking on those salaries of other guys.",
           "sourceFranchiseId": null,
           "partnerSourceId": "0004",
@@ -13425,7 +13355,6 @@
           "received": [
             "0504"
           ],
-          "byCommish": true,
           "comments": "We both have BYE week issues with our DST's.  Did you wanna do a swap of BUF and NE?",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -13442,7 +13371,6 @@
             "7391",
             "10372"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0002",
@@ -13461,7 +13389,6 @@
             "9843",
             "9044"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -13477,7 +13404,6 @@
           "received": [
             "9881"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0005",
@@ -13496,7 +13422,6 @@
             "12150",
             "7873"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -13514,7 +13439,6 @@
             "12188",
             "12205"
           ],
-          "byCommish": true,
           "comments": "here we go!",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -13528,7 +13452,6 @@
           "received": [
             "0511"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0006",
@@ -13545,7 +13468,6 @@
           "received": [
             "11668"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -13562,7 +13484,6 @@
             "DP_2_15",
             "FP_0006_2018_3"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0006",
@@ -13583,7 +13504,6 @@
             "8360",
             "FP_0014_2018_2"
           ],
-          "byCommish": true,
           "comments": "I can send Morris your was to serve as Elliot's handcuff as well include Brissett so you have a backup QB. That should free up some cap space for you as well to pick up any players the rest of the way.",
           "sourceFranchiseId": null,
           "partnerSourceId": "0014",
@@ -13605,7 +13525,6 @@
             "DP_1_7",
             "DP_1_17"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -13622,7 +13541,6 @@
           "received": [
             "FP_0006_2019_3"
           ],
-          "byCommish": true,
           "comments": "I'll take that cap hit for ya ;) ",
           "sourceFranchiseId": null,
           "partnerSourceId": "0006",
@@ -13642,7 +13560,6 @@
             "DP_1_4",
             "DP_1_11"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -13659,7 +13576,6 @@
           "received": [
             "FP_0011_2021_2"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -13675,7 +13591,6 @@
           "received": [
             "FP_0005_2021_2"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -13691,7 +13606,6 @@
           "received": [
             "DP_1_2"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -13707,7 +13621,6 @@
           "received": [
             "FP_0012_2022_2"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -13724,7 +13637,6 @@
           "received": [
             "13593"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -13743,7 +13655,6 @@
             "13424",
             "DP_2_4"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -13760,7 +13671,6 @@
             "14842",
             "11647"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -13782,7 +13692,6 @@
             "DP_0_11",
             "DP_2_0"
           ],
-          "byCommish": true,
           "comments": "This would give you a starting kicker, cheaper draft picks, injury protection at QB and 4 more players.  You would need 4 more players after this trade.",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -13802,7 +13711,6 @@
             "DP_0_16",
             "DP_1_10"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -13820,7 +13728,6 @@
           "received": [
             "7836"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -21023,7 +20930,6 @@
             "7510",
             "FP_0002_2008_1"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0002",
@@ -21039,7 +20945,6 @@
           "received": [
             "6573"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0013",
@@ -21055,7 +20960,6 @@
           "received": [
             "5724"
           ],
-          "byCommish": false,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0012",
@@ -21071,7 +20975,6 @@
           "received": [
             "4883"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0009",
@@ -21087,7 +20990,6 @@
           "received": [
             "FP_0016_2009_3"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0016",
@@ -21107,7 +21009,6 @@
             "7480",
             "FP_0009_2009_2"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0009",
@@ -21123,7 +21024,6 @@
           "received": [
             "FP_0012_2009_3"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0012",
@@ -21141,7 +21041,6 @@
           "received": [
             "5656"
           ],
-          "byCommish": true,
           "comments": "The 2nd round pick from Rolling Rockers will most likely be the 1st pick in the 2nd round.",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -21161,7 +21060,6 @@
             "4974",
             "FP_0013_2010_2"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0013",
@@ -21181,7 +21079,6 @@
             "9050",
             "DP_0_5"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0016",
@@ -21197,7 +21094,6 @@
           "received": [
             "DP_2_7"
           ],
-          "byCommish": false,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0013",
@@ -21213,7 +21109,6 @@
           "received": [
             "6475"
           ],
-          "byCommish": true,
           "comments": "Not sure if you'd be interested, but your kickers have the same bye week.",
           "sourceFranchiseId": null,
           "partnerSourceId": "0002",
@@ -21233,7 +21128,6 @@
             "DP_0_16",
             "DP_2_2"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0004",
@@ -21253,7 +21147,6 @@
             "9127",
             "0506"
           ],
-          "byCommish": true,
           "comments": "This trade would give you a 3rd round pick, vastly improve your defense, and would also allow you to not take a hit on your future salary cap on cut down day.",
           "sourceFranchiseId": null,
           "partnerSourceId": "0011",
@@ -21270,7 +21163,6 @@
           "received": [
             "0501"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0003",
@@ -21288,7 +21180,6 @@
           "received": [
             "7918"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0011",
@@ -21306,7 +21197,6 @@
             "6997",
             "FP_0007_2012_1"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -21324,7 +21214,6 @@
             "DP_0_11",
             "FP_0005_2012_2"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0005",
@@ -21340,7 +21229,6 @@
           "received": [
             "DP_2_12"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -21356,7 +21244,6 @@
           "received": [
             "0527"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -21372,7 +21259,6 @@
           "received": [
             "9604"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0006",
@@ -21388,7 +21274,6 @@
           "received": [
             "0512"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0009",
@@ -21405,7 +21290,6 @@
           "received": [
             "FP_0002_2012_2"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0002",
@@ -21422,7 +21306,6 @@
           "received": [
             "6952"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0005",
@@ -21440,7 +21323,6 @@
             "10333",
             "FP_0005_2012_3"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -21457,7 +21339,6 @@
           "received": [
             "9452"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0011",
@@ -21475,7 +21356,6 @@
             "FP_0016_2013_1",
             "FP_0016_2013_2"
           ],
-          "byCommish": false,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0016",
@@ -21492,7 +21372,6 @@
             "8774",
             "DP_1_10"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0006",
@@ -21511,7 +21390,6 @@
             "DP_1_2",
             "DP_1_17"
           ],
-          "byCommish": true,
           "comments": "I could do this one.",
           "sourceFranchiseId": null,
           "partnerSourceId": "0010",
@@ -21529,7 +21407,6 @@
             "7391",
             "9987"
           ],
-          "byCommish": false,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0003",
@@ -21550,7 +21427,6 @@
             "FP_0004_2013_3",
             "FP_0009_2013_3"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0003",
@@ -21567,7 +21443,6 @@
           "received": [
             "DP_0_12"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0004",
@@ -21583,7 +21458,6 @@
           "received": [
             "0528"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -21602,7 +21476,6 @@
             "9250",
             "FP_0014_2013_2"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0011",
@@ -21618,7 +21491,6 @@
           "received": [
             "9118"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0016",
@@ -21634,7 +21506,6 @@
           "received": [
             "10297"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0011",
@@ -21652,7 +21523,6 @@
             "9834",
             "FP_0012_2013_1"
           ],
-          "byCommish": true,
           "comments": "I'll have to drop Blount if you plan to accept, so let me know beforehand please.",
           "sourceFranchiseId": null,
           "partnerSourceId": "0014",
@@ -21668,7 +21538,6 @@
           "received": [
             "9080"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0011",
@@ -21685,7 +21554,6 @@
             "DP_1_0",
             "FP_0004_2014_3"
           ],
-          "byCommish": true,
           "comments": "I threw in next years 3rd. I want to keep my 2.17... besides there is only 2 spots between 2.17 and your 3rd rounder.... Not much of a difference and you pick up a 3rd next year.",
           "sourceFranchiseId": null,
           "partnerSourceId": "0004",
@@ -21701,7 +21569,6 @@
           "received": [
             "FP_0003_2014_3"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0003",
@@ -21721,7 +21588,6 @@
             "8010",
             "0509"
           ],
-          "byCommish": true,
           "comments": "This is the only trade I could give you for Welker that would make the cap space work out and still include DeAndre Hopkins. If you're interested, we would need to break this trade into smaller chunks so you can drop my scraps without hitting your roster limit (plus I'll have to move some of my guys off the practice squad so I don't go under the minimum). If this works for you, let me know and we'll coordinate with Brandon.",
           "sourceFranchiseId": null,
           "partnerSourceId": "0010",
@@ -21739,7 +21605,6 @@
             "10410",
             "11219"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0003",
@@ -21760,7 +21625,6 @@
             "1600",
             "FP_0015_2014_1"
           ],
-          "byCommish": true,
           "comments": "I do not any salary cap room to speak of so I cannot take on more cap than what I give up.  How about this as all have only 1 year contracts?",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -21779,7 +21643,6 @@
             "9823",
             "9884"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0014",
@@ -21798,7 +21661,6 @@
           "received": [
             "10308"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -21814,7 +21676,6 @@
           "received": [
             "10271"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -21830,7 +21691,6 @@
           "received": [
             "DP_2_11"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0014",
@@ -21846,7 +21706,6 @@
           "received": [
             "11152"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -21864,7 +21723,6 @@
             "9843",
             "0531"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0011",
@@ -21880,7 +21738,6 @@
           "received": [
             "8416"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0004",
@@ -21898,7 +21755,6 @@
             "DP_1_10",
             "FP_0015_2018_2"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -21915,7 +21771,6 @@
             "11222",
             "FP_0003_2018_2"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -21931,7 +21786,6 @@
           "received": [
             "FP_0007_2018_3"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -21951,7 +21805,6 @@
             "DP_2_2",
             "DP_2_4"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -21967,7 +21820,6 @@
           "received": [
             "FP_0006_2019_2"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0006",
@@ -21981,7 +21833,6 @@
           "received": [
             "11244"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -21998,7 +21849,6 @@
           "received": [
             "DP_1_14"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -22015,7 +21865,6 @@
           "received": [
             "DP_1_5"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -22033,7 +21882,6 @@
             "DP_0_13",
             "DP_1_15"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -22049,7 +21897,6 @@
           "received": [
             "13719"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0004",
@@ -22065,7 +21912,6 @@
           "received": [
             "10870"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -22081,7 +21927,6 @@
           "received": [
             "DP_1_5"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -22099,7 +21944,6 @@
             "13158",
             "12317"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -22115,7 +21959,6 @@
           "received": [
             "11193"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -22134,7 +21977,6 @@
             "FP_0004_2020_2",
             "FP_0011_2021_2"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -22150,7 +21992,6 @@
           "received": [
             "FP_0008_2020_3"
           ],
-          "byCommish": true,
           "comments": "This would help you with your cap space next season. ",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -22166,7 +22007,6 @@
           "received": [
             "12263"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -22183,7 +22023,6 @@
             "DP_2_11",
             "FP_0001_2021_3"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -22199,7 +22038,6 @@
           "received": [
             "DP_2_13"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -22215,7 +22053,6 @@
           "received": [
             "DP_2_2"
           ],
-          "byCommish": true,
           "comments": "I'm sure your Rd 3 next year will be at the end of the Rd, so let's bump my spot back one.  It's my way of playing hardball!  LOL",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -22231,7 +22068,6 @@
           "received": [
             "DP_1_3"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -22247,7 +22083,6 @@
           "received": [
             "DP_1_11"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -22265,7 +22100,6 @@
             "13404",
             "DP_1_7"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -22283,7 +22117,6 @@
             "DP_1_1",
             "DP_1_4"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0004",
@@ -22299,7 +22132,6 @@
           "received": [
             "DP_2_1"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0004",
@@ -22315,7 +22147,6 @@
           "received": [
             "0507"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -22331,7 +22162,6 @@
           "received": [
             "13622"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -22349,7 +22179,6 @@
             "15777",
             "11387"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -22366,7 +22195,6 @@
             "15757",
             "FP_0001_2023_1"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -22383,7 +22211,6 @@
             "13113",
             "13156"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -22400,7 +22227,6 @@
             "14208",
             "FP_0015_2023_1"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -22417,7 +22243,6 @@
             "13115",
             "FP_0005_2023_3"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -22436,7 +22261,6 @@
             "13629",
             "FP_0010_2023_3"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -22452,7 +22276,6 @@
           "received": [
             "13680"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0004",
@@ -22474,7 +22297,6 @@
             "FP_0011_2023_1",
             "FP_0011_2023_3"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -22490,7 +22312,6 @@
           "received": [
             "13772"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -22507,7 +22328,6 @@
             "DP_2_6",
             "DP_2_8"
           ],
-          "byCommish": true,
           "comments": "Jacob's handcuff",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -22525,7 +22345,6 @@
             "DP_2_3",
             "FP_0004_2024_3"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0004",
@@ -22542,7 +22361,6 @@
           "received": [
             "16187"
           ],
-          "byCommish": true,
           "comments": "I'm an idiot. I was thinking Brandon already processed.",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -22557,7 +22375,6 @@
             "FP_0008_2024_3"
           ],
           "received": [],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -22575,7 +22392,6 @@
             "14858",
             "15797"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -22594,7 +22410,6 @@
             "16188",
             "FP_0006_2025_2"
           ],
-          "byCommish": true,
           "comments": "This trade would get you a 1st this year, a Defense, my 1st for your 2nd next year, and alo some much needed cap space.",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -22612,7 +22427,6 @@
             "DP_0_7",
             "DP_1_7"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -22630,7 +22444,6 @@
             "DP_1_11",
             "DP_1_16"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -22644,7 +22457,6 @@
             "13354"
           ],
           "received": [],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0004",
@@ -22662,7 +22474,6 @@
           "received": [
             "16149"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -22679,7 +22490,6 @@
             "16582",
             "FP_0003_2025_2"
           ],
-          "byCommish": true,
           "comments": "Split the difference ",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -22695,7 +22505,6 @@
           "received": [
             "FP_0004_2025_2"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0004",
@@ -22711,7 +22520,6 @@
           "received": [
             "13189"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -22728,7 +22536,6 @@
           "received": [
             "DP_0_9"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -22746,7 +22553,6 @@
             "DP_2_7",
             "FP_0006_2026_2"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -22762,7 +22568,6 @@
           "received": [
             "15749"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -28068,7 +27873,6 @@
             "DP_0_12",
             "DP_1_4"
           ],
-          "byCommish": true,
           "comments": "How about this....",
           "sourceFranchiseId": "0010",
           "partnerSourceId": null,
@@ -28085,7 +27889,6 @@
             "DP_1_17",
             "DP_2_0"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": "0010",
           "partnerSourceId": null,
@@ -28107,7 +27910,6 @@
             "9854",
             "FP_0001_2012_1"
           ],
-          "byCommish": true,
           "comments": "I believe this would fit under the salary cap.",
           "sourceFranchiseId": "0010",
           "partnerSourceId": null,
@@ -28126,7 +27928,6 @@
             "FP_0008_2013_2",
             "FP_0016_2013_2"
           ],
-          "byCommish": true,
           "comments": "I could do this one.",
           "sourceFranchiseId": "0010",
           "partnerSourceId": null,
@@ -28143,7 +27944,6 @@
             "9315",
             "8838"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": "0010",
           "partnerSourceId": null,
@@ -28159,7 +27959,6 @@
           "received": [
             "FP_0014_2013_3"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": "0010",
           "partnerSourceId": "0014",
@@ -28176,7 +27975,6 @@
           "received": [
             "FP_0012_2014_1"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": "0010",
           "partnerSourceId": null,
@@ -28195,7 +27993,6 @@
             "0509",
             "FP_0014_2014_3"
           ],
-          "byCommish": true,
           "comments": "Not as big on the Jets defense, especially against Cincy. If we could get Prater added in I'd send the pick. Noticed you have 2 years on him, so I understand if you'd rather keep him.",
           "sourceFranchiseId": "0010",
           "partnerSourceId": "0014",
@@ -28215,7 +28012,6 @@
           "received": [
             "7653"
           ],
-          "byCommish": true,
           "comments": "This is the only trade I could give you for Welker that would make the cap space work out and still include DeAndre Hopkins. If you're interested, we would need to break this trade into smaller chunks so you can drop my scraps without hitting your roster limit (plus I'll have to move some of my guys off the practice squad so I don't go under the minimum). If this works for you, let me know and we'll coordinate with Brandon.",
           "sourceFranchiseId": "0010",
           "partnerSourceId": null,
@@ -28231,7 +28027,6 @@
           "received": [
             "DP_1_4"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": "0010",
           "partnerSourceId": null,
@@ -28247,7 +28042,6 @@
           "received": [
             "10409"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": "0010",
           "partnerSourceId": null,
@@ -28264,7 +28058,6 @@
             "FP_0014_2015_1",
             "FP_0014_2015_2"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": "0010",
           "partnerSourceId": "0014",
@@ -28281,7 +28074,6 @@
             "9064",
             "8268"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": "0010",
           "partnerSourceId": "0011",
@@ -28295,7 +28087,6 @@
             "13130"
           ],
           "received": [],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0004",
@@ -28309,7 +28100,6 @@
           "received": [
             "12626"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0004",
@@ -28323,7 +28113,6 @@
             "13163"
           ],
           "received": [],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -28337,7 +28126,6 @@
             "13364"
           ],
           "received": [],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0004",
@@ -28351,7 +28139,6 @@
           "received": [
             "13277"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -28365,7 +28152,6 @@
             "13630"
           ],
           "received": [],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -28379,7 +28165,6 @@
           "received": [
             "12676"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -28393,7 +28178,6 @@
           "received": [
             "FP_0014_2020_1"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -28407,7 +28191,6 @@
             "13234"
           ],
           "received": [],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -28421,7 +28204,6 @@
           "received": [
             "FP_0004_2020_1"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0004",
@@ -28439,7 +28221,6 @@
             "12150",
             "11679"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -28453,7 +28234,6 @@
           "received": [
             "13763"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0004",
@@ -28467,7 +28247,6 @@
             "13236"
           ],
           "received": [],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0004",
@@ -28481,7 +28260,6 @@
           "received": [
             "FP_0004_2020_2"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0004",
@@ -28495,7 +28273,6 @@
             "FP_0011_2020_1"
           ],
           "received": [],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -28509,7 +28286,6 @@
             "FP_0011_2020_2"
           ],
           "received": [],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0004",
@@ -28523,7 +28299,6 @@
             "14086"
           ],
           "received": [],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -28537,7 +28312,6 @@
           "received": [
             "12647"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0004",
@@ -28551,7 +28325,6 @@
             "8153"
           ],
           "received": [],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0004",
@@ -28565,7 +28338,6 @@
           "received": [
             "12634"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0004",
@@ -28579,7 +28351,6 @@
             "0525"
           ],
           "received": [],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -28593,7 +28364,6 @@
           "received": [
             "FP_0004_2020_3"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0004",
@@ -28612,7 +28382,6 @@
             "FP_0008_2021_1",
             "FP_0008_2021_2"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -28627,7 +28396,6 @@
             "12110"
           ],
           "received": [],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0004",
@@ -28641,7 +28409,6 @@
             "10729"
           ],
           "received": [],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -28655,7 +28422,6 @@
           "received": [
             "12637"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0004",
@@ -28669,7 +28435,6 @@
           "received": [
             "12188"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -28683,7 +28448,6 @@
           "received": [
             "0520"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -28697,7 +28461,6 @@
             "14139"
           ],
           "received": [],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -28711,7 +28474,6 @@
           "received": [
             "14076"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0004",
@@ -28725,7 +28487,6 @@
           "received": [
             "13637"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0004",
@@ -28740,7 +28501,6 @@
             "12212"
           ],
           "received": [],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -28754,7 +28514,6 @@
             "13190"
           ],
           "received": [],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0004",
@@ -28770,7 +28529,6 @@
           "received": [
             "FP_0008_2021_3"
           ],
-          "byCommish": true,
           "comments": "This would help you with your cap space next season. ",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -28788,7 +28546,6 @@
             "14129",
             "14145"
           ],
-          "byCommish": true,
           "comments": "Very fair and I completely understand, but I think Funchess has a small chance for a break out season. I'd do this (take out Funchess due to his high ceiling on GB) and replace with Mitchell.  You get your $900K cap relief immediately which will help with your rookies to be drafted and free agent pickups. having Dissly and Olsen on the same team is useless to us unless one gets hurt. ",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -28808,7 +28565,6 @@
           "received": [
             "12391"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -28823,7 +28579,6 @@
             "0506"
           ],
           "received": [],
-          "byCommish": true,
           "comments": "I'll take 1 of those guys",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -28841,7 +28596,6 @@
             "13418",
             "15882"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -28863,7 +28617,6 @@
             "FP_0008_2023_1",
             "FP_0010_2023_3"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -28881,7 +28634,6 @@
           "received": [
             "14102"
           ],
-          "byCommish": true,
           "comments": "I'd be willing to make that trade straight up with no draft picks, but otherwise I'd rather stand pat with Dotson on a 4-year than DK on a 1-year.",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -28899,7 +28651,6 @@
             "0503",
             "FP_0012_2025_2"
           ],
-          "byCommish": true,
           "comments": "I think this would work. It gives me the 2nd rounder I'm looking for. I end up shouldering a couple of your overvalued contracts and will have to take the cap hit when I cut Dissly, but it's less than cutting Diggs.",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -28917,7 +28668,6 @@
           "received": [
             "14102"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -28935,7 +28685,6 @@
             "0503",
             "FP_0012_2025_2"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -28953,7 +28702,6 @@
             "13176",
             "FP_0001_2025_3"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -28969,7 +28717,6 @@
           "received": [
             "FP_0004_2026_2"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0004",
@@ -28986,7 +28733,6 @@
             "DP_1_13",
             "FP_0005_2026_2"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -29004,7 +28750,6 @@
             "14122",
             "FP_0015_2026_2"
           ],
-          "byCommish": true,
           "comments": "Players included to make the salary cap work.",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -29023,7 +28768,6 @@
             "0524",
             "FP_0009_2026_3"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -29039,7 +28783,6 @@
           "received": [
             "FP_0010_2026_3"
           ],
-          "byCommish": true,
           "comments": "Offering in case you'd like to shore up your TE roster ahead of the playoffs.",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -29055,7 +28798,6 @@
           "received": [
             "FP_0005_2026_3"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -34839,7 +34581,6 @@
             "9448",
             "FP_0008_2012_2"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -34855,7 +34596,6 @@
           "received": [
             "0515"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -34871,7 +34611,6 @@
           "received": [
             "8360"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0002",
@@ -34887,7 +34626,6 @@
           "received": [
             "DP_1_13"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0002",
@@ -34910,7 +34648,6 @@
             "9843",
             "FP_0003_2013_1"
           ],
-          "byCommish": true,
           "comments": "Tossed a coin on Rice versus Moss...   i had Rice a few years back (when he was healthy and with Favre in Minnesota - so hoping he can stay uninjured for one year ",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -34926,7 +34663,6 @@
           "received": [
             "6951"
           ],
-          "byCommish": true,
           "comments": "As a DolFan - I try to avoid Jets players like the plague :) - and i really dont like Greene.   Would be interested in McGahee",
           "sourceFranchiseId": null,
           "partnerSourceId": "0006",
@@ -34942,7 +34678,6 @@
           "received": [
             "FP_0009_2013_1"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0003",
@@ -34963,7 +34698,6 @@
             "9044",
             "FP_0006_2013_3"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0006",
@@ -34981,7 +34715,6 @@
             "10077",
             "DP_1_14"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -34997,7 +34730,6 @@
           "received": [
             "10300"
           ],
-          "byCommish": true,
           "comments": "Interested in SJax's handcuff?",
           "sourceFranchiseId": null,
           "partnerSourceId": "0011",
@@ -35013,7 +34745,6 @@
           "received": [
             "8243"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0010",
@@ -35029,7 +34760,6 @@
           "received": [
             "DP_1_4"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0010",
@@ -35048,7 +34778,6 @@
             "11225",
             "FP_0008_2015_2"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -35068,7 +34797,6 @@
             "9693",
             "11874"
           ],
-          "byCommish": true,
           "comments": "Here's what I talked about in email.",
           "sourceFranchiseId": null,
           "partnerSourceId": "0011",
@@ -35087,7 +34815,6 @@
             "11252",
             "FP_0001_2015_1"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -35104,7 +34831,6 @@
           "received": [
             "11640"
           ],
-          "byCommish": true,
           "comments": "what do you think? ",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -35123,7 +34849,6 @@
             "12179",
             "DP_1_8"
           ],
-          "byCommish": true,
           "comments": "Does this work?   Think there is alot of talent at 1.03 this year and Bortles is solid for the next 3",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -35139,7 +34864,6 @@
           "received": [
             "7393"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -35156,7 +34880,6 @@
           "received": [
             "DP_0_11"
           ],
-          "byCommish": true,
           "comments": "Messed up the first one.. .dont want to give up all of next year yet",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -35172,7 +34895,6 @@
           "received": [
             "10976"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -35190,7 +34912,6 @@
           "received": [
             "10695"
           ],
-          "byCommish": true,
           "comments": "Dan - looks like no \"conditions\" - let me know if this works",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -35206,7 +34927,6 @@
           "received": [
             "6589"
           ],
-          "byCommish": true,
           "comments": "Oh i know i will regret this at some point.. Taylor will become the next Julio Jones.... but need to get strong for this final push",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -35227,7 +34947,6 @@
             "FP_0009_2018_1",
             "FP_0002_2018_1"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -35243,7 +34962,6 @@
           "received": [
             "FP_0010_2019_3"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -35260,7 +34978,6 @@
             "DP_0_13",
             "DP_1_9"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -35281,7 +34998,6 @@
             "14126",
             "FP_0009_2021_1"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -35298,7 +35014,6 @@
             "FP_0009_2022_1",
             "FP_0008_2022_2"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -35317,7 +35032,6 @@
             "10271",
             "FP_0006_2022_1"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -35333,7 +35047,6 @@
           "received": [
             "13124"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -35351,7 +35064,6 @@
             "14136",
             "DP_0_3"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -35369,7 +35081,6 @@
             "15283",
             "13680"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -35389,7 +35100,6 @@
             "14852",
             "11244"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -35404,7 +35114,6 @@
             "DP_1_4",
             "DP_1_5"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -35419,7 +35128,6 @@
             "DP_1_5"
           ],
           "received": [],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -35436,7 +35144,6 @@
             "DP_1_4",
             "DP_1_5"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -35459,7 +35166,6 @@
             "17072",
             "FP_0010_2026_2"
           ],
-          "byCommish": true,
           "comments": "Two slight changes - i like Little longer term and banking that this trade elevates your team and Computer Jocks doesnt do as well as you this year :)",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -35476,7 +35182,6 @@
             "10700",
             "FP_0015_2026_1"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -41174,7 +40879,6 @@
           "received": [
             "9899"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -41190,7 +40894,6 @@
           "received": [
             "DP_0_1"
           ],
-          "byCommish": true,
           "comments": "I'm interested in Foster. 1.02 player locked up for, I'm assuming 5 years, is probably equal to if not greater in value than Foster for 1 year. Let me know, not really willing to give up more as I'd rather lock up Ingram, Green, or Julio cheaply for 5 years than pay more than this.",
           "sourceFranchiseId": null,
           "partnerSourceId": "0014",
@@ -41206,7 +40909,6 @@
           "received": [
             "8670"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0014",
@@ -41222,7 +40924,6 @@
           "received": [
             "FP_0008_2012_3"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -41238,7 +40939,6 @@
           "received": [
             "FP_0004_2012_2"
           ],
-          "byCommish": true,
           "comments": "Hi are you interested in a good back up Starting QB?   I'm looking to rebuild with draft picks.  Let me know if see anything you like.",
           "sourceFranchiseId": null,
           "partnerSourceId": "0004",
@@ -41254,7 +40954,6 @@
           "received": [
             "7842"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -41272,7 +40971,6 @@
             "8490",
             "FP_0010_2012_3"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -41294,7 +40992,6 @@
             "DP_2_12",
             "DP_2_14"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -41313,7 +41010,6 @@
             "9575",
             "DP_0_1"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0014",
@@ -41330,7 +41026,6 @@
           "received": [
             "10500"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0010",
@@ -41347,7 +41042,6 @@
           "received": [
             "8657"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -41364,7 +41058,6 @@
             "FP_0010_2013_2",
             "FP_0008_2013_2"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0010",
@@ -41382,7 +41075,6 @@
             "DP_1_1",
             "DP_1_17"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0005",
@@ -41400,7 +41092,6 @@
             "10953",
             "8269"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -41424,7 +41115,6 @@
             "9936",
             "7396"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0016",
@@ -41444,7 +41134,6 @@
           "received": [
             "7836"
           ],
-          "byCommish": true,
           "comments": "Just accept.Starting line-up for me is Rogers, Blount, Lynch, Gordon, Johnson, Jones, Graham, Haushka, Seattle ",
           "sourceFranchiseId": null,
           "partnerSourceId": "0016",
@@ -41463,7 +41152,6 @@
             "7236",
             "FP_0015_2014_3"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0003",
@@ -41480,7 +41168,6 @@
             "DP_0_9",
             "DP_1_10"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0003",
@@ -41498,7 +41185,6 @@
             "8658",
             "FP_0006_2015_2"
           ],
-          "byCommish": true,
           "comments": "Yea, still interested in the original offer.  Don't want to give up Dgen's 2nd though.  ",
           "sourceFranchiseId": null,
           "partnerSourceId": "0006",
@@ -41518,7 +41204,6 @@
             "7836",
             "8360"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0011",
@@ -41536,7 +41221,6 @@
             "7877",
             "0528"
           ],
-          "byCommish": true,
           "comments": "here we go!",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -41552,7 +41236,6 @@
           "received": [
             "10273"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0011",
@@ -41568,7 +41251,6 @@
           "received": [
             "11972"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -41585,7 +41267,6 @@
             "FP_0007_2017_1",
             "FP_0005_2017_1"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -41601,7 +41282,6 @@
           "received": [
             "9118"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -41619,7 +41299,6 @@
             "12646",
             "12175"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -41635,7 +41314,6 @@
           "received": [
             "DP_2_15"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -41651,7 +41329,6 @@
           "received": [
             "FP_0004_2021_2"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0004",
@@ -41670,7 +41347,6 @@
             "10729",
             "FP_0007_2021_2"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -41688,7 +41364,6 @@
             "DP_0_2",
             "DP_1_2"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -41704,7 +41379,6 @@
           "received": [
             "FP_0001_2022_1"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -41720,7 +41394,6 @@
           "received": [
             "FP_0008_2022_1"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -41736,7 +41409,6 @@
           "received": [
             "DP_1_6"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -41753,7 +41425,6 @@
           "received": [
             "15754"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -41776,7 +41447,6 @@
             "FP_0009_2023_3",
             "FP_0006_2023_3"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -41793,7 +41463,6 @@
           "received": [
             "15714"
           ],
-          "byCommish": true,
           "comments": "Jacob's handcuff",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -41811,7 +41480,6 @@
           "received": [
             "14102"
           ],
-          "byCommish": true,
           "comments": "I think this would work. It gives me the 2nd rounder I'm looking for. I end up shouldering a couple of your overvalued contracts and will have to take the cap hit when I cut Dissly, but it's less than cutting Diggs.",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -41829,7 +41497,6 @@
             "0503",
             "FP_0012_2025_2"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -41847,7 +41514,6 @@
           "received": [
             "14102"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -47442,7 +47108,6 @@
             "FP_0003_2013_1",
             "FP_0003_2013_2"
           ],
-          "byCommish": true,
           "comments": "Scenario #2.    Happy hunting! ",
           "sourceFranchiseId": null,
           "partnerSourceId": "0003",
@@ -47459,7 +47124,6 @@
           "received": [
             "9851"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -47480,7 +47144,6 @@
             "DP_1_14",
             "DP_2_14"
           ],
-          "byCommish": true,
           "comments": "I want to hold on to my 2013 picks so I am re-countering with the trade parameters we discussed in e-mail :-)",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -47499,7 +47162,6 @@
             "DP_2_12",
             "FP_0002_2013_3"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0002",
@@ -47521,7 +47183,6 @@
             "DP_2_3",
             "FP_0012_2013_2"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -47538,7 +47199,6 @@
           "received": [
             "10313"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0011",
@@ -47557,7 +47217,6 @@
             "9150",
             "FP_0013_2013_3"
           ],
-          "byCommish": true,
           "comments": "Can you toss a 3rd my way and we'll shake hands and call it a day?  :)",
           "sourceFranchiseId": null,
           "partnerSourceId": "0013",
@@ -47580,7 +47239,6 @@
             "4907",
             "FP_0007_2013_3"
           ],
-          "byCommish": true,
           "comments": "Tossed a coin on Rice versus Moss...   i had Rice a few years back (when he was healthy and with Favre in Minnesota - so hoping he can stay uninjured for one year ",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -47598,7 +47256,6 @@
           "received": [
             "8657"
           ],
-          "byCommish": false,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0016",
@@ -47615,7 +47272,6 @@
             "4891",
             "10271"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -47631,7 +47287,6 @@
           "received": [
             "0504"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0005",
@@ -47649,7 +47304,6 @@
             "FP_0002_2013_2",
             "FP_0011_2014_2"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0011",
@@ -47668,7 +47322,6 @@
             "DP_1_11",
             "FP_0015_2014_2"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -47687,7 +47340,6 @@
             "10080",
             "DP_1_14"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0002",
@@ -47705,7 +47357,6 @@
             "DP_0_3",
             "DP_2_14"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -47723,7 +47374,6 @@
           "received": [
             "FP_0012_2014_3"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -47743,7 +47393,6 @@
             "9925",
             "FP_0009_2014_3"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0011",
@@ -47759,7 +47408,6 @@
           "received": [
             "0501"
           ],
-          "byCommish": true,
           "comments": "We both have BYE week issues with our DST's.  Did you wanna do a swap of BUF and NE?",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -47776,7 +47424,6 @@
             "8144",
             "FP_0002_2014_3"
           ],
-          "byCommish": true,
           "comments": "Any interest in moving your backup K and a 3rd for White?",
           "sourceFranchiseId": null,
           "partnerSourceId": "0002",
@@ -47792,7 +47439,6 @@
           "received": [
             "DP_1_0"
           ],
-          "byCommish": true,
           "comments": "What do you think?",
           "sourceFranchiseId": null,
           "partnerSourceId": "0004",
@@ -47808,7 +47454,6 @@
           "received": [
             "FP_0003_2015_2"
           ],
-          "byCommish": true,
           "comments": "Just so its out there if you want to move on it ",
           "sourceFranchiseId": null,
           "partnerSourceId": "0003",
@@ -47827,7 +47472,6 @@
             "10721",
             "DP_1_3"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -47843,7 +47487,6 @@
           "received": [
             "FP_0002_2015_3"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0002",
@@ -47860,7 +47503,6 @@
           "received": [
             "FP_0016_2015_2"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -47876,7 +47518,6 @@
           "received": [
             "9918"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0005",
@@ -47893,7 +47534,6 @@
             "9436",
             "10372"
           ],
-          "byCommish": true,
           "comments": "what do you think? ",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -47912,7 +47552,6 @@
             "10703",
             "11650"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -47928,7 +47567,6 @@
           "received": [
             "12142"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -47945,7 +47583,6 @@
             "DP_1_17",
             "FP_0007_2017_1"
           ],
-          "byCommish": true,
           "comments": "Messed up the first one.. .dont want to give up all of next year yet",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -47962,7 +47599,6 @@
             "7194",
             "FP_0001_2017_1"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -47984,7 +47620,6 @@
             "10312",
             "FP_0005_2017_1"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -48001,7 +47636,6 @@
           "received": [
             "FP_0012_2017_1"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -48017,7 +47651,6 @@
           "received": [
             "FP_0005_2017_2"
           ],
-          "byCommish": true,
           "comments": "If you're interested in acquiring Rudolph's tagging rights",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -48036,7 +47669,6 @@
             "10695",
             "FP_0010_2017_1"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -48052,7 +47684,6 @@
           "received": [
             "FP_0003_2018_2"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -48068,7 +47699,6 @@
           "received": [
             "12845"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -48085,7 +47715,6 @@
             "DP_1_0",
             "FP_0013_2018_2"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -48101,7 +47730,6 @@
           "received": [
             "FP_0006_2018_2"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0006",
@@ -48120,7 +47748,6 @@
             "9851",
             "12175"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -48137,7 +47764,6 @@
           "received": [
             "11679"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -48160,7 +47786,6 @@
             "10527",
             "12956"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -48179,7 +47804,6 @@
           "received": [
             "9448"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -48198,7 +47822,6 @@
             "11387",
             "FP_0002_2018_1"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -48219,7 +47842,6 @@
             "12150",
             "FP_0007_2018_3"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -48235,7 +47857,6 @@
           "received": [
             "11248"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -48255,7 +47876,6 @@
             "12801",
             "FP_0005_2019_1"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -48273,7 +47893,6 @@
             "11761",
             "DP_2_15"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -48291,7 +47910,6 @@
             "7393",
             "10960"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -48313,7 +47931,6 @@
             "13132",
             "FP_0003_2019_3"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -48329,7 +47946,6 @@
           "received": [
             "0531"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -48345,7 +47961,6 @@
           "received": [
             "FP_0016_2019_3"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -48363,7 +47978,6 @@
             "FP_0005_2020_2",
             "FP_0005_2020_3"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -48381,7 +47995,6 @@
             "FP_0014_2020_1",
             "FP_0004_2020_1"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -48400,7 +48013,6 @@
             "13163",
             "DP_0_14"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -48417,7 +48029,6 @@
           "received": [
             "FP_0006_2021_2"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -48434,7 +48045,6 @@
           "received": [
             "FP_0010_2021_1"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -48455,7 +48065,6 @@
             "0508",
             "FP_0007_2021_2"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -48472,7 +48081,6 @@
           "received": [
             "12930"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -48488,7 +48096,6 @@
           "received": [
             "0528"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -48504,7 +48111,6 @@
           "received": [
             "FP_0009_2021_3"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -48523,7 +48129,6 @@
           "received": [
             "10271"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -48539,7 +48144,6 @@
           "received": [
             "DP_2_3"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0004",
@@ -48557,7 +48161,6 @@
             "13630",
             "FP_0006_2022_1"
           ],
-          "byCommish": true,
           "comments": "How about this?",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -48575,7 +48178,6 @@
             "DP_2_1",
             "DP_2_6"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -48595,7 +48197,6 @@
             "14258",
             "10976"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -48612,7 +48213,6 @@
           "received": [
             "13672"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -48631,7 +48231,6 @@
             "10960",
             "13635"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -48647,7 +48246,6 @@
           "received": [
             "14104"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -48663,7 +48261,6 @@
           "received": [
             "13131"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -48679,7 +48276,6 @@
           "received": [
             "FP_0005_2023_1"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -48699,7 +48295,6 @@
             "FP_0006_2023_2",
             "FP_0006_2023_3"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -48715,7 +48310,6 @@
           "received": [
             "12141"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -48733,7 +48327,6 @@
             "DP_0_4",
             "DP_1_4"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -48751,7 +48344,6 @@
           "received": [
             "FP_0004_2023_1"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0004",
@@ -48770,7 +48362,6 @@
             "DP_1_7",
             "DP_1_9"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0004",
@@ -48790,7 +48381,6 @@
             "14123",
             "FP_0010_2023_2"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -48813,7 +48403,6 @@
             "13772",
             "FP_0012_2023_1"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -48829,7 +48418,6 @@
           "received": [
             "FP_0008_2024_2"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -48847,7 +48435,6 @@
             "15329",
             "FP_0007_2024_1"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -48863,7 +48450,6 @@
           "received": [
             "FP_0006_2024_2"
           ],
-          "byCommish": true,
           "comments": "Interested in CIN's new TE1?",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -48879,7 +48465,6 @@
           "received": [
             "FP_0006_2024_1"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -48895,7 +48480,6 @@
           "received": [
             "16193"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -48913,7 +48497,6 @@
             "14600",
             "0520"
           ],
-          "byCommish": true,
           "comments": "I'd be willing to make that trade straight up with no draft picks, but otherwise I'd rather stand pat with Dotson on a 4-year than DK on a 1-year.",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -48929,7 +48512,6 @@
           "received": [
             "12611"
           ],
-          "byCommish": true,
           "comments": "Did you wanna flip backup QBs with both backups sharing BYE's w/ our starters?",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -48945,7 +48527,6 @@
           "received": [
             "FP_0004_2024_2"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0004",
@@ -48965,7 +48546,6 @@
             "14113",
             "15789"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -48983,7 +48563,6 @@
             "14835",
             "FP_0015_2024_3"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -48999,7 +48578,6 @@
           "received": [
             "0527"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -49016,7 +48594,6 @@
           "received": [
             "15284"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -49032,7 +48609,6 @@
           "received": [
             "14056"
           ],
-          "byCommish": true,
           "comments": "If you're not planning to tag him. Pick is 3.04",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -49051,7 +48627,6 @@
           "received": [
             "15281"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -49067,7 +48642,6 @@
           "received": [
             "16194"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -49083,7 +48657,6 @@
           "received": [
             "FP_0015_2025_2"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -49099,7 +48672,6 @@
           "received": [
             "FP_0004_2025_3"
           ],
-          "byCommish": true,
           "comments": "Do you want to tag Tee Higgins before tonight's deadline?",
           "sourceFranchiseId": null,
           "partnerSourceId": "0004",
@@ -49116,7 +48688,6 @@
             "DP_1_3",
             "FP_0010_2026_2"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -49132,7 +48703,6 @@
           "received": [
             "FP_0004_2026_3"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0004",
@@ -49155,7 +48725,6 @@
             "15287",
             "16846"
           ],
-          "byCommish": true,
           "comments": "Two slight changes - i like Little longer term and banking that this trade elevates your team and Computer Jocks doesnt do as well as you this year :)",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -49173,7 +48742,6 @@
             "13593",
             "FP_0006_2026_3"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -49192,7 +48760,6 @@
             "14789",
             "0525"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -53989,7 +53556,6 @@
             "DP_2_7",
             "DP_2_8"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -54006,7 +53572,6 @@
             "8776",
             "FP_0009_2015_3"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -54022,7 +53587,6 @@
           "received": [
             "10369"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -54045,7 +53609,6 @@
             "11250",
             "8359"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -54062,7 +53625,6 @@
           "received": [
             "10308"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -54078,7 +53640,6 @@
           "received": [
             "10273"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -54094,7 +53655,6 @@
           "received": [
             "FP_0007_2018_1"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -54110,7 +53670,6 @@
           "received": [
             "12181"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0006",
@@ -54126,7 +53685,6 @@
           "received": [
             "11783"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -54143,7 +53701,6 @@
             "DP_1_2",
             "FP_0013_2023_2"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -54159,7 +53716,6 @@
           "received": [
             "0518"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -54176,7 +53732,6 @@
             "0519",
             "FP_0015_2023_2"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -54206,7 +53761,6 @@
             "FP_0009_2023_2",
             "FP_0003_2023_3"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -54236,7 +53790,6 @@
             "15768",
             "14867"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -54263,7 +53816,6 @@
             "FP_0009_2023_2",
             "FP_0003_2023_3"
           ],
-          "byCommish": true,
           "comments": "The original deal included wabbits second not Music City. ",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -54279,7 +53831,6 @@
           "received": [
             "FP_0009_2024_3"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -54295,7 +53846,6 @@
           "received": [
             "0520"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -54313,7 +53863,6 @@
             "16620",
             "FP_0008_2025_2"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -54329,7 +53878,6 @@
           "received": [
             "13192"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -54347,7 +53895,6 @@
             "15788",
             "FP_0008_2025_3"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -54362,7 +53909,6 @@
             "DP_1_5"
           ],
           "received": [],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -54377,7 +53923,6 @@
             "DP_1_4",
             "DP_1_5"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -54394,7 +53939,6 @@
           "received": [
             "DP_0_11"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -58853,7 +58397,6 @@
             "11642",
             "DP_0_2"
           ],
-          "byCommish": true,
           "comments": "Does this work?   Think there is alot of talent at 1.03 this year and Bortles is solid for the next 3",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -58870,7 +58413,6 @@
             "12631",
             "FP_0014_2017_2"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0014",
@@ -58886,7 +58428,6 @@
           "received": [
             "10722"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -58902,7 +58443,6 @@
           "received": [
             "10276"
           ],
-          "byCommish": true,
           "comments": "Hi Mike. Are you planning on tagging both Mark Ingram and Lamar Miller? If you don't plan on offering one of them a tag, I would trade your 2nd round pick for the chance to tag one of them. If you are tagging both, I would also be interested in Carlos Hyde for the pick. Let me know what you think.",
           "sourceFranchiseId": null,
           "partnerSourceId": "0014",
@@ -58918,7 +58458,6 @@
           "received": [
             "12206"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -58935,7 +58474,6 @@
           "received": [
             "12177"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -58951,7 +58489,6 @@
           "received": [
             "9467"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -58967,7 +58504,6 @@
           "received": [
             "FP_0005_2019_3"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -58983,7 +58519,6 @@
           "received": [
             "12140"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -59005,7 +58540,6 @@
             "DP_2_0",
             "FP_0003_2021_2"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -59022,7 +58556,6 @@
             "13639",
             "FP_0006_2021_2"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -59038,7 +58571,6 @@
           "received": [
             "FP_0005_2022_3"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -59055,7 +58587,6 @@
           "received": [
             "13128"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -59071,7 +58602,6 @@
           "received": [
             "13610"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -59089,7 +58619,6 @@
           "received": [
             "14104"
           ],
-          "byCommish": true,
           "comments": "Could you consider trading AJ Brown? He is on a one year contract and you would have Mike Williams available next year along with a first round pick.",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -63285,7 +62814,6 @@
             "10409",
             "DP_1_3"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -63302,7 +62830,6 @@
           "received": [
             "DP_0_12"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0006",
@@ -63321,7 +62848,6 @@
           "received": [
             "5848"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -63337,7 +62863,6 @@
           "received": [
             "FP_0007_2023_2"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -67067,7 +66592,6 @@
             "10742",
             "10318"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -67083,7 +66607,6 @@
           "received": [
             "10312"
           ],
-          "byCommish": true,
           "comments": "If you're interested in acquiring Rudolph's tagging rights",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -67102,7 +66625,6 @@
             "10261",
             "0506"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -67122,7 +66644,6 @@
             "12176",
             "11678"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -67144,7 +66665,6 @@
             "DP_1_0",
             "DP_1_13"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -67160,7 +66680,6 @@
           "received": [
             "7422"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -67178,7 +66697,6 @@
             "14075",
             "DP_2_8"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -67194,7 +66712,6 @@
           "received": [
             "11760"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -67210,7 +66727,6 @@
           "received": [
             "14265"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -67226,7 +66742,6 @@
           "received": [
             "13614"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0004",
@@ -67242,7 +66757,6 @@
           "received": [
             "11670"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -67258,7 +66772,6 @@
           "received": [
             "13131"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -67275,7 +66788,6 @@
           "received": [
             "13404"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -67292,7 +66804,6 @@
           "received": [
             "12476"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -67309,7 +66820,6 @@
           "received": [
             "DP_1_1"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -67325,7 +66835,6 @@
           "received": [
             "13630"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -71159,7 +70668,6 @@
           "received": [
             "DP_0_9"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -71175,7 +70683,6 @@
           "received": [
             "DP_1_15"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -71191,7 +70698,6 @@
           "received": [
             "FP_0013_2017_3"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -71207,7 +70713,6 @@
           "received": [
             "10695"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -71224,7 +70729,6 @@
             "DP_2_14",
             "FP_0014_2018_1"
           ],
-          "byCommish": true,
           "comments": "Counter for Ryan only.",
           "sourceFranchiseId": null,
           "partnerSourceId": "0014",
@@ -71242,7 +70746,6 @@
             "DP_1_15",
             "FP_0006_2018_1"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0006",
@@ -71269,7 +70772,6 @@
             "9250",
             "10729"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -71288,7 +70790,6 @@
             "FP_0013_2018_2",
             "FP_0006_2018_2"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -71305,7 +70806,6 @@
           "received": [
             "11192"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0006",
@@ -71321,7 +70821,6 @@
           "received": [
             "11232"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -71338,7 +70837,6 @@
             "DP_2_2",
             "DP_2_4"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -71360,7 +70858,6 @@
             "FP_0009_2019_1",
             "FP_0005_2019_1"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -71378,7 +70875,6 @@
             "FP_0014_2019_2",
             "FP_0003_2019_2"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -71396,7 +70892,6 @@
             "13622",
             "FP_0008_2020_2"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -71418,7 +70913,6 @@
             "DP_2_3",
             "FP_0013_2021_1"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -71438,7 +70932,6 @@
             "13131",
             "13156"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -71454,7 +70947,6 @@
           "received": [
             "FP_0009_2023_2"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -71472,7 +70964,6 @@
             "14800",
             "FP_0006_2023_2"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -71488,7 +70979,6 @@
           "received": [
             "FP_0008_2023_3"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -71518,7 +71008,6 @@
             "15768",
             "14867"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -71548,7 +71037,6 @@
             "FP_0009_2023_2",
             "FP_0003_2023_3"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -71575,7 +71063,6 @@
             "15768",
             "14867"
           ],
-          "byCommish": true,
           "comments": "The original deal included wabbits second not Music City. ",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -71595,7 +71082,6 @@
             "14798",
             "14085"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -71611,7 +71097,6 @@
           "received": [
             "FP_0015_2024_3"
           ],
-          "byCommish": true,
           "comments": "If you're not planning to tag him. Pick is 3.04",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -71630,7 +71115,6 @@
             "DP_1_2",
             "DP_1_4"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -71650,7 +71134,6 @@
             "FP_0006_2025_1",
             "FP_0008_2025_1"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -71667,7 +71150,6 @@
           "received": [
             "16618"
           ],
-          "byCommish": true,
           "comments": "Split the difference ",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -75627,7 +75109,6 @@
           "received": [
             "8687"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0006",
@@ -75646,7 +75127,6 @@
             "9881",
             "7393"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -75662,7 +75142,6 @@
           "received": [
             "12153"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -75681,7 +75160,6 @@
             "FP_0005_2017_2",
             "FP_0009_2017_3"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -75698,7 +75176,6 @@
             "12887",
             "FP_0016_2018_3"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -75714,7 +75191,6 @@
           "received": [
             "FP_0004_2018_1"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0004",
@@ -75734,7 +75210,6 @@
             "FP_0008_2019_1",
             "FP_0008_2019_3"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -75752,7 +75227,6 @@
             "13193",
             "DP_1_5"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -75769,7 +75243,6 @@
             "FP_0008_2019_2",
             "FP_0006_2019_2"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -75785,7 +75258,6 @@
           "received": [
             "13114"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -75805,7 +75277,6 @@
             "DP_1_6",
             "DP_2_13"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -75822,7 +75293,6 @@
             "11192",
             "FP_0009_2021_2"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -75842,7 +75312,6 @@
             "13629",
             "FP_0005_2023_1"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -75861,7 +75330,6 @@
             "FP_0015_2023_1",
             "FP_0005_2023_3"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -75881,7 +75349,6 @@
             "15109",
             "FP_0006_2023_2"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -75896,7 +75363,6 @@
             "13134",
             "FP_0008_2024_3"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -75912,7 +75378,6 @@
           "received": [
             "DP_1_7"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -75929,7 +75394,6 @@
           "received": [
             "13163"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -75945,7 +75409,6 @@
           "received": [
             "11244"
           ],
-          "byCommish": true,
           "comments": "Offering in case you'd like to shore up your TE roster ahead of the playoffs.",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -75961,7 +75424,6 @@
           "received": [
             "DP_2_10"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -79094,7 +78556,6 @@
             "11244"
           ],
           "received": [],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -79110,7 +78571,6 @@
           "received": [
             "FP_0003_2019_2"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -79128,7 +78588,6 @@
           "received": [
             "11192"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -79149,7 +78608,6 @@
             "10722",
             "FP_0006_2020_3"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -79167,7 +78625,6 @@
           "received": [
             "13763"
           ],
-          "byCommish": true,
           "comments": "Very fair and I completely understand, but I think Funchess has a small chance for a break out season. I'd do this (take out Funchess due to his high ceiling on GB) and replace with Mitchell.  You get your $900K cap relief immediately which will help with your rookies to be drafted and free agent pickups. having Dissly and Olsen on the same team is useless to us unless one gets hurt. ",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -79183,7 +78640,6 @@
           "received": [
             "FP_0001_2021_3"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -79201,7 +78657,6 @@
             "DP_0_1",
             "DP_2_1"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -79217,7 +78672,6 @@
           "received": [
             "FP_0008_2022_3"
           ],
-          "byCommish": true,
           "comments": "I'm sure your Rd 3 next year will be at the end of the Rd, so let's bump my spot back one.  It's my way of playing hardball!  LOL",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -79235,7 +78689,6 @@
             "DP_2_14",
             "FP_0009_2022_2"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -79254,7 +78707,6 @@
             "15734",
             "DP_1_13"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -79271,7 +78723,6 @@
             "16153",
             "16206"
           ],
-          "byCommish": true,
           "comments": "I'm an idiot. I was thinking Brandon already processed.",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -79292,7 +78743,6 @@
             "14109",
             "FP_0013_2024_2"
           ],
-          "byCommish": true,
           "comments": "I get where you are coming from in your counter proposal.  If I move Mahomes now I am basically playing for next season and so I am in the mindset of acquiring draft capital.  If I am going to lose a 2nd, I would like to get the 3rd then as well. Also, I would also be interested in the trade without giving up my 2nd and not acquiring your 3rd.  Let me know.",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -79310,7 +78760,6 @@
             "DP_1_7",
             "DP_2_2"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -82238,7 +81687,6 @@
           "received": [
             "12317"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -82259,7 +81707,6 @@
             "11192",
             "FP_0014_2020_1"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -82273,7 +81720,6 @@
           "received": [
             "13163"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -82287,7 +81733,6 @@
             "10276"
           ],
           "received": [],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0004",
@@ -82301,7 +81746,6 @@
             "13277"
           ],
           "received": [],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -82315,7 +81759,6 @@
           "received": [
             "13630"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -82329,7 +81772,6 @@
             "12676"
           ],
           "received": [],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -82343,7 +81785,6 @@
           "received": [
             "13156"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0004",
@@ -82357,7 +81798,6 @@
             "13156"
           ],
           "received": [],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0004",
@@ -82373,7 +81813,6 @@
           "received": [
             "13156"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0004",
@@ -82387,7 +81826,6 @@
             "FP_0014_2020_1"
           ],
           "received": [],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -82401,7 +81839,6 @@
           "received": [
             "13234"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -82418,7 +81855,6 @@
           "received": [
             "13188"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0004",
@@ -82432,7 +81868,6 @@
             "0512"
           ],
           "received": [],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0004",
@@ -82446,7 +81881,6 @@
           "received": [
             "FP_0011_2020_1"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -82460,7 +81894,6 @@
             "FP_0006_2020_2"
           ],
           "received": [],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0004",
@@ -82474,7 +81907,6 @@
           "received": [
             "14086"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -82488,7 +81920,6 @@
           "received": [
             "0525"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -82502,7 +81933,6 @@
           "received": [
             "13753"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0004",
@@ -82516,7 +81946,6 @@
           "received": [
             "10729"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -82531,7 +81960,6 @@
             "13768"
           ],
           "received": [],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0004",
@@ -82545,7 +81973,6 @@
             "12188"
           ],
           "received": [],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -82559,7 +81986,6 @@
             "0520"
           ],
           "received": [],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -82573,7 +81999,6 @@
           "received": [
             "14139"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -82588,7 +82013,6 @@
             "2842",
             "0521"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0004",
@@ -82602,7 +82026,6 @@
           "received": [
             "13680"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0004",
@@ -82616,7 +82039,6 @@
           "received": [
             "12386"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0004",
@@ -82631,7 +82053,6 @@
             "9431",
             "12212"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -82645,7 +82066,6 @@
             "13634"
           ],
           "received": [],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": "0004",
@@ -82664,7 +82084,6 @@
             "DP_1_9",
             "DP_2_9"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -82681,7 +82100,6 @@
           "received": [
             "DP_0_10"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -82698,7 +82116,6 @@
             "DP_2_8",
             "FP_0009_2021_3"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -82714,7 +82131,6 @@
           "received": [
             "0506"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -82732,7 +82148,6 @@
           "received": [
             "13132"
           ],
-          "byCommish": true,
           "comments": "How about this?",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -82752,7 +82167,6 @@
             "14136",
             "DP_0_7"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -82767,7 +82181,6 @@
             "13666",
             "0506"
           ],
-          "byCommish": true,
           "comments": "I'll take 1 of those guys",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -82787,7 +82200,6 @@
           "received": [
             "14104"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -82803,7 +82215,6 @@
           "received": [
             "13188"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -82819,7 +82230,6 @@
           "received": [
             "14141"
           ],
-          "byCommish": true,
           "comments": "Interested in CIN's new TE1?",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -82835,7 +82245,6 @@
           "received": [
             "16165"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -82851,7 +82260,6 @@
           "received": [
             "10697"
           ],
-          "byCommish": true,
           "comments": "Did you wanna flip backup QBs with both backups sharing BYE's w/ our starters?",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -82869,7 +82277,6 @@
             "13154",
             "FP_0013_2024_1"
           ],
-          "byCommish": true,
           "comments": "Could you consider trading AJ Brown? He is on a one year contract and you would have Mike Williams available next year along with a first round pick.",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -82891,7 +82298,6 @@
             "DP_1_10",
             "DP_2_10"
           ],
-          "byCommish": true,
           "comments": "This would give you a starting kicker, cheaper draft picks, injury protection at QB and 4 more players.  You would need 4 more players after this trade.",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -82910,7 +82316,6 @@
             "DP_0_16",
             "FP_0008_2025_1"
           ],
-          "byCommish": true,
           "comments": "This trade would get you a 1st this year, a Defense, my 1st for your 2nd next year, and alo some much needed cap space.",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -82930,7 +82335,6 @@
             "11647",
             "DP_0_11"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -82950,7 +82354,6 @@
             "13593",
             "14797"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -82968,7 +82371,6 @@
             "13629",
             "16646"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,
@@ -82986,7 +82388,6 @@
             "14835",
             "FP_0009_2026_2"
           ],
-          "byCommish": true,
           "comments": "",
           "sourceFranchiseId": null,
           "partnerSourceId": null,

--- a/scripts/compute-franchise-history.mjs
+++ b/scripts/compute-franchise-history.mjs
@@ -486,7 +486,7 @@ const ensureFranchise = (id) => {
       },
       headToHead: {}, // opponentFranchiseId -> { wins, losses, ties }
       matchupHistory: {}, // opponentFranchiseId -> [{year, week, score, opponentScore, isPlayoff, playoffRound, sourceFranchiseId}]
-      trades: [], // [{year, timestamp, partnerId, gaveUp[], received[], byCommish, comments, sourceFranchiseId, partnerSourceId}]
+      trades: [], // [{year, timestamp, partnerId, gaveUp[], received[], comments, sourceFranchiseId, partnerSourceId}]
       draftPicks: [], // [{year, round, pick, playerId, viaTrade, comments, timestamp, sourceFranchiseId}]
       auctionWins: [], // [{year, playerId, winningBid, timestamp, sourceFranchiseId}]
     });
@@ -945,7 +945,6 @@ for (const year of years) {
     const aGave = String(tx.franchise1_gave_up || '').split(',').filter(Boolean);
     const bGave = String(tx.franchise2_gave_up || '').split(',').filter(Boolean);
     const timestamp = parseNum(tx.timestamp);
-    const byCommish = String(tx.by_commish || '') === '1';
     const comments = tx.comments || '';
 
     // Pull player names for any numeric asset codes used in this trade so
@@ -971,7 +970,6 @@ for (const year of years) {
         partnerId: fB,
         gaveUp: aGave,
         received: bGave,
-        byCommish,
         comments,
         sourceFranchiseId: fA !== aTarget ? fA : null,
         partnerSourceId: fB !== bTarget ? fB : null,
@@ -985,7 +983,6 @@ for (const year of years) {
         partnerId: fA,
         gaveUp: bGave,
         received: aGave,
-        byCommish,
         comments,
         sourceFranchiseId: fB !== bTarget ? fB : null,
         partnerSourceId: fA !== aTarget ? fA : null,

--- a/src/pages/theleague/franchises/[id].astro
+++ b/src/pages/theleague/franchises/[id].astro
@@ -337,7 +337,6 @@ type FranchiseTrade = {
   partnerId: string;
   gaveUp: string[];
   received: string[];
-  byCommish: boolean;
   comments: string;
   bothAttributed: boolean;
 };
@@ -624,11 +623,6 @@ const formatBid = (n: number): string => {
                         <span class="partner-name">{partnerName}</span>
                       </a>
                       <span class="dim small trade-date">{tradeDateLabel(t)}</span>
-                      {t.byCommish && (
-                        <span class="commish-tag" title="Trade was processed by the commissioner">
-                          commish
-                        </span>
-                      )}
                     </div>
                     <div class="trade-cols">
                       <div class="trade-col">
@@ -1499,15 +1493,6 @@ const formatBid = (n: number): string => {
   .trade-date {
     margin-left: auto;
     font-variant-numeric: tabular-nums;
-  }
-  .commish-tag {
-    font-size: 0.6875rem;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    background: var(--surface-3, #ebebeb);
-    padding: 0.125rem 0.375rem;
-    border-radius: 0.25rem;
-    color: var(--text-tertiary, #666);
   }
   .trade-cols {
     display: grid;

--- a/src/pages/theleague/rivalries/[pair].astro
+++ b/src/pages/theleague/rivalries/[pair].astro
@@ -119,7 +119,6 @@ type Trade = {
   partnerId: string;
   gaveUp: string[];
   received: string[];
-  byCommish: boolean;
   comments: string;
   bothAttributed: boolean;
 };
@@ -378,7 +377,6 @@ const titleB = frB.currentNameMedium || frB.currentName;
               <div class="trade-date">
                 <span class="t-year">{t.year}</span>
                 <span class="dim small">{tradeDateLabel(t)}</span>
-                {t.byCommish && <span class="commish-tag" title="Trade was processed by the commissioner">commish</span>}
               </div>
               <div class="trade-cols">
                 <div class="trade-col">
@@ -814,16 +812,6 @@ const titleB = frB.currentNameMedium || frB.currentName;
   .t-year {
     font-weight: 700;
     font-variant-numeric: tabular-nums;
-  }
-  .commish-tag {
-    margin-left: auto;
-    font-size: 0.6875rem;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    background: var(--surface-3, #ebebeb);
-    padding: 0.125rem 0.375rem;
-    border-radius: 0.25rem;
-    color: var(--text-tertiary, #666);
   }
   .trade-cols {
     display: grid;


### PR DESCRIPTION
## Summary

Drops the "commish" pill from the franchise trade ledger and the rivalry
trade list. **99% of TheLeague's trades carry MFL's `by_commish=1` flag**
(593 / 599 league-wide) because the commissioner historically processes
every deal through MFL's admin UI rather than owners submitting/accepting
through the in-app trade flow. The pill was visual noise on virtually
every trade and conveyed nothing useful.

The now-unused `byCommish` field is also pruned from
`data/theleague/derived/franchise-history.json` and the franchise/rivalry
page types. Other parts of the codebase (`schefter-transaction-parser`,
`trade-alert`, `pages/api/trades/pending`) still consume `by_commish` from
raw MFL transactions for tier classification — those are untouched.

## Why this PR is a single commit now

When this branch was first opened it also carried the trade-ledger and
draft+auction commits, but those landed on main via #190 in the meantime.
The branch was rebased on top of `cbd69e9` and the duplicates dropped, so
the diff here is now just the commish-pill removal.

## Test plan

- [ ] `/theleague/franchises/0001` — trade ledger renders without the
      "commish" pill on any card.
- [ ] `/theleague/rivalries/0001-vs-0011` — same, on the trade list.
- [ ] No new unit-test failures (baseline: 11 pre-existing failures on
      main, unchanged after this commit).
