### PR TITLE
fix(modal): keep contract declaration modal inside the mobile viewport

### DIFF
--- a/src/components/theleague/ContractDeclarationModal.astro
+++ b/src/components/theleague/ContractDeclarationModal.astro
@@ -266,7 +266,11 @@
     z-index: 1001;
     justify-content: center;
     align-items: center;
-    padding: 1rem;
+    padding:
+      max(1rem, env(safe-area-inset-top, 0px))
+      max(1rem, env(safe-area-inset-right, 0px))
+      max(1rem, env(safe-area-inset-bottom, 0px))
+      max(1rem, env(safe-area-inset-left, 0px));
   }
 
   .contract-declaration-modal.active {
@@ -288,7 +292,10 @@
     box-shadow: var(--shadow-xl);
     width: 100%;
     max-width: 440px;
+    /* Use dvh (dynamic viewport height) so the mobile URL/nav bars don't clip
+       the modal. Falls back to vh on older browsers. */
     max-height: 88vh;
+    max-height: min(88vh, calc(100dvh - 2rem));
     display: flex;
     flex-direction: column;
     overflow: hidden;


### PR DESCRIPTION
## Summary
- The contract declaration modal was clipping past the bottom of the viewport (and visually flush against the top) on mobile because `max-height: 88vh` counts the URL/nav bars that are usually visible.
- Switch to `min(88vh, 100dvh - 2rem)` so the modal always fits inside the visible area; keep the `88vh` line as a fallback for browsers without `dvh` support.
- Pad the outer container with `env(safe-area-inset-*)` so the status bar / home indicator no longer overlap it.

Follow-up to #200 — surfaced when the new "Declare Contract" entry pushed the action sheet long enough to overflow on a phone.

## Test plan
- [ ] Open the roster page on mobile, tap the action button on a freshly signed player → modal sits below the URL bar with breathing room above the stepper, and the action list scrolls inside the modal instead of running off the bottom of the screen.
- [ ] Same on desktop → modal still centered with no visible regression.

https://claude.ai/code/session_01R9FmNF1sf8qTL1RSnhNyvL

---
_Generated by [Claude Code](https://claude.ai/code/session_01R9FmNF1sf8qTL1RSnhNyvL)_