### PR TITLE
feat(hp-auc): open PlayerDetailsModal from auction rows

### DIFF
--- a/src/components/theleague/hp-sections/HpAuctionsCard.astro
+++ b/src/components/theleague/hp-sections/HpAuctionsCard.astro
@@ -68,6 +68,7 @@ const formatDollar = (n: number): string => `$${formatCompactNumber(n)}`;
                 nflTeam={row.nflTeam}
                 mflId={row.playerId}
                 espnId={row.espnId}
+                playerData={row.modalData}
                 size="compact"
               />
             </td>
@@ -151,6 +152,8 @@ const formatDollar = (n: number): string => `$${formatCompactNumber(n)}`;
    * adding/removing rows at runtime — if an auction ends or is added the
    * server-rendered table will reflect it on the next page load.
    */
+  import { initPlayerModalTrigger } from '../../../utils/player-modal-trigger';
+
   const BID_WINDOW_MS = 36 * 60 * 60 * 1000;
 
   function timeLeftMs(anchorSeconds: number): number {
@@ -263,6 +266,10 @@ const formatDollar = (n: number): string => `$${formatCompactNumber(n)}`;
 
     const refreshBtn = root.querySelector<HTMLButtonElement>('[data-hp-auc-refresh]');
     refreshBtn?.addEventListener('click', () => window.location.reload());
+
+    // Open PlayerDetailsModal when a player name is clicked. The modal itself
+    // is mounted once at the page level (theleague/index.astro).
+    initPlayerModalTrigger(root);
   }
 
   document.addEventListener('astro:page-load', init);

--- a/src/pages/theleague/index.astro
+++ b/src/pages/theleague/index.astro
@@ -16,6 +16,7 @@ import HpStandingsCompact from '../../components/theleague/hp-sections/HpStandin
 import HpUnsignedFaCard from '../../components/theleague/hp-sections/HpUnsignedFaCard.astro';
 import HpAuctionsCard from '../../components/theleague/hp-sections/HpAuctionsCard.astro';
 import HpQuickLinks from '../../components/theleague/hp-sections/HpQuickLinks.astro';
+import PlayerDetailsModal from '../../components/theleague/PlayerDetailsModal.astro';
 import { getAuthUser } from '../../utils/auth';
 import { resolveHeroState, parseTestDate, isAuctionStripPeriod } from '../../utils/hero-resolver';
 import { enrichHeroState, isDraftComplete } from '../../utils/offseason-hero-data';
@@ -31,7 +32,7 @@ import { computeLeagueSummary, type SalaryPlayer, type TeamConfig } from '../../
 import { getDraftCapitalFromDraftResults } from '../../utils/future-draft-picks-utils';
 import { parseNumber } from '../../utils/formatters';
 import { resolveUnsignedFaAlerts, type DashboardPlayerContext } from '../../utils/homepage-dashboard';
-import { loadActiveAuctions } from '../../utils/homepage-auctions';
+import { loadActiveAuctions, type MflPlayerExtras } from '../../utils/homepage-auctions';
 import { getCachedRosters } from '../../utils/mfl-roster-cache';
 import type { SchefterFeed as FeedType } from '../../types/schefter';
 import type { WhatsNewEntry } from '../../types/whats-new';
@@ -170,6 +171,7 @@ const hpPlayerIdentityMap = getPlayerMap(parseInt(currentSalaryYear) || getCurre
 const playerMetaById = new Map<string, { name: string; position: string }>();
 const eligibilityPlayersById = new Map<string, MFLPlayerInfo>();
 const playerDisplayById = new Map<string, DashboardPlayerContext>();
+const playerExtrasById = new Map<string, MflPlayerExtras>();
 for (const p of Array.isArray(rawPlayerFeed) ? rawPlayerFeed : [rawPlayerFeed]) {
   if (!p?.id) continue;
   const identity = hpPlayerIdentityMap.get(p.id);
@@ -182,6 +184,7 @@ for (const p of Array.isArray(rawPlayerFeed) ? rawPlayerFeed : [rawPlayerFeed]) 
     status: p.status,
     draft_year: p.draft_year,
   });
+  playerExtrasById.set(p.id, p as MflPlayerExtras);
   if (!playerDisplayById.has(p.id)) {
     playerDisplayById.set(p.id, {
       id: p.id,
@@ -300,6 +303,7 @@ const activeAuctions = showAuctionsCard
       year: leagueYear,
       leagueId: mflLeagueId,
       playerMap: hpPlayerIdentityMap,
+      playerExtras: playerExtrasById,
       teams: (leagueConfig.teams ?? []) as any[],
     })
   : [];
@@ -415,11 +419,14 @@ if (heroState.phase === 'playoffs' && heroState.slot === 'standings') {
         isAuthenticated={isAuthenticated}
       />
       {showAuctionsCard && activeAuctions.length > 0 && (
-        <HpAuctionsCard
-          auctions={activeAuctions}
-          placeBidUrl={placeBidUrl}
-          completedAuctionsUrl={completedAuctionsUrl}
-        />
+        <>
+          <HpAuctionsCard
+            auctions={activeAuctions}
+            placeBidUrl={placeBidUrl}
+            completedAuctionsUrl={completedAuctionsUrl}
+          />
+          <PlayerDetailsModal />
+        </>
       )}
       <HpTeamSnapshot
         isAuthenticated={isAuthenticated}

--- a/src/utils/homepage-auctions.ts
+++ b/src/utils/homepage-auctions.ts
@@ -8,6 +8,7 @@
  */
 import type { PlayerIdentity } from './player-map';
 import { fetchLiveAuctions } from './live-auctions';
+import type { PlayerModalData } from './player-modal-trigger';
 
 interface TeamConfigEntry {
   franchiseId: string;
@@ -17,6 +18,25 @@ interface TeamConfigEntry {
   abbrev?: string;
   banner?: string;
   icon?: string;
+}
+
+/** Subset of MFL `players.json` fields used to build the player modal payload. */
+export interface MflPlayerExtras {
+  id?: string;
+  name?: string;
+  position?: string;
+  team?: string;
+  birthdate?: string;
+  college?: string;
+  height?: string;
+  weight?: string;
+  jersey?: string;
+  draft_year?: string;
+  draft_round?: string;
+  draft_pick?: string;
+  draft_team?: string;
+  espn_id?: string;
+  status?: string;
 }
 
 export interface HomepageAuctionRow {
@@ -36,6 +56,8 @@ export interface HomepageAuctionRow {
   franchiseIcon?: string;
   /** Unix seconds — last meaningful bid (or init if none yet). */
   anchorTimestamp: number;
+  /** Optional payload for PlayerDetailsModal (bio, draft, college). */
+  modalData?: PlayerModalData;
 }
 
 interface FetchOpts {
@@ -44,13 +66,51 @@ interface FetchOpts {
   /** MFL league id (defaults to 13522). */
   leagueId?: string;
   playerMap: Map<string, PlayerIdentity>;
+  /** Optional MFL `players.json` extras keyed by player id — used to build modal data. */
+  playerExtras?: Map<string, MflPlayerExtras>;
   teams: TeamConfigEntry[];
   /** Optional fetch override (e.g. for testing). */
   fetchImpl?: typeof fetch;
 }
 
+function toNumber(value: string | undefined | null): number | null {
+  if (value == null || value === '') return null;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+function buildModalData(
+  playerId: string,
+  ident: PlayerIdentity | undefined,
+  extras: MflPlayerExtras | undefined,
+  bid: number,
+  franchiseId: string,
+): PlayerModalData {
+  return {
+    id: playerId,
+    espnId: ident?.espnId ?? extras?.espn_id ?? null,
+    name: ident?.name,
+    position: ident?.position ?? extras?.position,
+    nflTeam: ident?.nflTeam ?? extras?.team,
+    salary: bid,
+    contractYears: 1,
+    contractType: 'AUCTION',
+    franchiseId: franchiseId || null,
+    birthdate: toNumber(extras?.birthdate),
+    college: extras?.college ?? null,
+    height: toNumber(extras?.height),
+    weight: toNumber(extras?.weight),
+    number: toNumber(extras?.jersey),
+    draftYear: toNumber(extras?.draft_year),
+    draftRound: toNumber(extras?.draft_round),
+    draftPick: toNumber(extras?.draft_pick),
+    draftTeam: extras?.draft_team ?? null,
+    status: extras?.status ?? null,
+  };
+}
+
 export async function loadActiveAuctions(opts: FetchOpts): Promise<HomepageAuctionRow[]> {
-  const { playerMap, teams, year, leagueId, fetchImpl } = opts;
+  const { playerMap, teams, year, leagueId, fetchImpl, playerExtras } = opts;
 
   const snapshot = await fetchLiveAuctions({ year, leagueId, fetchImpl });
   const auctions = snapshot.auctions;
@@ -67,7 +127,10 @@ export async function loadActiveAuctions(opts: FetchOpts): Promise<HomepageAucti
     if (typeof anchor !== 'number' || anchor <= 0) continue;
 
     const ident = playerMap.get(playerId);
+    const extras = playerExtras?.get(playerId);
     const team = auc.franchise ? teamById.get(auc.franchise) : undefined;
+    const franchiseId = auc.franchise ?? '';
+    const bid = typeof auc.bid === 'number' ? auc.bid : 0;
 
     rows.push({
       playerId,
@@ -76,13 +139,14 @@ export async function loadActiveAuctions(opts: FetchOpts): Promise<HomepageAucti
       nflTeam: ident?.nflTeam ?? '',
       headshot: ident?.headshot,
       espnId: ident?.espnId ?? undefined,
-      bid: typeof auc.bid === 'number' ? auc.bid : 0,
-      franchiseId: auc.franchise ?? '',
+      bid,
+      franchiseId,
       franchiseName: team?.name ?? auc.franchise ?? 'Unknown',
       franchiseAbbrev: team?.abbrev ?? team?.nameShort ?? '',
       franchiseBanner: team?.banner,
       franchiseIcon: team?.icon,
       anchorTimestamp: anchor,
+      modalData: buildModalData(playerId, ident, extras, bid, franchiseId),
     });
   }
 


### PR DESCRIPTION
## Why

Per request — clicking a player on the Current Auctions card should open a quick-view of their bio, draft history, and college. We already have a `PlayerDetailsModal` used on Rosters / Insights / Free Agents; this just wires it up.

## What

- **Loader**: `loadActiveAuctions` now accepts the MFL `players.json` extras (birthdate, college, height, weight, jersey, draft_year/round/pick/team, espn_id) and produces a `modalData: PlayerModalData` payload per row.
- **Card**: each row's `<PlayerCell>` gets `playerData={row.modalData}`, so the player name renders as a `[data-player-modal]` trigger. The card's script calls `initPlayerModalTrigger(.hp-auc)` to open the modal on click.
- **Page**: `<PlayerDetailsModal />` is mounted once on `theleague/index.astro`, only when the auctions card is visible, so the homepage payload stays light when the card is hidden.

## Modal payload includes

- Identity: `id`, `espnId`, `name`, `position`, `nflTeam`
- Bio: `birthdate` (age pill), `college`, `height`, `weight`, `number`
- Draft: `draftYear`, `draftRound`, `draftPick`, `draftTeam`
- Auction context: `salary` = current high bid, `contractYears: 1`, `contractType: 'AUCTION'`, `franchiseId` = current high bidder

## Test plan

- [ ] Merge → wait for production deploy
- [ ] On `/`, click any player in the Current Auctions card and confirm the modal opens with bio + draft + college
- [ ] Confirm the modal still closes via the X button and ESC
- [ ] Confirm the rest of the homepage (hero, team snapshot, standings) still renders normally
- [ ] On a phone-width viewport, confirm clicking a player still opens the modal even with the bidder column hidden

Stacked atop #196 (now merged).

https://claude.ai/code/session_01SYeanvRVRd6JhtxaG6QG3t

---
_Generated by [Claude Code](https://claude.ai/code/session_01SYeanvRVRd6JhtxaG6QG3t)_