### PR TITLE
fix(homepage): call MFL auction API directly, drop SSR self-fetch

### DIFF
--- a/src/pages/api/live-auction.ts
+++ b/src/pages/api/live-auction.ts
@@ -1,136 +1,22 @@
 import type { APIRoute } from 'astro';
+import { fetchLiveAuctions } from '../../utils/live-auctions';
 import { getCurrentLeagueYear } from '../../utils/league-year';
 
 export const prerender = false;
 
-const DEFAULT_HOST = 'https://api.myfantasyleague.com';
-const DEFAULT_LEAGUE_ID = '13522';
-
-/**
- * Parses MFL auction transaction string format: "{playerId}|{amount}|"
- */
-function parseAuctionTransaction(transaction: string): { playerId: string; amount: number } | null {
-  const parts = transaction.split('|');
-  if (parts.length < 2 || !parts[0] || !parts[1]) return null;
-  const amount = parseInt(parts[1], 10);
-  if (isNaN(amount)) return null;
-  return { playerId: parts[0], amount };
-}
-
 export const GET: APIRoute = async ({ url }) => {
   const year = url.searchParams.get('year') || getCurrentLeagueYear().toString();
-  const leagueId = url.searchParams.get('L') || DEFAULT_LEAGUE_ID;
+  const leagueId = url.searchParams.get('L') || undefined;
 
   try {
-    // Fetch both auctionResults (completed) and transactions (live bids) in parallel
-    const [resultsResponse, txnResponse] = await Promise.all([
-      fetch(`${DEFAULT_HOST}/${year}/export?TYPE=auctionResults&L=${leagueId}&JSON=1`, {
-        headers: { 'User-Agent': 'Mozilla/5.0 (compatible; FantasyLeague/1.0)' },
-      }),
-      fetch(`${DEFAULT_HOST}/${year}/export?TYPE=transactions&L=${leagueId}&JSON=1`, {
-        headers: { 'User-Agent': 'Mozilla/5.0 (compatible; FantasyLeague/1.0)' },
-      }),
-    ]);
-
-    const auctions: Record<string, { bid: number; franchise: string; status: 'won' | 'active'; lastBidTime: number | null; initTime: number | null }> = {};
-    // Track AUCTION_INIT timestamps separately (first nomination time per player)
-    const initTimes: Record<string, number> = {};
-
-    // 1. Parse completed auction results (highest priority — these are final)
-    if (resultsResponse.ok) {
-      const data = await resultsResponse.json();
-      const auctionUnit = data?.auctionResults?.auctionUnit;
-      if (auctionUnit?.auction) {
-        const auctionList = Array.isArray(auctionUnit.auction)
-          ? auctionUnit.auction
-          : [auctionUnit.auction];
-        for (const a of auctionList) {
-          if (a?.player && a?.winningBid) {
-            auctions[a.player] = {
-              bid: parseInt(a.winningBid, 10),
-              franchise: a.franchise || '',
-              status: 'won',
-              lastBidTime: parseInt(a.lastBidTime, 10) || null,
-              initTime: parseInt(a.timeStarted, 10) || null,
-            };
-          }
-        }
-      }
-    }
-
-    // 2. Parse transactions for live auction bids (AUCTION_BID, AUCTION_WON, AUCTION_INIT)
-    if (txnResponse.ok) {
-      const txnData = await txnResponse.json();
-      let transactions = txnData?.transactions?.transaction;
-      if (transactions && !Array.isArray(transactions)) transactions = [transactions];
-
-      if (Array.isArray(transactions)) {
-        // First pass: collect all AUCTION_INIT timestamps
-        for (const txn of transactions) {
-          if (txn?.type === 'AUCTION_INIT' && txn?.transaction) {
-            const parsed = parseAuctionTransaction(txn.transaction);
-            if (parsed) {
-              const ts = parseInt(txn.timestamp, 10) || 0;
-              // Keep the earliest init time per player
-              if (!initTimes[parsed.playerId] || ts < initTimes[parsed.playerId]) {
-                initTimes[parsed.playerId] = ts;
-              }
-            }
-          }
-        }
-
-        // Second pass: process bids and wins
-        for (const txn of transactions) {
-          if (!txn?.type || !txn?.transaction) continue;
-          const parsed = parseAuctionTransaction(txn.transaction);
-          if (!parsed) continue;
-
-          if (txn.type === 'AUCTION_WON') {
-            // Won overrides any bid — this is the final price
-            auctions[parsed.playerId] = {
-              bid: parsed.amount,
-              franchise: txn.franchise || '',
-              status: 'won',
-              lastBidTime: parseInt(txn.timestamp, 10) || null,
-              initTime: initTimes[parsed.playerId] || null,
-            };
-          } else if (txn.type === 'AUCTION_BID' || txn.type === 'AUCTION_INIT') {
-            // Only set if we don't already have a won result or a higher bid
-            const existing = auctions[parsed.playerId];
-            if (!existing || (existing.status !== 'won' && parsed.amount > existing.bid)) {
-              const newFranchise = txn.franchise || '';
-              // 36h timer resets only when the high bidder changes (proxy exceeded),
-              // not when the same franchise's proxy auto-responds to a lower bid
-              const franchiseChanged = !existing || existing.franchise !== newFranchise;
-              auctions[parsed.playerId] = {
-                bid: parsed.amount,
-                franchise: newFranchise,
-                status: 'active',
-                lastBidTime: franchiseChanged
-                  ? (parseInt(txn.timestamp, 10) || null)
-                  : (existing?.lastBidTime ?? null),
-                initTime: initTimes[parsed.playerId] || null,
-              };
-            }
-          }
-        }
-      }
-    }
-
-    return new Response(
-      JSON.stringify({
-        auctions,
-        timestamp: Date.now(),
-        count: Object.keys(auctions).length,
-      }),
-      {
-        status: 200,
-        headers: {
-          'Content-Type': 'application/json',
-          'Cache-Control': 'no-cache, no-store, must-revalidate',
-        },
-      }
-    );
+    const snapshot = await fetchLiveAuctions({ year, leagueId });
+    return new Response(JSON.stringify(snapshot), {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json',
+        'Cache-Control': 'no-cache, no-store, must-revalidate',
+      },
+    });
   } catch (error) {
     console.error('Error fetching auction results:', error);
     return new Response(
@@ -140,10 +26,7 @@ export const GET: APIRoute = async ({ url }) => {
         count: 0,
         error: 'Failed to fetch auction results',
       }),
-      {
-        status: 500,
-        headers: { 'Content-Type': 'application/json' },
-      }
+      { status: 500, headers: { 'Content-Type': 'application/json' } },
     );
   }
 };

--- a/src/pages/theleague/index.astro
+++ b/src/pages/theleague/index.astro
@@ -297,7 +297,8 @@ const unsignedFaAlerts = resolveUnsignedFaAlerts({
 // Avoids hitting MFL year-round on every homepage render.
 const activeAuctions = showAuctionsCard
   ? await loadActiveAuctions({
-      baseUrl: Astro.url,
+      year: leagueYear,
+      leagueId: mflLeagueId,
       playerMap: hpPlayerIdentityMap,
       teams: (leagueConfig.teams ?? []) as any[],
     })

--- a/src/utils/homepage-auctions.ts
+++ b/src/utils/homepage-auctions.ts
@@ -1,11 +1,13 @@
 /**
  * Homepage active-auction loader.
  *
- * Calls the internal /api/live-auction endpoint at SSR time, joins each active
- * auction against the player identity map and team config, and returns rows
- * ready to render in the HpAuctionsCard. Errors and empty payloads return [].
+ * Calls fetchLiveAuctions() directly (no SSR self-fetch) and joins each
+ * active auction against the player identity map and team config. Returns
+ * rows ready to render in the HpAuctionsCard. Errors and empty payloads
+ * return [] but are logged server-side for visibility.
  */
 import type { PlayerIdentity } from './player-map';
+import { fetchLiveAuctions } from './live-auctions';
 
 interface TeamConfigEntry {
   franchiseId: string;
@@ -37,29 +39,21 @@ export interface HomepageAuctionRow {
 }
 
 interface FetchOpts {
-  baseUrl: URL;
+  /** League year (defaults to current). */
+  year?: number | string;
+  /** MFL league id (defaults to 13522). */
+  leagueId?: string;
   playerMap: Map<string, PlayerIdentity>;
   teams: TeamConfigEntry[];
-  /** Optional override (e.g. for testing). */
+  /** Optional fetch override (e.g. for testing). */
   fetchImpl?: typeof fetch;
 }
 
 export async function loadActiveAuctions(opts: FetchOpts): Promise<HomepageAuctionRow[]> {
-  const { baseUrl, playerMap, teams } = opts;
-  const fetchImpl = opts.fetchImpl ?? fetch;
+  const { playerMap, teams, year, leagueId, fetchImpl } = opts;
 
-  let payload: any;
-  try {
-    const url = new URL('/api/live-auction', baseUrl);
-    const res = await fetchImpl(url.toString());
-    if (!res.ok) return [];
-    payload = await res.json();
-  } catch {
-    return [];
-  }
-
-  const auctions = payload?.auctions;
-  if (!auctions || typeof auctions !== 'object') return [];
+  const snapshot = await fetchLiveAuctions({ year, leagueId, fetchImpl });
+  const auctions = snapshot.auctions;
 
   const teamById = new Map<string, TeamConfigEntry>();
   for (const t of teams) {
@@ -67,8 +61,7 @@ export async function loadActiveAuctions(opts: FetchOpts): Promise<HomepageAucti
   }
 
   const rows: HomepageAuctionRow[] = [];
-  for (const [playerId, raw] of Object.entries(auctions)) {
-    const auc = raw as { bid?: number; franchise?: string; status?: string; lastBidTime?: number | null; initTime?: number | null };
+  for (const [playerId, auc] of Object.entries(auctions)) {
     if (auc?.status !== 'active') continue;
     const anchor = auc.lastBidTime ?? auc.initTime ?? 0;
     if (typeof anchor !== 'number' || anchor <= 0) continue;
@@ -92,6 +85,10 @@ export async function loadActiveAuctions(opts: FetchOpts): Promise<HomepageAucti
       anchorTimestamp: anchor,
     });
   }
+
+  console.log(
+    `[homepage-auctions] snapshot=${snapshot.count} active=${rows.length}`,
+  );
 
   // Sort soonest-to-end first; rows without an anchor sink to the bottom.
   const BID_WINDOW_SEC = 36 * 60 * 60;

--- a/src/utils/live-auctions.ts
+++ b/src/utils/live-auctions.ts
@@ -1,0 +1,145 @@
+/**
+ * Live MFL auction snapshot.
+ *
+ * Joins MFL's `auctionResults` (final wins) with `transactions`
+ * (`AUCTION_INIT` / `AUCTION_BID` / `AUCTION_WON`) into a single map of
+ * `playerId → { bid, franchise, status, lastBidTime, initTime }`.
+ *
+ * Used by both the `/api/live-auction` route (for client polling) and the
+ * homepage SSR loader so we don't pay for a self-fetch round-trip.
+ */
+import { getCurrentLeagueYear } from './league-year';
+
+const DEFAULT_HOST = 'https://api.myfantasyleague.com';
+const DEFAULT_LEAGUE_ID = '13522';
+
+export interface LiveAuctionEntry {
+  bid: number;
+  franchise: string;
+  status: 'won' | 'active';
+  lastBidTime: number | null;
+  initTime: number | null;
+}
+
+export interface LiveAuctionSnapshot {
+  auctions: Record<string, LiveAuctionEntry>;
+  timestamp: number;
+  count: number;
+}
+
+export interface FetchAuctionOpts {
+  year?: string | number;
+  leagueId?: string;
+  host?: string;
+  fetchImpl?: typeof fetch;
+}
+
+function parseAuctionTransaction(transaction: string): { playerId: string; amount: number } | null {
+  const parts = transaction.split('|');
+  if (parts.length < 2 || !parts[0] || !parts[1]) return null;
+  const amount = parseInt(parts[1], 10);
+  if (isNaN(amount)) return null;
+  return { playerId: parts[0], amount };
+}
+
+export async function fetchLiveAuctions(opts: FetchAuctionOpts = {}): Promise<LiveAuctionSnapshot> {
+  const year = String(opts.year ?? getCurrentLeagueYear());
+  const leagueId = opts.leagueId ?? DEFAULT_LEAGUE_ID;
+  const host = opts.host ?? DEFAULT_HOST;
+  const fetchImpl = opts.fetchImpl ?? fetch;
+
+  const auctions: Record<string, LiveAuctionEntry> = {};
+  const initTimes: Record<string, number> = {};
+
+  try {
+    const [resultsResponse, txnResponse] = await Promise.all([
+      fetchImpl(`${host}/${year}/export?TYPE=auctionResults&L=${leagueId}&JSON=1`, {
+        headers: { 'User-Agent': 'Mozilla/5.0 (compatible; FantasyLeague/1.0)' },
+      }),
+      fetchImpl(`${host}/${year}/export?TYPE=transactions&L=${leagueId}&JSON=1`, {
+        headers: { 'User-Agent': 'Mozilla/5.0 (compatible; FantasyLeague/1.0)' },
+      }),
+    ]);
+
+    if (resultsResponse.ok) {
+      const data = await resultsResponse.json();
+      const auctionUnit = data?.auctionResults?.auctionUnit;
+      if (auctionUnit?.auction) {
+        const auctionList = Array.isArray(auctionUnit.auction)
+          ? auctionUnit.auction
+          : [auctionUnit.auction];
+        for (const a of auctionList) {
+          if (a?.player && a?.winningBid) {
+            auctions[a.player] = {
+              bid: parseInt(a.winningBid, 10),
+              franchise: a.franchise || '',
+              status: 'won',
+              lastBidTime: parseInt(a.lastBidTime, 10) || null,
+              initTime: parseInt(a.timeStarted, 10) || null,
+            };
+          }
+        }
+      }
+    }
+
+    if (txnResponse.ok) {
+      const txnData = await txnResponse.json();
+      let transactions = txnData?.transactions?.transaction;
+      if (transactions && !Array.isArray(transactions)) transactions = [transactions];
+
+      if (Array.isArray(transactions)) {
+        for (const txn of transactions) {
+          if (txn?.type === 'AUCTION_INIT' && txn?.transaction) {
+            const parsed = parseAuctionTransaction(txn.transaction);
+            if (parsed) {
+              const ts = parseInt(txn.timestamp, 10) || 0;
+              if (!initTimes[parsed.playerId] || ts < initTimes[parsed.playerId]) {
+                initTimes[parsed.playerId] = ts;
+              }
+            }
+          }
+        }
+
+        for (const txn of transactions) {
+          if (!txn?.type || !txn?.transaction) continue;
+          const parsed = parseAuctionTransaction(txn.transaction);
+          if (!parsed) continue;
+
+          if (txn.type === 'AUCTION_WON') {
+            auctions[parsed.playerId] = {
+              bid: parsed.amount,
+              franchise: txn.franchise || '',
+              status: 'won',
+              lastBidTime: parseInt(txn.timestamp, 10) || null,
+              initTime: initTimes[parsed.playerId] || null,
+            };
+          } else if (txn.type === 'AUCTION_BID' || txn.type === 'AUCTION_INIT') {
+            const existing = auctions[parsed.playerId];
+            if (!existing || (existing.status !== 'won' && parsed.amount > existing.bid)) {
+              const newFranchise = txn.franchise || '';
+              const franchiseChanged = !existing || existing.franchise !== newFranchise;
+              auctions[parsed.playerId] = {
+                bid: parsed.amount,
+                franchise: newFranchise,
+                status: 'active',
+                lastBidTime: franchiseChanged
+                  ? (parseInt(txn.timestamp, 10) || null)
+                  : (existing?.lastBidTime ?? null),
+                initTime: initTimes[parsed.playerId] || null,
+              };
+            }
+          }
+        }
+      }
+    }
+  } catch (error) {
+    console.error('[live-auctions] Failed to fetch from MFL:', error);
+    return { auctions: {}, timestamp: Date.now(), count: 0 };
+  }
+
+  return {
+    auctions,
+    timestamp: Date.now(),
+    count: Object.keys(auctions).length,
+  };
+}


### PR DESCRIPTION
## Why

The Current Auctions card from #194 never appeared in production despite the visibility gate being true and active auctions existing. Confirmed in Vercel runtime logs: **zero** `/api/live-auction` hits since the merge, even on homepage requests.

## Root cause

The homepage loader was self-fetching its own public API during SSR:

```ts
const url = new URL('/api/live-auction', Astro.url);
const res = await fetch(url.toString());
```

On Vercel that round-trip from a serverless function back to its own custom domain can fail silently (timeout / DNS / mixed routing). The `catch` returned `[]`, so `activeAuctions.length > 0` was always false and the card was hidden — without any log entry to investigate.

## Fix

- Extract the MFL fetch + parse logic into `src/utils/live-auctions.ts` (`fetchLiveAuctions`).
- `/api/live-auction` now thinly wraps that util — same JSON contract for the client-side 60s poller in `HpAuctionsCard`.
- `loadActiveAuctions` (homepage loader) calls `fetchLiveAuctions` **directly**, removing the self-fetch entirely. Faster too — no extra hop or JSON round-trip.
- Add a `[homepage-auctions] snapshot=N active=M` log so future regressions surface in Vercel runtime logs instead of silently hiding the card.

## Test plan

- [ ] Merge → wait for production deploy
- [ ] Hit `https://www.theleague.us/` and confirm the Current Auctions card renders with the 5 active auctions
- [ ] Confirm `/api/live-auction` still returns the same JSON shape (used by the client-side poller)
- [ ] Check Vercel logs for `[homepage-auctions] snapshot=… active=…` line on homepage hits

https://claude.ai/code/session_01SYeanvRVRd6JhtxaG6QG3t

---
_Generated by [Claude Code](https://claude.ai/code/session_01SYeanvRVRd6JhtxaG6QG3t)_