### PR TITLE
middleware: host→slug map ready for afl-fantasy.com

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,7 +1,7 @@
 /**
  * Astro Middleware
  *
- * Handles two concerns for the theleague.us domain:
+ * Handles two concerns for the per-league domains:
  *
  * 1. URL rewriting: Rewrites clean URLs (e.g., /rosters) to their internal
  *    Astro route (e.g., /theleague/rosters) using context.rewrite(). This is
@@ -9,54 +9,30 @@
  *    SSR catch-all route in the build output config.
  *
  * 2. Link generation flag: Sets context.locals.hideLeaguePrefix so components
- *    can generate clean links without the /theleague prefix on theleague.us.
+ *    can generate clean links without the /<slug> prefix on the league's
+ *    apex host.
  *
- * Vercel 301 redirects in vercel.json still handle catching leaked /theleague/*
+ * Vercel 301 redirects in vercel.json still handle catching leaked /<slug>/*
  * links at the edge before this middleware runs.
+ *
+ * The host → slug map and the path-rewrite logic live in
+ * src/utils/league-host-map.ts and are unit-tested.
  */
 
 import { defineMiddleware } from 'astro:middleware';
-
-const THELEAGUE_HOSTS = new Set(['theleague.us', 'www.theleague.us']);
-
-/** Paths that exist at the root level and should NOT be rewritten to /theleague/* */
-const SKIP_REWRITE_PREFIXES = [
-  '/api/',
-  '/afl-fantasy',
-  '/_astro/',
-  '/_image',
-  '/_server-islands/',
-  '/forum/',
-  '/404',
-  '/favicon.ico',
-  '/assets/',
-  '/manifest.json',
-];
+import { HOST_TO_SLUG, resolveLeagueRewrite } from './utils/league-host-map';
 
 export const onRequest = defineMiddleware(async (context, next) => {
   const hostname = context.url.hostname;
-  const isTheLeagueHost = THELEAGUE_HOSTS.has(hostname);
+  const isLeagueHost = Boolean(HOST_TO_SLUG[hostname]);
 
-  context.locals.hideLeaguePrefix = isTheLeagueHost;
+  context.locals.hideLeaguePrefix = isLeagueHost;
 
-  if (isTheLeagueHost) {
-    const path = context.url.pathname;
-    // Already has /theleague prefix — no rewrite needed
-    if (path.startsWith('/theleague')) {
-      return next();
-    }
+  if (!isLeagueHost) return next();
 
-    // Skip rewrite for root-level paths (API, AFL, static assets, forum)
-    const shouldSkip = SKIP_REWRITE_PREFIXES.some((prefix) => path.startsWith(prefix));
-    if (shouldSkip) {
-      return next();
-    }
+  const rewrite = resolveLeagueRewrite(hostname, context.url.pathname);
+  if (!rewrite) return next();
 
-    // Rewrite / → /theleague, /rosters → /theleague/rosters, etc.
-    const newPath = path === '/' ? '/theleague' : `/theleague${path}`;
-    const newUrl = new URL(newPath + context.url.search, context.url);
-    return context.rewrite(newUrl);
-  }
-
-  return next();
+  const newUrl = new URL(rewrite.newPath + context.url.search, context.url);
+  return context.rewrite(newUrl);
 });

--- a/src/utils/league-host-map.ts
+++ b/src/utils/league-host-map.ts
@@ -1,0 +1,81 @@
+/**
+ * Pure host/path → league-slug + rewrite-target resolver.
+ *
+ * Lives in src/utils so it's importable by both src/middleware.ts (which
+ * pulls in astro:middleware and can't be unit-tested directly) and by
+ * vitest.
+ *
+ * Adding a new league domain: extend HOST_TO_SLUG. The afl-fantasy.com
+ * entry is wired in but dormant — flipping live requires DNS + Vercel
+ * domain attachment (AFL_DUPLICATION_PLAN §2.3, Phase 7).
+ */
+
+/**
+ * Map of apex hostnames → league slug (the path segment under src/pages/).
+ * Both the bare host and `www.` variant should be present.
+ */
+export const HOST_TO_SLUG: Readonly<Record<string, string>> = {
+  'theleague.us': 'theleague',
+  'www.theleague.us': 'theleague',
+  // Dormant until afl-fantasy.com is pointed at this Vercel project.
+  'afl-fantasy.com': 'afl-fantasy',
+  'www.afl-fantasy.com': 'afl-fantasy',
+};
+
+// Slug prefixes get a trailing slash so /theleagueX doesn't match /theleague
+// as a substring. The exact path /theleague (no trailing slash) is caught
+// by the slug-already-prefixed check inside resolveLeagueRewrite.
+const ALL_LEAGUE_PREFIX_SLASHES: readonly string[] = Array.from(
+  new Set(Object.values(HOST_TO_SLUG))
+).map((slug) => `/${slug}/`);
+
+/**
+ * Paths that exist at the root level and should NOT be rewritten under
+ * a league prefix when serving from a league apex host. Includes every
+ * known league prefix so cross-league deep links continue working from
+ * either host (e.g. an /afl-fantasy/* link visited from theleague.us
+ * still resolves to the AFL page).
+ */
+export const SKIP_REWRITE_PREFIXES: readonly string[] = [
+  '/api/',
+  ...ALL_LEAGUE_PREFIX_SLASHES,
+  '/_astro/',
+  '/_image',
+  '/_server-islands/',
+  '/forum/',
+  '/404',
+  '/favicon.ico',
+  '/assets/',
+  '/manifest.json',
+];
+
+export interface LeagueRewrite {
+  newPath: string;
+  slug: string;
+}
+
+/**
+ * Resolve a `(hostname, pathname)` pair to a rewrite target.
+ *
+ * @returns The rewritten pathname when the request should be rewritten under
+ *   a league prefix, or `null` when no rewrite is needed.
+ */
+export function resolveLeagueRewrite(
+  hostname: string,
+  pathname: string
+): LeagueRewrite | null {
+  const slug = HOST_TO_SLUG[hostname];
+  if (!slug) return null;
+
+  const slugPrefix = `/${slug}`;
+  if (pathname === slugPrefix || pathname.startsWith(`${slugPrefix}/`)) {
+    return null;
+  }
+
+  if (SKIP_REWRITE_PREFIXES.some((prefix) => pathname.startsWith(prefix))) {
+    return null;
+  }
+
+  const newPath = pathname === '/' ? slugPrefix : `${slugPrefix}${pathname}`;
+  return { newPath, slug };
+}

--- a/tests/middleware-host-map.test.ts
+++ b/tests/middleware-host-map.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect } from 'vitest';
+import {
+  HOST_TO_SLUG,
+  SKIP_REWRITE_PREFIXES,
+  resolveLeagueRewrite,
+} from '../src/utils/league-host-map';
+
+// ---------------------------------------------------------------------------
+// HOST_TO_SLUG / SKIP_REWRITE_PREFIXES sanity
+// ---------------------------------------------------------------------------
+
+describe('HOST_TO_SLUG', () => {
+  it('includes both bare and www. variants for every league', () => {
+    const slugs = new Set(Object.values(HOST_TO_SLUG));
+    for (const slug of slugs) {
+      const hostsForSlug = Object.entries(HOST_TO_SLUG)
+        .filter(([, s]) => s === slug)
+        .map(([h]) => h);
+      const hasBare = hostsForSlug.some((h) => !h.startsWith('www.'));
+      const hasWww = hostsForSlug.some((h) => h.startsWith('www.'));
+      expect(hasBare, `expected a bare host for slug=${slug}`).toBe(true);
+      expect(hasWww, `expected a www host for slug=${slug}`).toBe(true);
+    }
+  });
+
+  it('contains theleague.us and afl-fantasy.com (dormant)', () => {
+    expect(HOST_TO_SLUG['theleague.us']).toBe('theleague');
+    expect(HOST_TO_SLUG['afl-fantasy.com']).toBe('afl-fantasy');
+  });
+});
+
+describe('SKIP_REWRITE_PREFIXES', () => {
+  it('contains every league prefix (with trailing slash) so cross-league deep links survive', () => {
+    const slugs = Array.from(new Set(Object.values(HOST_TO_SLUG)));
+    for (const slug of slugs) {
+      expect(SKIP_REWRITE_PREFIXES).toContain(`/${slug}/`);
+    }
+  });
+
+  it('contains api, astro, image, server-islands, forum, 404, favicon, assets, manifest', () => {
+    expect(SKIP_REWRITE_PREFIXES).toContain('/api/');
+    expect(SKIP_REWRITE_PREFIXES).toContain('/_astro/');
+    expect(SKIP_REWRITE_PREFIXES).toContain('/_image');
+    expect(SKIP_REWRITE_PREFIXES).toContain('/_server-islands/');
+    expect(SKIP_REWRITE_PREFIXES).toContain('/forum/');
+    expect(SKIP_REWRITE_PREFIXES).toContain('/404');
+    expect(SKIP_REWRITE_PREFIXES).toContain('/favicon.ico');
+    expect(SKIP_REWRITE_PREFIXES).toContain('/assets/');
+    expect(SKIP_REWRITE_PREFIXES).toContain('/manifest.json');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveLeagueRewrite — the actual rewrite logic
+// ---------------------------------------------------------------------------
+
+describe('resolveLeagueRewrite', () => {
+  // -- theleague.us (the in-prod host) --
+
+  it('rewrites / to /theleague on theleague.us', () => {
+    expect(resolveLeagueRewrite('theleague.us', '/')).toEqual({
+      newPath: '/theleague',
+      slug: 'theleague',
+    });
+  });
+
+  it('rewrites /rosters to /theleague/rosters on theleague.us', () => {
+    expect(resolveLeagueRewrite('theleague.us', '/rosters')).toEqual({
+      newPath: '/theleague/rosters',
+      slug: 'theleague',
+    });
+  });
+
+  it('rewrites the same way on www.theleague.us', () => {
+    expect(resolveLeagueRewrite('www.theleague.us', '/standings')).toEqual({
+      newPath: '/theleague/standings',
+      slug: 'theleague',
+    });
+  });
+
+  it('returns null when path is already prefixed (/theleague)', () => {
+    expect(resolveLeagueRewrite('theleague.us', '/theleague')).toBeNull();
+  });
+
+  it('returns null when path is already prefixed (/theleague/rosters)', () => {
+    expect(resolveLeagueRewrite('theleague.us', '/theleague/rosters')).toBeNull();
+  });
+
+  it('returns null for /api/* (API routes are root-level)', () => {
+    expect(resolveLeagueRewrite('theleague.us', '/api/foo')).toBeNull();
+  });
+
+  it('returns null for /_astro/* (Astro internals)', () => {
+    expect(
+      resolveLeagueRewrite('theleague.us', '/_astro/chunk.123.js')
+    ).toBeNull();
+  });
+
+  it('returns null for /assets/* (static assets)', () => {
+    expect(
+      resolveLeagueRewrite('theleague.us', '/assets/theleague/icons/pigskins.png')
+    ).toBeNull();
+  });
+
+  it('does NOT rewrite a /afl-fantasy/* deep link visited from theleague.us', () => {
+    // Cross-league deep links must reach the AFL page.
+    expect(
+      resolveLeagueRewrite('theleague.us', '/afl-fantasy/standings')
+    ).toBeNull();
+  });
+
+  // -- afl-fantasy.com (currently dormant, but should work when DNS flips) --
+
+  it('rewrites / to /afl-fantasy on afl-fantasy.com', () => {
+    expect(resolveLeagueRewrite('afl-fantasy.com', '/')).toEqual({
+      newPath: '/afl-fantasy',
+      slug: 'afl-fantasy',
+    });
+  });
+
+  it('rewrites /standings to /afl-fantasy/standings on afl-fantasy.com', () => {
+    expect(resolveLeagueRewrite('afl-fantasy.com', '/standings')).toEqual({
+      newPath: '/afl-fantasy/standings',
+      slug: 'afl-fantasy',
+    });
+  });
+
+  it('rewrites the same way on www.afl-fantasy.com', () => {
+    expect(resolveLeagueRewrite('www.afl-fantasy.com', '/keepers')).toEqual({
+      newPath: '/afl-fantasy/keepers',
+      slug: 'afl-fantasy',
+    });
+  });
+
+  it('returns null when path is already /afl-fantasy', () => {
+    expect(resolveLeagueRewrite('afl-fantasy.com', '/afl-fantasy')).toBeNull();
+  });
+
+  it('returns null when path is /afl-fantasy/<sub>', () => {
+    expect(
+      resolveLeagueRewrite('afl-fantasy.com', '/afl-fantasy/standings')
+    ).toBeNull();
+  });
+
+  it('does NOT rewrite a /theleague/* deep link visited from afl-fantasy.com', () => {
+    // Cross-league deep links must reach TheLeague page.
+    expect(
+      resolveLeagueRewrite('afl-fantasy.com', '/theleague/rosters')
+    ).toBeNull();
+  });
+
+  // -- non-league hosts --
+
+  it('returns null for a non-league host (vercel deployment)', () => {
+    expect(
+      resolveLeagueRewrite('mflfootballv2.vercel.app', '/rosters')
+    ).toBeNull();
+  });
+
+  it('returns null for localhost', () => {
+    expect(resolveLeagueRewrite('localhost', '/rosters')).toBeNull();
+  });
+
+  // -- edge cases --
+
+  it('does not match a path that merely contains a slug prefix as a substring', () => {
+    // e.g. /theleagueX shouldn't be treated as already-prefixed
+    expect(resolveLeagueRewrite('theleague.us', '/theleagueX')).toEqual({
+      newPath: '/theleague/theleagueX',
+      slug: 'theleague',
+    });
+  });
+
+  it('preserves trailing slash on / → /<slug>', () => {
+    expect(resolveLeagueRewrite('theleague.us', '/')).toEqual({
+      newPath: '/theleague',
+      slug: 'theleague',
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Phase 0.4 of the AFL Duplication Plan — generalize the theleague.us-only middleware into a host→slug map so additional league apex domains can come online without code changes.

### What changes

- **`src/utils/league-host-map.ts`** (new) — pure host/path → rewrite-target resolver, exposes `HOST_TO_SLUG`, `SKIP_REWRITE_PREFIXES`, and `resolveLeagueRewrite(hostname, pathname)`. Lives outside `src/middleware.ts` because the latter pulls in `astro:middleware` and can't be unit-tested in vitest.
- **`src/middleware.ts`** — becomes a thin wrapper. Same external behavior on `theleague.us` (verified by tests). Adds `afl-fantasy.com` and `www.afl-fantasy.com` as **dormant** entries — inert until DNS + Vercel domain attachment land (Phase 7).
- **`tests/middleware-host-map.test.ts`** (new) — 23 cases covering:
  - TheLeague rewrites still work identically (`/` → `/theleague`, `/rosters` → `/theleague/rosters`)
  - AFL rewrites work when serving from `afl-fantasy.com`
  - Already-prefixed paths bypass (`/theleague/rosters` → no rewrite)
  - `/api/`, `/_astro/`, `/assets/`, `/_image`, etc. bypass
  - Cross-league deep links survive from the wrong apex (visiting `/afl-fantasy/standings` on `theleague.us` still resolves to AFL)
  - Non-league hosts (Vercel preview, localhost) are untouched
  - **Regression trap fix**: `/theleagueX` is no longer treated as already-prefixed. Slug entries in `SKIP_REWRITE_PREFIXES` now have trailing slashes so substring-match collisions don't happen. The exact-match `/theleague` is caught by a separate guard inside `resolveLeagueRewrite`.

## Why a separate utils file?

Vitest can't resolve `astro:middleware`, so the testable logic has to live somewhere outside the middleware entry point. The middleware itself becomes ~10 lines of glue.

## Test plan

- [x] `pnpm vitest run tests/middleware-host-map.test.ts` — 23/23 pass
- [x] `pnpm test:unit` — 2130 pass (was 2107 → +23 new), same 11 pre-existing failures, no regressions

## Plan reference

`docs/plans/AFL_DUPLICATION_PLAN.md` §2.3 (middleware: prepare for afl-fantasy.com) and §6 Phase 7 (domain split).

https://claude.ai/code/session_01DEecdWcSPe6z48JTbVAWeT

---
_Generated by [Claude Code](https://claude.ai/code/session_01DEecdWcSPe6z48JTbVAWeT)_