### PR TITLE
afl(nav): surface News link for AFL visitors

### DIFF
--- a/src/config/nav-config.json
+++ b/src/config/nav-config.json
@@ -12,7 +12,6 @@
           "icon": "news",
           "path": "/news",
           "external": false,
-          "leagueOnly": "theleague",
           "description": "The Schefter Report — breaking news, transactions, and league chatter"
         },
         {


### PR DESCRIPTION
## Summary

The `/news` page already exists for AFL (`src/pages/afl-fantasy/news.astro`, 52 lines, reads `data/afl-fantasy/schefter-feed.json` which is being written by `schefter-scan.yml`'s existing AFL dispatch). But the `News` nav link was gated to `leagueOnly: "theleague"` so AFL visitors couldn't find it.

This drops the gate. One-line change.

## Why this PR is small

The remaining `leagueOnly: "theleague"` entries on `/calendar`, `/whats-new`, `/schefter/tip`, `/franchises`, `/rules`, etc. need to either:

- **Land alongside their AFL page PRs** (#211, #212, #213, #214 add the AFL pages) — but each page PR is currently just the page, no nav update
- **Or land in a follow-up sweep PR** after those all merge

The `tests/nav-drawer-links.test.ts` integrity check forbids un-gating before the page exists, so I'm only un-gating `/news` here (where the AFL page is already on main).

## Test plan

- [x] `pnpm vitest run tests/nav-drawer-links.test.ts` — passes
- [x] `pnpm test:unit` — same 11 baseline failures, no regressions

https://claude.ai/code/session_01DEecdWcSPe6z48JTbVAWeT

---
_Generated by [Claude Code](https://claude.ai/code/session_01DEecdWcSPe6z48JTbVAWeT)_