### PR TITLE
afl(franchises): full-width banner above, team icon next to text

### DIFF
--- a/src/pages/afl-fantasy/franchises/[id].astro
+++ b/src/pages/afl-fantasy/franchises/[id].astro
@@ -66,11 +66,15 @@ const conferenceName = conference?.name ?? team.conference;
         ← All franchises
       </a>
 
+      {team.banner ? (
+        <img class="franchise-hero__banner" src={team.banner} alt="" loading="lazy" />
+      ) : null}
+
       <div class="franchise-hero__content">
-        {team.banner ? (
-          <img class="franchise-hero__banner" src={team.banner} alt="" loading="lazy" />
+        {team.icon ? (
+          <img class="franchise-hero__icon" src={team.icon} alt={`${team.name} icon`} loading="lazy" />
         ) : (
-          <div class="franchise-hero__banner-placeholder" />
+          <div class="franchise-hero__icon-placeholder" />
         )}
 
         <div class="franchise-hero__text">
@@ -194,27 +198,44 @@ const conferenceName = conference?.name ?? team.conference;
     text-decoration: underline;
   }
 
+  .franchise-hero__banner {
+    display: block;
+    width: 100%;
+    height: auto;
+    max-height: 240px;
+    object-fit: contain;
+    background: var(--bg-muted, #f3f4f6);
+    border-radius: 12px;
+    border: 1px solid var(--border-color, #e5e7eb);
+    margin-bottom: var(--spacing-md, 16px);
+  }
+
   .franchise-hero__content {
     display: flex;
     align-items: center;
     gap: var(--spacing-lg, 24px);
     background: var(--card-bg, #ffffff);
     border-radius: 12px;
-    overflow: hidden;
     border: 1px solid var(--border-color, #e5e7eb);
+    padding: var(--spacing-md, 16px);
   }
 
-  .franchise-hero__banner,
-  .franchise-hero__banner-placeholder {
-    width: 240px;
-    height: 160px;
+  .franchise-hero__icon,
+  .franchise-hero__icon-placeholder {
+    width: 96px;
+    height: 96px;
     flex-shrink: 0;
-    object-fit: cover;
+    object-fit: contain;
+    background: var(--bg-muted, #f3f4f6);
+    border-radius: 12px;
+    padding: 6px;
+  }
+
+  .franchise-hero__icon-placeholder {
     background: var(--bg-muted, #f3f4f6);
   }
 
   .franchise-hero__text {
-    padding: var(--spacing-md, 16px);
     min-width: 0;
   }
 


### PR DESCRIPTION
## Summary

Fixes the cropped banner on `/afl-fantasy/franchises/[id]`. The hero was using the wide team banner in a 240×160 `object-fit: cover` slot next to the text, which clipped most of the banner (e.g. "MOKAN" of "SMOKANE" for Smokane FC, per the screenshot).

## Layout change

Restructures the hero into two stacked blocks:

1. **Full-width team banner** at the top — `object-fit: contain`, `max-height: 240px`, so the full banner is visible without distortion or cropping.
2. **Content card below** with:
   - **Team icon** (96×96, contained) on the left
   - Tier pill / division / name / aliases on the right

Falls back to placeholders when a team has no banner or icon URL.

## Test plan

- [ ] Visit `/afl-fantasy/franchises/0001` (Smokane FC) — full banner visible up top, Smokane icon next to the name
- [ ] Visit a D-League team like `0003` — same layout, D-League pill
- [ ] Confirm mobile widths look sensible

## Visual reference

Before: banner was cropped horizontally to fit a fixed 240px-wide slot.
After: banner displays in full, icon takes the small slot.

https://claude.ai/code/session_01DEecdWcSPe6z48JTbVAWeT

---
_Generated by [Claude Code](https://claude.ai/code/session_01DEecdWcSPe6z48JTbVAWeT)_