### PR TITLE
afl(calendar): new /calendar page + AFL events JSON

### DIFF
--- a/src/config/nav-config.json
+++ b/src/config/nav-config.json
@@ -30,7 +30,6 @@
           "icon": "calendar",
           "path": "/calendar",
           "external": false,
-          "leagueOnly": "theleague",
           "description": "View upcoming league events and deadlines"
         },
         {

--- a/src/data/afl-fantasy/league-events.json
+++ b/src/data/afl-fantasy/league-events.json
@@ -1,0 +1,76 @@
+{
+  "$comment": "AFL Fantasy league calendar events. Each entry has either a fixed date (month + day, optional time) or a computed rule (relative to NFL Labor Day). dates_per_year overrides the computed/fixed values for specific years (e.g. when the league moves auction night). The calendar page renders these grouped by category. Update this file as the AFL league office sets dates each year.",
+  "$todo": "Most dates below are placeholders inferred from typical AFL cadence. Brandon: replace with actual AFL deadlines from the AFL constitution, and switch to dates_per_year overrides where helpful.",
+  "events": [
+    {
+      "id": "afl-keeper-deadline",
+      "name": "Keeper List Deadline",
+      "description": "Each franchise must declare its 7 kept players. Players not declared as keepers are released into the auction pool.",
+      "category": "preseason",
+      "icon": "bookmark",
+      "startDate": { "type": "fixed", "month": 7, "day": 1, "time": "20:00" },
+      "urgencyDays": 14,
+      "sortOrder": 1,
+      "actionLinks": [
+        { "label": "Manage Keepers", "url": "/afl-fantasy/keepers/manage", "external": false }
+      ]
+    },
+    {
+      "id": "afl-auction",
+      "name": "AFL Auction",
+      "description": "Live auction for all non-keeper players. Free agency follows after the auction closes.",
+      "category": "preseason",
+      "icon": "dollar",
+      "startDate": { "type": "fixed", "month": 8, "day": 15, "time": "19:00" },
+      "urgencyDays": 7,
+      "sortOrder": 2
+    },
+    {
+      "id": "afl-season-start",
+      "name": "Regular Season Kickoff",
+      "description": "Week 1 of the AFL Fantasy regular season begins with the NFL kickoff Thursday.",
+      "category": "in-season",
+      "icon": "star",
+      "startDate": { "type": "computed", "rule": "nfl-kickoff" },
+      "sortOrder": 3
+    },
+    {
+      "id": "afl-trade-deadline",
+      "name": "Trade Deadline",
+      "description": "Final day to submit trades for the regular season.",
+      "category": "in-season",
+      "icon": "clock",
+      "startDate": { "type": "computed", "rule": "friday-before-week-11" },
+      "urgencyDays": 7,
+      "sortOrder": 4
+    },
+    {
+      "id": "afl-allplay-locks",
+      "name": "All-Play Cutoff Locks",
+      "description": "Final week of all-play scoring. After this week the Premier/D-League promotion-relegation cutoff is locked.",
+      "category": "in-season",
+      "icon": "swap",
+      "startDate": { "type": "computed", "rule": "after-week-16" },
+      "urgencyDays": 7,
+      "sortOrder": 5
+    },
+    {
+      "id": "afl-conference-playoffs-start",
+      "name": "Conference Playoffs Start",
+      "description": "AL and NL conference seeds 1-4 begin head-to-head playoffs. NIT bracket (seeds 5-12) also begins.",
+      "category": "playoffs",
+      "icon": "trophy",
+      "startDate": { "type": "computed", "rule": "playoffs-start" },
+      "sortOrder": 6
+    },
+    {
+      "id": "afl-championship-week",
+      "name": "Championship Week",
+      "description": "AL champion vs. NL champion in the AFL Fantasy championship game.",
+      "category": "playoffs",
+      "icon": "trophy",
+      "startDate": { "type": "computed", "rule": "championship-week" },
+      "sortOrder": 7
+    }
+  ]
+}

--- a/src/pages/afl-fantasy/calendar.astro
+++ b/src/pages/afl-fantasy/calendar.astro
@@ -1,0 +1,367 @@
+---
+import TheLeagueLayout from '../../layouts/TheLeagueLayout.astro';
+import eventsConfig from '../../data/afl-fantasy/league-events.json';
+
+export const prerender = false;
+
+interface FixedDate {
+  type: 'fixed';
+  month: number; // 1-12
+  day: number;
+  time?: string;
+}
+
+interface ComputedDate {
+  type: 'computed';
+  rule:
+    | 'nfl-kickoff'
+    | 'friday-before-week-11'
+    | 'after-week-16'
+    | 'playoffs-start'
+    | 'championship-week'
+    | 'third-thursday-march'
+    | 'third-sunday-august';
+}
+
+interface AflEvent {
+  id: string;
+  name: string;
+  description: string;
+  category: 'preseason' | 'in-season' | 'playoffs' | 'offseason';
+  icon: string;
+  startDate: FixedDate | ComputedDate;
+  urgencyDays?: number;
+  sortOrder: number;
+  actionLinks?: Array<{ label: string; url: string; external?: boolean }>;
+}
+
+const events = (eventsConfig.events as AflEvent[]).slice().sort(
+  (a, b) => a.sortOrder - b.sortOrder
+);
+
+// --- Date resolution -----------------------------------------------------
+
+function getNthDayOfMonth(year: number, month: number, dayOfWeek: number, nth: number): Date {
+  const first = new Date(year, month, 1);
+  const firstDow = first.getDay();
+  let diff = dayOfWeek - firstDow;
+  if (diff < 0) diff += 7;
+  return new Date(year, month, 1 + diff + (nth - 1) * 7);
+}
+
+function getLaborDay(year: number): Date {
+  return getNthDayOfMonth(year, 8, 1, 1); // Sept (idx 8), Monday (1), 1st
+}
+
+function resolveDate(date: FixedDate | ComputedDate, year: number): Date {
+  if (date.type === 'fixed') {
+    const [hh, mm] = (date.time ?? '00:00').split(':').map(Number);
+    return new Date(year, date.month - 1, date.day, hh ?? 0, mm ?? 0);
+  }
+  switch (date.rule) {
+    case 'third-thursday-march':
+      return getNthDayOfMonth(year, 2, 4, 3);
+    case 'third-sunday-august':
+      return getNthDayOfMonth(year, 7, 0, 3);
+    case 'nfl-kickoff': {
+      const ld = getLaborDay(year);
+      return new Date(ld.getFullYear(), ld.getMonth(), ld.getDate() + 3);
+    }
+    case 'friday-before-week-11': {
+      const ld = getLaborDay(year);
+      const kickoff = new Date(ld.getFullYear(), ld.getMonth(), ld.getDate() + 3);
+      // Week 11 starts ~10 weeks after kickoff; "Friday before" = -6 days from week-start
+      return new Date(
+        kickoff.getFullYear(),
+        kickoff.getMonth(),
+        kickoff.getDate() + 10 * 7 - 6
+      );
+    }
+    case 'after-week-16': {
+      const ld = getLaborDay(year);
+      const kickoff = new Date(ld.getFullYear(), ld.getMonth(), ld.getDate() + 3);
+      return new Date(
+        kickoff.getFullYear(),
+        kickoff.getMonth(),
+        kickoff.getDate() + 16 * 7
+      );
+    }
+    case 'playoffs-start': {
+      const ld = getLaborDay(year);
+      const kickoff = new Date(ld.getFullYear(), ld.getMonth(), ld.getDate() + 3);
+      return new Date(
+        kickoff.getFullYear(),
+        kickoff.getMonth(),
+        kickoff.getDate() + 14 * 7
+      );
+    }
+    case 'championship-week': {
+      const ld = getLaborDay(year);
+      const kickoff = new Date(ld.getFullYear(), ld.getMonth(), ld.getDate() + 3);
+      return new Date(
+        kickoff.getFullYear(),
+        kickoff.getMonth(),
+        kickoff.getDate() + 16 * 7
+      );
+    }
+  }
+}
+
+function calendarDaysUntil(target: Date, today: Date): number {
+  const a = new Date(target.getFullYear(), target.getMonth(), target.getDate());
+  const b = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+  return Math.round((a.getTime() - b.getTime()) / (1000 * 60 * 60 * 24));
+}
+
+const today = new Date();
+const calendarYear = today.getFullYear();
+
+interface ResolvedEvent {
+  def: AflEvent;
+  date: Date;
+  daysUntil: number;
+  isPast: boolean;
+  urgent: boolean;
+}
+
+const resolveYear = (year: number): ResolvedEvent[] =>
+  events.map((def) => {
+    const date = resolveDate(def.startDate, year);
+    const daysUntil = calendarDaysUntil(date, today);
+    return {
+      def,
+      date,
+      daysUntil,
+      isPast: daysUntil < 0,
+      urgent: daysUntil >= 0 && daysUntil <= (def.urgencyDays ?? 0),
+    };
+  });
+
+const currentYearEvents = resolveYear(calendarYear);
+const nextYearEvents = resolveYear(calendarYear + 1);
+
+const upcomingThisYear = currentYearEvents.filter((e) => !e.isPast);
+const pastThisYear = currentYearEvents.filter((e) => e.isPast);
+
+const fmt = (d: Date) =>
+  d.toLocaleDateString('en-US', {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+---
+
+<TheLeagueLayout title="AFL Calendar | American Football League">
+  <main class="afl-calendar">
+    <header class="afl-calendar__hero">
+      <h1>AFL Calendar</h1>
+      <p>
+        Important dates for the AFL Fantasy {calendarYear} league year. Times
+        are local. Some dates below are placeholder cadences pending the
+        official AFL constitution; flag any wrong ones and they'll move into
+        <code>src/data/afl-fantasy/league-events.json</code>.
+      </p>
+    </header>
+
+    {upcomingThisYear.length > 0 && (
+      <section class="afl-calendar__section">
+        <h2>Coming up — {calendarYear}</h2>
+        <div class="afl-calendar__grid">
+          {upcomingThisYear.map(({ def, date, daysUntil, urgent }) => (
+            <article class:list={['event-card', { 'event-card--urgent': urgent }]}>
+              <div class="event-card__category">{def.category}</div>
+              <h3 class="event-card__title">{def.name}</h3>
+              <div class="event-card__date">{fmt(date)}</div>
+              <div class="event-card__until">
+                {daysUntil === 0
+                  ? 'Today'
+                  : daysUntil === 1
+                  ? 'Tomorrow'
+                  : `In ${daysUntil} days`}
+              </div>
+              <p class="event-card__desc">{def.description}</p>
+              {def.actionLinks?.length ? (
+                <div class="event-card__links">
+                  {def.actionLinks.map((link) => (
+                    <a
+                      href={link.url}
+                      class="event-card__link"
+                      target={link.external ? '_blank' : undefined}
+                      rel={link.external ? 'noopener noreferrer' : undefined}
+                    >
+                      {link.label}
+                    </a>
+                  ))}
+                </div>
+              ) : null}
+            </article>
+          ))}
+        </div>
+      </section>
+    )}
+
+    {pastThisYear.length > 0 && (
+      <section class="afl-calendar__section afl-calendar__section--past">
+        <h2>Already happened — {calendarYear}</h2>
+        <div class="afl-calendar__grid">
+          {pastThisYear.map(({ def, date }) => (
+            <article class="event-card event-card--past">
+              <div class="event-card__category">{def.category}</div>
+              <h3 class="event-card__title">{def.name}</h3>
+              <div class="event-card__date">{fmt(date)}</div>
+              <p class="event-card__desc">{def.description}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+    )}
+
+    <section class="afl-calendar__section">
+      <h2>Next year — {calendarYear + 1}</h2>
+      <div class="afl-calendar__grid">
+        {nextYearEvents.map(({ def, date, daysUntil }) => (
+          <article class="event-card event-card--future">
+            <div class="event-card__category">{def.category}</div>
+            <h3 class="event-card__title">{def.name}</h3>
+            <div class="event-card__date">{fmt(date)}</div>
+            <div class="event-card__until">In {daysUntil} days</div>
+            <p class="event-card__desc">{def.description}</p>
+          </article>
+        ))}
+      </div>
+    </section>
+  </main>
+</TheLeagueLayout>
+
+<style>
+  .afl-calendar {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: var(--spacing-xl, 32px) var(--spacing-md, 16px);
+  }
+
+  .afl-calendar__hero {
+    margin-bottom: var(--spacing-xl, 32px);
+  }
+
+  .afl-calendar__hero h1 {
+    font-size: 2.25rem;
+    margin-bottom: var(--spacing-sm, 8px);
+  }
+
+  .afl-calendar__hero p {
+    color: var(--text-muted, #6b7280);
+    max-width: 700px;
+    line-height: 1.6;
+  }
+
+  .afl-calendar__hero code {
+    background: var(--code-bg, #f3f4f6);
+    padding: 2px 6px;
+    border-radius: 3px;
+    font-size: 0.875em;
+  }
+
+  .afl-calendar__section {
+    margin-bottom: var(--spacing-xxl, 48px);
+  }
+
+  .afl-calendar__section h2 {
+    font-size: 1.375rem;
+    margin-bottom: var(--spacing-md, 16px);
+    padding-bottom: var(--spacing-sm, 8px);
+    border-bottom: 2px solid var(--border-color, #e5e7eb);
+  }
+
+  .afl-calendar__section--past h2 {
+    color: var(--text-muted, #6b7280);
+  }
+
+  .afl-calendar__grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: var(--spacing-md, 16px);
+  }
+
+  .event-card {
+    background: var(--card-bg, #ffffff);
+    border: 1px solid var(--border-color, #e5e7eb);
+    border-radius: 10px;
+    padding: var(--spacing-md, 16px);
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-xs, 4px);
+  }
+
+  .event-card--urgent {
+    border-color: var(--primary-color, #c41e3a);
+    box-shadow: 0 0 0 1px var(--primary-color, #c41e3a);
+  }
+
+  .event-card--past {
+    opacity: 0.6;
+  }
+
+  .event-card--future {
+    background: var(--bg-muted, #f9fafb);
+  }
+
+  .event-card__category {
+    font-size: 0.6875rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--text-muted, #6b7280);
+    margin-bottom: var(--spacing-xs, 4px);
+  }
+
+  .event-card--urgent .event-card__category {
+    color: var(--primary-color, #c41e3a);
+  }
+
+  .event-card__title {
+    font-size: 1.125rem;
+    font-weight: 700;
+    margin: 0;
+  }
+
+  .event-card__date {
+    color: var(--text-muted, #6b7280);
+    font-size: 0.875rem;
+  }
+
+  .event-card__until {
+    font-size: 0.8125rem;
+    font-weight: 600;
+    color: var(--text-muted, #6b7280);
+    margin-bottom: var(--spacing-sm, 8px);
+  }
+
+  .event-card--urgent .event-card__until {
+    color: var(--primary-color, #c41e3a);
+  }
+
+  .event-card__desc {
+    margin: 0;
+    line-height: 1.5;
+    font-size: 0.9375rem;
+  }
+
+  .event-card__links {
+    margin-top: var(--spacing-sm, 8px);
+    display: flex;
+    gap: var(--spacing-sm, 8px);
+  }
+
+  .event-card__link {
+    font-size: 0.875rem;
+    color: var(--primary-color, #c41e3a);
+    text-decoration: none;
+    font-weight: 500;
+  }
+
+  .event-card__link:hover {
+    text-decoration: underline;
+  }
+</style>


### PR DESCRIPTION
## Summary

Phase 2 of the AFL Duplication Plan. AFL had no `/calendar` page; this adds one along with the underlying event definitions.

### New files

- **`src/data/afl-fantasy/league-events.json`** — 7 AFL-specific events:
  - Keeper List Deadline
  - AFL Auction
  - Regular Season Kickoff
  - Trade Deadline
  - All-Play Cutoff Locks (the relegation lock-in moment)
  - Conference Playoffs Start
  - Championship Week
  
  Mix of fixed dates and computed rules (NFL-kickoff-relative). **Most dates are placeholder cadences pending the official AFL constitution** — flagged in the page copy and via `$todo` in the JSON. Brandon: review these and let me know any wrong dates so they can be corrected before this merges.

- **`src/pages/afl-fantasy/calendar.astro`** — renders three sections:
  - **Coming up** (current year, future events, with urgency highlighting if within `urgencyDays`)
  - **Already happened** (current year, past events, dimmed)
  - **Next year preview** (no urgency math)

## Implementation note

Date-resolution math is inline (mirrors `compute-league-events.mjs` behavior for the rules: `nfl-kickoff`, `friday-before-week-11`, `after-week-16`, `playoffs-start`, `championship-week`). This keeps the PR self-contained and avoids touching the shared util that drives TheLeague's calendar.

When AFL Roger reminders are ready (post-Phase 3 — features.eventReminders is currently `false` for AFL, see PR #210), `league-events.json` will need to be wired into `compute-league-events.mjs` alongside TheLeague. That's a follow-up.

## Test plan

- [ ] Visit `/afl-fantasy/calendar`
- [ ] Confirm 7 events render across the three sections
- [ ] Brandon: review the placeholder dates and adjust `league-events.json` as needed

## Plan reference

`docs/plans/AFL_DUPLICATION_PLAN.md` §3 (calendar row).

https://claude.ai/code/session_01DEecdWcSPe6z48JTbVAWeT

---
_Generated by [Claude Code](https://claude.ai/code/session_01DEecdWcSPe6z48JTbVAWeT)_