### PR TITLE
afl(franchises): index + per-team profile pages

### DIFF
--- a/src/config/nav-config.json
+++ b/src/config/nav-config.json
@@ -233,7 +233,6 @@
       "label": "League Reports",
       "phaseOrder": { "inSeason": 4, "offSeason": 5 },
       "defaultOpen": "never",
-      "leagueOnly": "theleague",
       "links": [
         {
           "id": "stats-hub",
@@ -241,6 +240,7 @@
           "icon": "bar-chart",
           "path": "/stats",
           "external": false,
+          "leagueOnly": "theleague",
           "description": "League analytics hub — salary benchmarks, awards, projected free agents, and team comparisons"
         },
         {
@@ -249,15 +249,16 @@
           "icon": "activity",
           "path": "/activity",
           "external": false,
+          "leagueOnly": "theleague",
           "description": "See when each franchise owner last visited the site"
         },
         {
           "id": "franchise-history",
-          "label": "Franchise History",
+          "label": "Franchises",
           "icon": "shield",
           "path": "/franchises",
           "external": false,
-          "description": "All-time records, championships, division titles, and award history per franchise"
+          "description": "All-time records, championships, and per-franchise profiles"
         },
         {
           "id": "rivalries",
@@ -265,6 +266,7 @@
           "icon": "trophy",
           "path": "/rivalries",
           "external": false,
+          "leagueOnly": "theleague",
           "description": "Head-to-head records, playoff meetings, and trade history between every pair of franchises"
         }
       ]

--- a/src/pages/afl-fantasy/franchises/[id].astro
+++ b/src/pages/afl-fantasy/franchises/[id].astro
@@ -1,0 +1,355 @@
+---
+import TheLeagueLayout from '../../../layouts/TheLeagueLayout.astro';
+import aflConfig from '../../../../data/afl-fantasy/afl.config.json';
+
+// Optional championship history — graceful when not yet committed (PR #207).
+const champHistoryGlob = import.meta.glob<{
+  default: {
+    championships?: Array<{
+      year: number;
+      champion: string;
+      runnerUp: string;
+      championName: string;
+      runnerUpName: string;
+    }>;
+  };
+}>('../../../../data/afl-fantasy/championship-history.json', { eager: true });
+
+const championshipHistory =
+  Object.values(champHistoryGlob)[0]?.default?.championships ?? [];
+
+// SSR: route is /afl-fantasy/franchises/:id where :id is the franchiseId
+// (e.g. "0001"). Astro handles dynamic route params.
+export async function getStaticPaths() {
+  // Static generation for all known AFL franchises so deep links work
+  // out of the box.
+  const cfg = (await import('../../../../data/afl-fantasy/afl.config.json'))
+    .default;
+  return (cfg.teams as Array<{ franchiseId: string }>).map((t) => ({
+    params: { id: t.franchiseId },
+  }));
+}
+
+const { id } = Astro.params;
+
+const team = (aflConfig.teams as Array<any>).find(
+  (t) => t.franchiseId === id
+);
+
+if (!team) {
+  return Astro.redirect('/afl-fantasy/franchises');
+}
+
+// Championships won (best-effort — pre-2024 entries reference historical
+// franchise IDs that may not match current IDs).
+const wonYears = championshipHistory
+  .filter((c) => c.champion === id)
+  .map((c) => c.year)
+  .sort((a, b) => b - a);
+
+const lostYears = championshipHistory
+  .filter((c) => c.runnerUp === id)
+  .map((c) => c.year)
+  .sort((a, b) => b - a);
+
+// Conference + division metadata
+const conference = (aflConfig.conferences ?? []).find(
+  (c: any) => c.code === team.conference
+);
+const conferenceName = conference?.name ?? team.conference;
+---
+
+<TheLeagueLayout title={`${team.name} | AFL Franchise`}>
+  <main class="franchise-detail">
+    <header class="franchise-hero">
+      <a class="franchise-hero__back" href="/afl-fantasy/franchises">
+        ← All franchises
+      </a>
+
+      <div class="franchise-hero__content">
+        {team.banner ? (
+          <img class="franchise-hero__banner" src={team.banner} alt="" loading="lazy" />
+        ) : (
+          <div class="franchise-hero__banner-placeholder" />
+        )}
+
+        <div class="franchise-hero__text">
+          <div class="franchise-hero__tier-row">
+            <span
+              class:list={[
+                'franchise-hero__tier-pill',
+                team.tier === 'Premier League'
+                  ? 'franchise-hero__tier-pill--premier'
+                  : 'franchise-hero__tier-pill--dleague',
+              ]}
+            >
+              {team.tier}
+            </span>
+            <span class="franchise-hero__div">
+              {conferenceName} {team.division}
+            </span>
+          </div>
+          <h1 class="franchise-hero__name">{team.name}</h1>
+          {team.aliases?.length ? (
+            <p class="franchise-hero__aliases">
+              Also known as: {team.aliases.join(', ')}
+            </p>
+          ) : null}
+        </div>
+      </div>
+    </header>
+
+    <div class="franchise-stats">
+      <div class="stat-card">
+        <div class="stat-card__value">
+          {wonYears.length === 0 ? '—' : wonYears.length}
+        </div>
+        <div class="stat-card__label">Championships</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-card__value">
+          {lostYears.length === 0 ? '—' : lostYears.length}
+        </div>
+        <div class="stat-card__label">Runner-ups</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-card__value">{team.tier === 'Premier League' ? 'P' : 'D'}</div>
+        <div class="stat-card__label">Tier</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-card__value">{team.abbrev}</div>
+        <div class="stat-card__label">Abbrev</div>
+      </div>
+    </div>
+
+    {wonYears.length > 0 && (
+      <section class="franchise-section">
+        <h2>Championship years</h2>
+        <ul class="champ-list">
+          {wonYears.map((y) => (
+            <li class="champ-list__win">
+              <span class="champ-list__year">{y}</span>
+              <span class="champ-list__verb">— champion</span>
+            </li>
+          ))}
+        </ul>
+      </section>
+    )}
+
+    {lostYears.length > 0 && (
+      <section class="franchise-section">
+        <h2>Runner-up years</h2>
+        <ul class="champ-list">
+          {lostYears.map((y) => (
+            <li class="champ-list__loss">
+              <span class="champ-list__year">{y}</span>
+              <span class="champ-list__verb">— runner-up</span>
+            </li>
+          ))}
+        </ul>
+      </section>
+    )}
+
+    <section class="franchise-section">
+      <h2>Quick links</h2>
+      <div class="quick-links">
+        <a class="quick-link" href={`/afl-fantasy/rosters?franchise=${id}`}>
+          📋 Roster
+        </a>
+        <a class="quick-link" href={`/afl-fantasy/standings?myteam=${id}`}>
+          📊 Standings (highlight this team)
+        </a>
+      </div>
+    </section>
+
+    <p class="franchise-footer">
+      Wider per-franchise history (year-by-year W-L, MVPs, biggest blowouts)
+      arrives in a later phase once <code>compute-franchise-history.mjs</code>
+      runs against AFL feeds.
+    </p>
+  </main>
+</TheLeagueLayout>
+
+<style>
+  .franchise-detail {
+    max-width: 960px;
+    margin: 0 auto;
+    padding: var(--spacing-xl, 32px) var(--spacing-md, 16px);
+  }
+
+  .franchise-hero {
+    margin-bottom: var(--spacing-xl, 32px);
+  }
+
+  .franchise-hero__back {
+    display: inline-block;
+    margin-bottom: var(--spacing-md, 16px);
+    color: var(--text-muted, #6b7280);
+    text-decoration: none;
+    font-size: 0.875rem;
+  }
+
+  .franchise-hero__back:hover {
+    color: var(--text-default);
+    text-decoration: underline;
+  }
+
+  .franchise-hero__content {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-lg, 24px);
+    background: var(--card-bg, #ffffff);
+    border-radius: 12px;
+    overflow: hidden;
+    border: 1px solid var(--border-color, #e5e7eb);
+  }
+
+  .franchise-hero__banner,
+  .franchise-hero__banner-placeholder {
+    width: 240px;
+    height: 160px;
+    flex-shrink: 0;
+    object-fit: cover;
+    background: var(--bg-muted, #f3f4f6);
+  }
+
+  .franchise-hero__text {
+    padding: var(--spacing-md, 16px);
+    min-width: 0;
+  }
+
+  .franchise-hero__tier-row {
+    display: flex;
+    gap: var(--spacing-sm, 8px);
+    margin-bottom: var(--spacing-sm, 8px);
+  }
+
+  .franchise-hero__tier-pill {
+    padding: 2px 10px;
+    border-radius: 9999px;
+    font-size: 0.75rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  .franchise-hero__tier-pill--premier {
+    background: var(--primary-color, #c41e3a);
+    color: white;
+  }
+
+  .franchise-hero__tier-pill--dleague {
+    background: var(--bg-muted, #e5e7eb);
+    color: var(--text-default);
+  }
+
+  .franchise-hero__div {
+    font-size: 0.8125rem;
+    color: var(--text-muted, #6b7280);
+    align-self: center;
+  }
+
+  .franchise-hero__name {
+    font-size: 2rem;
+    margin: 0 0 4px 0;
+  }
+
+  .franchise-hero__aliases {
+    color: var(--text-muted, #6b7280);
+    font-size: 0.875rem;
+    margin: 0;
+  }
+
+  .franchise-stats {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    gap: var(--spacing-md, 16px);
+    margin-bottom: var(--spacing-xl, 32px);
+  }
+
+  .stat-card {
+    text-align: center;
+    padding: var(--spacing-md, 16px);
+    background: var(--card-bg, #ffffff);
+    border: 1px solid var(--border-color, #e5e7eb);
+    border-radius: 8px;
+  }
+
+  .stat-card__value {
+    font-size: 2rem;
+    font-weight: 800;
+    color: var(--primary-color, #c41e3a);
+  }
+
+  .stat-card__label {
+    font-size: 0.8125rem;
+    color: var(--text-muted, #6b7280);
+    margin-top: 4px;
+  }
+
+  .franchise-section {
+    margin-bottom: var(--spacing-xl, 32px);
+  }
+
+  .franchise-section h2 {
+    font-size: 1.25rem;
+    margin-bottom: var(--spacing-md, 16px);
+  }
+
+  .champ-list {
+    list-style: none;
+    padding: 0;
+  }
+
+  .champ-list li {
+    padding: var(--spacing-sm, 8px) 0;
+    border-bottom: 1px solid var(--border-color, #e5e7eb);
+  }
+
+  .champ-list__year {
+    font-weight: 700;
+    margin-right: var(--spacing-sm, 8px);
+  }
+
+  .champ-list__win .champ-list__verb {
+    color: #d97706;
+  }
+
+  .champ-list__loss .champ-list__verb {
+    color: var(--text-muted, #6b7280);
+  }
+
+  .quick-links {
+    display: flex;
+    gap: var(--spacing-md, 16px);
+    flex-wrap: wrap;
+  }
+
+  .quick-link {
+    padding: var(--spacing-sm, 8px) var(--spacing-md, 16px);
+    background: var(--card-bg, #ffffff);
+    border: 1px solid var(--border-color, #e5e7eb);
+    border-radius: 8px;
+    text-decoration: none;
+    color: var(--text-default);
+    font-weight: 500;
+  }
+
+  .quick-link:hover {
+    background: var(--bg-muted, #f3f4f6);
+  }
+
+  .franchise-footer {
+    margin-top: var(--spacing-xl, 32px);
+    color: var(--text-muted, #6b7280);
+    font-size: 0.875rem;
+    font-style: italic;
+  }
+
+  .franchise-footer code {
+    background: var(--code-bg, #f3f4f6);
+    padding: 2px 6px;
+    border-radius: 3px;
+    font-style: normal;
+  }
+</style>

--- a/src/pages/afl-fantasy/franchises/index.astro
+++ b/src/pages/afl-fantasy/franchises/index.astro
@@ -1,0 +1,221 @@
+---
+import TheLeagueLayout from '../../../layouts/TheLeagueLayout.astro';
+import aflConfig from '../../../../data/afl-fantasy/afl.config.json';
+
+// Optional championship history — graceful when not yet committed (PR #207).
+const champHistoryGlob = import.meta.glob<{
+  default: {
+    championships?: Array<{ year: number; champion: string; runnerUp: string }>;
+  };
+}>('../../../../data/afl-fantasy/championship-history.json', { eager: true });
+
+const championships =
+  Object.values(champHistoryGlob)[0]?.default?.championships ?? [];
+
+// Build a "championships count" map keyed by current franchise ID.
+// Note: pre-2024 entries reference historical franchise IDs; this is a
+// best-effort current-franchise count. Full mapping needs franchise-history
+// derivations (Phase 5 work).
+const champsByFranchise = new Map<string, number>();
+for (const c of championships) {
+  champsByFranchise.set(c.champion, (champsByFranchise.get(c.champion) ?? 0) + 1);
+}
+
+const teams = (aflConfig.teams ?? []).slice().sort((a, b) => {
+  // Premier League first, then D-League. Within each tier, alpha by name.
+  const tierA = a.tier === 'Premier League' ? 0 : 1;
+  const tierB = b.tier === 'Premier League' ? 0 : 1;
+  if (tierA !== tierB) return tierA - tierB;
+  return a.name.localeCompare(b.name);
+});
+
+const totalFranchises = teams.length;
+const premierCount = teams.filter(t => t.tier === 'Premier League').length;
+const dLeagueCount = teams.filter(t => t.tier === 'D-League').length;
+---
+
+<TheLeagueLayout title="Franchises | AFL Fantasy">
+  <main class="franchises-page">
+    <header class="franchises-hero">
+      <h1>AFL Franchises</h1>
+      <p class="subtitle">
+        {totalFranchises} teams across two tiers — {premierCount} in
+        Premier League, {dLeagueCount} in D-League. Click a team for its
+        per-franchise profile.
+      </p>
+    </header>
+
+    <section class="tier-section">
+      <h2 class="tier-title tier-title--premier">
+        Premier League
+        <span class="tier-count">{premierCount} teams</span>
+      </h2>
+      <div class="franchises-grid">
+        {teams.filter(t => t.tier === 'Premier League').map(team => (
+          <a class="franchise-card" href={`/afl-fantasy/franchises/${team.franchiseId}`}>
+            <div class="franchise-card__icon-wrap">
+              <img src={team.icon} alt={`${team.name} icon`} loading="lazy" />
+            </div>
+            <div class="franchise-card__body">
+              <h3 class="franchise-card__name">{team.name}</h3>
+              <div class="franchise-card__meta">
+                <span class="franchise-card__div">{team.division}</span>
+                {champsByFranchise.has(team.franchiseId) && (
+                  <span class="franchise-card__champs" title={`${champsByFranchise.get(team.franchiseId)} championship(s)`}>
+                    🏆 ×{champsByFranchise.get(team.franchiseId)}
+                  </span>
+                )}
+              </div>
+            </div>
+          </a>
+        ))}
+      </div>
+    </section>
+
+    <section class="tier-section">
+      <h2 class="tier-title tier-title--dleague">
+        D-League
+        <span class="tier-count">{dLeagueCount} teams</span>
+      </h2>
+      <div class="franchises-grid">
+        {teams.filter(t => t.tier === 'D-League').map(team => (
+          <a class="franchise-card" href={`/afl-fantasy/franchises/${team.franchiseId}`}>
+            <div class="franchise-card__icon-wrap">
+              <img src={team.icon} alt={`${team.name} icon`} loading="lazy" />
+            </div>
+            <div class="franchise-card__body">
+              <h3 class="franchise-card__name">{team.name}</h3>
+              <div class="franchise-card__meta">
+                <span class="franchise-card__div">{team.division}</span>
+                {champsByFranchise.has(team.franchiseId) && (
+                  <span class="franchise-card__champs" title={`${champsByFranchise.get(team.franchiseId)} championship(s)`}>
+                    🏆 ×{champsByFranchise.get(team.franchiseId)}
+                  </span>
+                )}
+              </div>
+            </div>
+          </a>
+        ))}
+      </div>
+    </section>
+  </main>
+</TheLeagueLayout>
+
+<style>
+  .franchises-page {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: var(--spacing-xl, 32px) var(--spacing-md, 16px);
+  }
+
+  .franchises-hero {
+    text-align: center;
+    margin-bottom: var(--spacing-xxl, 48px);
+  }
+
+  .franchises-hero h1 {
+    font-size: 2.5rem;
+    margin-bottom: var(--spacing-sm, 8px);
+  }
+
+  .subtitle {
+    color: var(--text-muted, #6b7280);
+    max-width: 600px;
+    margin: 0 auto;
+  }
+
+  .tier-section {
+    margin-bottom: var(--spacing-xxl, 48px);
+  }
+
+  .tier-title {
+    font-size: 1.5rem;
+    margin-bottom: var(--spacing-lg, 24px);
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-md, 16px);
+    padding-bottom: var(--spacing-sm, 8px);
+    border-bottom: 2px solid var(--border-color, #e5e7eb);
+  }
+
+  .tier-title--premier {
+    color: var(--primary-color, #c41e3a);
+  }
+
+  .tier-count {
+    font-size: 0.875rem;
+    font-weight: 400;
+    color: var(--text-muted, #6b7280);
+  }
+
+  .franchises-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+    gap: var(--spacing-md, 16px);
+  }
+
+  .franchise-card {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-md, 16px);
+    padding: var(--spacing-md, 16px);
+    background: var(--card-bg, #ffffff);
+    border: 1px solid var(--border-color, #e5e7eb);
+    border-radius: 8px;
+    text-decoration: none;
+    color: var(--text-default);
+    transition: transform 0.15s ease, box-shadow 0.15s ease;
+  }
+
+  .franchise-card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  }
+
+  .franchise-card__icon-wrap {
+    width: 56px;
+    height: 56px;
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .franchise-card__icon-wrap img {
+    max-width: 100%;
+    max-height: 100%;
+    object-fit: contain;
+  }
+
+  .franchise-card__body {
+    min-width: 0;
+    flex: 1;
+  }
+
+  .franchise-card__name {
+    font-size: 1rem;
+    font-weight: 700;
+    margin: 0 0 4px 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .franchise-card__meta {
+    display: flex;
+    gap: var(--spacing-sm, 8px);
+    font-size: 0.8125rem;
+    color: var(--text-muted, #6b7280);
+  }
+
+  .franchise-card__div {
+    background: var(--code-bg, #f3f4f6);
+    padding: 2px 8px;
+    border-radius: 9999px;
+  }
+
+  .franchise-card__champs {
+    color: #d97706;
+    font-weight: 600;
+  }
+</style>


### PR DESCRIPTION
## Summary

Phase 1 of the AFL Duplication Plan. AFL had no `/franchises` pages. Adds two:

### `/afl-fantasy/franchises`
Grid of all 24 teams sectioned by tier (Premier League first, then D-League). Each card shows icon + division + a 🏆 trophy badge if the team has championships in `championship-history.json`.

### `/afl-fantasy/franchises/[id]`
Per-team profile, statically generated for every franchise in `afl.config.json`:

- Tier pill (Premier / D-League)
- Banner
- Conference + division
- Championship years (won + runner-up)
- Quick links to `/afl-fantasy/rosters?franchise=<id>` and `/afl-fantasy/standings?myteam=<id>` (auto-highlights the team via cookie write)

## Notes

Both pages are data-driven from `afl.config.json`. `championship-history.json` is loaded via `import.meta.glob` so the pages render gracefully even when PR #207 hasn't merged yet (championship sections just no-render).

The full TheLeague-style per-franchise history (year-by-year W-L, MVPs, biggest blowouts) requires `compute-franchise-history.mjs` to be generalized for AFL, which is later-phase work. The `[id]` page footer flags this explicitly.

## Test plan

- [ ] Visit `/afl-fantasy/franchises` → 24 cards split into Premier (top) and D-League sections
- [ ] Click any card → renders the per-team page
- [ ] After PR #207 lands, championship years appear on Balls Deep (#0022) and Mariachi Ninjas (#0015)
- [ ] Other 22 teams show no championships yet (full backfill is Phase 2)

## Plan reference

`docs/plans/AFL_DUPLICATION_PLAN.md` §3 (franchises rows) and §6 Phase 1.

https://claude.ai/code/session_01DEecdWcSPe6z48JTbVAWeT

---
_Generated by [Claude Code](https://claude.ai/code/session_01DEecdWcSPe6z48JTbVAWeT)_