### PR TITLE
feat(standings): link team banners to franchise pages

### DIFF
--- a/src/components/theleague/LeagueStandingsTable.astro
+++ b/src/components/theleague/LeagueStandingsTable.astro
@@ -6,9 +6,10 @@ export interface Props {
   year?: number;
   preferredTeamId?: string;
   rosterBaseUrl?: string;
+  franchiseBaseUrl?: string;
 }
 
-const { teams, year = new Date().getFullYear(), preferredTeamId, rosterBaseUrl } = Astro.props;
+const { teams, year = new Date().getFullYear(), preferredTeamId, rosterBaseUrl, franchiseBaseUrl } = Astro.props;
 
 function parseWLT(wlt: string | undefined) {
   if (!wlt) return { w: 0, l: 0, t: 0 };
@@ -82,6 +83,15 @@ function getRowColor(seed: number | undefined): string {
           const isTierBoundary = rowColor !== nextTier && nextTeam;
           const isPreferredTeam = preferredTeamId && team.id === preferredTeamId;
 
+          const bannerHref = franchiseBaseUrl
+            ? `${franchiseBaseUrl}/${team.id}`
+            : rosterBaseUrl
+              ? `${rosterBaseUrl}?franchise=${team.id}`
+              : null;
+          const bannerLabel = franchiseBaseUrl
+            ? `View ${team.teamName} franchise page`
+            : `View ${team.teamName} roster`;
+
           return (
             <tr
               class={`league-row ${rowColor} ${isTierBoundary ? 'tier-boundary' : ''}${isPreferredTeam ? ' preferred-team' : ''}`}
@@ -94,11 +104,11 @@ function getRowColor(seed: number | undefined): string {
               <td class="col-team">
                 <div class="team-info">
                   {team.teamBanner && (
-                    rosterBaseUrl ? (
+                    bannerHref ? (
                       <a
-                        href={`${rosterBaseUrl}?franchise=${team.id}`}
+                        href={bannerHref}
                         class="team-banner-link"
-                        aria-label={`View ${team.teamName} roster`}
+                        aria-label={bannerLabel}
                       >
                         <img
                           src={team.teamBanner}

--- a/src/components/theleague/StandingsTable.astro
+++ b/src/components/theleague/StandingsTable.astro
@@ -12,9 +12,10 @@ export interface Props {
   year?: number;
   preferredTeamId?: string;
   rosterBaseUrl?: string;
+  franchiseBaseUrl?: string;
 }
 
-const { teams, view, showDivisionHeader = false, divisionName = '', defendingChampion = '', defendingChampionYear, year = new Date().getFullYear(), preferredTeamId, rosterBaseUrl } = Astro.props;
+const { teams, view, showDivisionHeader = false, divisionName = '', defendingChampion = '', defendingChampionYear, year = new Date().getFullYear(), preferredTeamId, rosterBaseUrl, franchiseBaseUrl } = Astro.props;
 
 function parseWLT(wlt: string | undefined) {
   if (!wlt) return { w: 0, l: 0, t: 0 };
@@ -123,6 +124,15 @@ function calculateGamesBack(team: TeamStanding, allTeamsInDivision: TeamStanding
 
           const isPreferredTeam = preferredTeamId && team.id === preferredTeamId;
 
+          const bannerHref = franchiseBaseUrl
+            ? `${franchiseBaseUrl}/${team.id}`
+            : rosterBaseUrl
+              ? `${rosterBaseUrl}?franchise=${team.id}`
+              : null;
+          const bannerLabel = franchiseBaseUrl
+            ? `View ${team.teamName} franchise page`
+            : `View ${team.teamName} roster`;
+
           return (
             <tr
               class={`row-${index % 2 === 0 ? 'even' : 'odd'}${isPreferredTeam ? ' preferred-team' : ''}`}
@@ -142,11 +152,11 @@ function calculateGamesBack(team: TeamStanding, allTeamsInDivision: TeamStanding
               <td class="col-team">
                 <div class="team-info">
                   {team.teamBanner && (
-                    rosterBaseUrl ? (
+                    bannerHref ? (
                       <a
-                        href={`${rosterBaseUrl}?franchise=${team.id}`}
+                        href={bannerHref}
                         class="team-banner-link"
-                        aria-label={`View ${team.teamName} roster`}
+                        aria-label={bannerLabel}
                       >
                         <img
                           src={team.teamBanner}

--- a/src/pages/theleague/franchises/[id].astro
+++ b/src/pages/theleague/franchises/[id].astro
@@ -483,6 +483,16 @@ const formatBid = (n: number): string => {
             </li>
           )}
         </ul>
+        {team && (
+          <p class="hero-actions">
+            <a
+              class="btn-roster"
+              href={resolveLeaguePath(`/theleague/rosters?franchise=${id}`, hideLeaguePrefix)}
+            >
+              View Current Roster →
+            </a>
+          </p>
+        )}
       </div>
     </header>
 
@@ -1017,6 +1027,32 @@ const formatBid = (n: number): string => {
   .badge--mvp { background: #e6f7e6; color: #1f5d2d; }
   .badge--jerry { background: #ffe4e1; color: #8b2a1f; }
   .badge--osweiler { background: #f0e6f7; color: #4d2c66; }
+
+  .hero-actions {
+    margin: 0.875rem 0 0;
+  }
+  .btn-roster {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    padding: 0.5rem 0.875rem;
+    background: var(--accent);
+    color: #fff;
+    text-decoration: none;
+    font-weight: 600;
+    font-size: 0.875rem;
+    border-radius: 0.5rem;
+    transition: filter 0.15s ease, transform 0.15s ease;
+  }
+  .btn-roster:hover,
+  .btn-roster:focus-visible {
+    filter: brightness(1.1);
+    transform: translateY(-1px);
+  }
+  .btn-roster:focus-visible {
+    outline: 2px solid var(--color-focus, #2563eb);
+    outline-offset: 2px;
+  }
 
   .quick-stats {
     display: grid;

--- a/src/pages/theleague/standings.astro
+++ b/src/pages/theleague/standings.astro
@@ -154,7 +154,7 @@ const defendingChampions = getDivisionChampions(franchises, yearResolvedConfig);
               defendingChampionYear={selectedYear}
               year={selectedYear}
               preferredTeamId={yearPreferredTeamId}
-              rosterBaseUrl="/theleague/rosters"
+              franchiseBaseUrl="/theleague/franchises"
             />
           ))}
         </div>
@@ -162,13 +162,13 @@ const defendingChampions = getDivisionChampions(franchises, yearResolvedConfig);
 
       {view === 'league' && (
         <div class="league-view">
-          <LeagueStandingsTable teams={leagueStandings} year={selectedYear} preferredTeamId={yearPreferredTeamId} rosterBaseUrl="/theleague/rosters" />
+          <LeagueStandingsTable teams={leagueStandings} year={selectedYear} preferredTeamId={yearPreferredTeamId} franchiseBaseUrl="/theleague/franchises" />
         </div>
       )}
 
       {view === 'all_play' && (
         <div class="all-play-view">
-          <StandingsTable teams={allPlayStandings} view="all_play" year={selectedYear} preferredTeamId={yearPreferredTeamId} rosterBaseUrl="/theleague/rosters" />
+          <StandingsTable teams={allPlayStandings} view="all_play" year={selectedYear} preferredTeamId={yearPreferredTeamId} franchiseBaseUrl="/theleague/franchises" />
         </div>
       )}
 


### PR DESCRIPTION
Add a franchiseBaseUrl prop to StandingsTable and LeagueStandingsTable
that, when set, points the team banner link at /<base>/<team.id>
(matching the [id].astro franchise route) instead of the
/rosters?franchise=... query-style link.

Wire up the theleague standings page to pass
franchiseBaseUrl=\"/theleague/franchises\" so each banner now opens
that franchise's page. AFL still uses rosterBaseUrl since it has no
franchise pages.

https://claude.ai/code/session_01PKpxisGwzwovyDyBcgygGw