### PR TITLE
afl(nav): surface /keepers in nav drawer (afl-only section)

### DIFF
--- a/src/config/nav-config.json
+++ b/src/config/nav-config.json
@@ -301,6 +301,24 @@
           "description": "Pitch rule changes, suggest features, or float ideas"
         }
       ]
+    },
+    {
+      "id": "afl-keepers-section",
+      "label": "Keepers",
+      "phaseOrder": { "inSeason": 7, "offSeason": 4 },
+      "defaultOpen": "off-season",
+      "leagueOnly": "afl",
+      "links": [
+        {
+          "id": "afl-keepers",
+          "label": "Keepers",
+          "icon": "bookmark",
+          "path": "/keepers",
+          "external": false,
+          "leagueOnly": "afl",
+          "description": "Each franchise's 7-player keeper list"
+        }
+      ]
     }
   ],
   "adminFranchiseIds": ["0001", "0000"],
@@ -342,7 +360,8 @@
     "/draft-room": "/draft-room",
     "/suggestions": "/suggestions",
     "/stats": "/stats",
-    "/rules-chat": "/rules-chat"
+    "/rules-chat": "/rules-chat",
+    "/keepers": "/keepers"
   },
   "verifyTeamUrl": {
     "theleague": "https://{host}/{year}/home/{leagueId}?MODULE=MESSAGE20",


### PR DESCRIPTION
## Summary

Adds the AFL keepers nav entry — a new **Keepers** section that's `leagueOnly: "afl"`. Visible to AFL visitors only; TheLeague continues to show its existing "Cap & Contracts" section.

## Stacked on PR #215

This PR is stacked on top of [#215](https://github.com/braven112/mfl.football.v2/pull/215) (the keepers page). The base branch of this PR is `claude/afl-keepers-basic-Yqxnl`, so it'll auto-rebase onto `main` once #215 merges.

## Why I'm only touching one page's nav

The `tests/nav-drawer-links.test.ts` test asserts every nav-visible link maps to an existing page in that league's `src/pages/` tree. Un-gating `/calendar`, `/franchises`, `/rules`, `/about` for AFL would break the test until each page PR lands. Each of those needs its own follow-up nav-update PR, or merge them all and then a single un-gate sweep PR.

## Test plan

- [x] `pnpm vitest run tests/nav-drawer-links.test.ts` — 2/2 pass
- [x] `pnpm test:unit` — same 11 baseline failures, no regressions

## Plan reference

`docs/plans/AFL_DUPLICATION_PLAN.md` §4.1 (keepers suite).

https://claude.ai/code/session_01DEecdWcSPe6z48JTbVAWeT

---
_Generated by [Claude Code](https://claude.ai/code/session_01DEecdWcSPe6z48JTbVAWeT)_