### PR TITLE
afl(vercel): mirror /afl-fantasy redirects on afl-fantasy.com

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -23,6 +23,30 @@
       "destination": "/",
       "has": [{ "type": "host", "value": "www.theleague.us" }],
       "statusCode": 301
+    },
+    {
+      "source": "/afl-fantasy/:path*",
+      "destination": "/:path*",
+      "has": [{ "type": "host", "value": "afl-fantasy.com" }],
+      "statusCode": 301
+    },
+    {
+      "source": "/afl-fantasy/:path*",
+      "destination": "/:path*",
+      "has": [{ "type": "host", "value": "www.afl-fantasy.com" }],
+      "statusCode": 301
+    },
+    {
+      "source": "/afl-fantasy",
+      "destination": "/",
+      "has": [{ "type": "host", "value": "afl-fantasy.com" }],
+      "statusCode": 301
+    },
+    {
+      "source": "/afl-fantasy",
+      "destination": "/",
+      "has": [{ "type": "host", "value": "www.afl-fantasy.com" }],
+      "statusCode": 301
     }
   ],
   "rewrites": [


### PR DESCRIPTION
## Summary

Adds the AFL analog of the existing TheLeague edge-redirect block in `vercel.json`. When `afl-fantasy.com` is pointed at this Vercel project (Phase 7), visitors hitting `afl-fantasy.com/afl-fantasy/*` get a 301 to `afl-fantasy.com/*` — same clean-URL behavior TheLeague has on `theleague.us/theleague/*`.

The middleware layer (PR #208, already merged) already knows about `afl-fantasy.com` and rewrites internal Astro routes correctly. This redirect block is the edge-side complement that catches leaked or shared deep links so they stay on the apex.

## Inert until DNS attaches

Safe to ship now — these redirects only fire when the request `host` header matches `afl-fantasy.com` or `www.afl-fantasy.com`. TheLeague redirects continue working identically.

## To complete the domain setup (out-of-codebase)

This PR is **step 4 of 4**. The other three are:

1. **Own the domain** — buy `afl-fantasy.com` if you don't already.
2. **Vercel: attach the domain** — Vercel dashboard → Settings → Domains → add `afl-fantasy.com` and `www.afl-fantasy.com` (with www → apex redirect). Vercel will print DNS records to set.
3. **DNS at registrar** — A record for `@` to Vercel's IP, CNAME for `www` → `cname.vercel-dns.com`. Wait for SSL provisioning (~30 min).
4. **This PR** — merges the edge redirects.

Once those four are done, AFL serves at `afl-fantasy.com` with clean URLs (no `/afl-fantasy/` prefix).

## Test plan

- [x] `node -e "JSON.parse(...)"` — vercel.json is valid JSON
- [x] `pnpm test:unit` — same 11 baseline failures, no regressions
- [ ] Once DNS+Vercel attach lands: visit `afl-fantasy.com/afl-fantasy/standings` and confirm it 301s to `afl-fantasy.com/standings`
- [ ] Confirm `theleague.us/theleague/rosters` still 301s as before (no regression)

## Plan reference

`docs/plans/AFL_DUPLICATION_PLAN.md` §6 Phase 7 (domain split).

https://claude.ai/code/session_01DEecdWcSPe6z48JTbVAWeT

---
_Generated by [Claude Code](https://claude.ai/code/session_01DEecdWcSPe6z48JTbVAWeT)_