### PR TITLE
Add breathing room around rivalries matrix icons

### DIFF
--- a/src/pages/theleague/rivalries/index.astro
+++ b/src/pages/theleague/rivalries/index.astro
@@ -368,7 +368,7 @@ const lastYear = yearsCovered[yearsCovered.length - 1];
 
   .col-header {
     background: var(--surface-2, #f7f7f7);
-    padding: 0.375rem 0.25rem;
+    padding: 0.75rem 0.25rem 0.375rem;
     width: 3.25rem;
     min-width: 3.25rem;
     position: sticky;
@@ -391,7 +391,7 @@ const lastYear = yearsCovered[yearsCovered.length - 1];
 
   .row-header {
     background: var(--surface-2, #f7f7f7);
-    padding: 0.375rem 0.5rem;
+    padding: 0.375rem 0.5rem 0.375rem 0.875rem;
     text-align: left;
     width: 9rem;
     min-width: 9rem;


### PR DESCRIPTION
Bump left padding on row headers and top padding on column headers so
the team icons aren't pinned against the edges of the matrix table.