### PR TITLE
fix: persist contract cancel when years revert to current

### DIFF
--- a/src/pages/api/contracts/declare.ts
+++ b/src/pages/api/contracts/declare.ts
@@ -12,6 +12,7 @@ import {
   generateDeclarationId,
   addDeclaration,
   updateDeclaration,
+  deleteDeclaration,
   getPendingDeclarationForPlayer,
   getTeamFranchiseTag,
   getTeamExtension,
@@ -73,6 +74,30 @@ export const POST: APIRoute = async ({ request }) => {
       return new Response(
         JSON.stringify({ error: 'You can only submit declarations for your own team' }),
         { status: 403, headers: JSON_HEADERS },
+      );
+    }
+
+    // 3a. Cancel-pending shortcut: selecting the same years as the current
+    // contract means "revert any pending change for this player". Validation
+    // would reject equal years, so handle this before validation runs.
+    if (requestedYears === currentYears) {
+      const existing = await getPendingDeclarationForPlayer(playerId, franchiseId);
+      if (existing && existing.status === 'pending') {
+        const deleted = await deleteDeclaration(existing.id);
+        if (!deleted) {
+          return new Response(
+            JSON.stringify({ error: 'Failed to cancel pending declaration' }),
+            { status: 500, headers: JSON_HEADERS },
+          );
+        }
+      }
+      return new Response(
+        JSON.stringify({
+          success: true,
+          cancelled: true,
+          message: 'Pending declaration cancelled',
+        }),
+        { status: 200, headers: JSON_HEADERS },
       );
     }
 

--- a/src/pages/theleague/rosters.astro
+++ b/src/pages/theleague/rosters.astro
@@ -9653,26 +9653,20 @@ const defaultLastSeenText = formatLastSeen(defaultLastSeen);
       cdmError.style.display = 'none';
 
       const elig = cdmPlayerData.eligibility;
-
-      // If selecting the same years as current contract, cancel any pending declaration
-      if (cdmSelectedYears === elig?.currentYears) {
-        delete localDeclarations[cdmPlayerData.id];
-        delete declarationsByPlayer[cdmPlayerData.id];
-        cdmSubmitBtn.style.display = 'none';
-        cdmSuccess.style.display = 'flex';
-        updateView();
-        applyEligibilityStyling();
-        setTimeout(closeDeclarationModal, 1500);
-        return;
-      }
+      const isCancelling = cdmSelectedYears === elig?.currentYears;
 
       // Demo mode: skip API call, show success immediately
       const isDemoPlayer = demoActive && String(cdmPlayerData.id).startsWith('DEMO_');
       if (isDemoPlayer) {
-        localDeclarations[cdmPlayerData.id] = {
-          status: 'pending',
-          years: cdmSelectedYears,
-        };
+        if (isCancelling) {
+          delete localDeclarations[cdmPlayerData.id];
+          delete declarationsByPlayer[cdmPlayerData.id];
+        } else {
+          localDeclarations[cdmPlayerData.id] = {
+            status: 'pending',
+            years: cdmSelectedYears,
+          };
+        }
         cdmSubmitBtn.style.display = 'none';
         cdmSuccess.style.display = 'flex';
         updateView();
@@ -9721,17 +9715,23 @@ const defaultLastSeenText = formatLastSeen(defaultLastSeen);
         const result = await res.json();
         if (!res.ok) throw new Error(result.error || 'Declaration failed');
 
-        // Optimistic update
-        localDeclarations[cdmPlayerData.id] = {
-          status: 'pending',
-          years: cdmSelectedYears,
-        };
+        if (result.cancelled) {
+          delete localDeclarations[cdmPlayerData.id];
+          delete declarationsByPlayer[cdmPlayerData.id];
+        } else {
+          // Optimistic update
+          localDeclarations[cdmPlayerData.id] = {
+            status: 'pending',
+            years: cdmSelectedYears,
+          };
+        }
 
         cdmSubmitBtn.style.display = 'none';
         cdmSuccess.style.display = 'flex';
 
         // Refresh the years cells
         updateView();
+        applyEligibilityStyling();
 
         // Auto-close after short delay
         setTimeout(closeDeclarationModal, 1500);


### PR DESCRIPTION
When a user opened the contract modal for a player with a pending
declaration and selected the same years as the player's actual current
MFL contract (e.g., 4yr -> 3yr (saved), then 3yr -> back to 4yr), the
client treated it as "cancel pending" but only deleted the entry from
in-memory state. The persisted pending declaration was never touched, so
on refresh the SSR snapshot rehydrated the stale 3yr entry.

Fix:
- declare.ts: detect requestedYears === currentYears and delete any
  existing pending declaration for the player+franchise, returning
  { cancelled: true }. Validation rejects equal years, so this branch
  runs before validation.
- rosters.astro: drop the client-only same-years short-circuit. The
  request now flows through the API like any other submission; the
  success handler deletes from localDeclarations / declarationsByPlayer
  when the response carries cancelled: true. Demo mode still bypasses
  the API.

https://claude.ai/code/session_0136B5113QygHNB7Bdzf1apd