### PR TITLE
nav: dedupe getEquivalentRoute, gate LeagueSwitcher on dual-league

### DIFF
--- a/src/components/nav/LeagueSwitcher.astro
+++ b/src/components/nav/LeagueSwitcher.astro
@@ -22,7 +22,8 @@
  */
 
 import type { LeagueSwitcherProps } from '../../types/nav';
-import { resolveLeaguePath } from '../../utils/nav-utils';
+import { resolveLeaguePath, getEquivalentRoute } from '../../utils/nav-utils';
+import { hasTeamInBothLeagues } from '../../utils/league-context';
 
 interface Props extends LeagueSwitcherProps {
   /** Strip /theleague prefix from links (true on theleague.us domain) */
@@ -32,40 +33,16 @@ interface Props extends LeagueSwitcherProps {
 const {
   currentLeague,
   currentPath,
+  franchiseId,
   hideLeaguePrefix = false,
 } = Astro.props;
 
-/**
- * Get the equivalent route in the target league.
- *
- * Smart routing logic:
- * 1. Extract the page path from current URL (e.g., /theleague/rosters -> /rosters)
- * 2. Prepend the target league prefix
- * 3. Return the target league home if path is just the root
- *
- * Note: Route existence validation happens client-side via nav-config.json
- * or could be enhanced with a route map in the future.
- */
-function getEquivalentRoute(path: string, targetLeague: 'theleague' | 'afl'): string {
-  const targetBase = targetLeague === 'afl' ? '/afl-fantasy' : '/theleague';
-  const sourceBase = targetLeague === 'afl' ? '/theleague' : '/afl-fantasy';
-
-  // Extract the page portion after the league prefix
-  let pagePath = '';
-  if (path.startsWith('/theleague')) {
-    pagePath = path.slice('/theleague'.length);
-  } else if (path.startsWith('/afl-fantasy')) {
-    pagePath = path.slice('/afl-fantasy'.length);
-  }
-
-  // If no page path or just root, return league home
-  if (!pagePath || pagePath === '/') {
-    return targetBase;
-  }
-
-  // Construct equivalent URL
-  return `${targetBase}${pagePath}`;
-}
+// When a franchiseId is provided, gate visibility on dual-league ownership.
+// When omitted, render unconditionally (e.g. for a global header where any
+// visitor should be able to flip).
+const shouldRender =
+  franchiseId === undefined ||
+  hasTeamInBothLeagues(franchiseId, currentLeague);
 
 // Calculate target URLs for both leagues
 const theLeagueUrl = resolveLeaguePath(
@@ -83,6 +60,7 @@ const isTheLeagueActive = currentLeague === 'theleague';
 const isAflActive = currentLeague === 'afl';
 ---
 
+{shouldRender && (
 <nav
   class="league-switcher"
   aria-label="Switch league"
@@ -106,6 +84,7 @@ const isAflActive = currentLeague === 'afl';
     </a>
   </div>
 </nav>
+)}
 
 <style>
   .league-switcher {

--- a/src/components/nav/NavHeader.astro
+++ b/src/components/nav/NavHeader.astro
@@ -20,7 +20,7 @@
 
 import type { LeagueSlug, NavHeaderProps } from '../../types/nav';
 import { hasTeamInBothLeagues } from '../../utils/league-context';
-import { resolveLeaguePath } from '../../utils/nav-utils';
+import { resolveLeaguePath, getEquivalentRoute } from '../../utils/nav-utils';
 
 interface Props extends NavHeaderProps {
   /** Current page path for smart routing when switching leagues */
@@ -55,29 +55,9 @@ const logoAlt = league === 'afl' ? 'AFL Fantasy Logo' : 'TheLeague Logo';
 const targetLeague = league === 'afl' ? 'theleague' : 'afl';
 const targetLeagueName = league === 'afl' ? 'TheLeague' : 'AFL Fantasy';
 
-/**
- * Get the equivalent route in the target league.
- */
-function getEquivalentRoute(path: string, target: 'theleague' | 'afl'): string {
-  const targetBase = target === 'afl' ? '/afl-fantasy' : '/theleague';
-
-  // Extract the page portion after the league prefix
-  let pagePath = '';
-  if (path.startsWith('/theleague')) {
-    pagePath = path.slice('/theleague'.length);
-  } else if (path.startsWith('/afl-fantasy')) {
-    pagePath = path.slice('/afl-fantasy'.length);
-  }
-
-  // If no page path or just root, return league home
-  if (!pagePath || pagePath === '/') {
-    return targetBase;
-  }
-
-  // Construct equivalent URL
-  return `${targetBase}${pagePath}`;
-}
-
+// Equivalent-route logic lives in src/utils/nav-utils.ts and is shared with
+// LeagueSwitcher. nav-utils consults the route-equivalence map first and
+// falls back to the league home for paths that don't have a counterpart.
 const switchUrl = resolveLeaguePath(getEquivalentRoute(currentPath, targetLeague), hideLeaguePrefix);
 ---
 

--- a/src/types/nav.ts
+++ b/src/types/nav.ts
@@ -317,6 +317,15 @@ export interface LeagueSwitcherProps {
 
   /** Current page path for smart routing */
   currentPath: string;
+
+  /**
+   * Optional franchise ID. When provided, the switcher only renders if
+   * the franchise has a counterpart team in the other league
+   * (per CROSS_LEAGUE_TEAM_MAP). When omitted, the switcher renders
+   * unconditionally — useful for global headers and pages where any
+   * visitor should be able to flip between leagues.
+   */
+  franchiseId?: string;
 }
 
 /**

--- a/tests/nav-equivalent-route.test.ts
+++ b/tests/nav-equivalent-route.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+import { getEquivalentRoute } from '../src/utils/nav-utils';
+
+// LeagueSwitcher and NavHeader both consume getEquivalentRoute. These tests
+// lock in the cross-league deep-link behavior the 7 dual-league owners depend
+// on (AFL_DUPLICATION_PLAN §2.6).
+
+describe('getEquivalentRoute', () => {
+  // -- League home / root path --
+
+  it('rewrites /theleague to /afl-fantasy (league home)', () => {
+    expect(getEquivalentRoute('/theleague', 'afl')).toBe('/afl-fantasy');
+  });
+
+  it('rewrites /afl-fantasy to /theleague (league home)', () => {
+    expect(getEquivalentRoute('/afl-fantasy', 'theleague')).toBe('/theleague');
+  });
+
+  it('rewrites /theleague/ (with trailing slash) to /afl-fantasy', () => {
+    expect(getEquivalentRoute('/theleague/', 'afl')).toBe('/afl-fantasy');
+  });
+
+  // -- Route equivalence map hits --
+
+  it('rewrites /theleague/rosters to /afl-fantasy/rosters', () => {
+    expect(getEquivalentRoute('/theleague/rosters', 'afl')).toBe(
+      '/afl-fantasy/rosters'
+    );
+  });
+
+  it('rewrites /afl-fantasy/standings to /theleague/standings', () => {
+    expect(getEquivalentRoute('/afl-fantasy/standings', 'theleague')).toBe(
+      '/theleague/standings'
+    );
+  });
+
+  it('rewrites /theleague/playoffs to /afl-fantasy/playoffs', () => {
+    expect(getEquivalentRoute('/theleague/playoffs', 'afl')).toBe(
+      '/afl-fantasy/playoffs'
+    );
+  });
+
+  it('rewrites /theleague/calendar to /afl-fantasy/calendar', () => {
+    expect(getEquivalentRoute('/theleague/calendar', 'afl')).toBe(
+      '/afl-fantasy/calendar'
+    );
+  });
+
+  it('rewrites /theleague/news to /afl-fantasy/news', () => {
+    expect(getEquivalentRoute('/theleague/news', 'afl')).toBe(
+      '/afl-fantasy/news'
+    );
+  });
+
+  // -- Query string handling --
+
+  it('preserves query strings when an exact match exists', () => {
+    expect(getEquivalentRoute('/theleague/rosters?view=nextyear', 'afl')).toBe(
+      '/afl-fantasy/rosters?view=nextyear'
+    );
+  });
+
+  it('preserves query strings on a base-path match', () => {
+    // /standings?year=2024 is not in the map, but /standings is
+    expect(getEquivalentRoute('/theleague/standings?year=2024', 'afl')).toBe(
+      '/afl-fantasy/standings?year=2024'
+    );
+  });
+
+  // -- Fallback to league home --
+
+  it('falls back to league home for paths not in the equivalence map', () => {
+    // /theleague/contracts has no AFL counterpart (AFL has no contracts
+    // page — the plan calls for keepers instead).
+    expect(getEquivalentRoute('/theleague/contracts', 'afl')).toBe(
+      '/afl-fantasy'
+    );
+  });
+
+  it('falls back to league home for unknown deep paths', () => {
+    expect(getEquivalentRoute('/theleague/some-unknown-page', 'afl')).toBe(
+      '/afl-fantasy'
+    );
+  });
+
+  // -- Idempotence --
+
+  it('returns the same path when target league matches current league prefix', () => {
+    // Round-trip a TheLeague URL to TheLeague — should resolve to /theleague/rosters
+    // (the function strips the prefix and re-adds it).
+    expect(getEquivalentRoute('/theleague/rosters', 'theleague')).toBe(
+      '/theleague/rosters'
+    );
+  });
+
+  // -- Nested / tricky paths --
+
+  it('handles nested routes like /contracts/manage', () => {
+    expect(getEquivalentRoute('/theleague/contracts/manage', 'afl')).toBe(
+      '/afl-fantasy/contracts/manage'
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Phase 0.7 of the AFL Duplication Plan. Two issues found while auditing the existing cross-league switching code:

1. **`LeagueSwitcher.astro` and `NavHeader.astro` both had inline copies** of a `getEquivalentRoute` function. `src/utils/nav-utils.ts` already exports a more sophisticated version that consults the `routeEquivalence` map (handles known path mappings + query strings + falls back to league home for paths without a counterpart). Both inline copies are deleted in favor of the shared util.

2. **`LeagueSwitcher` had no franchise-aware visibility gate**. Adds an optional `franchiseId` prop:
   - When provided → switcher only renders if `hasTeamInBothLeagues(franchiseId, currentLeague)` is true (the 7 dual-league owners).
   - When omitted → renders unconditionally (for a global header where any visitor should flip).

The visual treatment of the existing chevron switcher in `NavHeader` is unchanged; only the routing logic moves to the shared util.

## What changes

- `src/components/nav/LeagueSwitcher.astro` — uses shared `getEquivalentRoute`, gates on optional `franchiseId`.
- `src/components/nav/NavHeader.astro` — uses shared `getEquivalentRoute` (its inline copy deleted).
- `src/types/nav.ts` — `LeagueSwitcherProps.franchiseId` documented.
- `tests/nav-equivalent-route.test.ts` — new, 14 tests covering home/root, map hits, query-string preservation, fallback to home (e.g. `/theleague/contracts → /afl-fantasy` because AFL has no contracts page), idempotence, nested routes.

## Test plan

- [x] `pnpm vitest run tests/nav-equivalent-route.test.ts` — 14/14 pass
- [x] `pnpm test:unit` — 2121 pass (was 2107 → +14 net, the 14 new cases), same 11 baseline failures

## Plan reference

`docs/plans/AFL_DUPLICATION_PLAN.md` §2.6 (cross-league navigation primitive).

https://claude.ai/code/session_01DEecdWcSPe6z48JTbVAWeT

---
_Generated by [Claude Code](https://claude.ai/code/session_01DEecdWcSPe6z48JTbVAWeT)_