### PR TITLE
feat(schefter): franchise milestone posts (franchise-history Phase 5)

### DIFF
--- a/.github/workflows/backfill-historical-feeds.yml
+++ b/.github/workflows/backfill-historical-feeds.yml
@@ -67,6 +67,8 @@ jobs:
 
           git config user.name "Historical Feed Backfill Bot"
           git config user.email "actions@users.noreply.github.com"
-          git add data/theleague/mfl-feeds/ data/theleague/derived/
+          # schefter-feed.json picks up any new milestone posts emitted by
+          # the compute step (Phase 5 — badge crossings auto-post).
+          git add data/theleague/mfl-feeds/ data/theleague/derived/ src/data/theleague/schefter-feed.json
           git commit -m "chore: backfill historical MFL feeds + recompute franchise history"
           git push origin HEAD:${{ github.ref_name }}

--- a/.github/workflows/schefter-trade-speculation.yml
+++ b/.github/workflows/schefter-trade-speculation.yml
@@ -5,6 +5,10 @@ on:
     # Daily at 8pm UTC = 1pm Pacific. NFL-calendar-aware cadence (per
     # scripts/lib/speculation-cadence.mjs) decides whether to actually post —
     # the cron just gives the scanner a once-a-day chance.
+    #
+    # This same cron also runs the franchise-history recompute below, which
+    # diffs new badges against the committed snapshot and auto-posts
+    # milestone events to the Schefter feed (Phase 5).
     - cron: "0 20 * * *"
   workflow_dispatch:
     inputs:
@@ -44,6 +48,14 @@ jobs:
           MFL_LEAGUE_SLUG: theleague
         run: node scripts/fetch-trade-bait.mjs
 
+      - name: Recompute franchise history (milestone diff)
+        # Runs the badge engine and diffs against the committed
+        # franchise-history.json snapshot. Newly-earned badges emit
+        # Schefter posts directly into src/data/theleague/schefter-feed.json
+        # (idempotent — dedup by deterministic post id).
+        if: github.event.inputs.dry_run != 'true'
+        run: node scripts/compute-franchise-history.mjs
+
       - name: Run speculation scanner
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -71,7 +83,9 @@ jobs:
 
           git config user.name "Schefter Bot"
           git config user.email "actions@users.noreply.github.com"
-          git add src/data/theleague/schefter-feed.json data/theleague/derived/speculation-history.json data/theleague/mfl-feeds
-          git commit -m "chore: schefter speculation — new trade speculation post"
+          # franchise-history.json: updated snapshot so milestone diff stays
+          # in sync. schefter-feed.json: trade-speculation + milestone posts.
+          git add src/data/theleague/schefter-feed.json data/theleague/derived/speculation-history.json data/theleague/derived/franchise-history.json data/theleague/mfl-feeds
+          git commit -m "chore: schefter daily — speculation + milestone scan"
           git pull --rebase origin main
           git push

--- a/scripts/compute-franchise-history.mjs
+++ b/scripts/compute-franchise-history.mjs
@@ -18,6 +18,11 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { buildBadgeContext, computeBadgesFor } from './badges.mjs';
+import {
+  diffNewAwards,
+  buildMilestonePost,
+  mergeMilestonePosts,
+} from './lib/franchise-milestone-posts.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
@@ -26,6 +31,7 @@ const SALARIES_DIR = path.join(ROOT, 'data/theleague');
 const LEAGUE_CONFIG_PATH = path.join(ROOT, 'src/data/theleague.config.json');
 const CHAMPIONSHIP_HISTORY_PATH = path.join(ROOT, 'data/theleague/championship-history.json');
 const OUTPUT_PATH = path.join(ROOT, 'data/theleague/derived/franchise-history.json');
+const SCHEFTER_FEED_PATH = path.join(ROOT, 'src/data/theleague/schefter-feed.json');
 
 const INDIVIDUAL_AWARD_MIN_SALARY = 1_500_000;
 
@@ -1142,6 +1148,51 @@ for (const [id, fr] of franchiseMap) {
 const badgeContext = buildBadgeContext(franchises, yearSummaries);
 for (const fid of Object.keys(franchises)) {
   franchises[fid].badges = computeBadgesFor(franchises[fid], badgeContext);
+}
+
+// Phase 5: Schefter milestone posts. The previously-committed
+// franchise-history.json is the snapshot we diff against — if it's missing
+// (fresh checkout / first run) we silently seed and emit nothing so we
+// don't flood the feed with retroactive posts for every existing badge.
+const previousOutput = readJson(OUTPUT_PATH);
+if (!previousOutput?.franchises) {
+  console.log('[franchise-history] no previous snapshot — milestone diff skipped (silent seed)');
+} else {
+  const newAwards = diffNewAwards(previousOutput.franchises, franchises);
+  if (newAwards.length === 0) {
+    console.log('[franchise-history] no new badges — milestone diff empty');
+  } else {
+    const now = new Date();
+    const milestonePosts = newAwards.map((entry) =>
+      buildMilestonePost({
+        franchiseId: entry.franchiseId,
+        badge: entry.badge,
+        award: entry.award,
+        franchise: franchises[entry.franchiseId],
+        now,
+      })
+    );
+    const feed = readJson(SCHEFTER_FEED_PATH);
+    if (feed && Array.isArray(feed.posts)) {
+      const { posts, added } = mergeMilestonePosts(feed.posts, milestonePosts);
+      if (added > 0) {
+        feed.posts = posts;
+        feed.lastScanTimestamp = now.toISOString();
+        fs.writeFileSync(SCHEFTER_FEED_PATH, JSON.stringify(feed, null, 2) + '\n');
+        console.log(
+          `[franchise-history] emitted ${added} new milestone post(s) to ${SCHEFTER_FEED_PATH}`
+        );
+      } else {
+        console.log(
+          `[franchise-history] ${milestonePosts.length} milestone(s) already in feed — no new posts`
+        );
+      }
+    } else {
+      console.warn(
+        `[franchise-history] could not load ${SCHEFTER_FEED_PATH} — skipping milestone emission`
+      );
+    }
+  }
 }
 
 const output = {

--- a/scripts/lib/franchise-milestone-posts.mjs
+++ b/scripts/lib/franchise-milestone-posts.mjs
@@ -1,0 +1,261 @@
+/**
+ * Franchise milestone posts — Phase 5.
+ *
+ * Pure module. Diffs the badges that `scripts/badges.mjs` computed in this
+ * run against the badges from the previous committed `franchise-history.json`,
+ * and emits Schefter feed posts for any newly-earned awards.
+ *
+ * Idempotent by post id: re-emitting the same milestone produces an
+ * identical post id, so `appendMilestonePosts` skips duplicates.
+ *
+ * No LLM call — phrasing is template-based, voiced per Schefter's
+ * personality.md (short, deadpan, no exclamation marks).
+ */
+
+const SLUG_RE = /[^a-z0-9]+/g;
+
+const slug = (s) =>
+  String(s).toLowerCase().replace(SLUG_RE, '-').replace(/^-+|-+$/g, '');
+
+/**
+ * Stable identifier for one award instance on a badge.
+ *
+ * Year-keyed badges (top-scorer, worst-to-first, cellar-dweller, etc.) fire
+ * once per qualifying year. Game-keyed badges include the week. Career
+ * milestones with no year/week fire exactly once when first earned —
+ * later runs that update the same badge's `value` don't re-fire.
+ */
+export function awardKey(badgeId, award) {
+  const parts = [badgeId];
+  if (award?.year != null) parts.push(`y${award.year}`);
+  if (award?.week != null) parts.push(`w${award.week}`);
+  return parts.join(':');
+}
+
+const collectAwardKeys = (badges) => {
+  const set = new Set();
+  for (const b of badges || []) {
+    for (const a of b.awards || []) set.add(awardKey(b.id, a));
+  }
+  return set;
+};
+
+/**
+ * Diff previous vs current badges across all franchises. Returns a list of
+ * newly-earned awards in stable order (franchiseId asc, badgeId asc).
+ *
+ * Pass an empty object for `prevFranchises` on first run — the diff
+ * yields nothing and the run silently seeds the snapshot.
+ */
+export function diffNewAwards(prevFranchises, nextFranchises) {
+  const out = [];
+  const fids = Object.keys(nextFranchises || {}).sort();
+  for (const fid of fids) {
+    const prevKeys = collectAwardKeys(prevFranchises?.[fid]?.badges);
+    const next = nextFranchises[fid];
+    const badges = next?.badges || [];
+    // Stable order: sort by badgeId so test output is deterministic.
+    const sortedBadges = [...badges].sort((a, b) => a.id.localeCompare(b.id));
+    for (const badge of sortedBadges) {
+      for (const award of badge.awards || []) {
+        const key = awardKey(badge.id, award);
+        if (prevKeys.has(key)) continue;
+        out.push({ franchiseId: fid, badge, award });
+      }
+    }
+  }
+  return out;
+}
+
+// ── Phrasing ─────────────────────────────────────────────────────────
+
+// Visual tier: league-wide records jump to 'breaking'; one-time career
+// milestones land at 'standard'; season honors stay 'minor'.
+const TIER_OVERRIDES = {
+  'highest-scoring-season-ever': 'breaking',
+  'all-time-highest-score': 'breaking',
+  'all-time-biggest-blowout': 'breaking',
+  'all-time-lowest-score': 'breaking',
+  'most-active-trader': 'breaking',
+  'perfect-regular-season': 'breaking',
+};
+
+const STANDARD_BADGES = new Set([
+  'triple-century',
+  'double-century',
+  'century-club',
+  'playoff-legend',
+  'playoff-veteran',
+  'decade-of-service',
+  'worst-to-first',
+]);
+
+export function tierFor(badgeId) {
+  if (TIER_OVERRIDES[badgeId]) return TIER_OVERRIDES[badgeId];
+  if (STANDARD_BADGES.has(badgeId)) return 'standard';
+  return 'minor';
+}
+
+const fmtPts = (v) => {
+  const n = Number(v);
+  if (!Number.isFinite(n)) return String(v);
+  return n.toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 2 });
+};
+
+/**
+ * Build headline + body for a milestone. `name` is the team's medium-form
+ * display name as of the current run (e.g. "Pigskins"). Templates are
+ * deterministic — no randomness — so re-runs produce the same text.
+ */
+export function phraseFor({ badgeId, award, name, fullName }) {
+  const yr = award?.year;
+  const wk = award?.week;
+  const val = award?.value;
+  const long = fullName || name;
+  switch (badgeId) {
+    case 'triple-century':
+      return {
+        headline: `300 career wins for ${name}`,
+        body: `${long} just crossed 300 all-time wins. Three centuries. Rare air in TheLeague's record book.`,
+      };
+    case 'double-century':
+      return {
+        headline: `${name} hits 200 career wins`,
+        body: `${long} now has 200 career wins. Two-hundred-win club. The kind of number you don't fake your way to.`,
+      };
+    case 'century-club':
+      return {
+        headline: `${name} joins the Century Club`,
+        body: `${long} clipped 100 career wins. Welcome to the Century Club. Plaque pending.`,
+      };
+    case 'playoff-legend':
+      return {
+        headline: `${name} reaches 10 playoff appearances`,
+        body: `${long} just earned a 10th playoff appearance. Postseason fixture. Hard to fluke that number.`,
+      };
+    case 'playoff-veteran':
+      return {
+        headline: `${name} earns Playoff Veteran status`,
+        body: `${long} clipped a 5th playoff appearance. Not a tourist anymore.`,
+      };
+    case 'decade-of-service':
+      return {
+        headline: `${name} marks a decade in the league`,
+        body: `${long} just closed a 10th season as the same franchise. Decade-of-service plaque on the wall.`,
+      };
+    case 'founding-member':
+      // Founding member only fires for franchises that show up in 2007 — a
+      // backfill case. Phrase it as a recognition, not breaking news.
+      return {
+        headline: `${name} — Class of 2007`,
+        body: `${long} logged as a founding member. Active in the inaugural 2007 season. Charter desk.`,
+      };
+    case 'best-record':
+      return {
+        headline: `${name} finishes #1 in the standings (${yr})`,
+        body: `${long} took the regular-season top seed in ${yr}. The standings don't lie.`,
+      };
+    case 'perfect-regular-season':
+      return {
+        headline: `${name} runs the table (${yr})`,
+        body: `${long} finished ${yr} undefeated. Perfect regular season. No notes.`,
+      };
+    case 'top-scorer':
+      return {
+        headline: `${name} is the ${yr} scoring champ`,
+        body: `${long} led TheLeague in regular-season points for ${yr}. Scoring title goes to the desk that put up the numbers.`,
+      };
+    case 'highest-scoring-season-ever':
+      return {
+        headline: `League record: ${name} sets the points-for mark`,
+        body: `${long} put up ${fmtPts(val)} points in ${yr}. New high-water mark for a single season. The board has been updated.`,
+      };
+    case 'worst-to-first':
+      return {
+        headline: `${name} pulls off worst-to-first`,
+        body: `${long} went from dead last to the playoffs in ${yr}. Worst-to-first. A rare league bit.`,
+      };
+    case 'cellar-dweller':
+      return {
+        headline: `${name} finishes dead last (${yr})`,
+        body: `${long} closed ${yr} at the bottom of the standings. The boards don't lie. Cellar-dweller plaque is in the mail.`,
+      };
+    case 'all-time-highest-score':
+      return {
+        headline: `League record: ${name} sets single-game high`,
+        body: `${long} dropped ${fmtPts(val)} in Week ${wk}, ${yr}. New all-time single-game record. League office has updated the book.`,
+      };
+    case 'all-time-biggest-blowout':
+      return {
+        headline: `League record: ${name} hangs the biggest blowout`,
+        body: `${long} won by ${fmtPts(val)} in Week ${wk}, ${yr}. New all-time blowout record. Mercy rule unavailable.`,
+      };
+    case 'all-time-lowest-score':
+      return {
+        headline: `League record (the bad kind): ${name} sets the low`,
+        body: `${long} put up ${fmtPts(val)} in Week ${wk}, ${yr}. New all-time single-game low. Brock Osweiler tier.`,
+      };
+    case 'most-active-trader':
+      return {
+        headline: `${name} is the all-time trade leader`,
+        body: `${long} now leads TheLeague in all-time trades — ${fmtPts(val)} deals on the books. Wheeler-and-dealer desk.`,
+      };
+    default:
+      return {
+        headline: `${name} earns a new badge`,
+        body: `${long} just unlocked a milestone${yr ? ` in ${yr}` : ''}. Quiet drop on the badge board.`,
+      };
+  }
+}
+
+/**
+ * Build a SchefterPost object for one new award.
+ *
+ * The id is deterministic from (franchiseId, badgeId, awardKey) so the
+ * feed-append step can dedupe a re-emission to a no-op.
+ */
+export function buildMilestonePost({ franchiseId, badge, award, franchise, now }) {
+  const name =
+    franchise?.currentNameMedium ||
+    franchise?.currentNameShort ||
+    franchise?.currentName ||
+    `Franchise ${franchiseId}`;
+  const fullName = franchise?.currentName || name;
+  const key = awardKey(badge.id, award);
+  const idSlug = slug(`${franchiseId}-${key}`);
+  const { headline, body } = phraseFor({ badgeId: badge.id, award, name, fullName });
+  return {
+    id: `sf_milestone_${idSlug}`,
+    timestamp: now.toISOString(),
+    type: 'transaction',
+    transactionSubType: 'milestone',
+    tier: tierFor(badge.id),
+    headline,
+    body,
+    authorId: 'claude',
+    franchiseIds: [franchiseId],
+    league: 'theleague',
+    milestone: {
+      badgeId: badge.id,
+      badgeName: badge.name,
+      icon: badge.icon,
+      tier: badge.tier,
+      awardKey: key,
+      award: { ...award },
+    },
+  };
+}
+
+/**
+ * Dedup-aware prepend. Returns `{posts, added}` — `added` is the count of
+ * newly-inserted posts. Existing posts in `feed.posts` with matching ids
+ * are preserved as-is (the first write wins on body text).
+ */
+export function mergeMilestonePosts(feedPosts, milestonePosts) {
+  const existingIds = new Set((feedPosts || []).map((p) => p.id));
+  const toAdd = milestonePosts.filter((p) => !existingIds.has(p.id));
+  return {
+    posts: [...toAdd, ...(feedPosts || [])],
+    added: toAdd.length,
+  };
+}

--- a/tests/franchise-milestone-posts.test.ts
+++ b/tests/franchise-milestone-posts.test.ts
@@ -1,0 +1,294 @@
+import { describe, it, expect } from 'vitest';
+// @ts-expect-error — sibling .mjs module, no .d.ts
+import {
+  awardKey,
+  diffNewAwards,
+  buildMilestonePost,
+  mergeMilestonePosts,
+  phraseFor,
+  tierFor,
+} from '../scripts/lib/franchise-milestone-posts.mjs';
+
+const pigskins = {
+  franchiseId: '0001',
+  currentName: 'Pacific Pigskins',
+  currentNameMedium: 'Pigskins',
+  currentNameShort: 'Pigskins',
+};
+
+const dangsters = {
+  franchiseId: '0002',
+  currentName: 'Da Dangsters',
+  currentNameMedium: 'Dangsters',
+  currentNameShort: 'Dangsters',
+};
+
+const badge = (id: string, awards: Record<string, unknown>[]) => ({
+  id,
+  name: id,
+  description: id,
+  icon: '*',
+  tier: 'career',
+  awards,
+});
+
+describe('awardKey', () => {
+  it('keys by badge id alone when the award has no year/week', () => {
+    expect(awardKey('century-club', { value: 100, suffix: 'wins' })).toBe('century-club');
+  });
+
+  it('includes year when present', () => {
+    expect(awardKey('top-scorer', { year: 2025 })).toBe('top-scorer:y2025');
+  });
+
+  it('includes year + week for single-game records', () => {
+    expect(awardKey('all-time-highest-score', { year: 2024, week: 7, score: 220 })).toBe(
+      'all-time-highest-score:y2024:w7'
+    );
+  });
+
+  it('ignores `value` so re-runs that bump a counter do not change the key', () => {
+    // 100 wins and 150 wins both produce the same `century-club` key,
+    // so the badge only fires the first time it's earned.
+    expect(awardKey('century-club', { value: 100 })).toBe(awardKey('century-club', { value: 150 }));
+  });
+});
+
+describe('diffNewAwards', () => {
+  it('treats an empty prev as "every current award is new" (silent-seed is a caller-side concern)', () => {
+    // diffNewAwards is pure. The caller in compute-franchise-history.mjs
+    // short-circuits when the previous file doesn't exist on disk; tests
+    // for that policy live alongside the caller. The pure diff just
+    // reports every new award against an empty baseline.
+    const next = {
+      '0001': { ...pigskins, badges: [badge('century-club', [{ value: 105 }])] },
+    };
+    expect(diffNewAwards({}, next)).toHaveLength(1);
+  });
+
+  it('returns nothing when badges are unchanged', () => {
+    const badges = [badge('century-club', [{ value: 105 }])];
+    const prev = { '0001': { ...pigskins, badges } };
+    const next = { '0001': { ...pigskins, badges } };
+    expect(diffNewAwards(prev, next)).toEqual([]);
+  });
+
+  it('emits when a franchise earns a brand-new badge', () => {
+    const prev = { '0001': { ...pigskins, badges: [] } };
+    const next = {
+      '0001': { ...pigskins, badges: [badge('century-club', [{ value: 100, suffix: 'wins' }])] },
+    };
+    const result = diffNewAwards(prev, next);
+    expect(result).toHaveLength(1);
+    expect(result[0].franchiseId).toBe('0001');
+    expect(result[0].badge.id).toBe('century-club');
+    expect(result[0].award).toEqual({ value: 100, suffix: 'wins' });
+  });
+
+  it('emits one entry per new year-keyed award (e.g. multi-year scoring champ backfill)', () => {
+    const prev = { '0001': { ...pigskins, badges: [badge('top-scorer', [{ year: 2010 }])] } };
+    const next = {
+      '0001': {
+        ...pigskins,
+        badges: [badge('top-scorer', [{ year: 2010 }, { year: 2022 }, { year: 2025 }])],
+      },
+    };
+    const result = diffNewAwards(prev, next);
+    expect(result.map((r) => r.award.year)).toEqual([2022, 2025]);
+  });
+
+  it('does not re-fire when a counter-style badge value updates (105 -> 150 wins)', () => {
+    const prev = {
+      '0001': { ...pigskins, badges: [badge('century-club', [{ value: 105 }])] },
+    };
+    const next = {
+      '0001': { ...pigskins, badges: [badge('century-club', [{ value: 150 }])] },
+    };
+    expect(diffNewAwards(prev, next)).toEqual([]);
+  });
+
+  it('handles badge graduation cleanly: century-club lost, double-century fires', () => {
+    const prev = {
+      '0001': { ...pigskins, badges: [badge('century-club', [{ value: 198 }])] },
+    };
+    const next = {
+      '0001': { ...pigskins, badges: [badge('double-century', [{ value: 205 }])] },
+    };
+    const result = diffNewAwards(prev, next);
+    expect(result).toHaveLength(1);
+    expect(result[0].badge.id).toBe('double-century');
+  });
+
+  it('handles record-holder change: previous holder loses (no fire), new holder gains (fires)', () => {
+    const prev = {
+      '0001': {
+        ...pigskins,
+        badges: [badge('all-time-highest-score', [{ year: 2010, week: 5, value: 180 }])],
+      },
+      '0002': { ...dangsters, badges: [] },
+    };
+    const next = {
+      '0001': { ...pigskins, badges: [] },
+      '0002': {
+        ...dangsters,
+        badges: [badge('all-time-highest-score', [{ year: 2026, week: 4, value: 195 }])],
+      },
+    };
+    const result = diffNewAwards(prev, next);
+    expect(result).toHaveLength(1);
+    expect(result[0].franchiseId).toBe('0002');
+    expect(result[0].award.year).toBe(2026);
+  });
+
+  it('output is sorted by franchiseId, then badgeId, for stable test snapshots', () => {
+    const prev = {};
+    const next = {
+      '0002': {
+        ...dangsters,
+        badges: [badge('top-scorer', [{ year: 2025 }]), badge('best-record', [{ year: 2025 }])],
+      },
+      '0001': { ...pigskins, badges: [badge('century-club', [{ value: 100 }])] },
+    };
+    // first run skips emission via the silent-seed rule — exercise the
+    // ordering by faking a prev with empty badge lists for both.
+    const prevSeeded = {
+      '0001': { ...pigskins, badges: [] },
+      '0002': { ...dangsters, badges: [] },
+    };
+    const result = diffNewAwards(prevSeeded, next);
+    expect(result.map((r) => `${r.franchiseId}:${r.badge.id}`)).toEqual([
+      '0001:century-club',
+      '0002:best-record',
+      '0002:top-scorer',
+    ]);
+  });
+});
+
+describe('buildMilestonePost', () => {
+  const now = new Date('2026-05-15T18:00:00Z');
+
+  it('produces a deterministic id (re-run yields the same id)', () => {
+    const award = { value: 100, suffix: 'wins' };
+    const b = badge('century-club', [award]);
+    const a = buildMilestonePost({ franchiseId: '0001', badge: b, award, franchise: pigskins, now });
+    const b2 = buildMilestonePost({ franchiseId: '0001', badge: b, award, franchise: pigskins, now });
+    expect(a.id).toBe(b2.id);
+    expect(a.id).toBe('sf_milestone_0001-century-club');
+  });
+
+  it('encodes year + week into the id for single-game records', () => {
+    const award = { year: 2026, week: 4, value: 195 };
+    const b = badge('all-time-highest-score', [award]);
+    const post = buildMilestonePost({ franchiseId: '0002', badge: b, award, franchise: dangsters, now });
+    expect(post.id).toBe('sf_milestone_0002-all-time-highest-score-y2026-w4');
+  });
+
+  it('uses the team medium-form display name in headline + body', () => {
+    const award = { value: 100, suffix: 'wins' };
+    const b = badge('century-club', [award]);
+    const post = buildMilestonePost({ franchiseId: '0001', badge: b, award, franchise: pigskins, now });
+    expect(post.headline).toContain('Pigskins');
+    expect(post.body).toContain('Pacific Pigskins');
+  });
+
+  it('records `milestone` metadata for renderers / analytics', () => {
+    const award = { year: 2025 };
+    const b = { ...badge('top-scorer', [award]), name: 'League Scoring Champ', icon: '🚀', tier: 'season' as const };
+    const post = buildMilestonePost({ franchiseId: '0001', badge: b, award, franchise: pigskins, now });
+    expect(post.milestone).toEqual({
+      badgeId: 'top-scorer',
+      badgeName: 'League Scoring Champ',
+      icon: '🚀',
+      tier: 'season',
+      awardKey: 'top-scorer:y2025',
+      award: { year: 2025 },
+    });
+  });
+
+  it('sets `type: "transaction"` + `transactionSubType: "milestone"` for renderer compatibility', () => {
+    const post = buildMilestonePost({
+      franchiseId: '0001',
+      badge: badge('century-club', [{ value: 100 }]),
+      award: { value: 100 },
+      franchise: pigskins,
+      now,
+    });
+    expect(post.type).toBe('transaction');
+    expect(post.transactionSubType).toBe('milestone');
+    expect(post.authorId).toBe('claude');
+    expect(post.league).toBe('theleague');
+    expect(post.franchiseIds).toEqual(['0001']);
+  });
+});
+
+describe('tierFor', () => {
+  it('promotes league-wide records to breaking', () => {
+    expect(tierFor('all-time-highest-score')).toBe('breaking');
+    expect(tierFor('most-active-trader')).toBe('breaking');
+    expect(tierFor('perfect-regular-season')).toBe('breaking');
+  });
+
+  it('keeps career milestones at standard', () => {
+    expect(tierFor('century-club')).toBe('standard');
+    expect(tierFor('playoff-legend')).toBe('standard');
+  });
+
+  it('drops single-season honors to minor', () => {
+    expect(tierFor('top-scorer')).toBe('minor');
+    expect(tierFor('best-record')).toBe('minor');
+  });
+});
+
+describe('phraseFor', () => {
+  it('avoids exclamation marks (Iron Rule in personality.md)', () => {
+    const text = phraseFor({
+      badgeId: 'century-club',
+      award: { value: 100 },
+      name: 'Pigskins',
+      fullName: 'Pacific Pigskins',
+    });
+    expect(text.headline).not.toContain('!');
+    expect(text.body).not.toContain('!');
+  });
+
+  it('handles unknown badge ids with a fallback', () => {
+    const text = phraseFor({
+      badgeId: 'made-up-badge',
+      award: { year: 2026 },
+      name: 'Pigskins',
+      fullName: 'Pacific Pigskins',
+    });
+    expect(text.headline).toContain('Pigskins');
+    expect(text.body).toContain('2026');
+  });
+});
+
+describe('mergeMilestonePosts', () => {
+  const now = new Date('2026-05-15T18:00:00Z');
+  const samplePost = (id: string) => ({ id, headline: '', body: '', timestamp: now.toISOString() });
+
+  it('prepends new posts to the existing feed', () => {
+    const existing = [samplePost('sf_existing_a')];
+    const incoming = [samplePost('sf_milestone_0001-century-club')];
+    const { posts, added } = mergeMilestonePosts(existing, incoming);
+    expect(added).toBe(1);
+    expect(posts[0].id).toBe('sf_milestone_0001-century-club');
+    expect(posts[1].id).toBe('sf_existing_a');
+  });
+
+  it('dedups against an existing post id', () => {
+    const id = 'sf_milestone_0001-century-club';
+    const existing = [samplePost(id)];
+    const incoming = [samplePost(id)];
+    const { posts, added } = mergeMilestonePosts(existing, incoming);
+    expect(added).toBe(0);
+    expect(posts).toEqual(existing);
+  });
+
+  it('handles an empty feed gracefully', () => {
+    const incoming = [samplePost('sf_milestone_0001-century-club')];
+    const { posts, added } = mergeMilestonePosts([], incoming);
+    expect(added).toBe(1);
+    expect(posts).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Diffs the new badges computed by compute-franchise-history.mjs against
the previously-committed franchise-history.json (the snapshot) and emits
Schefter feed posts for any newly-earned badge awards. Idempotent by
post id, so re-runs against the same snapshot are safe.

- scripts/lib/franchise-milestone-posts.mjs — pure module: awardKey diff,
  per-badge phrasing, post construction, dedup-aware merge.
- scripts/compute-franchise-history.mjs — wires the diff into the
  existing badge-engine step; silent-seeds on first run when no snapshot
  exists.
- backfill workflow now commits src/data/theleague/schefter-feed.json so
  milestone posts emitted during recompute persist.
- 25 unit tests cover the diff (graduation, record-holder change,
  multi-year award fans, value-only counter stability), post id
  determinism, phrasing fallbacks, and feed-merge dedup.