### PR TITLE
feat(stats): surface Franchises and Rivalries on the Stats hub

### DIFF
--- a/src/data/page-directory.json
+++ b/src/data/page-directory.json
@@ -359,6 +359,30 @@
     "popularity": 60
   },
   {
+    "id": "franchises",
+    "title": "Franchises",
+    "description": "All-time franchise records, championships, and historical identities going back to the league's first season",
+    "path": "/franchises",
+    "icon": "history",
+    "category": "reports",
+    "subcategory": "league-history",
+    "tags": ["franchises", "franchise", "teams", "history", "all time", "all-time", "career", "career records", "championships", "titles", "rings", "trophies", "trophy", "division titles", "win loss", "w-l", "winning percentage", "win pct", "owner", "owners", "owner history", "historical identities", "team names", "old names", "previous names", "rebrand", "rebranding", "banner", "banners", "logo history", "leaderboard", "all teams", "career wins", "career losses", "career points", "longevity", "years active", "mvp awards", "jerry jones", "brock osweiler", "dead money awards", "year by year", "per team page"],
+    "visibility": "all",
+    "popularity": 50
+  },
+  {
+    "id": "rivalries",
+    "title": "Rivalries",
+    "description": "Head-to-head matchup matrix between every pair of franchises, with hot rivalries highlighted by intensity and playoff history",
+    "path": "/rivalries",
+    "icon": "scoreboard-2",
+    "category": "reports",
+    "subcategory": "league-history",
+    "tags": ["rivalries", "rivalry", "head to head", "head-to-head", "h2h", "matchup", "matchups", "matrix", "vs", "versus", "all time", "all-time", "record", "records", "win loss", "w-l", "playoff history", "playoff meetings", "intensity", "hot rivalries", "blood feud", "grudge", "history", "rivalry history", "matchup history", "all teams", "every pair", "franchise vs franchise", "team vs team", "comparison", "compare teams"],
+    "visibility": "all",
+    "popularity": 48
+  },
+  {
     "id": "icons",
     "title": "Icon Gallery",
     "description": "Browse and test all SVG sprite icons with color picker and category filters",

--- a/src/pages/theleague/stats.astro
+++ b/src/pages/theleague/stats.astro
@@ -35,6 +35,11 @@ const SECTIONS: { id: string; title: string; description: string }[] = [
     description: 'Side-by-side cap, contract, and roster metrics across the league.',
   },
   {
+    id: 'league-history',
+    title: 'League History',
+    description: 'All-time franchise records, championships, and head-to-head rivalries.',
+  },
+  {
     id: 'salary-analytics',
     title: 'Salary Analytics',
     description: 'Position benchmarks, multi-year trends, and the historical archive.',


### PR DESCRIPTION
Adds page-directory entries for /franchises and /rivalries (already-built
pages that weren't wired into the hub) and creates a new "League History"
section on /stats so they're discoverable alongside Team Comparisons,
Salary Analytics, Awards, and Free Agency. Also seeds tags for /search
and enables sibling discovery via RelatedReports.