### PR TITLE
fix(cap): drop salary-file holdovers not on any current roster

### DIFF
--- a/src/pages/theleague/index.astro
+++ b/src/pages/theleague/index.astro
@@ -249,6 +249,14 @@ if (cachedRosterPlayers) {
       }
     }
   }
+  // Drop salary-file holdovers no longer on any roster — released free agents
+  // would otherwise keep their stale franchiseId and inflate that team's cap.
+  const rosteredIds = new Set(Object.keys(cachedRosterPlayers));
+  for (let i = salaryPlayers.length - 1; i >= 0; i--) {
+    if (!rosteredIds.has(salaryPlayers[i].id)) {
+      salaryPlayers.splice(i, 1);
+    }
+  }
 }
 
 const teamSummaries = computeLeagueSummary(salaryPlayers, rawAdjustments, draftCapitalMap, teamConfigs);

--- a/src/pages/theleague/league-summary.astro
+++ b/src/pages/theleague/league-summary.astro
@@ -178,6 +178,14 @@ if (cachedRosterPlayers) {
       }
     }
   }
+  // Drop salary-file holdovers no longer on any roster — released free agents
+  // would otherwise keep their stale franchiseId and inflate that team's cap.
+  const rosteredIds = new Set(Object.keys(cachedRosterPlayers));
+  for (let i = players.length - 1; i >= 0; i--) {
+    if (!rosteredIds.has(players[i].id)) {
+      players.splice(i, 1);
+    }
+  }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
The homepage and league-summary pages overlay Redis-cached rosters on
top of the prebuilt mfl-player-salaries-*.json. The overlay updates and
appends, but it never removed players who were on a team in the static
snapshot (W=1 of 2026) yet have since been released. Those holdovers
kept their stale franchiseId and were charged at 100% against the cap,
which made the My Team widget read $14K over cap (Pacific Pigskins) when
the actual cap was ~$920K under.

The user reported this as the practice-squad discount not being applied.
The discount is applied (normalizeStatus → getCapPercent), but two
released free agents — Taysom Hill and Miles Sanders, $467,500 each from
the W=1 snapshot — were inflating the charge by $935K, masking the
discount.

Fix: after the overlay, drop any salaryPlayer whose id is not in the
cached roster map. The cache is the authoritative current-roster source,
so anyone missing from it has been released. Active roster count and
per-team cap calc now match MFL.