### PR TITLE
schefter: replace slug-checks with per-league features map

### DIFF
--- a/scripts/schefter-scan.mjs
+++ b/scripts/schefter-scan.mjs
@@ -36,6 +36,14 @@ const MFL_HOST = process.env.MFL_HOST || 'api.myfantasyleague.com';
 const DRY_RUN = process.argv.includes('--dry-run');
 
 // ── League configs ──
+//
+// `features` is the single source of truth for which Schefter sub-pipelines
+// run for which league. Replaces the older `if (league.slug !== 'theleague')`
+// guards scattered across this file. To activate a flow for AFL, flip the
+// corresponding feature flag to true. AFL's commish-cadence flows
+// (rumorMill, tradeBait, eventReminders) currently default off — see
+// AFL_DUPLICATION_PLAN §2.4 for the rationale (different commish, different
+// calendar, AFL persona pending).
 
 const LEAGUES = [
   {
@@ -44,6 +52,11 @@ const LEAGUES = [
     feedPath: path.join(projectRoot, 'src', 'data', 'theleague', 'schefter-feed.json'),
     playersPath: (year) => path.join(projectRoot, 'data', 'theleague', 'mfl-feeds', String(year), 'players.json'),
     configPath: path.join(projectRoot, 'src', 'data', 'theleague.config.json'),
+    features: {
+      rumorMill: true,
+      tradeBait: true,
+      eventReminders: true,
+    },
   },
   {
     slug: 'afl',
@@ -51,6 +64,11 @@ const LEAGUES = [
     feedPath: path.join(projectRoot, 'data', 'afl-fantasy', 'schefter-feed.json'),
     playersPath: (year) => path.join(projectRoot, 'data', 'afl-fantasy', 'mfl-feeds', String(year), 'players.json'),
     configPath: path.join(projectRoot, 'data', 'afl-fantasy', 'afl.config.json'),
+    features: {
+      rumorMill: false,
+      tradeBait: false,
+      eventReminders: false,
+    },
   },
 ];
 
@@ -781,8 +799,9 @@ async function scanPendingTrades(league) {
     return 0;
   }
 
-  // Phase 1 is theleague-only (AFL has its own commish and cadence)
-  if (league.slug !== 'theleague') return 0;
+  if (!league.features?.rumorMill) {
+    return 0;
+  }
 
   console.log(`\n=== Scanning Pending Trades (Rumor Mill) for ${league.slug} ===`);
 
@@ -1115,7 +1134,9 @@ async function scanTradeBait(league) {
       process.env.SCHEFTER_RUMOR_MILL_ENABLED.toLowerCase() === 'false') {
     return 0;
   }
-  if (league.slug !== 'theleague') return 0;
+  if (!league.features?.tradeBait) {
+    return 0;
+  }
 
   console.log(`\n=== Scanning Trade Bait (Rumor Mill) for ${league.slug} ===`);
 
@@ -1426,9 +1447,8 @@ function pickRogerTemplate(touchId, eventId) {
 async function scanEventReminders(league) {
   console.log(`\n=== Scanning event reminders for ${league.slug} ===`);
 
-  // Only TheLeague gets Ask Roger posts (AFL has different calendar)
-  if (league.slug !== 'theleague') {
-    console.log('  Skipping — Ask Roger is TheLeague only');
+  if (!league.features?.eventReminders) {
+    console.log(`  Skipping — eventReminders feature flag is off for ${league.slug}`);
     return 0;
   }
 


### PR DESCRIPTION
## Summary

Phase 0.5 of the AFL Duplication Plan. Three TheLeague-only guards in `scripts/schefter-scan.mjs` were checking `league.slug !== 'theleague'` to skip the rumor-mill, trade-bait, and event-reminder (Ask Roger) flows on AFL. Replaces those with a `features` block on each `LEAGUES` entry — flipping a flag is now a one-line edit instead of a code search.

```js
{
  slug: 'theleague',
  // ...
  features: {
    rumorMill: true,
    tradeBait: true,
    eventReminders: true,
  },
},
{
  slug: 'afl',
  // ...
  features: {
    rumorMill: false,
    tradeBait: false,
    eventReminders: false,
  },
},
```

AFL keeps all three off for now (different commish, different calendar, AFL Schefter persona still pending — see plan §4.4). When AFL is ready, flip the flag.

## Per CLAUDE.md guidance

> A few legacy vars predate this rule (SCHEFTER_RUMOR_MILL_ENABLED, SCHEFTER_TRADE_OFFER_RUMORS_ENABLED). Don't add more, and prefer moving the existing ones into code if you're already touching the file.

This PR follows that rule — the new flags are code constants, not GitHub vars. The legacy `SCHEFTER_RUMOR_MILL_ENABLED` env-var gate is left untouched (orthogonal — kills the feature globally; the new config flag picks per-league).

## Test plan

- [x] `node --check scripts/schefter-scan.mjs` — syntax OK
- [x] Script loads, both LEAGUES dispatch, both reach their first network call. AFL skips rumorMill / tradeBait / eventReminders without error.
- [x] `pnpm test:unit` — 2107 pass, same 11 baseline failures, no regressions

## Note: `data/schefter/groupme-suppressions.json`

The 2-char diff to that file is an artifact of running the load test locally; it's a runtime auto-generated file. Safe to ignore in review (per CLAUDE.md merge-conflict rules, those files prefer `--theirs` from main).

## Plan reference

`docs/plans/AFL_DUPLICATION_PLAN.md` §2.4 (Schefter pipeline parameterization) and §4.4 (AFL Schefter persona — pending).

https://claude.ai/code/session_01DEecdWcSPe6z48JTbVAWeT

---
_Generated by [Claude Code](https://claude.ai/code/session_01DEecdWcSPe6z48JTbVAWeT)_