### PR TITLE
fix(schefter): never frame trade rumors as the rookie draft

### DIFF
--- a/scripts/schefter-rumor-scan.mjs
+++ b/scripts/schefter-rumor-scan.mjs
@@ -1328,6 +1328,7 @@ Redaction rules (HARD — never violate):
   NEVER surface franchise names, owner names, raw draft pick slot numbers, or player names EXCEPT when escalatedPlayer.tier === "named".
   NEVER invent a name, team, or pick slot. If a field isn't in the structured tip data, it does not exist.
   NEVER cross-reference multiple trade_offer tips in a way that lets the reader triangulate who's trading with whom.
+  NEVER frame a trade-offer tip as the rookie draft, the NFL draft, "draft-room" activity, "draft chatter", "draft strategy", "auto-pilot picks", or any league draft event (see HARD RULE 21). A trade_offer is one team considering a trade — phrase it as shopping/fielding-calls/kicking-the-tires, never as draft activity. Any internal metadata that mentions "draft" reflects trade-builder saves, not the rookie draft.
 
 Escalation guidance:
   - tier "base" (no escalatedPlayer field): stay vague. Use the volumeHint plus AT MOST ONE of (positionTokens first entry, pickTokens first entry) — not both. If divisionHint is present, it's an alternative to position/pick; don't combine.
@@ -1653,6 +1654,11 @@ IRON RULES (override every other rule — if anything below appears to conflict,
     - Still anonymized per rules 1–6 and hostile-reframed per rules 12–16.
     - Close with a quick sign-off: "That's the file. Have a good weekend." or similar. One sentence max.
     - Length cap: 180 words total.
+
+21. NEVER FRAME A TRADE RUMOR AS THE ROOKIE DRAFT. The rumor mill reports on TRADE ACTIVITY — owners shopping players, fielding calls, kicking the tires, making offers. The league's rookie draft is a separate, once-a-year three-round event with its own dedicated coverage; it is NEVER the subject of a rumor-mill post unless a tip's \`text\` field explicitly names it. Specifically:
+    - Trade-offer tips (source: "trade_offer") are about ONE TEAM CONSIDERING A TRADE. Phrase as "shopping", "looking to move", "fielding calls on", "in talks about", "kicking the tires on", "putting out feelers on" — NEVER as "draft chatter", "draft-room buzz", "the draft's in full swing", "rookie-draft strategy", "auto-pilot picks", "half the league locked in", or any framing that implies a league draft event is underway or imminent.
+    - The internal "draft" vocabulary you may encounter in tip metadata (e.g. owner activity counts, repeat-offerer signals) reflects TRADE-BUILDER SAVES — owners drafting trade proposals in the trade tool. It is NOT the rookie draft. Treat all "draft"-flavored metadata as a trade-shopping intensity signal and nothing else.
+    - The only path to mentioning the rookie draft (or NFL draft) is when a tip's literal \`text\` field references it. Even then, you may only acknowledge what the tip actually says — never extend the framing to other tips in the batch, and never invent a "draft is happening now" backdrop.
 
 Voice: "League sources tell me…", "I'm told…", "Hearing…", "A division rival whispers…". Salt, not sugar.`;
 

--- a/tests/schefter-rumor-topic-focus.test.ts
+++ b/tests/schefter-rumor-topic-focus.test.ts
@@ -459,3 +459,34 @@ describe('rumor-scan Friday mailbag — once-a-week sweep of pending gossip', ()
   });
 });
 
+describe('rumor-scan rookie-draft scope guard (HARD RULE 21)', () => {
+  // Pinning test: the rumor mill must never frame a trade rumor as the
+  // rookie draft. The system prompt's hard rule prohibits "draft-room"
+  // framing on trade_offer tips; the trade-offer playbook reiterates it.
+  //
+  // History: on 2026-05-12 the scanner posted "Rookie draft's reached
+  // that sweet spot where half the league is locked in, half is on
+  // auto-pilot…" days AFTER the actual rookie draft completed. The
+  // LLM had hallucinated rookie-draft framing on top of trade-builder
+  // "draft" signals (saved trade proposals). HARD RULE 21 forbids that
+  // confusion; this test keeps the rule in place.
+  const src = read('scripts/schefter-rumor-scan.mjs');
+
+  it('HARD RULE 21 forbids framing trade rumors as the rookie draft', () => {
+    expect(src).toMatch(/21\.\s*NEVER FRAME A TRADE RUMOR AS THE ROOKIE DRAFT/);
+  });
+
+  it('HARD RULE 21 names the offending phrases the LLM previously reached for', () => {
+    expect(src).toMatch(/draft-room buzz|draft chatter|draft's in full swing|rookie-draft strategy|auto-pilot picks|half the league locked in/);
+  });
+
+  it('HARD RULE 21 clarifies that "draft" metadata refers to trade-builder saves, not the rookie draft', () => {
+    expect(src).toMatch(/TRADE-BUILDER SAVES/);
+    expect(src).toMatch(/NOT the rookie draft/);
+  });
+
+  it('trade-offer playbook redaction rules reiterate the rookie-draft ban', () => {
+    expect(src).toMatch(/NEVER frame a trade-offer tip as the rookie draft/);
+  });
+});
+


### PR DESCRIPTION
The rumor mill posted "Rookie draft's reached that sweet spot where
half the league is locked in, half is on auto-pilot…" on 2026-05-12 —
five days after the rookie draft actually completed. The LLM hallucinated
rookie-draft framing on top of trade-builder "draft" signals (saved
trade proposals in the trade tool, which the scanner uses as a soft
shopping intensity signal — see scripts/lib/scan-draft-trades.mjs).

Add HARD RULE 21 to the rumor-scan system prompt explicitly forbidding
rookie-draft / NFL-draft / draft-room / auto-pilot framing on trade
rumors, and clarifying that any internal "draft" metadata refers to
trade-builder saves, not the league's rookie draft. A trade_offer tip
is one team considering a trade — phrase as shopping / fielding calls /
kicking the tires, never as draft activity.

Reiterate the ban in the trade-offer playbook's redaction-rules block
so the LLM sees it in both the global rules section and the playbook
that applies specifically to trade_offer tips.

Pin the rule in tests/schefter-rumor-topic-focus.test.ts so a future
edit can't silently drop the guard.

https://claude.ai/code/session_01LfNaXrk2YLmoWkzsDtJAWZ