### PR TITLE
nav: resolveLeaguePath strips /afl-fantasy too, not just /theleague

### DIFF
--- a/src/utils/nav-utils.ts
+++ b/src/utils/nav-utils.ts
@@ -85,20 +85,26 @@ const LEAGUE_PREFIXES: Record<LeagueSlug, string> = {
 };
 
 /**
- * Strip the /theleague prefix from a path when serving on theleague.us.
+ * Strip the active league prefix from a path when serving on the league's
+ * apex domain (theleague.us, afl-fantasy.com).
  *
- * On theleague.us, Vercel rewrites clean URLs (e.g. /rosters) to internal
- * /theleague/rosters paths. This function ensures generated links match
- * the clean URL the user sees in their browser.
+ * The middleware sets `Astro.locals.hideLeaguePrefix` to true for any
+ * recognized league host (see src/utils/league-host-map.ts) and rewrites
+ * incoming clean URLs (e.g. /rosters) to internal Astro routes
+ * (/theleague/rosters or /afl-fantasy/rosters). This function is the
+ * outbound complement: it strips whichever league prefix is present so
+ * generated <a href> targets match the clean URL the user sees.
  *
- * @param path - Internal path (e.g. '/theleague/rosters')
- * @param hidePrefix - Whether to strip the prefix (true on theleague.us)
+ * @param path - Internal path (e.g. '/theleague/rosters' or '/afl-fantasy/rosters')
+ * @param hidePrefix - Whether to strip the prefix (true on a league apex host)
  * @returns Clean path (e.g. '/rosters') or original path if hidePrefix is false
  */
 export function resolveLeaguePath(path: string, hidePrefix: boolean): string {
   if (!hidePrefix) return path;
-  if (path === '/theleague') return '/';
-  if (path.startsWith('/theleague/')) return path.slice('/theleague'.length);
+  for (const prefix of Object.values(LEAGUE_PREFIXES)) {
+    if (path === prefix) return '/';
+    if (path.startsWith(`${prefix}/`)) return path.slice(prefix.length);
+  }
   return path;
 }
 

--- a/tests/resolve-league-path.test.ts
+++ b/tests/resolve-league-path.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import { resolveLeaguePath } from '../src/utils/nav-utils';
+
+// resolveLeaguePath is the outbound complement to the middleware host map.
+// When the request comes in on a league apex host (theleague.us,
+// afl-fantasy.com) the middleware sets locals.hideLeaguePrefix=true and
+// rewrites the URL internally. resolveLeaguePath ensures generated <a>
+// targets match the clean URL the user sees in the address bar.
+
+describe('resolveLeaguePath', () => {
+  describe('hidePrefix = false (e.g. preview deployment, localhost)', () => {
+    it('returns /theleague paths unchanged', () => {
+      expect(resolveLeaguePath('/theleague/rosters', false)).toBe(
+        '/theleague/rosters'
+      );
+    });
+
+    it('returns /afl-fantasy paths unchanged', () => {
+      expect(resolveLeaguePath('/afl-fantasy/standings', false)).toBe(
+        '/afl-fantasy/standings'
+      );
+    });
+
+    it('returns root unchanged', () => {
+      expect(resolveLeaguePath('/', false)).toBe('/');
+    });
+  });
+
+  describe('hidePrefix = true (on a league apex host)', () => {
+    it('strips /theleague from /theleague/rosters → /rosters', () => {
+      expect(resolveLeaguePath('/theleague/rosters', true)).toBe('/rosters');
+    });
+
+    it('maps bare /theleague → /', () => {
+      expect(resolveLeaguePath('/theleague', true)).toBe('/');
+    });
+
+    it('strips /afl-fantasy from /afl-fantasy/standings → /standings', () => {
+      expect(resolveLeaguePath('/afl-fantasy/standings', true)).toBe(
+        '/standings'
+      );
+    });
+
+    it('maps bare /afl-fantasy → /', () => {
+      expect(resolveLeaguePath('/afl-fantasy', true)).toBe('/');
+    });
+
+    it('strips deep paths /afl-fantasy/franchises/0001 → /franchises/0001', () => {
+      expect(resolveLeaguePath('/afl-fantasy/franchises/0001', true)).toBe(
+        '/franchises/0001'
+      );
+    });
+
+    it('preserves query strings', () => {
+      expect(resolveLeaguePath('/afl-fantasy/standings?view=all_play', true)).toBe(
+        '/standings?view=all_play'
+      );
+    });
+
+    it('leaves non-league paths unchanged', () => {
+      // /api/* and other root-level paths should pass through unmolested
+      expect(resolveLeaguePath('/api/foo', true)).toBe('/api/foo');
+      expect(resolveLeaguePath('/assets/icon.png', true)).toBe('/assets/icon.png');
+    });
+
+    it('does not strip /theleagueX (substring collision guard)', () => {
+      // The check is for exact prefix match or `/theleague/`, so /theleagueX
+      // is left alone. (Also see middleware-host-map.test.ts for the
+      // inbound-side equivalent of this trap.)
+      expect(resolveLeaguePath('/theleagueX', true)).toBe('/theleagueX');
+    });
+
+    it('does not strip /afl-fantasy-x (substring collision guard)', () => {
+      expect(resolveLeaguePath('/afl-fantasy-x', true)).toBe('/afl-fantasy-x');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Found a missing piece for the `afl-fantasy.com` domain setup. The middleware (#208, merged) already rewrites inbound clean URLs to internal `/afl-fantasy/*` routes. The vercel.json redirects (#218) catch leaked deep links. **But the outbound link helper was theleague.us-specific** — any generated `<a>` on `afl-fantasy.com` would still emit `/afl-fantasy/standings` even though the URL bar shows just `/standings`.

This means visitors on `afl-fantasy.com` would see the prefix re-appear in:
- Every nav drawer link
- Every internal anchor on every page
- The `LeagueSwitcher` and `NavHeader` targets

### Fix

`resolveLeaguePath` now iterates over `LEAGUE_PREFIXES` and strips whichever league prefix is present. Behavior on `theleague.us` is unchanged (the loop hits `/theleague` first, same as the old code).

```diff
- if (path === '/theleague') return '/';
- if (path.startsWith('/theleague/')) return path.slice('/theleague'.length);
+ for (const prefix of Object.values(LEAGUE_PREFIXES)) {
+   if (path === prefix) return '/';
+   if (path.startsWith(`${prefix}/`)) return path.slice(prefix.length);
+ }
```

### Tests

`tests/resolve-league-path.test.ts` — 12 cases covering:
- `hidePrefix=false` pass-through (preview deployments, localhost)
- TheLeague strip behavior (unchanged from before)
- AFL strip behavior (new)
- Deep paths, query strings, non-league paths (`/api/*`, `/assets/*`)
- Substring-collision guards (`/theleagueX`, `/afl-fantasy-x` stay unmolested)

## Test plan

- [x] `pnpm vitest run tests/resolve-league-path.test.ts` — 12/12 pass
- [x] `pnpm test:unit` — same 11 baseline failures (2172 pass, was 2160 → +12)
- [ ] After merge + deploy: visit `afl-fantasy.com` and confirm nav drawer links read `/standings`, `/rosters`, `/news` etc. — not `/afl-fantasy/standings`

## Plan reference

`docs/plans/AFL_DUPLICATION_PLAN.md` §6 Phase 7 (domain split).

https://claude.ai/code/session_01DEecdWcSPe6z48JTbVAWeT

---
_Generated by [Claude Code](https://claude.ai/code/session_01DEecdWcSPe6z48JTbVAWeT)_