### PR TITLE
afl(rosters): polish hero + coach-style table, keep-7 hint

### DIFF
--- a/src/pages/afl-fantasy/rosters.astro
+++ b/src/pages/afl-fantasy/rosters.astro
@@ -33,6 +33,11 @@ const playersFeeds = import.meta.glob('../../../data/afl-fantasy/mfl-feeds/*/pla
   eager: true,
 });
 
+// Projected scores — optional, only present in-season.
+const projectedScoresFeeds = import.meta.glob('../../../data/afl-fantasy/mfl-feeds/*/projectedScores.json', {
+  eager: true,
+});
+
 // Extract available years
 const availableYears = Object.keys(rostersFeeds)
   .map(path => {
@@ -64,9 +69,28 @@ const playersData = getModuleData(
   playersFeeds[`../../../data/afl-fantasy/mfl-feeds/${selectedYear}/players.json`]
 );
 
+const projectedScoresData = getModuleData(
+  projectedScoresFeeds[`../../../data/afl-fantasy/mfl-feeds/${selectedYear}/projectedScores.json`]
+);
+
 if (!rostersData?.rosters?.franchise || !playersData?.players?.player) {
   return Astro.redirect(`${baseUrl}/rosters?year=${defaultYear}`);
 }
+
+// Build projected-score map (playerId -> score). Empty when feed is empty
+// (offseason).
+const projectedScoreById = new Map<string, number>();
+const projWeek = projectedScoresData?.projectedScores?.week;
+const projScores = projectedScoresData?.projectedScores?.playerScore;
+if (Array.isArray(projScores)) {
+  for (const ps of projScores) {
+    if (ps?.id && ps.score && ps.score !== '') {
+      const n = Number(ps.score);
+      if (Number.isFinite(n)) projectedScoreById.set(ps.id, n);
+    }
+  }
+}
+const hasProjections = projectedScoreById.size > 0;
 
 // Create players lookup map
 const playersMap = new Map();
@@ -92,24 +116,27 @@ const teamsList = aflConfig.teams
     abbrev: team.abbrev,
     division: team.division,
     icon: team.icon,
+    banner: team.banner,
+    tier: team.tier,
+    conference: team.conference,
   }))
   .sort((a, b) => {
-    // Sort by division first, then by name
     if (a.division !== b.division) {
       return a.division.localeCompare(b.division);
     }
     return a.name.localeCompare(b.name);
   });
 
-// Get selected team info
-const selectedTeam = teamsList.find(t => t.id === selectedFranchiseId) || teamsList[0];
+// Get selected team info — fall back to full config entry for banner + tier
+const selectedTeamRaw = aflConfig.teams.find(t => t.franchiseId === selectedFranchiseId)
+  ?? aflConfig.teams[0];
 
 // Get roster for selected franchise
 const franchiseRoster = rostersData.rosters.franchise.find(
   (f: any) => f.id === selectedFranchiseId
 );
 
-// Build roster with player details
+// Build roster with player details + projected score
 const roster = franchiseRoster?.player?.map((p: any) => {
   const playerInfo = playersMap.get(p.id) || {};
   return {
@@ -120,6 +147,7 @@ const roster = franchiseRoster?.player?.map((p: any) => {
     team: playerInfo.team || 'N/A',
     age: playerInfo.age || 'N/A',
     college: playerInfo.college || 'N/A',
+    projected: projectedScoreById.get(p.id) ?? null,
   };
 }) || [];
 
@@ -139,9 +167,19 @@ roster.forEach((player: any) => {
   rosterByPosition.get(pos)!.push(player);
 });
 
-// Sort players within each position by name
+// Sort: active first, then projected (when present) or alpha
 rosterByPosition.forEach(players => {
-  players.sort((a, b) => a.name.localeCompare(b.name));
+  players.sort((a, b) => {
+    // Active roster floats to top
+    if (a.status === 'ROSTER' && b.status !== 'ROSTER') return -1;
+    if (a.status !== 'ROSTER' && b.status === 'ROSTER') return 1;
+    if (hasProjections) {
+      const aProj = a.projected ?? -1;
+      const bProj = b.projected ?? -1;
+      if (aProj !== bProj) return bProj - aProj;
+    }
+    return a.name.localeCompare(b.name);
+  });
 });
 
 // Calculate roster counts
@@ -149,72 +187,119 @@ const totalPlayers = roster.length;
 const activeRoster = roster.filter((p: any) => p.status === 'ROSTER').length;
 const taxiSquad = roster.filter((p: any) => p.status === 'TAXI_SQUAD').length;
 const injured = roster.filter((p: any) => p.status === 'INJURED_RESERVE').length;
+
+// AFL keeps 7. The top 7 active players (by projected when in-season, by
+// "active roster" when offseason) are likely keeper candidates — shown as a
+// small hint, NOT enforced (no special keeper rules per AFL constitution).
+const topSevenIds = new Set<string>(
+  roster
+    .filter((p: any) => p.status === 'ROSTER')
+    .slice()
+    .sort((a: any, b: any) => {
+      if (hasProjections) {
+        const aProj = a.projected ?? -1;
+        const bProj = b.projected ?? -1;
+        if (aProj !== bProj) return bProj - aProj;
+      }
+      // Offseason fallback: alpha (no special keeper rules to apply)
+      return a.name.localeCompare(b.name);
+    })
+    .slice(0, 7)
+    .map((p: any) => p.id),
+);
+
+const conference = (aflConfig.conferences ?? []).find(
+  (c: any) => c.code === selectedTeamRaw.conference,
+);
+const conferenceName = conference?.name ?? selectedTeamRaw.conference;
 ---
 
-<TheLeagueLayout title={`AFL Fantasy - ${selectedTeam.name} Roster`}>
-  <div class="rosters-page">
-    <!-- Header -->
+<TheLeagueLayout title={`${selectedTeamRaw.name} Roster | AFL Fantasy`}>
+  <main class="rosters-page">
+    <!-- Hero: full-width banner above, icon + name below (mirrors franchise detail) -->
     <header class="roster-hero">
+      {selectedTeamRaw.banner ? (
+        <img class="roster-hero__banner" src={selectedTeamRaw.banner} alt="" loading="lazy" />
+      ) : null}
+
       <div class="roster-hero__content">
-        <div class="roster-hero__team">
-          {selectedTeam.icon && (
-            <img src={selectedTeam.icon} alt={selectedTeam.name} class="team-logo" />
-          )}
-          <div>
-            <h1 class="team-name">{selectedTeam.name}</h1>
-            <p class="team-abbrev">{selectedTeam.abbrev}</p>
-          </div>
-        </div>
-
-        <!-- Team Selector -->
-        <div class="team-selector">
-          <label for="franchise-select">Select Team:</label>
-          <select
-            id="franchise-select"
-            onchange={`window.location.href = '${baseUrl}/rosters?year=${selectedYear}&franchise=' + this.value`}
-          >
-            {teamsList.map(team => (
-              <option value={team.id} selected={team.id === selectedFranchiseId}>
-                {team.name}
-              </option>
-            ))}
-          </select>
-        </div>
-      </div>
-
-      <!-- Roster Stats -->
-      <div class="roster-stats">
-        <div class="stat-card">
-          <div class="stat-value">{totalPlayers}</div>
-          <div class="stat-label">Total Players</div>
-        </div>
-        <div class="stat-card">
-          <div class="stat-value">{activeRoster}</div>
-          <div class="stat-label">Active Roster</div>
-        </div>
-        {taxiSquad > 0 && (
-          <div class="stat-card">
-            <div class="stat-value">{taxiSquad}</div>
-            <div class="stat-label">Taxi Squad</div>
-          </div>
+        {selectedTeamRaw.icon ? (
+          <img class="roster-hero__icon" src={selectedTeamRaw.icon} alt={`${selectedTeamRaw.name} icon`} loading="lazy" />
+        ) : (
+          <div class="roster-hero__icon-placeholder" />
         )}
-        {injured > 0 && (
-          <div class="stat-card">
-            <div class="stat-value">{injured}</div>
-            <div class="stat-label">Injured Reserve</div>
+
+        <div class="roster-hero__text">
+          <div class="roster-hero__tier-row">
+            <span class:list={[
+              'roster-hero__tier-pill',
+              selectedTeamRaw.tier === 'Premier League'
+                ? 'roster-hero__tier-pill--premier'
+                : 'roster-hero__tier-pill--dleague',
+            ]}>
+              {selectedTeamRaw.tier}
+            </span>
+            <span class="roster-hero__div">
+              {conferenceName} {selectedTeamRaw.division}
+            </span>
           </div>
-        )}
+          <h1 class="roster-hero__name">{selectedTeamRaw.name}</h1>
+
+          <form class="roster-hero__switch" method="get">
+            <input type="hidden" name="year" value={selectedYear} />
+            <label for="franchise-select" class="visually-hidden">Switch team</label>
+            <select
+              id="franchise-select"
+              name="franchise"
+              onchange="this.form.submit()"
+            >
+              {teamsList.map(team => (
+                <option value={team.id} selected={team.id === selectedFranchiseId}>
+                  {team.name}
+                </option>
+              ))}
+            </select>
+          </form>
+        </div>
       </div>
     </header>
 
+    <!-- AFL identity strip: explains the 7-keeper context without
+         enforcing keeper-eligibility logic the league doesn't have. -->
+    <aside class="afl-roster-context">
+      <strong>AFL Fantasy keeps 7.</strong>
+      Each franchise designates 7 players to retain into next season — no
+      salary cap, no contracts, no special-rules eligibility. The top-7
+      indicator below highlights this team's likely keep set
+      {hasProjections ? `(by projected points, week ${projWeek})` : '(by active roster, alpha)'}
+      — it's a hint, not an enforced selection. Submit real keepers on
+      <a href="/keepers">the keepers page</a> once that surface is wired up.
+    </aside>
+
+    <!-- Roster stats -->
+    <div class="roster-stats">
+      <div class="stat-pill"><span class="stat-pill__value">{totalPlayers}</span><span class="stat-pill__label">Players</span></div>
+      <div class="stat-pill"><span class="stat-pill__value">{activeRoster}</span><span class="stat-pill__label">Active</span></div>
+      {taxiSquad > 0 && (
+        <div class="stat-pill"><span class="stat-pill__value">{taxiSquad}</span><span class="stat-pill__label">Taxi</span></div>
+      )}
+      {injured > 0 && (
+        <div class="stat-pill"><span class="stat-pill__value">{injured}</span><span class="stat-pill__label">IR</span></div>
+      )}
+      <div class="stat-pill stat-pill--keep">
+        <span class="stat-pill__value">7</span>
+        <span class="stat-pill__label">Kept next year</span>
+      </div>
+    </div>
+
     <!-- Roster Table by Position -->
-    <main class="roster-content">
+    <section class="roster-content">
       {Array.from(rosterByPosition.entries())
         .filter(([_, players]) => players.length > 0)
         .map(([position, players]) => (
           <div class="position-group">
             <h2 class="position-title">
-              {position} ({players.length})
+              {position} <span class="position-count">×{players.length}</span>
             </h2>
 
             <div class="roster-table">
@@ -222,25 +307,32 @@ const injured = roster.filter((p: any) => p.status === 'INJURED_RESERVE').length
                 <thead>
                   <tr>
                     <th class="player-col">Player</th>
-                    <th class="pos-col">Pos</th>
-                    <th class="team-col">NFL Team</th>
+                    <th class="team-col">NFL</th>
                     <th class="age-col">Age</th>
-                    <th class="college-col">College</th>
+                    {hasProjections && <th class="proj-col">Proj</th>}
                     <th class="status-col">Status</th>
                   </tr>
                 </thead>
                 <tbody>
                   {players.map((player: any) => (
-                    <tr>
+                    <tr class:list={[{ 'roster-row--top7': topSevenIds.has(player.id) }]}>
                       <td class="player-col">
-                        <div class="player-name">{player.name}</div>
+                        <div class="player-name">
+                          {topSevenIds.has(player.id) && (
+                            <span class="keep-badge" title="Likely keeper (top 7)">★</span>
+                          )}
+                          {player.name}
+                        </div>
                       </td>
-                      <td class="pos-col">{player.position}</td>
                       <td class="team-col">{player.team}</td>
                       <td class="age-col">{player.age}</td>
-                      <td class="college-col">{player.college}</td>
+                      {hasProjections && (
+                        <td class="proj-col">
+                          {player.projected != null ? player.projected.toFixed(1) : '—'}
+                        </td>
+                      )}
                       <td class="status-col">
-                        <span class={`status-badge status-${player.status.toLowerCase().replace('_', '-')}`}>
+                        <span class:list={['status-badge', `status-${player.status.toLowerCase().replace('_', '-')}`]}>
                           {player.status.replace('_', ' ')}
                         </span>
                       </td>
@@ -251,133 +343,195 @@ const injured = roster.filter((p: any) => p.status === 'INJURED_RESERVE').length
             </div>
           </div>
         ))}
-    </main>
-  </div>
+    </section>
+  </main>
 </TheLeagueLayout>
 
 <style>
   .rosters-page {
-    display: grid;
-    gap: 2rem;
+    max-width: 1100px;
+    margin: 0 auto;
     padding: 2rem 1rem;
+    display: grid;
+    gap: 1.5rem;
   }
 
-  .roster-hero {
-    background: #fff;
-    border-radius: 1rem;
-    box-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1);
-    padding: 2rem;
+  .visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    border: 0;
+  }
+
+  /* ---- Hero (mirrors /franchises/[id].astro layout) ---- */
+
+  .roster-hero__banner {
+    display: block;
+    width: 100%;
+    height: auto;
+    max-height: 240px;
+    object-fit: contain;
+    background: var(--bg-muted, #f3f4f6);
+    border-radius: 12px;
+    border: 1px solid var(--border-color, #e5e7eb);
+    margin-bottom: var(--spacing-md, 16px);
   }
 
   .roster-hero__content {
     display: flex;
-    justify-content: space-between;
     align-items: center;
-    margin-bottom: 2rem;
-    flex-wrap: wrap;
-    gap: 1.5rem;
+    gap: var(--spacing-lg, 24px);
+    background: var(--card-bg, #ffffff);
+    border-radius: 12px;
+    border: 1px solid var(--border-color, #e5e7eb);
+    padding: var(--spacing-md, 16px);
   }
 
-  .roster-hero__team {
-    display: flex;
-    align-items: center;
-    gap: 1.5rem;
-  }
-
-  .team-logo {
-    width: 80px;
-    height: 80px;
+  .roster-hero__icon,
+  .roster-hero__icon-placeholder {
+    width: 96px;
+    height: 96px;
+    flex-shrink: 0;
     object-fit: contain;
-    border-radius: 0.5rem;
+    background: var(--bg-muted, #f3f4f6);
+    border-radius: 12px;
+    padding: 6px;
   }
 
-  .team-name {
-    font-size: 2rem;
-    font-weight: 700;
-    margin: 0;
-    color: #1e293b;
+  .roster-hero__text {
+    min-width: 0;
+    flex: 1;
   }
 
-  .team-abbrev {
-    font-size: 1.125rem;
-    color: #64748b;
-    margin: 0.25rem 0 0 0;
-  }
-
-  .team-selector {
+  .roster-hero__tier-row {
     display: flex;
+    gap: var(--spacing-sm, 8px);
+    margin-bottom: var(--spacing-sm, 8px);
     align-items: center;
-    gap: 0.75rem;
   }
 
-  .team-selector label {
-    font-weight: 600;
-    color: #475569;
+  .roster-hero__tier-pill {
+    padding: 2px 10px;
+    border-radius: 9999px;
+    font-size: 0.75rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
   }
 
-  .team-selector select {
-    padding: 0.5rem 1rem;
-    border: 2px solid #dddcdc;
+  .roster-hero__tier-pill--premier {
+    background: var(--primary-color, #c41e3a);
+    color: white;
+  }
+
+  .roster-hero__tier-pill--dleague {
+    background: var(--bg-muted, #e5e7eb);
+    color: var(--text-default);
+  }
+
+  .roster-hero__div {
+    font-size: 0.8125rem;
+    color: var(--text-muted, #6b7280);
+  }
+
+  .roster-hero__name {
+    font-size: 2rem;
+    margin: 0 0 0.5rem 0;
+  }
+
+  .roster-hero__switch select {
+    padding: 0.4rem 0.75rem;
+    border: 1px solid #d1d5db;
     border-radius: 0.5rem;
-    font-size: 1rem;
+    font-size: 0.9375rem;
     background: white;
     cursor: pointer;
-    min-width: 250px;
+    min-width: 200px;
   }
 
-  .team-selector select:hover {
-    border-color: #cbd5e1;
+  /* ---- AFL keeper context strip ---- */
+
+  .afl-roster-context {
+    background: #fff7ed;
+    border: 1px solid #fdba74;
+    color: #7c2d12;
+    border-radius: 0.75rem;
+    padding: 0.875rem 1rem;
+    font-size: 0.9375rem;
+    line-height: 1.5;
   }
 
-  .team-selector select:focus {
-    outline: none;
-    border-color: #c41e3a;
+  .afl-roster-context a {
+    color: var(--primary-color, #c41e3a);
+    font-weight: 600;
   }
+
+  /* ---- Stats pills ---- */
 
   .roster-stats {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-    gap: 1rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
   }
 
-  .stat-card {
-    background: linear-gradient(135deg, #c41e3a 0%, #002244 100%);
-    color: white;
-    padding: 1.5rem;
-    border-radius: 0.75rem;
-    text-align: center;
-  }
-
-  .stat-value {
-    font-size: 2rem;
-    font-weight: 700;
-    margin-bottom: 0.5rem;
-  }
-
-  .stat-label {
+  .stat-pill {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 0.375rem;
+    background: var(--card-bg, #fff);
+    border: 1px solid var(--border-color, #e5e7eb);
+    border-radius: 9999px;
+    padding: 0.4rem 0.875rem;
     font-size: 0.875rem;
-    opacity: 0.9;
   }
+
+  .stat-pill__value {
+    font-weight: 700;
+    font-size: 1rem;
+  }
+
+  .stat-pill__label {
+    color: var(--text-muted, #6b7280);
+  }
+
+  .stat-pill--keep {
+    background: #fff7ed;
+    border-color: #fdba74;
+    color: #7c2d12;
+  }
+
+  /* ---- Roster table ---- */
 
   .roster-content {
     display: grid;
-    gap: 2rem;
+    gap: 1rem;
   }
 
   .position-group {
     background: #fff;
-    border-radius: 1rem;
-    box-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1);
+    border-radius: 0.75rem;
+    border: 1px solid var(--border-color, #e5e7eb);
     overflow: hidden;
   }
 
   .position-title {
-    font-size: 1.5rem;
+    font-size: 1.0625rem;
     font-weight: 700;
-    padding: 1.5rem 2rem;
+    padding: 0.75rem 1.25rem;
     margin: 0;
-    background: linear-gradient(135deg, #c41e3a 0%, #002244 100%);
-    color: white;
+    background: var(--bg-muted, #f9fafb);
+    border-bottom: 1px solid var(--border-color, #e5e7eb);
+    color: var(--text-default, #1f2937);
+  }
+
+  .position-count {
+    font-weight: 500;
+    color: var(--text-muted, #6b7280);
+    font-size: 0.9375rem;
   }
 
   .roster-table {
@@ -390,72 +544,86 @@ const injured = roster.filter((p: any) => p.status === 'INJURED_RESERVE').length
   }
 
   thead {
-    background: #f8fafc;
-    border-bottom: 2px solid #dddcdc;
+    background: #fff;
+    border-bottom: 1px solid var(--border-color, #e5e7eb);
   }
 
   th {
-    padding: 1rem;
+    padding: 0.5rem 1rem;
     text-align: left;
     font-weight: 600;
-    color: #475569;
-    font-size: 0.875rem;
+    color: var(--text-muted, #6b7280);
+    font-size: 0.75rem;
     text-transform: uppercase;
     letter-spacing: 0.05em;
   }
 
   tbody tr {
-    border-bottom: 1px solid #dddcdc;
+    border-bottom: 1px solid var(--border-color, #f1f5f9);
+  }
+
+  tbody tr:last-child {
+    border-bottom: none;
   }
 
   tbody tr:hover {
-    background: #f8fafc;
+    background: #fafafa;
+  }
+
+  .roster-row--top7 {
+    background: #fffbeb;
+  }
+
+  .roster-row--top7:hover {
+    background: #fef3c7;
   }
 
   td {
-    padding: 1rem;
+    padding: 0.625rem 1rem;
   }
 
   .player-col {
-    min-width: 200px;
+    min-width: 180px;
   }
 
   .player-name {
     font-weight: 600;
     color: #1e293b;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
   }
 
-  .pos-col {
-    width: 80px;
+  .keep-badge {
+    color: #d97706;
+    font-size: 1rem;
+    line-height: 1;
+  }
+
+  .team-col,
+  .age-col,
+  .proj-col {
+    width: 70px;
     text-align: center;
+    color: var(--text-muted, #6b7280);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .proj-col {
     font-weight: 600;
-    color: #64748b;
-  }
-
-  .team-col {
-    width: 100px;
-    text-align: center;
-  }
-
-  .age-col {
-    width: 80px;
-    text-align: center;
-  }
-
-  .college-col {
-    min-width: 150px;
+    color: var(--text-default, #1f2937);
   }
 
   .status-col {
-    width: 120px;
-    text-align: center;
+    width: 110px;
+    text-align: right;
   }
 
   .status-badge {
     display: inline-block;
-    padding: 0.25rem 0.75rem;
+    padding: 0.125rem 0.625rem;
     border-radius: 9999px;
-    font-size: 0.75rem;
+    font-size: 0.6875rem;
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.05em;
@@ -481,44 +649,33 @@ const injured = roster.filter((p: any) => p.status === 'INJURED_RESERVE').length
       padding: 1rem 0.5rem;
     }
 
-    .roster-hero {
-      padding: 1.5rem;
-    }
-
     .roster-hero__content {
       flex-direction: column;
       align-items: flex-start;
+      gap: 0.75rem;
     }
 
-    .team-logo {
-      width: 60px;
-      height: 60px;
+    .roster-hero__icon,
+    .roster-hero__icon-placeholder {
+      width: 72px;
+      height: 72px;
     }
 
-    .team-name {
+    .roster-hero__name {
       font-size: 1.5rem;
     }
 
-    .team-selector {
+    .roster-hero__switch select {
       width: 100%;
-    }
-
-    .team-selector select {
-      flex: 1;
       min-width: 0;
     }
 
-    .position-title {
-      font-size: 1.25rem;
-      padding: 1rem 1.5rem;
+    .age-col {
+      display: none;
     }
 
     th, td {
-      padding: 0.75rem 0.5rem;
-    }
-
-    .college-col {
-      display: none;
+      padding: 0.5rem 0.625rem;
     }
   }
 </style>


### PR DESCRIPTION
## Summary

Polishes `/afl-fantasy/rosters` to match the franchises page hero style and drops everything that was hinting at salary-cap mechanics AFL doesn't have. Implements plan §3 rosters row with the user's clarification: **no special keeper rules, just keep 7**.

## Hero

Mirrors the `/franchises/[id].astro` layout:

- Full-width team **banner** above (`object-fit: contain`, no crop)
- **Icon + tier pill + division + name** in a content card below
- Team-switcher dropdown moved into the hero card (form-driven so it works with JS off)

## Content

- **AFL keeper context strip** ("AFL Fantasy keeps 7…") so visitors immediately understand the league shape — no salary cap, no contracts.
- **Stat pills** replace the heavy gradient stat cards. A "7 kept next year" pill anchors the AFL-specific dimension.
- **Optional `Proj` column** wired off `projectedScores.json` — gracefully omitted offseason when MFL returns empty (current state: May 2026).
- **Top-7 ★ badge** on likely keepers with a soft amber row highlight. By projected points in-season, by alpha offseason. **NOT enforced** — AFL has no special keeper-eligibility rules; this is just a UI hint. Actual keeper selection lives on `/keepers`.
- Position groups now sort: active first → projected desc (when available) → alpha.
- Drops the standalone College column from the default table (won't make sense in coach-style focus); Age stays since it's a real keep-decision input.

## Test plan

- [ ] Visit `/afl-fantasy/rosters` — verify hero looks like franchises page, banner full visible
- [ ] Switch teams via the dropdown — page reloads with new roster
- [ ] `?franchise=0001` (Smokane FC) renders the Smokane banner + icon
- [ ] Check mobile width — icon shrinks, age column hides, switcher fills width
- [ ] Confirm ★ badge appears on the alphabetically-first 7 active players (offseason)
- [ ] When season starts and `projectedScores.json` populates, `Proj` column appears and ★ shifts to projection leaders

## Plan reference

`docs/plans/AFL_DUPLICATION_PLAN.md` §3 rosters row, plus user clarification ("we don't have special keeper rules other than we keep 7").

https://claude.ai/code/session_01DEecdWcSPe6z48JTbVAWeT

---
_Generated by [Claude Code](https://claude.ai/code/session_01DEecdWcSPe6z48JTbVAWeT)_