### PR TITLE
fix(afl-standings): reword misleading all-play subtitles

### DIFF
--- a/src/pages/afl-fantasy/standings.astro
+++ b/src/pages/afl-fantasy/standings.astro
@@ -173,7 +173,7 @@ const promoRegTeams = [
         {view === 'all_play' && (
           <>
             <h1 class="section-title">Premier League Standings</h1>
-            <p class="subtitle">Top 4 advance to playoffs • Bottom 2 relegated to D-League</p>
+            <p class="subtitle">All-play side competition • Bottom 2 of bubble drop to D-League next year</p>
           </>
         )}
       </div>
@@ -308,8 +308,8 @@ const promoRegTeams = [
           <div class="promo-reg-header">
             <img src="/assets/afl/premier.svg" alt="Premier League Logo" class="promo-reg-logo" />
             <div class="promo-reg-text">
-              <h2 class="promo-reg-title">Promotion/Relegation playoff standings</h2>
-              <p class="promo-reg-subtitle">Top 2 will be in the Premier League next season.</p>
+              <h2 class="promo-reg-title">Promotion/Relegation cutoff</h2>
+              <p class="promo-reg-subtitle">Final all-play standings cut — top 2 are in Premier League next season, bottom 2 in D-League.</p>
             </div>
           </div>
 


### PR DESCRIPTION
## Summary

Per the AFL Duplication Plan, the all-play view of the AFL standings page was using copy that overstated what's happening:

- **"Top 4 advance to playoffs • Bottom 2 relegated to D-League"** implied there's a Premier League playoff. There isn't — there are no Premier or D-League tier playoffs (those are H2H AL/NL brackets).
- **"Promotion/Relegation playoff standings"** suggests a bracket of games. It's a final-standings cut: Premier #9–10 + D-League #3–4 ranked together by all-play; top 2 are in Premier next year, bottom 2 in D-League. No extra games are played.

Reworded both to describe the mechanic accurately.

## Changes

- `src/pages/afl-fantasy/standings.astro`:
  - "Premier League Standings" subtitle now reads: _"All-play side competition • Bottom 2 of bubble drop to D-League next year"_
  - Section title changed from _"Promotion/Relegation playoff standings"_ to _"Promotion/Relegation cutoff"_, and the explainer line clarifies it's a final all-play cut.

## Test plan

- [ ] Visit `/afl-fantasy/standings?view=all_play` and confirm both copy changes render
- [ ] Confirm no other view labels were affected (`?view=division`, `?view=league`)

## Plan reference

`docs/plans/AFL_DUPLICATION_PLAN.md` — §3 standings row follow-up #3 and §4.2 tier mechanics.

https://claude.ai/code/session_01DEecdWcSPe6z48JTbVAWeT

---
_Generated by [Claude Code](https://claude.ai/code/session_01DEecdWcSPe6z48JTbVAWeT)_