### PR TITLE
afl: add conference utility + fix cross-league bleed in shared code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,10 @@ data/*/salary-history/
 # from Upstash Redis. See src/utils/contract-storage.ts.
 data/*/contract-declarations.json
 
+# AFL keeper plans: local-dev-only filesystem fallback. Production reads
+# from Upstash Redis. See src/utils/afl-keepers-storage.ts.
+data/*/keeper-plans.json
+
 # Salary history - only keep summary-week-*.json files
 src/data/salary-history/**/raw-*.json
 src/data/salary-history/**/summary-2*.json

--- a/src/components/afl-fantasy/AFLActionModal.astro
+++ b/src/components/afl-fantasy/AFLActionModal.astro
@@ -16,112 +16,117 @@
  */
 ---
 
-<div class="afl-action-modal" id="afl-action-modal" role="dialog" aria-modal="true" aria-labelledby="aam-title" hidden>
+<div class="afl-action-modal" id="afl-action-modal" role="dialog" aria-modal="true" aria-labelledby="aam-player-name" hidden>
   <div class="afl-action-modal__overlay" data-aam-close></div>
   <div class="afl-action-modal__content">
-    <button class="aam-close" data-aam-close aria-label="Close (ESC)" title="Close">
+    <!-- Circular close button — same shape as TheLeague's ContractDeclarationModal (cdm-close) -->
+    <button class="aam-close" data-aam-close aria-label="Close (ESC)" title="Close (ESC)">
       <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true">
         <path d="M14 4L4 14M4 4l10 10" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" />
       </svg>
     </button>
 
-    <header class="aam-header">
-      <h3 class="aam-title" id="aam-title">Manage Player</h3>
-      <p class="aam-subtitle" id="aam-subtitle">&mdash;</p>
-    </header>
+    <div class="aam-body">
+      <!-- Hero Identity — mirrors TheLeague's cdm-hero (avatar + name + team logo + position) -->
+      <div class="aam-hero">
+        <div class="aam-hero__avatar">
+          <img id="aam-headshot" alt="Player headshot" />
+        </div>
+        <div class="aam-hero__info">
+          <h3 class="aam-hero__name" id="aam-player-name">&mdash;</h3>
+          <div class="aam-hero__meta">
+            <img class="aam-hero__team-logo" id="aam-nfl-logo" src="" alt="" />
+            <span class="aam-hero__meta-text" id="aam-meta-text">&mdash;</span>
+          </div>
+        </div>
+      </div>
 
-    <!-- Step 1: action selector -->
-    <div class="aam-step" data-aam-step="select">
-      <ul class="aam-actions" role="list">
-        <li>
-          <button class="aam-action" data-aam-action="ir-to" type="button" hidden>
-            <span class="aam-action__icon" aria-hidden="true">
-              <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
-                <path d="M12 2v6m0 0v14m0-14h7a3 3 0 010 6h-7M5 8h7" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
-              </svg>
-            </span>
-            <span class="aam-action__body">
-              <span class="aam-action__label">Move to IR</span>
-              <span class="aam-action__desc">Place this player on Injured Reserve</span>
-            </span>
-          </button>
-        </li>
-        <li>
-          <button class="aam-action" data-aam-action="ir-from" type="button" hidden>
-            <span class="aam-action__icon" aria-hidden="true">
-              <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
-                <path d="M5 12h14m0 0l-6-6m6 6l-6 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-              </svg>
-            </span>
-            <span class="aam-action__body">
-              <span class="aam-action__label">Activate from IR</span>
-              <span class="aam-action__desc">Return this player to the active roster</span>
-            </span>
-          </button>
-        </li>
-        <li>
-          <button class="aam-action" data-aam-action="trade-bait-add" type="button" hidden>
-            <span class="aam-action__icon" aria-hidden="true">
-              <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
-                <path d="M12 5v14M5 12h14" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
-              </svg>
-            </span>
-            <span class="aam-action__body">
-              <span class="aam-action__label">Add to Trade Block</span>
-              <span class="aam-action__desc">Signal that you'd consider trade offers</span>
-            </span>
-          </button>
-        </li>
-        <li>
-          <button class="aam-action" data-aam-action="trade-bait-remove" type="button" hidden>
-            <span class="aam-action__icon" aria-hidden="true">
-              <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
-                <path d="M5 12h14" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
-              </svg>
-            </span>
-            <span class="aam-action__body">
-              <span class="aam-action__label">Remove from Trade Block</span>
-              <span class="aam-action__desc">Take this player off the trade block</span>
-            </span>
-          </button>
-        </li>
-        <li>
-          <button class="aam-action" data-aam-action="trade" type="button">
-            <span class="aam-action__icon" aria-hidden="true">
-              <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
-                <path d="M7 17l-4-4m0 0l4-4m-4 4h18m-4-4l4 4m0 0l-4 4" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-              </svg>
-            </span>
-            <span class="aam-action__body">
-              <span class="aam-action__label">Trade Player</span>
-              <span class="aam-action__desc">Open the trade builder with this player loaded</span>
-            </span>
-          </button>
-        </li>
-        <li>
-          <button class="aam-action aam-action--destructive" data-aam-action="cut" type="button">
-            <span class="aam-action__icon" aria-hidden="true">
-              <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
-                <path d="M3 6h18M8 6V4a2 2 0 012-2h4a2 2 0 012 2v2m3 0v14a2 2 0 01-2 2H7a2 2 0 01-2-2V6h14z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-              </svg>
-            </span>
-            <span class="aam-action__body">
-              <span class="aam-action__label">Cut Player</span>
-              <span class="aam-action__desc">Release back into the auction pool</span>
-            </span>
-          </button>
-        </li>
-      </ul>
-    </div>
+      <!-- Action eyebrow — accent bar + uppercase label, matches cdm-section__title pattern -->
+      <div class="aam-section">
+        <h4 class="aam-section__title">Manage Player</h4>
 
-    <!-- Step 2: confirm -->
-    <div class="aam-step" data-aam-step="confirm" hidden>
-      <p class="aam-confirm__copy" id="aam-confirm-copy">&mdash;</p>
-      <div class="aam-error" id="aam-error" hidden></div>
-      <div class="aam-success" id="aam-success" hidden></div>
-      <div class="aam-confirm__actions">
-        <button class="aam-btn aam-btn--ghost" type="button" data-aam-cancel>Back</button>
-        <button class="aam-btn aam-btn--primary" type="button" id="aam-confirm-btn">Confirm</button>
+        <!-- Step 1: action selector -->
+        <div class="aam-step" data-aam-step="select">
+          <ul class="aam-actions" role="list">
+            <li>
+              <button class="aam-action" data-aam-action="ir-to" type="button" hidden>
+                <span class="aam-action__icon" aria-hidden="true">
+                  <svg aria-hidden="true"><use href="/assets/icons/sprite.svg#icon-ambulance" /></svg>
+                </span>
+                <span class="aam-action__body">
+                  <span class="aam-action__label">Move to IR</span>
+                  <span class="aam-action__desc">Pause participation &mdash; player stays on your roster</span>
+                </span>
+              </button>
+            </li>
+            <li>
+              <button class="aam-action" data-aam-action="ir-from" type="button" hidden>
+                <span class="aam-action__icon" aria-hidden="true">
+                  <svg aria-hidden="true"><use href="/assets/icons/sprite.svg#icon-ambulance" /></svg>
+                </span>
+                <span class="aam-action__body">
+                  <span class="aam-action__label">Activate from IR</span>
+                  <span class="aam-action__desc">Restore to active roster</span>
+                </span>
+              </button>
+            </li>
+            <li>
+              <button class="aam-action" data-aam-action="trade-bait-add" type="button" hidden>
+                <span class="aam-action__icon" aria-hidden="true">
+                  <svg aria-hidden="true"><use href="/assets/icons/sprite.svg#icon-bookmark" /></svg>
+                </span>
+                <span class="aam-action__body">
+                  <span class="aam-action__label">Add to Trade Block</span>
+                  <span class="aam-action__desc">Signal that you'd consider trade offers</span>
+                </span>
+              </button>
+            </li>
+            <li>
+              <button class="aam-action" data-aam-action="trade-bait-remove" type="button" hidden>
+                <span class="aam-action__icon" aria-hidden="true">
+                  <svg aria-hidden="true"><use href="/assets/icons/sprite.svg#icon-bookmark" /></svg>
+                </span>
+                <span class="aam-action__body">
+                  <span class="aam-action__label">Remove from Trade Block</span>
+                  <span class="aam-action__desc">Take this player off the trade block</span>
+                </span>
+              </button>
+            </li>
+            <li>
+              <button class="aam-action" data-aam-action="trade" type="button">
+                <span class="aam-action__icon" aria-hidden="true">
+                  <svg aria-hidden="true"><use href="/assets/icons/sprite.svg#icon-exchange" /></svg>
+                </span>
+                <span class="aam-action__body">
+                  <span class="aam-action__label">Trade Player</span>
+                  <span class="aam-action__desc">Open the trade builder with this player loaded</span>
+                </span>
+              </button>
+            </li>
+            <li>
+              <button class="aam-action aam-action--destructive" data-aam-action="cut" type="button">
+                <span class="aam-action__icon" aria-hidden="true">
+                  <svg aria-hidden="true"><use href="/assets/icons/sprite.svg#icon-user-times" /></svg>
+                </span>
+                <span class="aam-action__body">
+                  <span class="aam-action__label">Cut Player</span>
+                  <span class="aam-action__desc">Release back into the auction pool</span>
+                </span>
+              </button>
+            </li>
+          </ul>
+        </div>
+
+        <!-- Step 2: confirm — replaces the action grid within the same section -->
+        <div class="aam-step" data-aam-step="confirm" hidden>
+          <p class="aam-confirm__copy" id="aam-confirm-copy">&mdash;</p>
+          <div class="aam-error" id="aam-error" hidden></div>
+          <div class="aam-success" id="aam-success" hidden></div>
+          <div class="aam-confirm__actions">
+            <button class="aam-btn aam-btn--ghost" type="button" data-aam-cancel>Back</button>
+            <button class="aam-btn aam-btn--primary" type="button" id="aam-confirm-btn">Confirm</button>
+          </div>
+        </div>
       </div>
     </div>
   </div>
@@ -139,6 +144,12 @@
     isOnTradeBait?: boolean;
     /** Owner's franchise ID (for trade-builder routing) */
     franchiseId?: string;
+    /** Headshot URL (jpg/png/svg) — drives the hero avatar */
+    headshot?: string;
+    /** Position code (QB/RB/WR/TE/PK/DEF) — shown next to NFL logo */
+    position?: string;
+    /** NFL team code in any format — used to load the team logo SVG */
+    nflTeam?: string;
   }
 
   const _modalEl = document.getElementById('afl-action-modal') as HTMLDivElement | null;
@@ -147,13 +158,38 @@
   } else {
     // Pin into a const so closures keep the non-null narrowing
     const modal: HTMLDivElement = _modalEl;
-    const subtitleEl = modal.querySelector('#aam-subtitle') as HTMLElement;
+    const playerNameEl = modal.querySelector('#aam-player-name') as HTMLElement;
+    const headshotEl = modal.querySelector('#aam-headshot') as HTMLImageElement;
+    const nflLogoEl = modal.querySelector('#aam-nfl-logo') as HTMLImageElement;
+    const metaTextEl = modal.querySelector('#aam-meta-text') as HTMLElement;
     const stepSelect = modal.querySelector('[data-aam-step="select"]') as HTMLElement;
     const stepConfirm = modal.querySelector('[data-aam-step="confirm"]') as HTMLElement;
     const confirmCopy = modal.querySelector('#aam-confirm-copy') as HTMLElement;
     const confirmBtn = modal.querySelector('#aam-confirm-btn') as HTMLButtonElement;
     const errorEl = modal.querySelector('#aam-error') as HTMLElement;
     const successEl = modal.querySelector('#aam-success') as HTMLElement;
+
+    // Default fallback headshot — matches /assets/default-headshot.svg used elsewhere.
+    // Keeps the avatar circle from breaking when MFL doesn't have a photo for a player.
+    const DEFAULT_HEADSHOT = '/assets/default-headshot.svg';
+
+    // MFL → standard NFL team code translation. Just the ones MFL uses
+    // differently from the standard 2-3 letter codes (everything else is
+    // already valid). Kept local to avoid pulling in nfl-logo.ts which
+    // would force this script out of inline mode.
+    const MFL_TO_STD: Record<string, string> = {
+      JAC: 'JAX',
+      LAR: 'LA',
+      LA: 'LA',
+      LAA: 'LAR',
+      WAS: 'WSH',
+      WSH: 'WSH',
+    };
+    function normalizeNflCode(code: string): string {
+      if (!code) return '';
+      const up = code.toUpperCase().trim();
+      return MFL_TO_STD[up] ?? up;
+    }
 
     const actionButtons = {
       'ir-to': modal.querySelector('[data-aam-action="ir-to"]') as HTMLButtonElement,
@@ -170,7 +206,23 @@
     function openModal(payload: ActionPayload) {
       currentPayload = payload;
       pendingAction = null;
-      subtitleEl.textContent = payload.playerName;
+
+      // Hero — mirrors TheLeague's cdm-hero populator. Headshot falls back to
+      // the default silhouette when MFL has no photo (pre-draft rookies, free
+      // agents); team logo falls back to the generic NFL shield when team is
+      // missing. The image's onerror attribute swaps to the same default if
+      // the headshot URL 404s mid-load.
+      playerNameEl.textContent = payload.playerName;
+      headshotEl.src = payload.headshot || DEFAULT_HEADSHOT;
+      headshotEl.alt = `${payload.playerName} headshot`;
+      headshotEl.onerror = () => { headshotEl.src = DEFAULT_HEADSHOT; };
+      const teamCode = payload.nflTeam ? normalizeNflCode(payload.nflTeam) : '';
+      nflLogoEl.src = teamCode
+        ? `/assets/nfl-logos/${teamCode}.svg`
+        : '/assets/nfl-logos/NFL.svg';
+      nflLogoEl.alt = teamCode || 'NFL';
+      metaTextEl.textContent = payload.position || '';
+
       errorEl.hidden = true;
       errorEl.textContent = '';
       successEl.hidden = true;
@@ -406,45 +458,118 @@
     to   { opacity: 1; transform: translateY(0) scale(1); }
   }
 
+  /* Circular close button — matches cdm-close in TheLeague's ContractDeclarationModal */
   .aam-close {
     position: absolute;
-    top: 0.75rem;
-    right: 0.75rem;
+    top: 0.875rem;
+    right: 0.875rem;
     width: 32px;
     height: 32px;
     border: 0;
-    background: transparent;
-    border-radius: 0.375rem;
-    color: #6b7280;
+    background: var(--color-gray-100, #f3f4f6);
+    border-radius: 50%;
+    color: var(--color-gray-600, #4b5563);
     cursor: pointer;
     display: inline-flex;
     align-items: center;
     justify-content: center;
+    z-index: 1;
+    transition: background-color 0.15s ease, color 0.15s ease;
   }
 
   .aam-close:hover {
-    background: #f3f4f6;
-    color: #111827;
+    background: var(--color-gray-200, #e5e7eb);
+    color: var(--color-gray-900, #111827);
   }
 
-  .aam-header {
-    margin: 0 2rem 1rem 0;
+  .aam-body {
+    padding-right: 2.25rem; /* leave room for the absolute-positioned close button */
   }
 
-  .aam-title {
+  /* Player Identity Hero — mirrors TheLeague's cdm-hero block: square rounded
+     avatar on the left, large bold name + meta row to its right. Matches the
+     hero typography of the player-details + contract-declaration modals so
+     all three player-centric modals read as siblings. */
+  .aam-hero {
+    display: flex;
+    align-items: center;
+    gap: 0.875rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .aam-hero__avatar {
+    flex-shrink: 0;
+    width: 64px;
+    height: 64px;
+    border-radius: 0.625rem;
+    overflow: hidden;
+    background: var(--color-gray-100, #f3f4f6);
+    border: 1px solid var(--color-gray-200, #e5e7eb);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .aam-hero__avatar img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    object-position: center top;
+  }
+
+  .aam-hero__info {
+    min-width: 0;
+    flex: 1;
+  }
+
+  .aam-hero__name {
     margin: 0;
+    font-size: 1.25rem;
+    font-weight: 800;
+    line-height: 1.2;
+    color: var(--color-gray-900, #0f172a);
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .aam-hero__meta {
+    margin-top: 0.375rem;
+    display: flex;
+    align-items: center;
+    gap: 0.4375rem;
+  }
+
+  .aam-hero__team-logo {
+    width: 18px;
+    height: 18px;
+    object-fit: contain;
+    flex-shrink: 0;
+  }
+
+  .aam-hero__meta-text {
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: var(--color-gray-700, #374151);
+    letter-spacing: 0.02em;
+  }
+
+  /* Action eyebrow — accent bar + uppercase label, same pattern TheLeague
+     uses for section titles inside CDM. */
+  .aam-section {
+    padding-top: 0.875rem;
+    border-top: 1px solid var(--color-gray-100, #f3f4f6);
+  }
+
+  .aam-section__title {
+    margin: 0 0 0.625rem;
+    padding-left: 0.625rem;
     font-size: 0.75rem;
     font-weight: 700;
     letter-spacing: 0.075em;
     text-transform: uppercase;
-    color: #6b7280;
-  }
-
-  .aam-subtitle {
-    margin: 0.25rem 0 0;
-    font-size: 1.125rem;
-    font-weight: 700;
-    color: #0f172a;
+    color: var(--color-gray-500, #6b7280);
+    border-left: 3px solid var(--color-primary, #1c497c);
+    line-height: 1.4;
   }
 
   .aam-actions {
@@ -484,21 +609,30 @@
     outline-offset: 1px;
   }
 
+  /* Icon tile — same sizing/treatment as cdm-action-option__icon. SVG inside
+     uses currentColor + responsive width/height so the sprite scales with the
+     tile. */
   .aam-action__icon {
     flex-shrink: 0;
-    width: 32px;
-    height: 32px;
+    width: 36px;
+    height: 36px;
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    background: #f3f4f6;
-    border-radius: 0.375rem;
-    color: #4b5563;
+    background: var(--color-gray-100, #f3f4f6);
+    border-radius: 0.5rem;
+    color: var(--color-gray-600, #4b5563);
+  }
+
+  .aam-action__icon svg {
+    width: 18px;
+    height: 18px;
+    fill: currentColor;
   }
 
   .aam-action--destructive .aam-action__icon {
-    background: #fee2e2;
-    color: #991b1b;
+    background: var(--color-error-light, #fee2e2);
+    color: var(--color-error-dark, #991b1b);
   }
 
   .aam-action__body {

--- a/src/components/afl-fantasy/AFLActionModal.astro
+++ b/src/components/afl-fantasy/AFLActionModal.astro
@@ -1,0 +1,594 @@
+---
+/**
+ * AFLActionModal — owner-only player action menu for AFL roster pages.
+ *
+ * Two-step flow:
+ *   1. Choose action (Move to IR / Activate / Cut / Trade Block / Trade)
+ *   2. Confirm + execute via /api/* — same write endpoints TheLeague uses,
+ *      since user.leagueId on the JWT scopes them per-league.
+ *
+ * AFL has no salary cap, no contracts, no franchise tag, and no extension
+ * — so the action set is intentionally short. Trade routes to the AFL
+ * trade builder (built in a later commit).
+ *
+ * Open via window.openAFLActionModal({ playerId, playerName, status,
+ * isOnTradeBait }). Close via the X button, overlay click, or ESC.
+ */
+---
+
+<div class="afl-action-modal" id="afl-action-modal" role="dialog" aria-modal="true" aria-labelledby="aam-title" hidden>
+  <div class="afl-action-modal__overlay" data-aam-close></div>
+  <div class="afl-action-modal__content">
+    <button class="aam-close" data-aam-close aria-label="Close (ESC)" title="Close">
+      <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true">
+        <path d="M14 4L4 14M4 4l10 10" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" />
+      </svg>
+    </button>
+
+    <header class="aam-header">
+      <h3 class="aam-title" id="aam-title">Manage Player</h3>
+      <p class="aam-subtitle" id="aam-subtitle">&mdash;</p>
+    </header>
+
+    <!-- Step 1: action selector -->
+    <div class="aam-step" data-aam-step="select">
+      <ul class="aam-actions" role="list">
+        <li>
+          <button class="aam-action" data-aam-action="ir-to" type="button" hidden>
+            <span class="aam-action__icon" aria-hidden="true">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
+                <path d="M12 2v6m0 0v14m0-14h7a3 3 0 010 6h-7M5 8h7" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+              </svg>
+            </span>
+            <span class="aam-action__body">
+              <span class="aam-action__label">Move to IR</span>
+              <span class="aam-action__desc">Place this player on Injured Reserve</span>
+            </span>
+          </button>
+        </li>
+        <li>
+          <button class="aam-action" data-aam-action="ir-from" type="button" hidden>
+            <span class="aam-action__icon" aria-hidden="true">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
+                <path d="M5 12h14m0 0l-6-6m6 6l-6 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+              </svg>
+            </span>
+            <span class="aam-action__body">
+              <span class="aam-action__label">Activate from IR</span>
+              <span class="aam-action__desc">Return this player to the active roster</span>
+            </span>
+          </button>
+        </li>
+        <li>
+          <button class="aam-action" data-aam-action="trade-bait-add" type="button" hidden>
+            <span class="aam-action__icon" aria-hidden="true">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
+                <path d="M12 5v14M5 12h14" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+              </svg>
+            </span>
+            <span class="aam-action__body">
+              <span class="aam-action__label">Add to Trade Block</span>
+              <span class="aam-action__desc">Signal that you'd consider trade offers</span>
+            </span>
+          </button>
+        </li>
+        <li>
+          <button class="aam-action" data-aam-action="trade-bait-remove" type="button" hidden>
+            <span class="aam-action__icon" aria-hidden="true">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
+                <path d="M5 12h14" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+              </svg>
+            </span>
+            <span class="aam-action__body">
+              <span class="aam-action__label">Remove from Trade Block</span>
+              <span class="aam-action__desc">Take this player off the trade block</span>
+            </span>
+          </button>
+        </li>
+        <li>
+          <button class="aam-action" data-aam-action="trade" type="button">
+            <span class="aam-action__icon" aria-hidden="true">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
+                <path d="M7 17l-4-4m0 0l4-4m-4 4h18m-4-4l4 4m0 0l-4 4" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+              </svg>
+            </span>
+            <span class="aam-action__body">
+              <span class="aam-action__label">Trade Player</span>
+              <span class="aam-action__desc">Open the trade builder with this player loaded</span>
+            </span>
+          </button>
+        </li>
+        <li>
+          <button class="aam-action aam-action--destructive" data-aam-action="cut" type="button">
+            <span class="aam-action__icon" aria-hidden="true">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
+                <path d="M3 6h18M8 6V4a2 2 0 012-2h4a2 2 0 012 2v2m3 0v14a2 2 0 01-2 2H7a2 2 0 01-2-2V6h14z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+              </svg>
+            </span>
+            <span class="aam-action__body">
+              <span class="aam-action__label">Cut Player</span>
+              <span class="aam-action__desc">Release back into the auction pool</span>
+            </span>
+          </button>
+        </li>
+      </ul>
+    </div>
+
+    <!-- Step 2: confirm -->
+    <div class="aam-step" data-aam-step="confirm" hidden>
+      <p class="aam-confirm__copy" id="aam-confirm-copy">&mdash;</p>
+      <div class="aam-error" id="aam-error" hidden></div>
+      <div class="aam-success" id="aam-success" hidden></div>
+      <div class="aam-confirm__actions">
+        <button class="aam-btn aam-btn--ghost" type="button" data-aam-cancel>Back</button>
+        <button class="aam-btn aam-btn--primary" type="button" id="aam-confirm-btn">Confirm</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+  type ModalAction = 'ir-to' | 'ir-from' | 'cut' | 'trade-bait-add' | 'trade-bait-remove' | 'trade';
+
+  interface ActionPayload {
+    playerId: string;
+    playerName: string;
+    /** ROSTER | INJURED_RESERVE — drives which IR action is shown */
+    status?: string;
+    /** Whether the player is currently on the trade block */
+    isOnTradeBait?: boolean;
+    /** Owner's franchise ID (for trade-builder routing) */
+    franchiseId?: string;
+  }
+
+  const _modalEl = document.getElementById('afl-action-modal') as HTMLDivElement | null;
+  if (!_modalEl) {
+    console.error('[afl-action-modal] root element not found');
+  } else {
+    // Pin into a const so closures keep the non-null narrowing
+    const modal: HTMLDivElement = _modalEl;
+    const subtitleEl = modal.querySelector('#aam-subtitle') as HTMLElement;
+    const stepSelect = modal.querySelector('[data-aam-step="select"]') as HTMLElement;
+    const stepConfirm = modal.querySelector('[data-aam-step="confirm"]') as HTMLElement;
+    const confirmCopy = modal.querySelector('#aam-confirm-copy') as HTMLElement;
+    const confirmBtn = modal.querySelector('#aam-confirm-btn') as HTMLButtonElement;
+    const errorEl = modal.querySelector('#aam-error') as HTMLElement;
+    const successEl = modal.querySelector('#aam-success') as HTMLElement;
+
+    const actionButtons = {
+      'ir-to': modal.querySelector('[data-aam-action="ir-to"]') as HTMLButtonElement,
+      'ir-from': modal.querySelector('[data-aam-action="ir-from"]') as HTMLButtonElement,
+      'cut': modal.querySelector('[data-aam-action="cut"]') as HTMLButtonElement,
+      'trade-bait-add': modal.querySelector('[data-aam-action="trade-bait-add"]') as HTMLButtonElement,
+      'trade-bait-remove': modal.querySelector('[data-aam-action="trade-bait-remove"]') as HTMLButtonElement,
+      'trade': modal.querySelector('[data-aam-action="trade"]') as HTMLButtonElement,
+    };
+
+    let currentPayload: ActionPayload | null = null;
+    let pendingAction: ModalAction | null = null;
+
+    function openModal(payload: ActionPayload) {
+      currentPayload = payload;
+      pendingAction = null;
+      subtitleEl.textContent = payload.playerName;
+      errorEl.hidden = true;
+      errorEl.textContent = '';
+      successEl.hidden = true;
+      successEl.textContent = '';
+
+      const onIR = payload.status === 'INJURED_RESERVE';
+      actionButtons['ir-to'].hidden = onIR;
+      actionButtons['ir-from'].hidden = !onIR;
+      actionButtons['trade-bait-add'].hidden = !!payload.isOnTradeBait;
+      actionButtons['trade-bait-remove'].hidden = !payload.isOnTradeBait;
+
+      stepSelect.hidden = false;
+      stepConfirm.hidden = true;
+      modal.hidden = false;
+      modal.classList.add('is-open');
+      document.body.style.overflow = 'hidden';
+    }
+
+    function closeModal() {
+      modal.hidden = true;
+      modal.classList.remove('is-open');
+      document.body.style.overflow = '';
+      currentPayload = null;
+      pendingAction = null;
+    }
+
+    function confirmCopyFor(action: ModalAction, name: string): string {
+      switch (action) {
+        case 'ir-to':
+          return `Move ${name} to Injured Reserve? They'll free up an active roster slot but stay under your control.`;
+        case 'ir-from':
+          return `Activate ${name} from Injured Reserve? They'll move back into your active roster.`;
+        case 'cut':
+          return `Release ${name}? This drops them back into the AFL auction pool. This action cannot be undone here.`;
+        case 'trade-bait-add':
+          return `Add ${name} to your public trade block? Other owners will see this player is available.`;
+        case 'trade-bait-remove':
+          return `Remove ${name} from your trade block?`;
+        case 'trade':
+          return `Open the trade builder with ${name} preloaded?`;
+      }
+    }
+
+    function showStep(step: 'select' | 'confirm') {
+      stepSelect.hidden = step !== 'select';
+      stepConfirm.hidden = step !== 'confirm';
+    }
+
+    function pickAction(action: ModalAction) {
+      if (!currentPayload) return;
+      pendingAction = action;
+      confirmCopy.textContent = confirmCopyFor(action, currentPayload.playerName);
+      confirmBtn.textContent = action === 'cut' ? 'Cut Player' : 'Confirm';
+      confirmBtn.classList.toggle('aam-btn--danger', action === 'cut');
+      confirmBtn.disabled = false;
+      errorEl.hidden = true;
+      successEl.hidden = true;
+      showStep('confirm');
+    }
+
+    async function postJson(url: string, body: any): Promise<{ ok: boolean; data: any }> {
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      const data = await res.json().catch(() => ({}));
+      return { ok: res.ok && (data?.success ?? true), data };
+    }
+
+    function refreshRowAfterIR(playerId: string, newStatus: string) {
+      const row = document.querySelector<HTMLTableRowElement>(`tr[data-player-id="${playerId}"]`);
+      if (!row) return;
+      row.dataset.playerStatus = newStatus;
+      const badge = row.querySelector('.status-badge');
+      if (badge) {
+        const onIR = newStatus === 'INJURED_RESERVE';
+        badge.textContent = onIR ? 'IR' : 'Active';
+        badge.classList.toggle('status-badge--ir', onIR);
+        badge.classList.toggle('status-badge--active', !onIR);
+      }
+    }
+
+    function removeRowAfterCut(playerId: string) {
+      const row = document.querySelector<HTMLTableRowElement>(`tr[data-player-id="${playerId}"]`);
+      if (!row) return;
+      const tbody = row.parentElement;
+      row.remove();
+      // If a position block emptied out, hide it
+      if (tbody && tbody.children.length === 0) {
+        const block = tbody.closest('.position-block');
+        if (block) (block as HTMLElement).hidden = true;
+      }
+    }
+
+    function refreshRowAfterTradeBait(playerId: string, isOn: boolean) {
+      const row = document.querySelector<HTMLTableRowElement>(`tr[data-player-id="${playerId}"]`);
+      if (!row) return;
+      row.dataset.onTradeBait = isOn ? 'true' : 'false';
+      const nameEl = row.querySelector('.player-cell__name');
+      if (!nameEl) return;
+      const existing = nameEl.querySelector('.bait-badge');
+      if (isOn && !existing) {
+        const badge = document.createElement('span');
+        badge.className = 'bait-badge';
+        badge.title = 'On trade block';
+        badge.textContent = 'TB';
+        nameEl.appendChild(badge);
+      } else if (!isOn && existing) {
+        existing.remove();
+      }
+    }
+
+    async function executeAction() {
+      if (!currentPayload || !pendingAction) return;
+      const { playerId, playerName, franchiseId } = currentPayload;
+      const action = pendingAction;
+
+      if (action === 'trade') {
+        const target = `/afl-fantasy/trade-builder?from=${encodeURIComponent(franchiseId ?? '')}&player=${encodeURIComponent(playerId)}`;
+        window.location.href = target;
+        return;
+      }
+
+      confirmBtn.disabled = true;
+      const origLabel = confirmBtn.textContent;
+      confirmBtn.textContent = 'Working…';
+      errorEl.hidden = true;
+
+      try {
+        let result: { ok: boolean; data: any };
+        if (action === 'cut') {
+          result = await postJson('/api/cut-player', { playerId });
+        } else if (action === 'ir-to') {
+          result = await postJson('/api/move-to-ir', { playerId, direction: 'to' });
+        } else if (action === 'ir-from') {
+          result = await postJson('/api/move-to-ir', { playerId, direction: 'from' });
+        } else if (action === 'trade-bait-add') {
+          result = await postJson('/api/trade-bait', { playerId, action: 'add' });
+        } else if (action === 'trade-bait-remove') {
+          result = await postJson('/api/trade-bait', { playerId, action: 'remove' });
+        } else {
+          throw new Error(`Unknown action: ${action}`);
+        }
+
+        if (!result.ok) {
+          throw new Error(result.data?.message || result.data?.error || 'Request failed');
+        }
+
+        // Optimistic UI updates so the user sees the result without reload
+        if (action === 'ir-to') refreshRowAfterIR(playerId, 'INJURED_RESERVE');
+        if (action === 'ir-from') refreshRowAfterIR(playerId, 'ROSTER');
+        if (action === 'cut') removeRowAfterCut(playerId);
+        if (action === 'trade-bait-add') refreshRowAfterTradeBait(playerId, true);
+        if (action === 'trade-bait-remove') refreshRowAfterTradeBait(playerId, false);
+
+        successEl.textContent = `${playerName} — done.`;
+        successEl.hidden = false;
+        confirmBtn.textContent = origLabel;
+        setTimeout(() => closeModal(), 1200);
+      } catch (err: any) {
+        errorEl.textContent = err?.message || 'Something went wrong. Please try again.';
+        errorEl.hidden = false;
+        confirmBtn.disabled = false;
+        confirmBtn.textContent = origLabel;
+      }
+    }
+
+    // ── Event wiring ──
+    Object.entries(actionButtons).forEach(([action, btn]) => {
+      btn?.addEventListener('click', () => pickAction(action as ModalAction));
+    });
+
+    confirmBtn.addEventListener('click', () => {
+      void executeAction();
+    });
+
+    modal.querySelectorAll('[data-aam-close]').forEach((el) => {
+      el.addEventListener('click', () => closeModal());
+    });
+
+    modal.querySelectorAll('[data-aam-cancel]').forEach((el) => {
+      el.addEventListener('click', () => showStep('select'));
+    });
+
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape' && !modal.hidden) closeModal();
+    });
+
+    // Expose a global opener so any roster table on the page can trigger us
+    (window as any).openAFLActionModal = openModal;
+  }
+</script>
+
+<style>
+  .afl-action-modal {
+    position: fixed;
+    inset: 0;
+    z-index: 1100;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 1rem;
+  }
+
+  .afl-action-modal[hidden] {
+    display: none;
+  }
+
+  .afl-action-modal__overlay {
+    position: absolute;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.5);
+    backdrop-filter: blur(2px);
+    cursor: pointer;
+  }
+
+  .afl-action-modal__content {
+    position: relative;
+    width: 100%;
+    max-width: 460px;
+    max-height: 90vh;
+    overflow-y: auto;
+    background: #fff;
+    border-radius: 0.75rem;
+    box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.4);
+    padding: 1.25rem;
+    animation: aam-pop 140ms ease-out;
+  }
+
+  @keyframes aam-pop {
+    from { opacity: 0; transform: translateY(8px) scale(0.98); }
+    to   { opacity: 1; transform: translateY(0) scale(1); }
+  }
+
+  .aam-close {
+    position: absolute;
+    top: 0.75rem;
+    right: 0.75rem;
+    width: 32px;
+    height: 32px;
+    border: 0;
+    background: transparent;
+    border-radius: 0.375rem;
+    color: #6b7280;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .aam-close:hover {
+    background: #f3f4f6;
+    color: #111827;
+  }
+
+  .aam-header {
+    margin: 0 2rem 1rem 0;
+  }
+
+  .aam-title {
+    margin: 0;
+    font-size: 0.75rem;
+    font-weight: 700;
+    letter-spacing: 0.075em;
+    text-transform: uppercase;
+    color: #6b7280;
+  }
+
+  .aam-subtitle {
+    margin: 0.25rem 0 0;
+    font-size: 1.125rem;
+    font-weight: 700;
+    color: #0f172a;
+  }
+
+  .aam-actions {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 0.375rem;
+  }
+
+  .aam-action {
+    display: flex;
+    align-items: center;
+    gap: 0.875rem;
+    width: 100%;
+    padding: 0.75rem 0.875rem;
+    background: #fff;
+    border: 1px solid #e5e7eb;
+    border-radius: 0.5rem;
+    color: #111827;
+    text-align: left;
+    cursor: pointer;
+    transition: background-color 120ms ease, border-color 120ms ease;
+  }
+
+  .aam-action[hidden] {
+    display: none;
+  }
+
+  .aam-action:hover:not(:disabled) {
+    background: #f9fafb;
+    border-color: #c41e3a;
+  }
+
+  .aam-action:focus-visible {
+    outline: 2px solid #c41e3a;
+    outline-offset: 1px;
+  }
+
+  .aam-action__icon {
+    flex-shrink: 0;
+    width: 32px;
+    height: 32px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: #f3f4f6;
+    border-radius: 0.375rem;
+    color: #4b5563;
+  }
+
+  .aam-action--destructive .aam-action__icon {
+    background: #fee2e2;
+    color: #991b1b;
+  }
+
+  .aam-action__body {
+    display: grid;
+    gap: 0.125rem;
+    min-width: 0;
+  }
+
+  .aam-action__label {
+    font-size: 0.9375rem;
+    font-weight: 600;
+  }
+
+  .aam-action__desc {
+    font-size: 0.75rem;
+    color: #6b7280;
+  }
+
+  .aam-confirm__copy {
+    margin: 0 0 1rem;
+    font-size: 0.9375rem;
+    line-height: 1.5;
+    color: #374151;
+  }
+
+  .aam-error,
+  .aam-success {
+    padding: 0.625rem 0.75rem;
+    border-radius: 0.375rem;
+    font-size: 0.8125rem;
+    margin-bottom: 0.75rem;
+  }
+
+  .aam-error {
+    background: #fef2f2;
+    color: #991b1b;
+    border: 1px solid #fecaca;
+  }
+
+  .aam-success {
+    background: #ecfdf5;
+    color: #065f46;
+    border: 1px solid #a7f3d0;
+  }
+
+  .aam-confirm__actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.5rem;
+  }
+
+  .aam-btn {
+    padding: 0.5rem 1rem;
+    border-radius: 0.375rem;
+    font-size: 0.875rem;
+    font-weight: 600;
+    cursor: pointer;
+    border: 1px solid transparent;
+  }
+
+  .aam-btn:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+
+  .aam-btn--ghost {
+    background: transparent;
+    color: #4b5563;
+    border-color: #d1d5db;
+  }
+
+  .aam-btn--ghost:hover:not(:disabled) {
+    background: #f3f4f6;
+  }
+
+  .aam-btn--primary {
+    background: #c41e3a;
+    color: #fff;
+  }
+
+  .aam-btn--primary:hover:not(:disabled) {
+    background: #a31a31;
+  }
+
+  .aam-btn--danger {
+    background: #991b1b;
+    color: #fff;
+  }
+
+  .aam-btn--danger:hover:not(:disabled) {
+    background: #7f1d1d;
+  }
+</style>

--- a/src/components/afl-fantasy/AFLActionModal.astro
+++ b/src/components/afl-fantasy/AFLActionModal.astro
@@ -169,9 +169,13 @@
     const errorEl = modal.querySelector('#aam-error') as HTMLElement;
     const successEl = modal.querySelector('#aam-success') as HTMLElement;
 
-    // Default fallback headshot — matches /assets/default-headshot.svg used elsewhere.
-    // Keeps the avatar circle from breaking when MFL doesn't have a photo for a player.
-    const DEFAULT_HEADSHOT = '/assets/default-headshot.svg';
+    // Default fallback headshot — same MFL no_photo URL the rest of the codebase
+    // uses (see DEFAULT_HEADSHOT_URL in src/constants/roster-constants.ts and
+    // PlayerDetailsModal's DEFAULT_IMG). Keeps the avatar tile from breaking
+    // when ESPN doesn't have a headshot for a player (free agents, defenses,
+    // pre-draft rookies).
+    const DEFAULT_HEADSHOT =
+      'https://www49.myfantasyleague.com/player_photos_2010/no_photo_available.jpg';
 
     // MFL → standard NFL team code translation. Just the ones MFL uses
     // differently from the standard 2-3 letter codes (everything else is

--- a/src/components/afl-fantasy/KeeperPlanner.astro
+++ b/src/components/afl-fantasy/KeeperPlanner.astro
@@ -385,21 +385,28 @@ const roundLabel = (round: string) => {
           slot.classList.remove('kp-slot--empty');
           slot.classList.add('kp-slot--filled');
           slot.innerHTML = '';
+
           const num = document.createElement('span');
           num.className = 'kp-slot__num';
           num.textContent = String(idx + 1);
           slot.appendChild(num);
-          const label = document.createElement('div');
-          label.className = 'kp-slot__player';
-          const nameSpan = document.createElement('span');
-          nameSpan.className = 'kp-slot__name';
-          nameSpan.textContent = info?.name || playerId;
-          const posSpan = document.createElement('span');
-          posSpan.className = 'kp-slot__pos';
-          posSpan.textContent = info?.position || '';
-          label.appendChild(nameSpan);
-          label.appendChild(posSpan);
-          slot.appendChild(label);
+
+          // Reuse the full PlayerCell lockup from the matching cut card so the
+          // slot picks up the avatar, NFL logo, position pill, and — critically —
+          // the `data-player-modal` attribute that wires the player-details modal
+          // trigger. Falls back to bare name text when the source card isn't
+          // available (defensive; shouldn't happen in practice).
+          const card = findCard(playerId);
+          const sourceCell = card?.querySelector('.kp-card__player');
+          const wrapper = document.createElement('div');
+          wrapper.className = 'kp-slot__player';
+          if (sourceCell) {
+            wrapper.innerHTML = sourceCell.innerHTML;
+          } else {
+            wrapper.textContent = info?.name || playerId;
+          }
+          slot.appendChild(wrapper);
+
           const arrow = document.createElement('button');
           arrow.type = 'button';
           arrow.className = 'kp-arrow kp-arrow--down';
@@ -849,12 +856,22 @@ const roundLabel = (round: string) => {
     border-color: #166534;
   }
 
+  /* Wrapper for the cloned PlayerCell lockup. Flex so the cell stretches
+     to fill the row while the arrow stays anchored on the right. */
   .kp-slot__player {
-    display: grid;
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    align-items: center;
+  }
+
+  .kp-slot__player .player-cell {
     flex: 1;
     min-width: 0;
   }
 
+  /* Legacy fallback text styles — used only when the PlayerCell clone
+     fails (defensive path inside renderSlots). */
   .kp-slot__name {
     font-size: 0.875rem;
     font-weight: 600;
@@ -1010,34 +1027,52 @@ const roundLabel = (round: string) => {
     border-radius: 0.25rem;
   }
 
+  /* Promote / demote arrow — same icon-button shape as ufa-action-btn on the
+     roster page so the design system reads consistently across both AFL
+     surfaces. Carries a subtle semantic tint via the SVG color (green to
+     promote, red to demote) without painting the whole button. */
   .kp-arrow {
-    width: 28px;
-    height: 28px;
-    border-radius: 0.375rem;
-    border: 0;
-    cursor: pointer;
     display: inline-flex;
     align-items: center;
     justify-content: center;
+    width: 28px;
+    height: 28px;
+    padding: 0;
+    border: 1px solid var(--color-gray-200, #d1d5db);
+    background: var(--content-bg, var(--color-white, #fff));
+    border-radius: var(--radius-sm, 4px);
+    cursor: pointer;
     flex-shrink: 0;
+    transition: background-color 0.18s ease, border-color 0.18s ease,
+      box-shadow 0.18s ease, color 0.18s ease;
+  }
+
+  .kp-arrow:hover {
+    border-color: var(--color-gray-300, #9ca3af);
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+  }
+
+  .kp-arrow:focus-visible {
+    outline: 2px solid var(--color-primary, #1c497c);
+    outline-offset: 1px;
   }
 
   .kp-arrow--up {
-    background: #dcfce7;
-    color: #166534;
+    color: var(--color-success-dark, #059669);
   }
 
   .kp-arrow--up:hover {
-    background: #bbf7d0;
+    background: var(--color-success-light, #d1fae5);
+    color: var(--color-success-dark, #047857);
   }
 
   .kp-arrow--down {
-    background: #fee2e2;
-    color: #991b1b;
+    color: var(--color-gray-500, #6b7280);
   }
 
   .kp-arrow--down:hover {
-    background: #fecaca;
+    background: var(--color-gray-50, #f9fafb);
+    color: var(--color-gray-700, #374151);
   }
 
   /* Draft picks */

--- a/src/components/afl-fantasy/KeeperPlanner.astro
+++ b/src/components/afl-fantasy/KeeperPlanner.astro
@@ -1,0 +1,1252 @@
+---
+/**
+ * KeeperPlanner — AFL offseason scratchpad.
+ *
+ * Owners can drag (or click-arrow) players above/below "the line".
+ * Above the line = the 7 keepers they intend to protect. Below the
+ * line = everyone who's going to get cut. Plan auto-saves to the
+ * server (debounced) so it persists across devices.
+ *
+ * The "Finalize keepers" CTA runs sequential POSTs to /api/cut-player
+ * to actually drop the non-keepers from the MFL roster. AFL has no
+ * formal keeper construct on MFL, so the "keepers" themselves are
+ * implicit — they're just whoever's left after the bulk cut.
+ *
+ * Renders inert (no script wiring) on non-owner pages. The roster page
+ * gates inclusion on isOwner, so unauthorized owners never see this UI.
+ */
+
+import PlayerCell from '../theleague/PlayerCell.astro';
+import { KEEPER_LIMIT } from '../../utils/afl-keepers-storage';
+
+export interface KeeperPlannerPlayer {
+  id: string;
+  name: string;
+  position: string;
+  team: string;
+  age: string;
+  espnId?: string;
+  status: string;
+}
+
+export interface KeeperPlannerDraftPick {
+  year: string;
+  round: string;
+  originalPickFor: string;
+  originalPickForName?: string;
+  isTraded: boolean;
+}
+
+export interface Props {
+  franchiseId: string;
+  year: number;
+  /** All players on the franchise's current roster, ordered however the caller likes. */
+  roster: KeeperPlannerPlayer[];
+  /** Future draft picks the franchise currently owns for this year. */
+  draftPicks?: KeeperPlannerDraftPick[];
+}
+
+const { franchiseId, year, roster, draftPicks = [] } = Astro.props;
+
+// Position group order for the cut pool sort
+const POSITION_ORDER = ['QB', 'RB', 'WR', 'TE', 'PK', 'Def', 'DEF'];
+const positionRank = (pos: string) => {
+  const idx = POSITION_ORDER.indexOf(pos);
+  return idx === -1 ? POSITION_ORDER.length : idx;
+};
+
+// Sort roster: by position group, then name. Initial render is "everyone in the cut pool".
+const sortedRoster = [...roster].sort((a, b) => {
+  const r = positionRank(a.position) - positionRank(b.position);
+  return r !== 0 ? r : a.name.localeCompare(b.name);
+});
+
+const buildModalData = (p: KeeperPlannerPlayer) => ({
+  id: p.id,
+  espnId: p.espnId,
+  name: p.name,
+  position: p.position,
+  nflTeam: p.team,
+  status: p.status,
+  franchiseId,
+});
+
+// Round labels (1st / 2nd / 3rd / 4th / Nth)
+const roundLabel = (round: string) => {
+  const n = parseInt(round, 10);
+  if (!Number.isFinite(n)) return round;
+  const tens = n % 100;
+  if (tens >= 11 && tens <= 13) return `${n}th`;
+  const ones = n % 10;
+  if (ones === 1) return `${n}st`;
+  if (ones === 2) return `${n}nd`;
+  if (ones === 3) return `${n}rd`;
+  return `${n}th`;
+};
+---
+
+<section
+  class="keeper-planner"
+  data-keeper-planner
+  data-franchise-id={franchiseId}
+  data-year={year}
+  data-keeper-limit={KEEPER_LIMIT}
+>
+  <header class="kp-intro">
+    <h2 class="kp-intro__title">Keeper planner</h2>
+    <p class="kp-intro__copy">
+      Drag (or use the arrow buttons) to move up to {KEEPER_LIMIT} players above the line.
+      Everyone below the line gets cut when you finalize. Plan saves automatically.
+    </p>
+  </header>
+
+  <!-- Above-the-line: keepers -->
+  <div
+    class="kp-zone kp-zone--keepers"
+    data-zone="keepers"
+    aria-label={`Keepers — drag here to keep (max ${KEEPER_LIMIT})`}
+  >
+    <header class="kp-zone__header">
+      <div class="kp-zone__title-group">
+        <span class="kp-zone__icon kp-zone__icon--keep" aria-hidden="true">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none">
+            <path d="M5 15l7-7 7 7" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" />
+          </svg>
+        </span>
+        <h3 class="kp-zone__title">Above the line — keepers</h3>
+      </div>
+      <span class="kp-counter" data-counter="keepers">
+        <span data-count="keepers">0</span><span class="kp-counter__sep"> / </span><span>{KEEPER_LIMIT}</span>
+      </span>
+    </header>
+
+    <div class="kp-slots" data-slots>
+      {Array.from({ length: KEEPER_LIMIT }).map((_, i) => (
+        <div class="kp-slot kp-slot--empty" data-slot-index={i} aria-label="Empty keeper slot">
+          <span class="kp-slot__num">{i + 1}</span>
+          <span class="kp-slot__hint">Drag a player here</span>
+        </div>
+      ))}
+    </div>
+  </div>
+
+  <!-- Status bar / actions -->
+  <div class="kp-statusbar">
+    <div class="kp-status" data-status>Ready</div>
+    <div class="kp-actions">
+      <button type="button" class="kp-btn kp-btn--ghost" data-action="reset">Reset</button>
+      <button type="button" class="kp-btn kp-btn--primary" data-action="finalize" disabled>
+        Finalize keepers
+      </button>
+    </div>
+  </div>
+
+  <!-- Below-the-line: will be cut -->
+  <div
+    class="kp-zone kp-zone--cuts"
+    data-zone="cuts"
+    aria-label="Players that will be cut on finalize"
+  >
+    <header class="kp-zone__header">
+      <div class="kp-zone__title-group">
+        <span class="kp-zone__icon kp-zone__icon--cut" aria-hidden="true">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none">
+            <path d="M19 9l-7 7-7-7" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" />
+          </svg>
+        </span>
+        <h3 class="kp-zone__title">Below the line — will be cut</h3>
+      </div>
+      <span class="kp-counter" data-counter="cuts">
+        <span data-count="cuts">{roster.length}</span> players
+      </span>
+    </header>
+
+    <ul class="kp-cards" data-cards>
+      {sortedRoster.map((player) => (
+        <li
+          class="kp-card"
+          data-card
+          data-player-id={player.id}
+          draggable="true"
+          tabindex="0"
+        >
+          <div class="kp-card__player">
+            <PlayerCell
+              name={player.name}
+              position={player.position}
+              nflTeam={player.team}
+              mflId={player.id}
+              espnId={player.espnId}
+              playerData={buildModalData(player)}
+              size="compact"
+            />
+          </div>
+          <div class="kp-card__meta">
+            <span class="kp-card__age" title="Age">{player.age}</span>
+            {player.status === 'INJURED_RESERVE' && <span class="kp-card__ir-pill">IR</span>}
+          </div>
+          <button
+            type="button"
+            class="kp-arrow kp-arrow--up"
+            data-move="up"
+            aria-label={`Keep ${player.name}`}
+            title="Move to keepers"
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+              <path d="M5 15l7-7 7 7" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" />
+            </svg>
+          </button>
+        </li>
+      ))}
+    </ul>
+  </div>
+
+  {draftPicks.length > 0 && (
+    <div class="kp-picks">
+      <header class="kp-picks__header">
+        <h3 class="kp-picks__title">{year + 1} draft assets</h3>
+        <span class="kp-picks__count">{draftPicks.length} picks</span>
+      </header>
+      <ul class="kp-picks__list">
+        {draftPicks.map((pick) => (
+          <li class="kp-picks__pick">
+            <span class="kp-picks__round">{roundLabel(pick.round)} round</span>
+            {pick.isTraded ? (
+              <span class="kp-picks__via">
+                via {pick.originalPickForName ?? pick.originalPickFor}
+              </span>
+            ) : (
+              <span class="kp-picks__via">Original</span>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  )}
+</section>
+
+<!-- Finalize confirmation modal -->
+<div class="kp-finalize" id="kp-finalize" role="dialog" aria-modal="true" aria-labelledby="kp-finalize-title" hidden>
+  <div class="kp-finalize__overlay" data-finalize-close></div>
+  <div class="kp-finalize__content">
+    <button type="button" class="kp-finalize__close" data-finalize-close aria-label="Close">
+      <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
+        <path d="M14 4L4 14M4 4l10 10" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" />
+      </svg>
+    </button>
+    <h3 class="kp-finalize__title" id="kp-finalize-title">Finalize keepers</h3>
+    <p class="kp-finalize__copy" id="kp-finalize-copy">
+      &mdash;
+    </p>
+
+    <div class="kp-finalize__lists">
+      <div class="kp-finalize__col">
+        <h4>Keeping</h4>
+        <ul id="kp-finalize-keep"></ul>
+      </div>
+      <div class="kp-finalize__col">
+        <h4>Cutting</h4>
+        <ul id="kp-finalize-cut"></ul>
+      </div>
+    </div>
+
+    <div class="kp-finalize__progress" id="kp-finalize-progress" hidden>
+      <div class="kp-finalize__bar"><span id="kp-finalize-bar-fill"></span></div>
+      <p class="kp-finalize__progress-label" id="kp-finalize-progress-label">&mdash;</p>
+    </div>
+
+    <div class="kp-finalize__error" id="kp-finalize-error" hidden></div>
+
+    <div class="kp-finalize__actions">
+      <button type="button" class="kp-btn kp-btn--ghost" data-finalize-cancel>Back</button>
+      <button type="button" class="kp-btn kp-btn--danger" id="kp-finalize-confirm">
+        Cut everyone below the line
+      </button>
+    </div>
+  </div>
+</div>
+
+<script>
+  interface PlayerLookup {
+    id: string;
+    name: string;
+    position: string;
+  }
+
+  const _root = document.querySelector<HTMLElement>('[data-keeper-planner]');
+  if (!_root) {
+    // Component not on this page — bail silently.
+  } else {
+    // Pin into a const so inner closures keep the non-null narrowing
+    const root: HTMLElement = _root;
+    const franchiseId = root.dataset.franchiseId || '';
+    const year = Number(root.dataset.year || '0');
+    const KEEPER_LIMIT = Number(root.dataset.keeperLimit || '7');
+
+    const slotsEl = root.querySelector<HTMLElement>('[data-slots]');
+    const cardsEl = root.querySelector<HTMLElement>('[data-cards]');
+    const counterKeepers = root.querySelector<HTMLElement>('[data-count="keepers"]');
+    const counterCuts = root.querySelector<HTMLElement>('[data-count="cuts"]');
+    const statusEl = root.querySelector<HTMLElement>('[data-status]');
+    const resetBtn = root.querySelector<HTMLButtonElement>('[data-action="reset"]');
+    const finalizeBtn = root.querySelector<HTMLButtonElement>('[data-action="finalize"]');
+
+    // Collect every card's data for fast lookup
+    const cardData = new Map<string, PlayerLookup>();
+    const initialCardsByPos = new Map<string, HTMLLIElement[]>();
+    cardsEl?.querySelectorAll<HTMLLIElement>('[data-card]').forEach((card) => {
+      const id = card.dataset.playerId || '';
+      const nameEl = card.querySelector('.player-cell__name');
+      const posEl = card.querySelector('.player-meta__pos');
+      const name = nameEl?.textContent?.trim() || `Player ${id}`;
+      // Position label may include "QB - RC" style suffix; strip suffix.
+      const positionRaw = posEl?.textContent?.trim().split('-')[0]?.trim() || '';
+      cardData.set(id, { id, name, position: positionRaw });
+      const list = initialCardsByPos.get(positionRaw) || [];
+      list.push(card);
+      initialCardsByPos.set(positionRaw, list);
+    });
+
+    // Local state — single source of truth, mirrored into the DOM each render.
+    const keeperIds: string[] = [];
+
+    let saveTimer: number | null = null;
+    let isSaving = false;
+    let pendingSavePayload: string[] | null = null;
+    const STATUS_RESET_MS = 1800;
+
+    function setStatus(text: string, kind?: 'ok' | 'err' | 'work') {
+      if (!statusEl) return;
+      statusEl.textContent = text;
+      statusEl.dataset.kind = kind || '';
+    }
+
+    function flashStatus(text: string, kind: 'ok' | 'err') {
+      setStatus(text, kind);
+      window.setTimeout(() => {
+        if (statusEl?.textContent === text) setStatus(keeperIds.length === KEEPER_LIMIT ? 'Roster locked in.' : 'Ready');
+      }, STATUS_RESET_MS);
+    }
+
+    async function flushSave() {
+      if (!pendingSavePayload) return;
+      const payload = pendingSavePayload;
+      pendingSavePayload = null;
+      isSaving = true;
+      setStatus('Saving…', 'work');
+      try {
+        const res = await fetch('/api/afl-keepers', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ franchise: franchiseId, year, keepers: payload }),
+        });
+        const data = await res.json().catch(() => ({}));
+        if (!res.ok || !data?.success) {
+          throw new Error(data?.message || `Save failed (${res.status})`);
+        }
+        flashStatus('Saved.', 'ok');
+      } catch (err: any) {
+        flashStatus(err?.message || 'Save failed.', 'err');
+      } finally {
+        isSaving = false;
+        if (pendingSavePayload) void flushSave();
+      }
+    }
+
+    function scheduleSave() {
+      pendingSavePayload = keeperIds.slice();
+      if (isSaving) return;
+      if (saveTimer != null) window.clearTimeout(saveTimer);
+      saveTimer = window.setTimeout(() => {
+        saveTimer = null;
+        void flushSave();
+      }, 600);
+    }
+
+    function updateCounters() {
+      if (counterKeepers) counterKeepers.textContent = String(keeperIds.length);
+      if (counterCuts) counterCuts.textContent = String(cardData.size - keeperIds.length);
+      const keepZone = root.querySelector('[data-zone="keepers"]');
+      if (keepZone) keepZone.classList.toggle('kp-zone--full', keeperIds.length >= KEEPER_LIMIT);
+      if (finalizeBtn) finalizeBtn.disabled = keeperIds.length !== KEEPER_LIMIT;
+    }
+
+    function findCard(playerId: string): HTMLLIElement | null {
+      return root.querySelector<HTMLLIElement>(`[data-card][data-player-id="${playerId}"]`);
+    }
+
+    function renderSlots() {
+      if (!slotsEl) return;
+      slotsEl.querySelectorAll<HTMLElement>('[data-slot-index]').forEach((slot) => {
+        const idx = Number(slot.dataset.slotIndex);
+        const playerId = keeperIds[idx];
+        if (playerId) {
+          const info = cardData.get(playerId);
+          slot.classList.remove('kp-slot--empty');
+          slot.classList.add('kp-slot--filled');
+          slot.innerHTML = '';
+          const num = document.createElement('span');
+          num.className = 'kp-slot__num';
+          num.textContent = String(idx + 1);
+          slot.appendChild(num);
+          const label = document.createElement('div');
+          label.className = 'kp-slot__player';
+          const nameSpan = document.createElement('span');
+          nameSpan.className = 'kp-slot__name';
+          nameSpan.textContent = info?.name || playerId;
+          const posSpan = document.createElement('span');
+          posSpan.className = 'kp-slot__pos';
+          posSpan.textContent = info?.position || '';
+          label.appendChild(nameSpan);
+          label.appendChild(posSpan);
+          slot.appendChild(label);
+          const arrow = document.createElement('button');
+          arrow.type = 'button';
+          arrow.className = 'kp-arrow kp-arrow--down';
+          arrow.dataset.move = 'down';
+          arrow.dataset.slotPlayerId = playerId;
+          arrow.setAttribute('aria-label', `Remove ${info?.name || playerId} from keepers`);
+          arrow.title = 'Send back to cut pool';
+          arrow.innerHTML = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true"><path d="M19 9l-7 7-7-7" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" /></svg>';
+          slot.appendChild(arrow);
+          slot.draggable = true;
+          slot.dataset.playerId = playerId;
+        } else {
+          slot.classList.add('kp-slot--empty');
+          slot.classList.remove('kp-slot--filled');
+          slot.innerHTML = `<span class="kp-slot__num">${idx + 1}</span><span class="kp-slot__hint">Drag a player here</span>`;
+          slot.draggable = false;
+          delete slot.dataset.playerId;
+        }
+      });
+    }
+
+    function setCardVisibility(playerId: string, hidden: boolean) {
+      const card = findCard(playerId);
+      if (card) card.hidden = hidden;
+    }
+
+    function moveToKeepers(playerId: string): boolean {
+      if (keeperIds.includes(playerId)) return false;
+      if (keeperIds.length >= KEEPER_LIMIT) {
+        flashStatus(`Limit is ${KEEPER_LIMIT}. Bump someone else first.`, 'err');
+        return false;
+      }
+      keeperIds.push(playerId);
+      setCardVisibility(playerId, true);
+      renderSlots();
+      updateCounters();
+      scheduleSave();
+      return true;
+    }
+
+    function moveToCuts(playerId: string): boolean {
+      const idx = keeperIds.indexOf(playerId);
+      if (idx === -1) return false;
+      keeperIds.splice(idx, 1);
+      setCardVisibility(playerId, false);
+      renderSlots();
+      updateCounters();
+      scheduleSave();
+      return true;
+    }
+
+    // ── Arrow buttons (click-based, mobile-friendly) ──
+    root.addEventListener('click', (e) => {
+      const target = e.target as HTMLElement;
+      const moveBtn = target.closest('[data-move]') as HTMLButtonElement | null;
+      if (!moveBtn) return;
+      e.stopPropagation();
+      const direction = moveBtn.dataset.move;
+      const card = moveBtn.closest('[data-card]') as HTMLElement | null;
+      const slotPlayerId = moveBtn.dataset.slotPlayerId;
+      const playerId = card?.dataset.playerId || slotPlayerId;
+      if (!playerId) return;
+      if (direction === 'up') moveToKeepers(playerId);
+      else if (direction === 'down') moveToCuts(playerId);
+    });
+
+    // ── Drag and drop ──
+    let dragId: string | null = null;
+
+    root.addEventListener('dragstart', (e) => {
+      const card = (e.target as HTMLElement).closest<HTMLElement>('[data-card], [data-slot-index]');
+      if (!card) return;
+      const id = card.dataset.playerId;
+      if (!id) return;
+      dragId = id;
+      try {
+        e.dataTransfer?.setData('text/plain', id);
+        if (e.dataTransfer) e.dataTransfer.effectAllowed = 'move';
+      } catch {}
+      card.classList.add('is-dragging');
+    });
+
+    root.addEventListener('dragend', (e) => {
+      const card = (e.target as HTMLElement).closest<HTMLElement>('[data-card], [data-slot-index]');
+      card?.classList.remove('is-dragging');
+      dragId = null;
+      root.querySelectorAll('.is-drop-target').forEach((el) => el.classList.remove('is-drop-target'));
+    });
+
+    root.addEventListener('dragover', (e) => {
+      const zone = (e.target as HTMLElement).closest<HTMLElement>('[data-zone]');
+      if (!zone) return;
+      e.preventDefault();
+      if (e.dataTransfer) e.dataTransfer.dropEffect = 'move';
+      zone.classList.add('is-drop-target');
+    });
+
+    root.addEventListener('dragleave', (e) => {
+      const zone = (e.target as HTMLElement).closest<HTMLElement>('[data-zone]');
+      if (!zone) return;
+      // Only remove highlight when leaving the zone entirely
+      const next = e.relatedTarget as Node | null;
+      if (!next || !zone.contains(next)) {
+        zone.classList.remove('is-drop-target');
+      }
+    });
+
+    root.addEventListener('drop', (e) => {
+      const zone = (e.target as HTMLElement).closest<HTMLElement>('[data-zone]');
+      if (!zone) return;
+      e.preventDefault();
+      zone.classList.remove('is-drop-target');
+      const id = dragId || e.dataTransfer?.getData('text/plain') || '';
+      if (!id) return;
+      if (zone.dataset.zone === 'keepers') moveToKeepers(id);
+      else if (zone.dataset.zone === 'cuts') moveToCuts(id);
+    });
+
+    // ── Reset ──
+    resetBtn?.addEventListener('click', async () => {
+      if (!keeperIds.length) return;
+      if (!confirm('Clear all keepers from the planner?')) return;
+      while (keeperIds.length) {
+        const id = keeperIds.pop();
+        if (id) setCardVisibility(id, false);
+      }
+      renderSlots();
+      updateCounters();
+      try {
+        setStatus('Resetting…', 'work');
+        const res = await fetch(`/api/afl-keepers?franchise=${franchiseId}&year=${year}`, {
+          method: 'DELETE',
+        });
+        if (!res.ok) throw new Error('Reset failed.');
+        flashStatus('Cleared.', 'ok');
+      } catch (err: any) {
+        flashStatus(err?.message || 'Reset failed.', 'err');
+      }
+    });
+
+    // ── Finalize ──
+    const finalizeModal = document.getElementById('kp-finalize') as HTMLDivElement | null;
+    const finalizeOpen = () => {
+      if (!finalizeModal) return;
+      const keepList = finalizeModal.querySelector<HTMLUListElement>('#kp-finalize-keep');
+      const cutList = finalizeModal.querySelector<HTMLUListElement>('#kp-finalize-cut');
+      const copy = finalizeModal.querySelector<HTMLParagraphElement>('#kp-finalize-copy');
+      const cutIds: string[] = [];
+      for (const id of cardData.keys()) {
+        if (!keeperIds.includes(id)) cutIds.push(id);
+      }
+      if (keepList) {
+        keepList.innerHTML = keeperIds
+          .map((id) => `<li>${cardData.get(id)?.name ?? id}</li>`)
+          .join('');
+      }
+      if (cutList) {
+        cutList.innerHTML = cutIds
+          .map((id) => `<li>${cardData.get(id)?.name ?? id}</li>`)
+          .join('');
+      }
+      if (copy) {
+        copy.textContent = `Confirming will cut ${cutIds.length} players from your roster on MFL. The ${keeperIds.length} above stay. This cannot be undone here.`;
+      }
+      const progress = finalizeModal.querySelector<HTMLElement>('#kp-finalize-progress');
+      const error = finalizeModal.querySelector<HTMLElement>('#kp-finalize-error');
+      const confirm = finalizeModal.querySelector<HTMLButtonElement>('#kp-finalize-confirm');
+      if (progress) progress.hidden = true;
+      if (error) error.hidden = true;
+      if (confirm) {
+        confirm.disabled = false;
+        confirm.textContent = 'Cut everyone below the line';
+      }
+      finalizeModal.hidden = false;
+      document.body.style.overflow = 'hidden';
+    };
+
+    const finalizeClose = () => {
+      if (!finalizeModal) return;
+      finalizeModal.hidden = true;
+      document.body.style.overflow = '';
+    };
+
+    finalizeBtn?.addEventListener('click', () => {
+      if (keeperIds.length !== KEEPER_LIMIT) return;
+      finalizeOpen();
+    });
+    finalizeModal?.querySelectorAll('[data-finalize-close]').forEach((el) => {
+      el.addEventListener('click', finalizeClose);
+    });
+    finalizeModal?.querySelectorAll('[data-finalize-cancel]').forEach((el) => {
+      el.addEventListener('click', finalizeClose);
+    });
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape' && finalizeModal && !finalizeModal.hidden) finalizeClose();
+    });
+
+    const confirmBtn = finalizeModal?.querySelector<HTMLButtonElement>('#kp-finalize-confirm');
+    confirmBtn?.addEventListener('click', async () => {
+      if (!finalizeModal) return;
+      const progress = finalizeModal.querySelector<HTMLElement>('#kp-finalize-progress');
+      const bar = finalizeModal.querySelector<HTMLElement>('#kp-finalize-bar-fill');
+      const label = finalizeModal.querySelector<HTMLElement>('#kp-finalize-progress-label');
+      const error = finalizeModal.querySelector<HTMLElement>('#kp-finalize-error');
+      if (error) error.hidden = true;
+
+      const cutIds: string[] = [];
+      for (const id of cardData.keys()) {
+        if (!keeperIds.includes(id)) cutIds.push(id);
+      }
+
+      if (cutIds.length === 0) {
+        finalizeClose();
+        return;
+      }
+
+      if (progress) progress.hidden = false;
+      confirmBtn.disabled = true;
+      confirmBtn.textContent = 'Cutting…';
+
+      let done = 0;
+      const failures: Array<{ id: string; name: string; message: string }> = [];
+      for (const id of cutIds) {
+        try {
+          const res = await fetch('/api/cut-player', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ playerId: id }),
+          });
+          const data = await res.json().catch(() => ({}));
+          if (!res.ok || !data?.success) {
+            failures.push({
+              id,
+              name: cardData.get(id)?.name || id,
+              message: data?.message || `HTTP ${res.status}`,
+            });
+          }
+        } catch (err: any) {
+          failures.push({
+            id,
+            name: cardData.get(id)?.name || id,
+            message: err?.message || 'Network error',
+          });
+        }
+        done += 1;
+        if (label) label.textContent = `Cut ${done} of ${cutIds.length}…`;
+        if (bar) bar.style.width = `${Math.round((done / cutIds.length) * 100)}%`;
+      }
+
+      if (failures.length === 0) {
+        if (label) label.textContent = `Cut ${done} of ${cutIds.length}. Reloading roster…`;
+        // Clear the saved plan since cuts are now permanent.
+        try {
+          await fetch(`/api/afl-keepers?franchise=${franchiseId}&year=${year}`, { method: 'DELETE' });
+        } catch {}
+        setTimeout(() => window.location.reload(), 800);
+      } else {
+        if (error) {
+          error.hidden = false;
+          error.innerHTML =
+            `<strong>${failures.length} of ${cutIds.length} cuts failed.</strong><br/>` +
+            failures.map((f) => `${f.name}: ${f.message}`).join('<br/>') +
+            '<br/><br/>The successful cuts went through. Reload the page and try the failures individually.';
+        }
+        confirmBtn.disabled = false;
+        confirmBtn.textContent = 'Retry remaining';
+      }
+    });
+
+    // ── Initial load from server ──
+    async function loadPlan() {
+      try {
+        const res = await fetch(`/api/afl-keepers?franchise=${franchiseId}&year=${year}`, {
+          headers: { 'Accept': 'application/json' },
+        });
+        if (!res.ok) return; // user might not be the owner — fine
+        const data = await res.json().catch(() => null);
+        const savedKeepers: string[] = data?.plan?.keepers ?? [];
+        for (const id of savedKeepers) {
+          if (cardData.has(id) && keeperIds.length < KEEPER_LIMIT && !keeperIds.includes(id)) {
+            keeperIds.push(id);
+            setCardVisibility(id, true);
+          }
+        }
+        renderSlots();
+        updateCounters();
+      } catch (err) {
+        console.warn('[keeper-planner] load failed:', err);
+      }
+    }
+
+    renderSlots();
+    updateCounters();
+    void loadPlan();
+  }
+</script>
+
+<style>
+  .keeper-planner {
+    display: grid;
+    gap: 1rem;
+  }
+
+  .kp-intro {
+    background: #fff;
+    border-radius: 0.75rem;
+    padding: 1rem 1.25rem;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.06);
+  }
+
+  .kp-intro__title {
+    margin: 0 0 0.25rem;
+    font-size: 1.125rem;
+    font-weight: 700;
+    color: #0f172a;
+  }
+
+  .kp-intro__copy {
+    margin: 0;
+    font-size: 0.875rem;
+    color: #4b5563;
+    line-height: 1.5;
+  }
+
+  /* Zones */
+  .kp-zone {
+    background: #fff;
+    border-radius: 0.75rem;
+    padding: 1rem;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.06);
+    transition: outline 120ms ease;
+    outline: 2px dashed transparent;
+    outline-offset: -2px;
+  }
+
+  .kp-zone.is-drop-target {
+    outline-color: #c41e3a;
+  }
+
+  .kp-zone--full {
+    background: #f0fdf4;
+  }
+
+  .kp-zone__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 0.75rem;
+  }
+
+  .kp-zone__title-group {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .kp-zone__icon {
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .kp-zone__icon--keep {
+    background: #dcfce7;
+    color: #166534;
+  }
+
+  .kp-zone__icon--cut {
+    background: #fee2e2;
+    color: #991b1b;
+  }
+
+  .kp-zone__title {
+    margin: 0;
+    font-size: 0.8125rem;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: #374151;
+  }
+
+  .kp-counter {
+    font-size: 0.8125rem;
+    font-weight: 700;
+    color: #6b7280;
+  }
+
+  .kp-counter__sep {
+    color: #d1d5db;
+  }
+
+  /* Slots */
+  .kp-slots {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+    gap: 0.5rem;
+  }
+
+  .kp-slot {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.625rem 0.75rem;
+    border: 2px dashed #e5e7eb;
+    border-radius: 0.5rem;
+    min-height: 56px;
+  }
+
+  .kp-slot--empty .kp-slot__hint {
+    color: #9ca3af;
+    font-size: 0.75rem;
+  }
+
+  .kp-slot--filled {
+    background: #ecfdf5;
+    border-style: solid;
+    border-color: #a7f3d0;
+    cursor: grab;
+  }
+
+  .kp-slot--filled.is-dragging {
+    opacity: 0.5;
+  }
+
+  .kp-slot__num {
+    flex-shrink: 0;
+    width: 22px;
+    height: 22px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: #fff;
+    color: #6b7280;
+    border-radius: 50%;
+    font-size: 0.75rem;
+    font-weight: 700;
+    border: 1px solid #e5e7eb;
+  }
+
+  .kp-slot--filled .kp-slot__num {
+    background: #166534;
+    color: #fff;
+    border-color: #166534;
+  }
+
+  .kp-slot__player {
+    display: grid;
+    flex: 1;
+    min-width: 0;
+  }
+
+  .kp-slot__name {
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: #0f172a;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .kp-slot__pos {
+    font-size: 0.6875rem;
+    color: #6b7280;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+  }
+
+  /* Status bar */
+  .kp-statusbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    background: #fff;
+    border-radius: 0.5rem;
+    padding: 0.5rem 0.75rem;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.06);
+  }
+
+  .kp-status {
+    font-size: 0.8125rem;
+    color: #4b5563;
+  }
+
+  .kp-status[data-kind="work"] {
+    color: #6b7280;
+    font-style: italic;
+  }
+
+  .kp-status[data-kind="ok"] {
+    color: #166534;
+  }
+
+  .kp-status[data-kind="err"] {
+    color: #991b1b;
+  }
+
+  .kp-actions {
+    display: flex;
+    gap: 0.5rem;
+  }
+
+  .kp-btn {
+    padding: 0.5rem 1rem;
+    border-radius: 0.375rem;
+    border: 1px solid transparent;
+    font-size: 0.8125rem;
+    font-weight: 600;
+    cursor: pointer;
+  }
+
+  .kp-btn:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+
+  .kp-btn--ghost {
+    background: transparent;
+    color: #4b5563;
+    border-color: #d1d5db;
+  }
+
+  .kp-btn--ghost:hover:not(:disabled) {
+    background: #f3f4f6;
+  }
+
+  .kp-btn--primary {
+    background: #166534;
+    color: #fff;
+  }
+
+  .kp-btn--primary:hover:not(:disabled) {
+    background: #14532d;
+  }
+
+  .kp-btn--danger {
+    background: #991b1b;
+    color: #fff;
+  }
+
+  .kp-btn--danger:hover:not(:disabled) {
+    background: #7f1d1d;
+  }
+
+  /* Cards (cut pool) */
+  .kp-cards {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+    gap: 0.5rem;
+  }
+
+  .kp-card {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 0.625rem;
+    background: #fff;
+    border: 1px solid #e5e7eb;
+    border-radius: 0.5rem;
+    cursor: grab;
+    transition: border-color 120ms ease, box-shadow 120ms ease;
+  }
+
+  .kp-card:hover {
+    border-color: #c41e3a;
+  }
+
+  .kp-card.is-dragging {
+    opacity: 0.5;
+  }
+
+  .kp-card[hidden] {
+    display: none;
+  }
+
+  .kp-card__player {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .kp-card__meta {
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
+  }
+
+  .kp-card__age {
+    font-size: 0.75rem;
+    color: #6b7280;
+    font-weight: 600;
+  }
+
+  .kp-card__ir-pill {
+    display: inline-block;
+    padding: 0 0.375rem;
+    font-size: 0.625rem;
+    font-weight: 800;
+    background: #fee2e2;
+    color: #991b1b;
+    border-radius: 0.25rem;
+  }
+
+  .kp-arrow {
+    width: 28px;
+    height: 28px;
+    border-radius: 0.375rem;
+    border: 0;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+  }
+
+  .kp-arrow--up {
+    background: #dcfce7;
+    color: #166534;
+  }
+
+  .kp-arrow--up:hover {
+    background: #bbf7d0;
+  }
+
+  .kp-arrow--down {
+    background: #fee2e2;
+    color: #991b1b;
+  }
+
+  .kp-arrow--down:hover {
+    background: #fecaca;
+  }
+
+  /* Draft picks */
+  .kp-picks {
+    background: #fff;
+    border-radius: 0.75rem;
+    padding: 1rem;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.06);
+  }
+
+  .kp-picks__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 0.5rem;
+  }
+
+  .kp-picks__title {
+    margin: 0;
+    font-size: 0.8125rem;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: #374151;
+  }
+
+  .kp-picks__count {
+    font-size: 0.75rem;
+    font-weight: 700;
+    color: #6b7280;
+  }
+
+  .kp-picks__list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.375rem;
+  }
+
+  .kp-picks__pick {
+    background: #f3f4f6;
+    border-radius: 0.375rem;
+    padding: 0.25rem 0.625rem;
+    font-size: 0.75rem;
+    color: #374151;
+    display: flex;
+    flex-direction: column;
+    line-height: 1.2;
+  }
+
+  .kp-picks__round {
+    font-weight: 700;
+  }
+
+  .kp-picks__via {
+    color: #6b7280;
+    font-size: 0.6875rem;
+  }
+
+  /* Finalize modal */
+  .kp-finalize {
+    position: fixed;
+    inset: 0;
+    z-index: 1100;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 1rem;
+  }
+
+  .kp-finalize[hidden] {
+    display: none;
+  }
+
+  .kp-finalize__overlay {
+    position: absolute;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.5);
+    backdrop-filter: blur(2px);
+  }
+
+  .kp-finalize__content {
+    position: relative;
+    width: 100%;
+    max-width: 560px;
+    max-height: 90vh;
+    overflow-y: auto;
+    background: #fff;
+    border-radius: 0.75rem;
+    box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.4);
+    padding: 1.5rem;
+  }
+
+  .kp-finalize__close {
+    position: absolute;
+    top: 0.75rem;
+    right: 0.75rem;
+    width: 32px;
+    height: 32px;
+    border: 0;
+    background: transparent;
+    color: #6b7280;
+    border-radius: 0.375rem;
+    cursor: pointer;
+  }
+
+  .kp-finalize__close:hover {
+    background: #f3f4f6;
+  }
+
+  .kp-finalize__title {
+    margin: 0 2rem 0.5rem 0;
+    font-size: 1.125rem;
+    font-weight: 700;
+    color: #0f172a;
+  }
+
+  .kp-finalize__copy {
+    margin: 0 0 1rem;
+    font-size: 0.875rem;
+    color: #4b5563;
+    line-height: 1.5;
+  }
+
+  .kp-finalize__lists {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem;
+    margin-bottom: 1rem;
+  }
+
+  .kp-finalize__col h4 {
+    margin: 0 0 0.5rem;
+    font-size: 0.75rem;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: #6b7280;
+  }
+
+  .kp-finalize__col ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    font-size: 0.8125rem;
+    color: #111827;
+    max-height: 180px;
+    overflow-y: auto;
+  }
+
+  .kp-finalize__col li {
+    padding: 0.125rem 0;
+  }
+
+  .kp-finalize__progress {
+    margin-bottom: 0.75rem;
+  }
+
+  .kp-finalize__bar {
+    height: 8px;
+    background: #f3f4f6;
+    border-radius: 4px;
+    overflow: hidden;
+  }
+
+  .kp-finalize__bar span {
+    display: block;
+    height: 100%;
+    width: 0;
+    background: #166534;
+    transition: width 200ms ease;
+  }
+
+  .kp-finalize__progress-label {
+    margin: 0.375rem 0 0;
+    font-size: 0.75rem;
+    color: #6b7280;
+  }
+
+  .kp-finalize__error {
+    margin-bottom: 0.75rem;
+    padding: 0.75rem;
+    background: #fef2f2;
+    color: #991b1b;
+    border: 1px solid #fecaca;
+    border-radius: 0.375rem;
+    font-size: 0.8125rem;
+    line-height: 1.4;
+  }
+
+  .kp-finalize__actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.5rem;
+  }
+
+  @media (max-width: 720px) {
+    .kp-slots {
+      grid-template-columns: 1fr;
+    }
+
+    .kp-cards {
+      grid-template-columns: 1fr;
+    }
+
+    .kp-finalize__lists {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/src/components/afl-fantasy/KeeperPlanner.astro
+++ b/src/components/afl-fantasy/KeeperPlanner.astro
@@ -1047,6 +1047,16 @@ const roundLabel = (round: string) => {
       box-shadow 0.18s ease, color 0.18s ease;
   }
 
+  /* Pin the inline SVG to a consistent visual size — keeps the down arrow
+     from rendering as an empty box when the upstream <svg width=14> attrs
+     get nuked by some browser stylesheets, and matches what we did on the
+     AFLActionModal action tiles. */
+  .kp-arrow svg {
+    width: 14px;
+    height: 14px;
+    display: block;
+  }
+
   .kp-arrow:hover {
     border-color: var(--color-gray-300, #9ca3af);
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
@@ -1066,13 +1076,18 @@ const roundLabel = (round: string) => {
     color: var(--color-success-dark, #047857);
   }
 
+  /* Down arrow ("send back to cut pool") — keep the same icon-button shape
+     as the up arrow, but in a neutral-dark tone instead of green so the two
+     buttons don't fight for attention. gray-500 was too faint on phone
+     screens — it rendered as a visually-empty box. gray-700 reads cleanly
+     against white at the same weight as the up-arrow chevron. */
   .kp-arrow--down {
-    color: var(--color-gray-500, #6b7280);
+    color: var(--color-gray-700, #374151);
   }
 
   .kp-arrow--down:hover {
     background: var(--color-gray-50, #f9fafb);
-    color: var(--color-gray-700, #374151);
+    color: var(--color-gray-900, #111827);
   }
 
   /* Draft picks */

--- a/src/components/theleague/LoginForm.astro
+++ b/src/components/theleague/LoginForm.astro
@@ -18,6 +18,12 @@ export interface Props {
   redirectUrl?: string;
   /** League ID override (defaults to 13522) */
   leagueId?: string;
+  /**
+   * Season year override forwarded to MFL. AFL passes 2025 because its
+   * 2026 league hasn't been created on MFL yet; calling /2026/myleagues
+   * for the AFL leagueId returns nothing, so franchise resolution fails.
+   */
+  seasonYear?: number | string;
   /** Logo src override — defaults to The League logo */
   logoSrc?: string;
   /** Logo alt text */
@@ -33,6 +39,7 @@ const {
   showLogo = compact,
   redirectUrl,
   leagueId = '13522',
+  seasonYear,
   logoSrc = '/assets/logos/theleague-logo.svg',
   logoAlt = 'The League logo',
   subtitle = 'Enter your MFL credentials',
@@ -44,6 +51,7 @@ const {
   class:list={['login-form', { 'login-form--compact': compact }, className]}
   data-redirect-url={redirectUrl}
   data-league-id={leagueId}
+  data-season-year={seasonYear != null ? String(seasonYear) : ''}
 >
   <!-- Branded Header -->
   <div class:list={['login-header', { 'login-header--compact': compact }]}>
@@ -158,6 +166,8 @@ const {
     // Server-rendered redirect from component prop (highest priority)
     const componentRedirect = formWrapper.dataset.redirectUrl;
     const leagueId = formWrapper.dataset.leagueId || '13522';
+    const seasonYearAttr = formWrapper.dataset.seasonYear || '';
+    const seasonYear = /^\d{4}$/.test(seasonYearAttr) ? Number(seasonYearAttr) : null;
 
     // ── Form submission ──────────────────────────────────────────
     form.addEventListener('submit', async (e) => {
@@ -192,6 +202,7 @@ const {
             username: usernameInput.value,
             password: passwordInput.value,
             leagueId,
+            ...(seasonYear != null ? { year: seasonYear } : {}),
           }),
         });
 

--- a/src/components/theleague/LoginForm.astro
+++ b/src/components/theleague/LoginForm.astro
@@ -18,6 +18,12 @@ export interface Props {
   redirectUrl?: string;
   /** League ID override (defaults to 13522) */
   leagueId?: string;
+  /** Logo src override — defaults to The League logo */
+  logoSrc?: string;
+  /** Logo alt text */
+  logoAlt?: string;
+  /** Subtitle override under "Sign In" */
+  subtitle?: string;
   /** Optional class for consumer styling hooks */
   class?: string;
 }
@@ -27,6 +33,9 @@ const {
   showLogo = compact,
   redirectUrl,
   leagueId = '13522',
+  logoSrc = '/assets/logos/theleague-logo.svg',
+  logoAlt = 'The League logo',
+  subtitle = 'Enter your MFL credentials',
   class: className,
 } = Astro.props;
 ---
@@ -41,14 +50,14 @@ const {
     {showLogo && (
       <img
         class="login-header__logo"
-        src="/assets/logos/theleague-logo.svg"
-        alt="The League logo"
+        src={logoSrc}
+        alt={logoAlt}
         width={compact ? 48 : 64}
         height={compact ? 48 : 64}
       />
     )}
     <h2 class="login-header__title">Sign In</h2>
-    <p class="login-header__subtitle">Enter your MFL credentials</p>
+    <p class="login-header__subtitle">{subtitle}</p>
   </div>
 
   <!-- Login Form -->

--- a/src/components/theleague/PlayerCell.astro
+++ b/src/components/theleague/PlayerCell.astro
@@ -29,7 +29,7 @@
  */
 
 import '../../styles/player-cell.css';
-import { DEFAULT_HEADSHOT_URL, buildHeadshotOnerror, getPlayerHeadshot } from '../../constants/roster-constants';
+import { buildHeadshotOnerror, getPlayerHeadshot } from '../../constants/roster-constants';
 import { normalizeTeamCode } from '../../utils/nfl-logo';
 import type { PlayerModalData } from '../../utils/player-modal-trigger';
 
@@ -82,12 +82,18 @@ const normalizedTeam = nflTeam ? normalizeTeamCode(nflTeam) : '';
 const teamLogoUrl = normalizedTeam ? `/assets/nfl-logos/${normalizedTeam}.svg` : '';
 
 // Prefer the caller-supplied headshot URL — server-side builders pick the
-// right endpoint (NFL combiner, college-football, or MFL photo) based on
-// which IDs are available. Only fall back to getPlayerHeadshot when nothing
-// was passed in; that path assumes an NFL ID, which breaks for pre-draft
-// rookies that only have a college ESPN ID.
-const resolvedHeadshot =
-  headshot || (resolvedEspnId ? getPlayerHeadshot(resolvedMflId, resolvedEspnId) : DEFAULT_HEADSHOT_URL);
+// right endpoint (ESPN NFL direct, college-football, or MFL photo) based on
+// the IDs they have available. When no headshot URL is passed, fall through
+// to getPlayerHeadshot, which is the same cascade PlayerDetailsModal uses:
+//   - ESPN NFL direct URL when we have an NFL espn_id
+//   - MFL photo URL when we only have an MFL id
+//   - DEFAULT_HEADSHOT_URL when neither is present
+// The previous version skipped from "no espnId" straight to DEFAULT, which
+// meant any player missing an espn_id rendered as the MFL silhouette even
+// when MFL had a perfectly good photo (Breece Hall on the AFL feed — his
+// row showed the silhouette, his click-through modal loaded fine because
+// PlayerDetailsModal does try the MFL photo URL as a step before default).
+const resolvedHeadshot = headshot || getPlayerHeadshot(resolvedMflId, resolvedEspnId);
 // Avatar: DEF uses team logo, others use headshot
 const avatarSrc = isDef && teamLogoUrl ? teamLogoUrl : resolvedHeadshot;
 

--- a/src/components/theleague/PlayerDetailsModal.astro
+++ b/src/components/theleague/PlayerDetailsModal.astro
@@ -11,9 +11,14 @@
 
 export interface Props {
   class?: string;
+  /**
+   * Hide all contract / salary UI. AFL has no salaries or contracts;
+   * showing the "Free Agent" fallback is misleading there.
+   */
+  hideContract?: boolean;
 }
 
-const { class: className } = Astro.props;
+const { class: className, hideContract = false } = Astro.props;
 ---
 
 <div class:list={['player-details-modal', className]}>
@@ -54,10 +59,12 @@ const { class: className } = Astro.props;
           <span class="pdm-metric__value" id="metric-ppg-value">&mdash;</span>
           <span class="pdm-metric__label">Per Game</span>
         </div>
-        <div class="pdm-metric" id="metric-card-contract">
-          <span class="pdm-metric__value" id="metric-contract-value">&mdash;</span>
-          <span class="pdm-metric__label" id="metric-contract-label">Contract</span>
-        </div>
+        {!hideContract && (
+          <div class="pdm-metric" id="metric-card-contract">
+            <span class="pdm-metric__value" id="metric-contract-value">&mdash;</span>
+            <span class="pdm-metric__label" id="metric-contract-label">Contract</span>
+          </div>
+        )}
       </div>
 
       <!-- Weekly Results (promoted position) -->
@@ -113,10 +120,12 @@ const { class: className } = Astro.props;
               <span id="detail-college">&mdash;</span>
             </span>
           </div>
-          <div class="pdm-detail" id="detail-row-contract">
-            <span class="pdm-detail__label">Contract</span>
-            <span class="pdm-detail__value" id="detail-contract-detail">&mdash;</span>
-          </div>
+          {!hideContract && (
+            <div class="pdm-detail" id="detail-row-contract">
+              <span class="pdm-detail__label">Contract</span>
+              <span class="pdm-detail__value" id="detail-contract-detail">&mdash;</span>
+            </div>
+          )}
           <div class="pdm-detail" id="detail-row-bye">
             <span class="pdm-detail__label">Bye</span>
             <span class="pdm-detail__value" id="detail-bye-value">&mdash;</span>

--- a/src/constants/roster-constants.ts
+++ b/src/constants/roster-constants.ts
@@ -78,13 +78,26 @@ export function resolveEspnId(
 /**
  * Get player headshot URL, preferring ESPN high-quality images when available.
  * Falls back to MFL photo, then to default placeholder.
+ *
+ * Uses ESPN's *direct* headshot endpoint (not the combiner CDN). The combiner
+ * variant — `a.espncdn.com/combiner/i?img=...&w=96&h=70` — resizes to a
+ * thumbnail at the CDN, which is bandwidth-friendly for avatar tiles BUT
+ * silently returns nothing for a handful of players whose entries are stale
+ * on the combiner. The direct URL is the canonical source ESPN uses for the
+ * same image, has the same hit rate as MFL (every active player), and is what
+ * PlayerDetailsModal already calls — so keeping the row's initial src in
+ * lockstep means the row and the modal share a cache entry and either both
+ * succeed or both fail. (Discovered when Breece Hall rendered as the MFL
+ * silhouette on the AFL roster while his modal hero loaded fine: the modal
+ * was using the direct URL and the row was using the combiner.)
+ *
  * @param mflId - MFL player ID
  * @param espnId - Optional ESPN player ID for higher quality headshots
  * @returns URL to player headshot image
  */
 export function getPlayerHeadshot(mflId?: string, espnId?: string): string {
   if (espnId) {
-    return `https://a.espncdn.com/combiner/i?img=/i/headshots/nfl/players/full/${espnId}.png&w=96&h=70&cb=1`;
+    return `https://a.espncdn.com/i/headshots/nfl/players/full/${espnId}.png`;
   }
   return getPlayerImageUrl(mflId);
 }

--- a/src/pages/afl-fantasy/franchises/[id].astro
+++ b/src/pages/afl-fantasy/franchises/[id].astro
@@ -1,6 +1,9 @@
 ---
 import TheLeagueLayout from '../../../layouts/TheLeagueLayout.astro';
 import aflConfig from '../../../../data/afl-fantasy/afl.config.json';
+import { getAuthUser } from '../../../utils/auth';
+
+export const prerender = false;
 
 // Optional championship history — graceful when not yet committed (PR #207).
 const champHistoryGlob = import.meta.glob<{
@@ -19,17 +22,9 @@ const championshipHistory =
   Object.values(champHistoryGlob)[0]?.default?.championships ?? [];
 
 // SSR: route is /afl-fantasy/franchises/:id where :id is the franchiseId
-// (e.g. "0001"). Astro handles dynamic route params.
-export async function getStaticPaths() {
-  // Static generation for all known AFL franchises so deep links work
-  // out of the box.
-  const cfg = (await import('../../../../data/afl-fantasy/afl.config.json'))
-    .default;
-  return (cfg.teams as Array<{ franchiseId: string }>).map((t) => ({
-    params: { id: t.franchiseId },
-  }));
-}
-
+// (e.g. "0001"). Rendered per-request so we can detect the viewer's
+// auth state and reveal owner-only CTAs (Manage roster / Open trade
+// builder) without hydrating a client component.
 const { id } = Astro.params;
 
 const team = (aflConfig.teams as Array<any>).find(
@@ -57,6 +52,14 @@ const conference = (aflConfig.conferences ?? []).find(
   (c: any) => c.code === team.conference
 );
 const conferenceName = conference?.name ?? team.conference;
+
+// Auth — surface owner-only CTAs at the top of the page when the
+// viewer matches this franchise.
+const authUser = getAuthUser(Astro.request);
+const isOwner =
+  !!authUser &&
+  authUser.leagueId === '19621' &&
+  authUser.franchiseId === id;
 ---
 
 <TheLeagueLayout title={`${team.name} | AFL Franchise`}>
@@ -100,6 +103,38 @@ const conferenceName = conference?.name ?? team.conference;
             </p>
           ) : null}
         </div>
+      </div>
+
+      <!-- Action bar: owner-only CTAs + universal roster link -->
+      <div class="franchise-actions">
+        <a class="franchise-action franchise-action--primary" href={`/afl-fantasy/rosters?franchise=${id}`}>
+          <span class="franchise-action__icon" aria-hidden="true">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
+              <path d="M9 5H5a2 2 0 00-2 2v12a2 2 0 002 2h14a2 2 0 002-2V7a2 2 0 00-2-2h-4M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+            </svg>
+          </span>
+          View roster
+        </a>
+        {isOwner && (
+          <>
+            <a class="franchise-action" href={`/afl-fantasy/rosters?franchise=${id}&view=planner`}>
+              <span class="franchise-action__icon" aria-hidden="true">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
+                  <path d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 100 4m0-4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 100 4m0-4v2m0-6V4" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+                </svg>
+              </span>
+              Keeper planner
+            </a>
+            <a class="franchise-action" href={`/afl-fantasy/trade-builder?from=${id}`}>
+              <span class="franchise-action__icon" aria-hidden="true">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
+                  <path d="M7 17l-4-4m0 0l4-4m-4 4h18m-4-4l4 4m0 0l-4 4" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+                </svg>
+              </span>
+              Open trade builder
+            </a>
+          </>
+        )}
       </div>
     </header>
 
@@ -157,9 +192,6 @@ const conferenceName = conference?.name ?? team.conference;
     <section class="franchise-section">
       <h2>Quick links</h2>
       <div class="quick-links">
-        <a class="quick-link" href={`/afl-fantasy/rosters?franchise=${id}`}>
-          📋 Roster
-        </a>
         <a class="quick-link" href={`/afl-fantasy/standings?myteam=${id}`}>
           📊 Standings (highlight this team)
         </a>
@@ -218,6 +250,49 @@ const conferenceName = conference?.name ?? team.conference;
     border-radius: 12px;
     border: 1px solid var(--border-color, #e5e7eb);
     padding: var(--spacing-md, 16px);
+  }
+
+  .franchise-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-top: var(--spacing-md, 16px);
+  }
+
+  .franchise-action {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 0.875rem;
+    background: #fff;
+    color: #c41e3a;
+    border: 1px solid #c41e3a;
+    border-radius: 0.5rem;
+    font-size: 0.875rem;
+    font-weight: 600;
+    text-decoration: none;
+    transition: background-color 120ms ease, color 120ms ease;
+  }
+
+  .franchise-action:hover {
+    background: #c41e3a;
+    color: #fff;
+  }
+
+  .franchise-action--primary {
+    background: #c41e3a;
+    color: #fff;
+  }
+
+  .franchise-action--primary:hover {
+    background: #a31a31;
+    border-color: #a31a31;
+  }
+
+  .franchise-action__icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
   }
 
   .franchise-hero__icon,

--- a/src/pages/afl-fantasy/login.astro
+++ b/src/pages/afl-fantasy/login.astro
@@ -1,0 +1,60 @@
+---
+/**
+ * AFL Fantasy login page — mirrors /theleague/login but posts to MFL
+ * with leagueId=19621 so the resulting JWT scopes the user to AFL.
+ *
+ * Without this page, every login on the site dropped the user into
+ * TheLeague (13522) regardless of which site they came from, which is
+ * why AFL owners weren't seeing owner-only UI (action menus, keeper
+ * planner, trade builder).
+ */
+
+import TheLeagueLayout from '../../layouts/TheLeagueLayout.astro';
+import LoginForm from '../../components/theleague/LoginForm.astro';
+import { getAuthUser } from '../../utils/auth';
+
+export const prerender = false;
+
+const AFL_LEAGUE_ID = '19621';
+
+// If already authenticated as an AFL owner, redirect into the AFL home.
+// If authenticated against a different league, fall through so the user
+// can re-sign-in against AFL (this scenario is real — same person can
+// own teams in both leagues).
+const authUser = getAuthUser(Astro.request);
+if (authUser?.leagueId === AFL_LEAGUE_ID) {
+  return Astro.redirect('/afl-fantasy');
+}
+
+// Where to redirect on successful login — honor ?next= for deep links,
+// otherwise drop them on the AFL home.
+const next = Astro.url.searchParams.get('next');
+const safeNext = next && next.startsWith('/afl-fantasy') ? next : '/afl-fantasy';
+---
+
+<TheLeagueLayout title="Sign In — AFL Fantasy">
+  <div class="afl-login-page">
+    <LoginForm
+      leagueId={AFL_LEAGUE_ID}
+      redirectUrl={safeNext}
+      logoSrc="/assets/logos/afl-logo.svg"
+      logoAlt="AFL Fantasy logo"
+      subtitle="Sign in with your MFL credentials for the American Football League"
+    />
+  </div>
+</TheLeagueLayout>
+
+<style>
+  .afl-login-page {
+    display: flex;
+    justify-content: center;
+    align-items: flex-start;
+    padding: 4rem var(--spacing-lg, 1.5rem) var(--spacing-2xl, 3rem);
+  }
+
+  @media (max-width: 640px) {
+    .afl-login-page {
+      padding: 2.5rem var(--spacing-md, 1rem) var(--spacing-xl, 2rem);
+    }
+  }
+</style>

--- a/src/pages/afl-fantasy/login.astro
+++ b/src/pages/afl-fantasy/login.astro
@@ -16,6 +16,12 @@ import { getAuthUser } from '../../utils/auth';
 export const prerender = false;
 
 const AFL_LEAGUE_ID = '19621';
+// MFL hasn't been set up for AFL 2026 yet — last completed season is 2025.
+// `myleagues` for 2026 returns nothing for this league, which is why owners
+// who tried to sign in before this fix saw "your franchise could not be
+// determined". Once the 2026 AFL league exists on MFL, this can drop back
+// to the current year via getCurrentLeagueYear().
+const AFL_LOGIN_YEAR = 2025;
 
 // If already authenticated as an AFL owner, redirect into the AFL home.
 // If authenticated against a different league, fall through so the user
@@ -36,6 +42,7 @@ const safeNext = next && next.startsWith('/afl-fantasy') ? next : '/afl-fantasy'
   <div class="afl-login-page">
     <LoginForm
       leagueId={AFL_LEAGUE_ID}
+      seasonYear={AFL_LOGIN_YEAR}
       redirectUrl={safeNext}
       logoSrc="/assets/logos/afl-logo.svg"
       logoAlt="AFL Fantasy logo"

--- a/src/pages/afl-fantasy/rosters.astro
+++ b/src/pages/afl-fantasy/rosters.astro
@@ -454,6 +454,7 @@ const pageConfig = {
       <div class="team-card__actions">
         <div class="view-tabs">
           <button
+            type="button"
             class="view-tab"
             data-view="roster"
             data-active={initialView === 'roster' ? 'true' : 'false'}
@@ -466,6 +467,7 @@ const pageConfig = {
             <span class="view-tab__label">Roster</span>
           </button>
           <button
+            type="button"
             class="view-tab"
             data-view="analytics"
             data-active={initialView === 'analytics' ? 'true' : 'false'}
@@ -478,6 +480,7 @@ const pageConfig = {
             <span class="view-tab__label">Analytics</span>
           </button>
           <button
+            type="button"
             class="view-tab"
             data-view="planner"
             data-active={initialView === 'planner' ? 'true' : 'false'}
@@ -799,7 +802,14 @@ const pageConfig = {
       ) : (
         <div class="coming-soon">
           <h2>Planner</h2>
-          <p>The keeper planner is private to each team owner. Sign in as {selectedTeam.name}'s owner to use it.</p>
+          <p>The keeper planner is private to each team owner.</p>
+          {!authUser && (
+            <p>
+              <a class="coming-soon__cta" href={`/afl-fantasy/login?next=/afl-fantasy/rosters?franchise=${selectedFranchiseId}&view=planner`}>
+                Sign in to AFL Fantasy →
+              </a>
+            </p>
+          )}
         </div>
       )}
     </section>
@@ -833,7 +843,13 @@ const pageConfig = {
         tab.setAttribute('data-active', String(isActive));
       });
       Array.from(containers).forEach((container) => {
-        container.hidden = container.dataset.viewContent !== viewName;
+        const isActive = container.dataset.viewContent === viewName;
+        // Use inline style + drop the SSR-set [hidden] attribute. Belt and
+        // suspenders so the toggle is robust against any [hidden] vs class
+        // specificity weirdness in scoped Astro styles.
+        container.style.display = isActive ? 'grid' : 'none';
+        if (isActive) container.removeAttribute('hidden');
+        else container.setAttribute('hidden', '');
       });
       if (labelEl && VIEW_LABELS[viewName]) {
         labelEl.textContent = VIEW_LABELS[viewName];
@@ -845,7 +861,8 @@ const pageConfig = {
     }
 
     Array.from(tabs).forEach((tab) => {
-      tab.addEventListener('click', () => {
+      tab.addEventListener('click', (e) => {
+        e.preventDefault();
         const viewName = tab.dataset.view;
         if (viewName) switchView(viewName);
       });

--- a/src/pages/afl-fantasy/rosters.astro
+++ b/src/pages/afl-fantasy/rosters.astro
@@ -1268,6 +1268,7 @@ const pageConfig = {
       padding: 0.55rem 0.5rem;
       text-align: right;
       background: var(--color-gray-50, #f9fafb);
+      white-space: nowrap;
     }
 
     .roster-table th[data-column="player"] {

--- a/src/pages/afl-fantasy/rosters.astro
+++ b/src/pages/afl-fantasy/rosters.astro
@@ -7,6 +7,7 @@ import KeeperPlanner, {
   type KeeperPlannerPlayer,
   type KeeperPlannerDraftPick,
 } from '../../components/afl-fantasy/KeeperPlanner.astro';
+import { spriteUrl } from '../../utils/sprite-url';
 import { getAuthUser } from '../../utils/auth';
 import {
   setAFLPreference,
@@ -16,7 +17,6 @@ import {
 import {
   getAllTeams,
   getTeamsGroupedByConference,
-  getConferenceShort,
   getConferenceName,
   getTeam,
   type AFLTeam,
@@ -171,7 +171,6 @@ if (isValidFranchiseId(queryFranchiseId)) {
 }
 
 const selectedTeam: AFLTeam = getTeam(selectedFranchiseId) ?? allTeams[0]!;
-const conferenceShort = getConferenceShort(selectedTeam.conference);
 const conferenceName = getConferenceName(selectedTeam.conference);
 
 // Owner detection: only AFL users on their own team see write actions
@@ -237,7 +236,6 @@ const totalPlayers = roster.length;
 const activeRoster = roster.filter((p) => p.status === 'ROSTER').length;
 const injuredReserve = roster.filter((p) => p.status === 'INJURED_RESERVE').length;
 const ROSTER_SIZE = 16;
-const openSlots = Math.max(0, ROSTER_SIZE - totalPlayers);
 
 // Build the KeeperPlanner inputs (only really used when isOwner is true)
 const plannerRoster: KeeperPlannerPlayer[] = roster.map((p) => ({
@@ -433,202 +431,208 @@ const pageConfig = {
 ---
 
 <TheLeagueLayout title={`AFL Fantasy — ${selectedTeam.name} Roster`}>
-  <main class="afl-rosters" data-initial-view={initialView}>
+  <section class="roster-page" data-initial-view={initialView}>
     <!-- Team Header Card -->
-    <header class="afl-rosters__header">
-      <div class="header-card">
-        <div class="header-card__left">
-          {selectedTeam.icon && (
-            <img class="header-card__icon" src={selectedTeam.icon} alt={`${selectedTeam.name} logo`} />
-          )}
-          <div class="header-card__identity">
-            <div class="header-card__pills">
-              <span
-                class:list={[
-                  'pill',
-                  'pill--conf',
-                  selectedTeam.conference === '00' ? 'pill--conf-al' : 'pill--conf-nl',
-                ]}
-                title={conferenceName}
-              >
-                {conferenceShort}
-              </span>
-              <span class="pill pill--division">{selectedTeam.division}</span>
-              <span
-                class:list={[
-                  'pill',
-                  'pill--tier',
-                  selectedTeam.tier === 'Premier League' ? 'pill--tier-premier' : 'pill--tier-dleague',
-                ]}
-              >
-                {selectedTeam.tier}
-              </span>
-              {isOwner && <span class="pill pill--owner">Your team</span>}
-            </div>
-            <h1 class="header-card__name">{selectedTeam.name}</h1>
-            <a class="header-card__profile-link" href={`/afl-fantasy/franchises/${selectedTeam.franchiseId}`}>
-              View franchise profile →
-            </a>
-          </div>
-        </div>
-
-        <div class="header-card__right">
-          <div class="control">
-            <label for="franchise-select">Team</label>
-            <select id="franchise-select" data-current-franchise={selectedFranchiseId}>
-              {teamsByConference.map((group) => (
-                <optgroup label={group.conferenceName}>
-                  {group.teams
-                    .slice()
-                    .sort((a, b) => a.name.localeCompare(b.name))
-                    .map((t) => (
-                      <option value={t.franchiseId} selected={t.franchiseId === selectedFranchiseId}>
-                        {t.name}
-                      </option>
-                    ))}
-                </optgroup>
-              ))}
-            </select>
-          </div>
-
-          <div class="control">
-            <label for="year-select">Year</label>
-            <select id="year-select" data-current-year={selectedYear}>
-              {availableYears.map((year) => (
-                <option value={year} selected={year === selectedYear}>{year}</option>
-              ))}
-            </select>
-          </div>
-        </div>
-      </div>
-
-      <!-- View tabs -->
-      <nav class="view-tabs" role="tablist" aria-label="Roster view">
-        <button class="view-tab" data-view="roster" role="tab" aria-selected={initialView === 'roster'}>
-          <span class="view-tab__label">Roster</span>
-        </button>
-        <button class="view-tab" data-view="analytics" role="tab" aria-selected={initialView === 'analytics'}>
-          <span class="view-tab__label">Analytics</span>
-        </button>
-        <button class="view-tab" data-view="planner" role="tab" aria-selected={initialView === 'planner'}>
-          <span class="view-tab__label">Planner</span>
-        </button>
-      </nav>
-
-      <!-- Roster summary strip -->
-      <div class="summary-strip">
-        <div class="summary-stat">
-          <span class="summary-stat__value">{activeRoster}</span>
-          <span class="summary-stat__label">Active</span>
-        </div>
-        <div class="summary-stat">
-          <span class="summary-stat__value">{injuredReserve}</span>
-          <span class="summary-stat__label">IR</span>
-        </div>
-        <div class="summary-stat">
-          <span class="summary-stat__value">{totalPlayers}<span class="summary-stat__denom">/{ROSTER_SIZE}</span></span>
-          <span class="summary-stat__label">Roster</span>
-        </div>
-        {openSlots > 0 && (
-          <div class="summary-stat summary-stat--accent">
-            <span class="summary-stat__value">{openSlots}</span>
-            <span class="summary-stat__label">Open</span>
-          </div>
+    <div class="team-card" data-team-identity>
+      {selectedTeam.icon && (
+        <img src={selectedTeam.icon} alt={`${selectedTeam.name} icon`} />
+      )}
+      <div class="team-card__identity">
+        <p class="team-card__label" data-view-label>AFL Roster</p>
+        <h2 class="team-card__name">{selectedTeam.name}</h2>
+        <p class="team-card__meta">
+          {conferenceName} · {selectedTeam.division}
+        </p>
+        {isOwner && (
+          <p class="team-card__last-seen" data-level="active">
+            <span class="last-seen-dot" aria-hidden="true"></span>
+            <span>Your team</span>
+          </p>
         )}
       </div>
-    </header>
+
+      <div class="team-card__actions">
+        <div class="view-tabs">
+          <button
+            class="view-tab"
+            data-view="roster"
+            data-active={initialView === 'roster' ? 'true' : 'false'}
+            aria-label="Roster View"
+            title="Roster View"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" class="view-tab__icon">
+              <use href={`${spriteUrl}#icon-users`}></use>
+            </svg>
+            <span class="view-tab__label">Roster</span>
+          </button>
+          <button
+            class="view-tab"
+            data-view="analytics"
+            data-active={initialView === 'analytics' ? 'true' : 'false'}
+            aria-label="Analytics View"
+            title="Analytics View"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" class="view-tab__icon">
+              <use href={`${spriteUrl}#icon-bar-chart`}></use>
+            </svg>
+            <span class="view-tab__label">Analytics</span>
+          </button>
+          <button
+            class="view-tab"
+            data-view="planner"
+            data-active={initialView === 'planner' ? 'true' : 'false'}
+            aria-label="Keeper Planner"
+            title="Keeper Planner"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" class="view-tab__icon">
+              <use href={`${spriteUrl}#icon-chalkboard`}></use>
+            </svg>
+            <span class="view-tab__label">Planner</span>
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Compact controls: team + year switcher -->
+    <div class="roster-controls-bar">
+      <div class="roster-controls-bar__group">
+        <label for="franchise-select">Team</label>
+        <select id="franchise-select" data-current-franchise={selectedFranchiseId}>
+          {teamsByConference.map((group) => (
+            <optgroup label={group.conferenceName}>
+              {group.teams
+                .slice()
+                .sort((a, b) => a.name.localeCompare(b.name))
+                .map((t) => (
+                  <option value={t.franchiseId} selected={t.franchiseId === selectedFranchiseId}>
+                    {t.name}
+                  </option>
+                ))}
+            </optgroup>
+          ))}
+        </select>
+      </div>
+      <div class="roster-controls-bar__group">
+        <label for="year-select">Year</label>
+        <select id="year-select" data-current-year={selectedYear}>
+          {availableYears.map((year) => (
+            <option value={year} selected={year === selectedYear}>{year}</option>
+          ))}
+        </select>
+      </div>
+      <a class="roster-controls-bar__profile" href={`/afl-fantasy/franchises/${selectedTeam.franchiseId}`}>
+        Franchise profile →
+      </a>
+    </div>
+
+    <!-- Roster summary -->
+    <div class="roster-summary">
+      <article>
+        <p>Active roster</p>
+        <strong>{activeRoster}<span class="roster-summary__denom">/{ROSTER_SIZE}</span></strong>
+      </article>
+      <article>
+        <p>Injured reserve</p>
+        <strong>{injuredReserve}</strong>
+      </article>
+      <article>
+        <p>Total players</p>
+        <strong>{totalPlayers}</strong>
+      </article>
+      <article>
+        <p>Open active slots</p>
+        <strong>{Math.max(0, ROSTER_SIZE - activeRoster)}</strong>
+      </article>
+    </div>
 
     <!-- Roster View -->
     <section class="view-container" data-view-content="roster" hidden={initialView !== 'roster'}>
-      {sortedPositions
-        .filter((pos) => (rosterByPosition.get(pos)?.length ?? 0) > 0)
-        .map((position) => {
-          const players = rosterByPosition.get(position)!;
-          return (
-            <div class="position-block">
-              <header class="position-block__header">
-                <h2 class="position-block__title">{position}</h2>
-                <span class="position-block__count">{players.length}</span>
-              </header>
-              <div class="position-block__table-wrap">
-                <table class="roster-table">
-                  <thead>
-                    <tr>
-                      <th class="col-player">Player</th>
-                      <th class="col-team">NFL</th>
-                      <th class="col-age">Age</th>
-                      <th class="col-college">College</th>
-                      <th class="col-status">Status</th>
-                      {isOwner && <th class="col-actions" aria-label="Actions"></th>}
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {players.map((player) => (
-                      <tr
-                        data-player-id={player.id}
-                        data-player-status={player.status}
-                        data-player-name={player.name}
-                        data-on-trade-bait={player.isOnTradeBait ? 'true' : 'false'}
-                      >
-                        <td class="col-player">
-                          <PlayerCell
-                            name={player.name}
-                            position={player.position}
-                            nflTeam={player.team}
-                            mflId={player.id}
-                            espnId={player.espn_id}
-                            playerData={buildPlayerModalData(player)}
-                            size="compact"
-                          >
-                            {player.isOnTradeBait && (
-                              <span slot="after-name" class="bait-badge" title="On trade block">TB</span>
-                            )}
-                          </PlayerCell>
-                        </td>
-                        <td class="col-team">{player.team}</td>
-                        <td class="col-age">{player.age}</td>
-                        <td class="col-college">{player.college}</td>
-                        <td class="col-status">
-                          <span
-                            class:list={[
-                              'status-badge',
-                              player.status === 'INJURED_RESERVE' && 'status-badge--ir',
-                              player.status === 'ROSTER' && 'status-badge--active',
-                            ]}
-                          >
-                            {player.status === 'INJURED_RESERVE' ? 'IR' : 'Active'}
-                          </span>
-                        </td>
-                        {isOwner && (
-                          <td class="col-actions">
-                            <button
-                              type="button"
-                              class="action-btn"
-                              data-action-trigger
-                              data-player-id={player.id}
-                              aria-label={`Manage ${player.name}`}
-                              title="Manage player"
-                            >
-                              <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-                                <circle cx="3" cy="8" r="1.5" fill="currentColor" />
-                                <circle cx="8" cy="8" r="1.5" fill="currentColor" />
-                                <circle cx="13" cy="8" r="1.5" fill="currentColor" />
-                              </svg>
-                            </button>
-                          </td>
-                        )}
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            </div>
-          );
-        })}
-
-      {roster.length === 0 && (
+      {roster.length === 0 ? (
         <div class="empty-state">
           <p>No roster data for this team in {selectedYear}.</p>
+        </div>
+      ) : (
+        <div class="roster-table-card">
+          <div class="roster-table-wrapper">
+            <table class="roster-table roster-table--afl">
+              <thead>
+                <tr>
+                  <th data-column="player">Player</th>
+                  <th data-column="college">College</th>
+                  <th data-column="status">Status</th>
+                  {isOwner && <th data-column="actions" aria-label="Actions"></th>}
+                </tr>
+              </thead>
+              <tbody>
+                {sortedPositions
+                  .flatMap((pos) => rosterByPosition.get(pos) ?? [])
+                  .map((player) => (
+                    <tr
+                      data-player-id={player.id}
+                      data-player-status={player.status}
+                      data-player-name={player.name}
+                      data-on-trade-bait={player.isOnTradeBait ? 'true' : 'false'}
+                      data-row-status={player.status === 'INJURED_RESERVE' ? 'ir' : 'active'}
+                    >
+                      <td data-column="player">
+                        <PlayerCell
+                          name={player.name}
+                          position={player.position}
+                          nflTeam={player.team}
+                          mflId={player.id}
+                          espnId={player.espn_id}
+                          playerData={buildPlayerModalData(player)}
+                          size="compact"
+                        >
+                          {player.isOnTradeBait && (
+                            <a
+                              slot="after-name"
+                              class="trade-bait-link"
+                              href={`/afl-fantasy/trade-builder?from=${selectedFranchiseId}&player=${player.id}`}
+                              title="On trade block"
+                              aria-label="On trade block"
+                            >
+                              🏷️
+                            </a>
+                          )}
+                        </PlayerCell>
+                      </td>
+                      <td data-column="college">{player.college === 'N/A' ? '—' : player.college}</td>
+                      <td data-column="status">
+                        <span
+                          class:list={[
+                            'status-pill',
+                            player.status === 'INJURED_RESERVE'
+                              ? 'status-pill--ir'
+                              : 'status-pill--active',
+                          ]}
+                        >
+                          {player.status === 'INJURED_RESERVE' ? 'IR' : 'Active'}
+                        </span>
+                      </td>
+                      {isOwner && (
+                        <td data-column="actions">
+                          <button
+                            type="button"
+                            class="ufa-action-btn"
+                            data-action-trigger
+                            data-player-id={player.id}
+                            aria-label={`Manage ${player.name}`}
+                            title="Manage player"
+                          >
+                            <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                              <circle cx="12" cy="5" r="2"/>
+                              <circle cx="12" cy="12" r="2"/>
+                              <circle cx="12" cy="19" r="2"/>
+                            </svg>
+                          </button>
+                        </td>
+                      )}
+                    </tr>
+                  ))}
+              </tbody>
+            </table>
+          </div>
         </div>
       )}
     </section>
@@ -816,14 +820,24 @@ const pageConfig = {
     const tabs = document.querySelectorAll<HTMLButtonElement>('.view-tab');
     const containers = document.querySelectorAll<HTMLElement>('[data-view-content]');
 
+    const VIEW_LABELS: Record<string, string> = {
+      roster: 'AFL Roster',
+      analytics: 'Advanced Analytics',
+      planner: 'Keeper Planner',
+    };
+    const labelEl = document.querySelector<HTMLElement>('[data-view-label]');
+
     function switchView(viewName: string) {
       Array.from(tabs).forEach((tab) => {
         const isActive = tab.dataset.view === viewName;
-        tab.setAttribute('aria-selected', String(isActive));
+        tab.setAttribute('data-active', String(isActive));
       });
       Array.from(containers).forEach((container) => {
         container.hidden = container.dataset.viewContent !== viewName;
       });
+      if (labelEl && VIEW_LABELS[viewName]) {
+        labelEl.textContent = VIEW_LABELS[viewName];
+      }
       const url = new URL(window.location.href);
       if (viewName === 'roster') url.searchParams.delete('view');
       else url.searchParams.set('view', viewName);
@@ -861,7 +875,7 @@ const pageConfig = {
     }
 
     // ── Player details modal trigger (delegated) ──
-    const rosterContainer = document.querySelector('.afl-rosters');
+    const rosterContainer = document.querySelector('.roster-page');
     if (rosterContainer) initPlayerModalTrigger(rosterContainer as HTMLElement);
 
     // ── Player action button → AFLActionModal (owner only) ──
@@ -890,404 +904,422 @@ const pageConfig = {
   </script>
 
   <style>
-    /* ── Page shell ── */
-    .afl-rosters {
-      max-width: 1200px;
+    /* ────────────────────────────────────────────────────────────────
+       AFL roster page — matches TheLeague's roster page visual language
+       (team-card hero, icon-tile view-tabs, roster-summary, roster-table).
+       Variables come from TheLeagueLayout's global stylesheet so the look
+       stays in lockstep with the rest of the site.
+       ──────────────────────────────────────────────────────────────── */
+
+    .roster-page {
+      max-width: 1180px;
       margin: 0 auto;
-      padding: 1.5rem 1rem 4rem;
+      padding: var(--padding-md, 1rem) var(--padding-md, 1rem) var(--padding-xxl, 3rem);
       display: grid;
-      gap: 1.25rem;
+      gap: var(--padding-md, 1rem);
     }
 
-    /* ── Header card ── */
-    .afl-rosters__header {
+    /* ── Team-card hero ── */
+    .team-card {
       display: grid;
-      gap: 0.75rem;
+      padding: var(--padding-md, 1rem);
+      padding-bottom: var(--padding-xxl, 3rem); /* room for tabs on mobile */
+      justify-items: center;
+      gap: var(--padding-sm, 0.5rem);
+      border-radius: var(--radius-lg, 1rem);
+      background: var(--content-bg, #fff);
+      box-shadow: var(--shadow-lg);
+      position: relative;
+      text-align: center;
     }
 
-    .header-card {
-      display: flex;
-      gap: 1.5rem;
-      justify-content: space-between;
-      align-items: center;
-      flex-wrap: wrap;
-      background: #fff;
-      border-radius: 1rem;
-      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.06);
-      padding: 1.5rem;
+    @media (min-width: 480px) {
+      .team-card {
+        display: flex;
+        align-items: center;
+        flex-wrap: wrap;
+        padding-inline: var(--padding-lg, 1.5rem);
+        justify-content: center;
+        padding-block: var(--padding-md, 1rem) var(--padding-sm, 0.5rem);
+        text-align: left;
+      }
     }
 
-    .header-card__left {
-      display: flex;
-      align-items: center;
-      gap: 1.25rem;
-      min-width: 0;
-      flex: 1 1 320px;
-    }
-
-    .header-card__icon {
+    .team-card img {
       width: 72px;
       height: 72px;
-      object-fit: contain;
+      border-radius: 14px;
+      object-fit: cover;
+    }
+
+    .team-card__identity {
+      min-width: 0;
+    }
+
+    .team-card__label {
+      text-transform: uppercase;
+      font-size: 0.75rem;
+      font-weight: 600;
+      letter-spacing: 0.06em;
+      color: var(--color-gray-400, #9ca3af);
+      margin: 0;
+    }
+
+    .team-card__name {
+      margin: 0;
+      font-size: 1.35rem;
+      font-weight: 700;
+      line-height: 1.2;
+      color: var(--color-gray-900, #111827);
+    }
+
+    .team-card__meta {
+      margin: 0;
+      color: var(--color-gray-500, #6b7280);
+      font-size: 0.875rem;
+    }
+
+    .team-card__last-seen {
+      font-size: 0.6875rem;
+      font-weight: 500;
+      color: var(--color-gray-500, #6b7280);
+      margin: 0.125rem 0 0;
+      display: inline-flex;
+      align-items: center;
+      gap: 0.3rem;
+    }
+
+    .last-seen-dot {
+      display: inline-block;
+      width: 0.4rem;
+      height: 0.4rem;
+      border-radius: 50%;
       flex-shrink: 0;
     }
 
-    .header-card__identity {
-      min-width: 0;
+    [data-level='active'] .last-seen-dot { background: var(--activity-green, #16a34a); }
+
+    /* View tabs (SVG icon tiles) — copied structurally from TheLeague */
+    .team-card__actions {
+      width: 100%;
     }
 
-    .header-card__pills {
+    @media (min-width: 480px) {
+      .team-card__actions {
+        width: auto;
+      }
+    }
+
+    .view-tabs {
       display: flex;
-      flex-wrap: wrap;
       gap: 0.5rem;
-      margin-bottom: 0.5rem;
+      justify-content: center;
     }
 
-    .pill {
-      display: inline-block;
-      padding: 0.125rem 0.5rem;
-      border-radius: 9999px;
+    @media (min-width: 480px) {
+      .view-tabs {
+        position: absolute;
+        right: var(--padding-lg, 1.5rem);
+        top: var(--padding-lg, 1.5rem);
+      }
+    }
+
+    .view-tab {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 0.25rem;
+      padding: 0.5rem 0.7rem;
+      border: 2px solid transparent;
+      border-radius: var(--radius-md, 0.5rem);
+      background: var(--color-gray-50, #f9fafb);
+      cursor: pointer;
+      transition: all 0.2s ease;
+      position: relative;
+      min-width: 69px;
+    }
+
+    .view-tab:hover {
+      background: var(--color-gray-200, #dddedf);
+      border-color: var(--color-gray-300, #d1d5db);
+    }
+
+    .view-tab[data-active="true"] {
+      background: color-mix(in srgb, var(--color-primary, #1c497c) 12%, white);
+      border-color: var(--color-primary, #1c497c);
+    }
+
+    .view-tab__icon {
+      width: 28px;
+      height: 28px;
+      fill: var(--color-gray-500, #6b7280);
+      color: var(--color-gray-500, #6b7280);
+    }
+
+    .view-tab[data-active="true"] .view-tab__icon {
+      fill: var(--color-primary, #1c497c);
+      color: var(--color-primary, #1c497c);
+    }
+
+    .view-tab__label {
+      font-size: 0.7rem;
+      font-weight: 500;
+      color: var(--color-gray-500, #6b7280);
+      white-space: nowrap;
+    }
+
+    .view-tab[data-active="true"] .view-tab__label {
+      color: var(--color-primary, #1c497c);
+    }
+
+    /* ── Inline controls bar (team + year switcher) ── */
+    .roster-controls-bar {
+      display: flex;
+      gap: 0.75rem;
+      align-items: center;
+      flex-wrap: wrap;
+      background: var(--content-bg, #fff);
+      border-radius: var(--radius-md, 0.5rem);
+      padding: 0.625rem 1rem;
+      box-shadow: var(--shadow-sm, 0 1px 2px rgba(0, 0, 0, 0.05));
+    }
+
+    .roster-controls-bar__group {
+      display: flex;
+      align-items: center;
+      gap: 0.4rem;
+    }
+
+    .roster-controls-bar__group label {
       font-size: 0.6875rem;
-      font-weight: 700;
+      font-weight: 600;
       text-transform: uppercase;
       letter-spacing: 0.05em;
-      line-height: 1.4;
+      color: var(--color-gray-500, #6b7280);
     }
 
-    .pill--conf-al {
-      background: #fee2e2;
-      color: #991b1b;
+    .roster-controls-bar__group select {
+      padding: 0.35rem 0.5rem;
+      border: 1px solid var(--color-gray-200, #e5e7eb);
+      border-radius: var(--radius-sm, 0.25rem);
+      background: #fff;
+      font-size: 0.85rem;
+      color: var(--color-gray-900, #111827);
+      cursor: pointer;
     }
 
-    .pill--conf-nl {
-      background: #dbeafe;
-      color: #1e3a8a;
-    }
-
-    .pill--division {
-      background: #f3f4f6;
-      color: #374151;
-    }
-
-    .pill--tier-premier {
-      background: #c41e3a;
-      color: #fff;
-    }
-
-    .pill--tier-dleague {
-      background: #e5e7eb;
-      color: #374151;
-    }
-
-    .pill--owner {
-      background: #fef3c7;
-      color: #92400e;
-      border: 1px solid #fbbf24;
-    }
-
-    .header-card__name {
-      font-size: 1.875rem;
-      font-weight: 700;
-      margin: 0 0 0.25rem;
-      color: #0f172a;
-      line-height: 1.1;
-    }
-
-    .header-card__profile-link {
+    .roster-controls-bar__profile {
+      margin-left: auto;
       font-size: 0.8125rem;
-      color: #c41e3a;
+      color: var(--color-primary, #1c497c);
       text-decoration: none;
       font-weight: 600;
     }
 
-    .header-card__profile-link:hover {
-      text-decoration: underline;
-    }
+    .roster-controls-bar__profile:hover { text-decoration: underline; }
 
-    .header-card__right {
-      display: flex;
-      gap: 0.75rem;
-      flex-wrap: wrap;
-    }
-
-    .control {
-      display: flex;
-      flex-direction: column;
-      gap: 0.25rem;
-      min-width: 160px;
-    }
-
-    .control label {
-      font-size: 0.6875rem;
-      font-weight: 700;
-      text-transform: uppercase;
-      letter-spacing: 0.05em;
-      color: #6b7280;
-    }
-
-    .control select {
-      padding: 0.5rem 0.75rem;
-      border: 1px solid #d1d5db;
-      border-radius: 0.5rem;
-      background: #fff;
-      font-size: 0.9375rem;
-      font-weight: 500;
-      cursor: pointer;
-    }
-
-    .control select:focus {
-      outline: 2px solid #c41e3a;
-      outline-offset: -1px;
-      border-color: #c41e3a;
-    }
-
-    /* ── View tabs ── */
-    .view-tabs {
-      display: flex;
-      gap: 0.25rem;
-      background: #fff;
-      border-radius: 0.75rem;
-      padding: 0.25rem;
-      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.06);
-    }
-
-    .view-tab {
-      flex: 1;
-      padding: 0.625rem 1rem;
-      border: 0;
-      background: transparent;
-      border-radius: 0.5rem;
-      font-size: 0.875rem;
-      font-weight: 600;
-      color: #6b7280;
-      cursor: pointer;
-      transition: background-color 120ms ease, color 120ms ease;
-    }
-
-    .view-tab:hover {
-      background: #f3f4f6;
-      color: #111827;
-    }
-
-    .view-tab[aria-selected="true"] {
-      background: #c41e3a;
-      color: #fff;
-    }
-
-    /* ── Summary strip ── */
-    .summary-strip {
+    /* ── Roster summary cards (matches TheLeague's .roster-summary) ── */
+    .roster-summary {
       display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
-      gap: 0.5rem;
-      background: #fff;
-      border-radius: 0.75rem;
-      padding: 0.75rem;
-      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.06);
+      grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+      gap: var(--padding-md, 1rem);
     }
 
-    .summary-stat {
-      text-align: center;
-      padding: 0.5rem;
+    .roster-summary article {
+      background: var(--content-bg, #fff);
+      border-radius: var(--radius-lg, 1rem);
+      padding: var(--padding-md, 1rem);
+      box-shadow: var(--shadow-md);
     }
 
-    .summary-stat__value {
+    .roster-summary p {
+      margin: 0;
+      color: var(--color-gray-500, #6b7280);
+      font-size: 0.8rem;
+    }
+
+    .roster-summary strong {
       display: block;
-      font-size: 1.5rem;
-      font-weight: 800;
-      color: #0f172a;
-      line-height: 1;
+      margin-top: 0.35rem;
+      font-size: clamp(1.1rem, 4vw, 1.6rem);
+      line-height: 1.2;
+      font-variant-numeric: tabular-nums;
+      color: var(--color-gray-900, #111827);
     }
 
-    .summary-stat__denom {
-      font-size: 0.875rem;
-      color: #9ca3af;
-      font-weight: 600;
-    }
-
-    .summary-stat__label {
-      display: block;
-      margin-top: 0.25rem;
-      font-size: 0.6875rem;
-      font-weight: 700;
-      text-transform: uppercase;
-      letter-spacing: 0.05em;
-      color: #6b7280;
-    }
-
-    .summary-stat--accent .summary-stat__value {
-      color: #c41e3a;
+    .roster-summary__denom {
+      color: var(--color-gray-400, #9ca3af);
+      font-size: 0.75em;
+      font-weight: 500;
     }
 
     /* ── View containers ── */
     .view-container {
       display: grid;
-      gap: 1.25rem;
+      gap: var(--padding-lg, 1.5rem);
     }
 
     .view-container[hidden] {
       display: none;
     }
 
-    /* ── Position blocks ── */
-    .position-block {
-      background: #fff;
-      border-radius: 0.75rem;
-      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.06);
+    /* ── Roster table card ── */
+    .roster-table-card {
+      background: var(--content-bg, #fff);
+      border-radius: var(--radius-lg, 1rem);
+      padding: var(--padding-md, 1rem);
+      box-shadow: var(--shadow-lg);
       overflow: hidden;
     }
 
-    .position-block__header {
-      display: flex;
-      align-items: center;
-      gap: 0.5rem;
-      padding: 0.875rem 1.25rem;
-      background: linear-gradient(135deg, #c41e3a 0%, #002244 100%);
-      color: #fff;
-    }
-
-    .position-block__title {
-      margin: 0;
-      font-size: 1rem;
-      font-weight: 700;
-      letter-spacing: 0.025em;
-      text-transform: uppercase;
-    }
-
-    .position-block__count {
-      font-size: 0.75rem;
-      font-weight: 600;
-      background: rgba(255, 255, 255, 0.2);
-      padding: 0.125rem 0.5rem;
-      border-radius: 9999px;
-    }
-
-    .position-block__table-wrap {
+    .roster-table-wrapper {
       overflow-x: auto;
+      border-radius: var(--radius-md, 0.5rem);
+      background: var(--content-bg, #fff);
     }
 
     .roster-table {
       width: 100%;
       border-collapse: collapse;
-      font-size: 0.875rem;
     }
 
     .roster-table thead {
-      background: #f9fafb;
+      background: var(--color-gray-50, #f9fafb);
+      border-bottom: 1px solid var(--content-border, #e2e8f0);
     }
 
     .roster-table th {
-      padding: 0.625rem 1rem;
-      text-align: left;
-      font-size: 0.6875rem;
-      font-weight: 700;
-      text-transform: uppercase;
-      letter-spacing: 0.05em;
-      color: #6b7280;
-      border-bottom: 1px solid #e5e7eb;
-    }
-
-    .roster-table td {
-      padding: 0.625rem 1rem;
-      border-bottom: 1px solid #f3f4f6;
-      vertical-align: middle;
-    }
-
-    .roster-table tbody tr:last-child td {
-      border-bottom: 0;
-    }
-
-    .roster-table tbody tr:hover {
-      background: #fafbfc;
-    }
-
-    .col-team,
-    .col-age,
-    .col-status,
-    .col-actions {
-      text-align: center;
-    }
-
-    .col-team {
-      width: 64px;
-      color: #6b7280;
+      font-size: 0.625rem;
       font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      color: var(--color-gray-400, #9ca3af);
+      padding: 0.55rem 0.5rem;
+      text-align: right;
+      background: var(--color-gray-50, #f9fafb);
     }
 
-    .col-age {
-      width: 56px;
-      color: #6b7280;
+    .roster-table th[data-column="player"] {
+      text-align: left;
+      padding-left: 0.75rem;
     }
 
-    .col-college {
-      color: #6b7280;
-      font-size: 0.8125rem;
+    .roster-table th[data-column="college"],
+    .roster-table th[data-column="status"] {
+      text-align: left;
     }
 
-    .col-status {
-      width: 92px;
-    }
-
-    .col-actions {
+    .roster-table th[data-column="actions"] {
       width: 48px;
     }
 
-    .status-badge {
+    .roster-table td {
+      padding: 0.65rem 0.5rem;
+      border-bottom: 1px solid var(--color-gray-50, #f9fafb);
+      vertical-align: middle;
+      font-size: 0.85rem;
+      color: var(--color-gray-700, #374151);
+    }
+
+    .roster-table td[data-column="player"] {
+      text-align: left;
+      padding-left: 0.75rem;
+    }
+
+    .roster-table td[data-column="college"] {
+      color: var(--color-gray-500, #6b7280);
+      font-size: 0.8rem;
+      max-width: 180px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .roster-table td[data-column="actions"] {
+      text-align: right;
+      padding-right: 0.5rem;
+    }
+
+    .roster-table tbody tr {
+      border-left: 3px solid transparent;
+    }
+
+    .roster-table tbody tr[data-row-status="active"] {
+      border-left-color: var(--activity-green, #16a34a);
+    }
+
+    .roster-table tbody tr[data-row-status="ir"] {
+      border-left-color: var(--color-danger, #dc2626);
+    }
+
+    .roster-table tbody tr:hover {
+      background: var(--color-gray-50, #f9fafb);
+    }
+
+    /* Status pill (small, inline) */
+    .status-pill {
       display: inline-block;
       padding: 0.125rem 0.5rem;
       border-radius: 9999px;
-      font-size: 0.6875rem;
+      font-size: 0.65rem;
       font-weight: 700;
       text-transform: uppercase;
       letter-spacing: 0.05em;
-      background: #e5e7eb;
-      color: #374151;
     }
 
-    .status-badge--active {
-      background: #dcfce7;
+    .status-pill--active {
+      background: color-mix(in srgb, var(--activity-green, #16a34a) 14%, white);
       color: #166534;
     }
 
-    .status-badge--ir {
-      background: #fee2e2;
+    .status-pill--ir {
+      background: color-mix(in srgb, var(--color-danger, #dc2626) 12%, white);
       color: #991b1b;
     }
 
-    .bait-badge {
-      display: inline-block;
-      margin-left: 0.375rem;
-      padding: 0 0.375rem;
-      font-size: 0.625rem;
-      font-weight: 800;
-      letter-spacing: 0.05em;
-      background: #fef3c7;
-      color: #92400e;
-      border-radius: 0.25rem;
-      vertical-align: middle;
-    }
-
-    .action-btn {
-      width: 28px;
-      height: 28px;
-      border: 0;
-      background: transparent;
-      border-radius: 0.375rem;
-      color: #6b7280;
-      cursor: pointer;
+    /* 3-dot action button — same look TheLeague uses */
+    .ufa-action-btn {
       display: inline-flex;
       align-items: center;
       justify-content: center;
-      transition: background-color 120ms ease, color 120ms ease;
+      width: 26px;
+      height: 26px;
+      padding: 0;
+      border: 1px solid var(--color-gray-200, #d1d5db);
+      background: var(--content-bg, #fff);
+      color: var(--color-gray-500, #6b7280);
+      border-radius: 4px;
+      cursor: pointer;
+      transition: all 0.18s ease;
     }
 
-    .action-btn:hover {
-      background: #f3f4f6;
-      color: #111827;
+    .ufa-action-btn:hover {
+      background: var(--color-gray-50, #f3f4f6);
+      color: var(--color-gray-700, #374151);
+      border-color: var(--color-gray-300, #9ca3af);
+      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
     }
 
-    .action-btn:focus-visible {
-      outline: 2px solid #c41e3a;
+    .ufa-action-btn:focus-visible {
+      outline: 2px solid var(--color-primary, #1c497c);
       outline-offset: 1px;
+    }
+
+    .trade-bait-link {
+      margin-left: 0.25rem;
+      font-size: 0.9rem;
+      display: inline-block;
+      cursor: pointer;
+      text-decoration: none;
+    }
+
+    /* Hide college column on narrow screens (no horizontal scroll needed) */
+    @media (max-width: 560px) {
+      .roster-table th[data-column="college"],
+      .roster-table td[data-column="college"] {
+        display: none;
+      }
     }
 
     /* ── Analytics view ── */
@@ -1559,40 +1591,16 @@ const pageConfig = {
       font-size: 1.25rem;
     }
 
-    /* ── Mobile ── */
+    /* Mobile: tighter table cells */
     @media (max-width: 720px) {
-      .afl-rosters {
-        padding: 1rem 0.5rem 3rem;
-      }
-
-      .header-card {
-        padding: 1rem;
-      }
-
-      .header-card__icon {
-        width: 56px;
-        height: 56px;
-      }
-
-      .header-card__name {
-        font-size: 1.5rem;
-      }
-
-      .header-card__right {
-        width: 100%;
-      }
-
-      .control {
-        flex: 1;
+      .roster-page {
+        padding: 0.5rem 0.5rem 3rem;
       }
 
       .roster-table th,
       .roster-table td {
-        padding: 0.5rem 0.5rem;
-      }
-
-      .col-college {
-        display: none;
+        padding: 0.5rem 0.4rem;
+        font-size: 0.8rem;
       }
     }
   </style>

--- a/src/pages/afl-fantasy/rosters.astro
+++ b/src/pages/afl-fantasy/rosters.astro
@@ -1,21 +1,30 @@
 ---
 import TheLeagueLayout from '../../layouts/TheLeagueLayout.astro';
-import { getLeagueContext, getLeagueBaseUrl } from '../../utils/league-context';
-import aflConfig from '../../../data/afl-fantasy/afl.config.json';
+import PlayerCell from '../../components/theleague/PlayerCell.astro';
+import PlayerDetailsModal from '../../components/theleague/PlayerDetailsModal.astro';
+import { getAuthUser } from '../../utils/auth';
 import {
   setAFLPreference,
+  getAFLPreference,
   getAFLTeamData,
 } from '../../utils/team-preferences';
-import { getCurrentLeagueYear } from '../../utils/league-year';
+import {
+  getAllTeams,
+  getTeamsGroupedByConference,
+  getConferenceShort,
+  getConferenceName,
+  getTeam,
+  type AFLTeam,
+} from '../../utils/afl-conference';
 
-// Get league context from URL
-const league = getLeagueContext(Astro.url);
-const baseUrl = getLeagueBaseUrl(league);
+export const prerender = false;
 
-// Team Preference Cookie Integration
+// AFL 2026 league hasn't been created on MFL yet — hardcode 2025 until
+// the new league exists and feeds populate. Once it does, this can become
+// the same auto-detect logic theleague uses.
+const FALLBACK_YEAR = 2025;
+
 const myTeamParam = Astro.url.searchParams.get('myteam');
-
-// If myteam parameter is provided, update the cookie preference
 if (myTeamParam) {
   const teamData = getAFLTeamData(myTeamParam);
   if (teamData) {
@@ -23,502 +32,992 @@ if (myTeamParam) {
   }
 }
 
-// Import rosters data for AFL Fantasy
 const rostersFeeds = import.meta.glob('../../../data/afl-fantasy/mfl-feeds/*/rosters.json', {
   eager: true,
 });
-
-// Import players data for AFL Fantasy
 const playersFeeds = import.meta.glob('../../../data/afl-fantasy/mfl-feeds/*/players.json', {
   eager: true,
 });
+const tradeBaitFeeds = import.meta.glob('../../../data/afl-fantasy/mfl-feeds/*/tradeBait.json', {
+  eager: true,
+});
 
-// Extract available years
-const availableYears = Object.keys(rostersFeeds)
-  .map(path => {
+const getModuleData = (mod: any) =>
+  mod && typeof mod === 'object' && 'default' in mod ? mod.default : mod;
+
+// Year selector: only include years where rosters.json has real data
+// (skip the empty/errored 2026 placeholder).
+const availableYears = Object.entries(rostersFeeds)
+  .map(([path, mod]) => {
     const match = path.match(/\/(\d{4})\/rosters\.json$/);
-    return match ? parseInt(match[1], 10) : null;
+    if (!match) return null;
+    const data = getModuleData(mod) as any;
+    if (!data?.rosters?.franchise) return null;
+    return parseInt(match[1], 10);
   })
   .filter((year): year is number => year !== null)
   .sort((a, b) => b - a);
 
-// Get selected year - default to latest available or current league year
-const defaultYear = availableYears[0] || getCurrentLeagueYear();
 const requestedYear = Astro.url.searchParams.get('year');
-const selectedYear = requestedYear ? parseInt(requestedYear, 10) : defaultYear;
-
-// Validate year
-if (!availableYears.includes(selectedYear)) {
-  return Astro.redirect(`${baseUrl}/rosters?year=${defaultYear}`);
-}
-
-// Get rosters data
-const getModuleData = (mod: any) =>
-  mod && typeof mod === 'object' && 'default' in mod ? mod.default : mod;
+const parsedYear = requestedYear ? parseInt(requestedYear, 10) : NaN;
+const selectedYear =
+  !isNaN(parsedYear) && availableYears.includes(parsedYear)
+    ? parsedYear
+    : (availableYears[0] ?? FALLBACK_YEAR);
 
 const rostersData = getModuleData(
   rostersFeeds[`../../../data/afl-fantasy/mfl-feeds/${selectedYear}/rosters.json`]
-);
-
+) as any;
 const playersData = getModuleData(
   playersFeeds[`../../../data/afl-fantasy/mfl-feeds/${selectedYear}/players.json`]
-);
+) as any;
+const tradeBaitData = getModuleData(
+  tradeBaitFeeds[`../../../data/afl-fantasy/mfl-feeds/${selectedYear}/tradeBait.json`]
+) as any;
 
 if (!rostersData?.rosters?.franchise || !playersData?.players?.player) {
-  return Astro.redirect(`${baseUrl}/rosters?year=${defaultYear}`);
+  return Astro.redirect(`/afl-fantasy/rosters?year=${availableYears[0] ?? FALLBACK_YEAR}`);
 }
 
-// Create players lookup map
-const playersMap = new Map();
-playersData.players.player.forEach((p: any) => {
+// Build players lookup
+type PlayerInfo = {
+  id: string;
+  name: string;
+  position: string;
+  team: string;
+  age: string;
+  college: string;
+  birthdate?: string;
+  height?: string;
+  weight?: string;
+  draft_year?: string;
+  draft_round?: string;
+  draft_pick?: string;
+  draft_team?: string;
+  espn_id?: string;
+  jersey?: string;
+};
+const playersMap = new Map<string, PlayerInfo>();
+for (const p of playersData.players.player as any[]) {
   playersMap.set(p.id, {
     id: p.id,
-    name: p.name,
-    position: p.position,
-    team: p.team,
-    age: p.age,
-    college: p.college,
+    name: p.name || `Player ${p.id}`,
+    position: p.position || 'N/A',
+    team: p.team || 'FA',
+    age: p.age || 'N/A',
+    college: p.college || 'N/A',
+    birthdate: p.birthdate,
+    height: p.height,
+    weight: p.weight,
+    draft_year: p.draft_year,
+    draft_round: p.draft_round,
+    draft_pick: p.draft_pick,
+    draft_team: p.draft_team,
+    espn_id: p.espn_id,
+    jersey: p.jersey,
   });
-});
+}
 
-// Get selected franchise from query param or default to first team
-const selectedFranchiseId = Astro.url.searchParams.get('franchise') || aflConfig.teams[0].franchiseId;
-
-// Build teams list for dropdown
-const teamsList = aflConfig.teams
-  .map(team => ({
-    id: team.franchiseId,
-    name: team.name,
-    abbrev: team.abbrev,
-    division: team.division,
-    icon: team.icon,
-  }))
-  .sort((a, b) => {
-    // Sort by division first, then by name
-    if (a.division !== b.division) {
-      return a.division.localeCompare(b.division);
+// Trade bait set for badges
+const tradeBaitSet = new Set<string>();
+const baitPlayers = tradeBaitData?.tradeBaits?.tradeBait;
+if (baitPlayers) {
+  const arr = Array.isArray(baitPlayers) ? baitPlayers : [baitPlayers];
+  for (const b of arr) {
+    const willGiveUp = (b?.willGiveUp ?? '') as string;
+    for (const id of willGiveUp.split(',')) {
+      const trimmed = id.trim();
+      if (/^\d+$/.test(trimmed)) tradeBaitSet.add(trimmed);
     }
-    return a.name.localeCompare(b.name);
-  });
+  }
+}
 
-// Get selected team info
-const selectedTeam = teamsList.find(t => t.id === selectedFranchiseId) || teamsList[0];
+// Auth + selected franchise resolution: query param > cookie > authUser > first AL team
+const authUser = getAuthUser(Astro.request);
+const aflPref = getAFLPreference(Astro.cookies);
 
-// Get roster for selected franchise
-const franchiseRoster = rostersData.rosters.franchise.find(
+const allTeams = getAllTeams();
+const teamsByConference = getTeamsGroupedByConference();
+const fallbackTeamId = allTeams[0]?.franchiseId ?? '0001';
+
+const queryFranchiseId = Astro.url.searchParams.get('franchise');
+const isValidFranchiseId = (id: string | null | undefined): boolean =>
+  !!id && allTeams.some((t) => t.franchiseId === id);
+
+let selectedFranchiseId: string;
+if (isValidFranchiseId(queryFranchiseId)) {
+  selectedFranchiseId = queryFranchiseId!;
+} else if (aflPref?.franchiseId && isValidFranchiseId(aflPref.franchiseId)) {
+  selectedFranchiseId = aflPref.franchiseId;
+} else if (
+  authUser?.leagueId === '19621' &&
+  authUser.franchiseId &&
+  isValidFranchiseId(authUser.franchiseId)
+) {
+  selectedFranchiseId = authUser.franchiseId;
+} else {
+  selectedFranchiseId = fallbackTeamId;
+}
+
+const selectedTeam: AFLTeam = getTeam(selectedFranchiseId) ?? allTeams[0]!;
+const conferenceShort = getConferenceShort(selectedTeam.conference);
+const conferenceName = getConferenceName(selectedTeam.conference);
+
+// Owner detection: only AFL users on their own team see write actions
+const isOwner =
+  !!authUser &&
+  authUser.leagueId === '19621' &&
+  authUser.franchiseId === selectedTeam.franchiseId;
+
+// Build roster
+type RosterEntry = PlayerInfo & {
+  status: string;
+  isOnTradeBait: boolean;
+};
+const franchiseRoster = (rostersData.rosters.franchise as any[]).find(
   (f: any) => f.id === selectedFranchiseId
 );
-
-// Build roster with player details
-const roster = franchiseRoster?.player?.map((p: any) => {
-  const playerInfo = playersMap.get(p.id) || {};
+const rosterPlayers = (franchiseRoster?.player ?? []) as Array<{ id: string; status: string }>;
+const roster: RosterEntry[] = rosterPlayers.map((p) => {
+  const info = playersMap.get(p.id);
   return {
     id: p.id,
-    status: p.status,
-    name: playerInfo.name || `Player ${p.id}`,
-    position: playerInfo.position || 'N/A',
-    team: playerInfo.team || 'N/A',
-    age: playerInfo.age || 'N/A',
-    college: playerInfo.college || 'N/A',
+    status: p.status || 'ROSTER',
+    name: info?.name || `Player ${p.id}`,
+    position: info?.position || 'N/A',
+    team: info?.team || 'FA',
+    age: info?.age || 'N/A',
+    college: info?.college || 'N/A',
+    birthdate: info?.birthdate,
+    height: info?.height,
+    weight: info?.weight,
+    draft_year: info?.draft_year,
+    draft_round: info?.draft_round,
+    draft_pick: info?.draft_pick,
+    draft_team: info?.draft_team,
+    espn_id: info?.espn_id,
+    jersey: info?.jersey,
+    isOnTradeBait: tradeBaitSet.has(p.id),
   };
-}) || [];
-
-// Group players by position
-const positionOrder = ['QB', 'RB', 'WR', 'TE', 'PK', 'Def', 'Coach'];
-const rosterByPosition = new Map<string, typeof roster>();
-
-positionOrder.forEach(pos => {
-  rosterByPosition.set(pos, []);
 });
 
-roster.forEach((player: any) => {
-  const pos = player.position;
-  if (!rosterByPosition.has(pos)) {
-    rosterByPosition.set(pos, []);
+// Group + sort by position; defenses last
+const POSITION_ORDER = ['QB', 'RB', 'WR', 'TE', 'PK', 'Def', 'DEF', 'Coach'];
+const positionRank = (pos: string) => {
+  const idx = POSITION_ORDER.indexOf(pos);
+  return idx === -1 ? POSITION_ORDER.length : idx;
+};
+const rosterByPosition = new Map<string, RosterEntry[]>();
+for (const player of roster) {
+  if (!rosterByPosition.has(player.position)) {
+    rosterByPosition.set(player.position, []);
   }
-  rosterByPosition.get(pos)!.push(player);
-});
-
-// Sort players within each position by name
-rosterByPosition.forEach(players => {
+  rosterByPosition.get(player.position)!.push(player);
+}
+const sortedPositions = Array.from(rosterByPosition.keys()).sort(
+  (a, b) => positionRank(a) - positionRank(b)
+);
+for (const players of rosterByPosition.values()) {
   players.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+// Roster summary
+const totalPlayers = roster.length;
+const activeRoster = roster.filter((p) => p.status === 'ROSTER').length;
+const injuredReserve = roster.filter((p) => p.status === 'INJURED_RESERVE').length;
+const ROSTER_SIZE = 16;
+const openSlots = Math.max(0, ROSTER_SIZE - totalPlayers);
+
+// Initial view from query param
+const requestedView = Astro.url.searchParams.get('view');
+const initialView = ['roster', 'analytics', 'planner'].includes(requestedView ?? '')
+  ? requestedView!
+  : 'roster';
+
+// Player modal payload builder — keeps the SSR data shape consistent with
+// PlayerDetailsModal expectations (no salary fields; modal hides contract).
+const buildPlayerModalData = (p: RosterEntry) => ({
+  id: p.id,
+  espnId: p.espn_id,
+  name: p.name,
+  position: p.position,
+  nflTeam: p.team,
+  status: p.status,
+  college: p.college,
+  height: p.height ? Number(p.height) : null,
+  weight: p.weight ? Number(p.weight) : null,
+  number: p.jersey ? Number(p.jersey) : null,
+  draftYear: p.draft_year ? Number(p.draft_year) : null,
+  draftRound: p.draft_round ? Number(p.draft_round) : null,
+  draftPick: p.draft_pick ? Number(p.draft_pick) : null,
+  draftTeam: p.draft_team ?? null,
+  birthdate: p.birthdate ? Number(p.birthdate) : null,
+  franchiseId: selectedFranchiseId,
 });
 
-// Calculate roster counts
-const totalPlayers = roster.length;
-const activeRoster = roster.filter((p: any) => p.status === 'ROSTER').length;
-const taxiSquad = roster.filter((p: any) => p.status === 'TAXI_SQUAD').length;
-const injured = roster.filter((p: any) => p.status === 'INJURED_RESERVE').length;
+// Page-level config exposed to client JS
+const pageConfig = {
+  selectedYear,
+  selectedFranchiseId,
+  isOwner,
+  leagueId: '19621',
+  initialView,
+};
 ---
 
-<TheLeagueLayout title={`AFL Fantasy - ${selectedTeam.name} Roster`}>
-  <div class="rosters-page">
-    <!-- Header -->
-    <header class="roster-hero">
-      <div class="roster-hero__content">
-        <div class="roster-hero__team">
+<TheLeagueLayout title={`AFL Fantasy — ${selectedTeam.name} Roster`}>
+  <main class="afl-rosters" data-initial-view={initialView}>
+    <!-- Team Header Card -->
+    <header class="afl-rosters__header">
+      <div class="header-card">
+        <div class="header-card__left">
           {selectedTeam.icon && (
-            <img src={selectedTeam.icon} alt={selectedTeam.name} class="team-logo" />
+            <img class="header-card__icon" src={selectedTeam.icon} alt={`${selectedTeam.name} logo`} />
           )}
-          <div>
-            <h1 class="team-name">{selectedTeam.name}</h1>
-            <p class="team-abbrev">{selectedTeam.abbrev}</p>
+          <div class="header-card__identity">
+            <div class="header-card__pills">
+              <span
+                class:list={[
+                  'pill',
+                  'pill--conf',
+                  selectedTeam.conference === '00' ? 'pill--conf-al' : 'pill--conf-nl',
+                ]}
+                title={conferenceName}
+              >
+                {conferenceShort}
+              </span>
+              <span class="pill pill--division">{selectedTeam.division}</span>
+              <span
+                class:list={[
+                  'pill',
+                  'pill--tier',
+                  selectedTeam.tier === 'Premier League' ? 'pill--tier-premier' : 'pill--tier-dleague',
+                ]}
+              >
+                {selectedTeam.tier}
+              </span>
+              {isOwner && <span class="pill pill--owner">Your team</span>}
+            </div>
+            <h1 class="header-card__name">{selectedTeam.name}</h1>
+            <a class="header-card__profile-link" href={`/afl-fantasy/franchises/${selectedTeam.franchiseId}`}>
+              View franchise profile →
+            </a>
           </div>
         </div>
 
-        <!-- Team Selector -->
-        <div class="team-selector">
-          <label for="franchise-select">Select Team:</label>
-          <select
-            id="franchise-select"
-            onchange={`window.location.href = '${baseUrl}/rosters?year=${selectedYear}&franchise=' + this.value`}
-          >
-            {teamsList.map(team => (
-              <option value={team.id} selected={team.id === selectedFranchiseId}>
-                {team.name}
-              </option>
-            ))}
-          </select>
+        <div class="header-card__right">
+          <div class="control">
+            <label for="franchise-select">Team</label>
+            <select id="franchise-select" data-current-franchise={selectedFranchiseId}>
+              {teamsByConference.map((group) => (
+                <optgroup label={group.conferenceName}>
+                  {group.teams
+                    .slice()
+                    .sort((a, b) => a.name.localeCompare(b.name))
+                    .map((t) => (
+                      <option value={t.franchiseId} selected={t.franchiseId === selectedFranchiseId}>
+                        {t.name}
+                      </option>
+                    ))}
+                </optgroup>
+              ))}
+            </select>
+          </div>
+
+          <div class="control">
+            <label for="year-select">Year</label>
+            <select id="year-select" data-current-year={selectedYear}>
+              {availableYears.map((year) => (
+                <option value={year} selected={year === selectedYear}>{year}</option>
+              ))}
+            </select>
+          </div>
         </div>
       </div>
 
-      <!-- Roster Stats -->
-      <div class="roster-stats">
-        <div class="stat-card">
-          <div class="stat-value">{totalPlayers}</div>
-          <div class="stat-label">Total Players</div>
+      <!-- View tabs -->
+      <nav class="view-tabs" role="tablist" aria-label="Roster view">
+        <button class="view-tab" data-view="roster" role="tab" aria-selected={initialView === 'roster'}>
+          <span class="view-tab__label">Roster</span>
+        </button>
+        <button class="view-tab" data-view="analytics" role="tab" aria-selected={initialView === 'analytics'}>
+          <span class="view-tab__label">Analytics</span>
+        </button>
+        <button class="view-tab" data-view="planner" role="tab" aria-selected={initialView === 'planner'}>
+          <span class="view-tab__label">Planner</span>
+        </button>
+      </nav>
+
+      <!-- Roster summary strip -->
+      <div class="summary-strip">
+        <div class="summary-stat">
+          <span class="summary-stat__value">{activeRoster}</span>
+          <span class="summary-stat__label">Active</span>
         </div>
-        <div class="stat-card">
-          <div class="stat-value">{activeRoster}</div>
-          <div class="stat-label">Active Roster</div>
+        <div class="summary-stat">
+          <span class="summary-stat__value">{injuredReserve}</span>
+          <span class="summary-stat__label">IR</span>
         </div>
-        {taxiSquad > 0 && (
-          <div class="stat-card">
-            <div class="stat-value">{taxiSquad}</div>
-            <div class="stat-label">Taxi Squad</div>
-          </div>
-        )}
-        {injured > 0 && (
-          <div class="stat-card">
-            <div class="stat-value">{injured}</div>
-            <div class="stat-label">Injured Reserve</div>
+        <div class="summary-stat">
+          <span class="summary-stat__value">{totalPlayers}<span class="summary-stat__denom">/{ROSTER_SIZE}</span></span>
+          <span class="summary-stat__label">Roster</span>
+        </div>
+        {openSlots > 0 && (
+          <div class="summary-stat summary-stat--accent">
+            <span class="summary-stat__value">{openSlots}</span>
+            <span class="summary-stat__label">Open</span>
           </div>
         )}
       </div>
     </header>
 
-    <!-- Roster Table by Position -->
-    <main class="roster-content">
-      {Array.from(rosterByPosition.entries())
-        .filter(([_, players]) => players.length > 0)
-        .map(([position, players]) => (
-          <div class="position-group">
-            <h2 class="position-title">
-              {position} ({players.length})
-            </h2>
-
-            <div class="roster-table">
-              <table>
-                <thead>
-                  <tr>
-                    <th class="player-col">Player</th>
-                    <th class="pos-col">Pos</th>
-                    <th class="team-col">NFL Team</th>
-                    <th class="age-col">Age</th>
-                    <th class="college-col">College</th>
-                    <th class="status-col">Status</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {players.map((player: any) => (
+    <!-- Roster View -->
+    <section class="view-container" data-view-content="roster" hidden={initialView !== 'roster'}>
+      {sortedPositions
+        .filter((pos) => (rosterByPosition.get(pos)?.length ?? 0) > 0)
+        .map((position) => {
+          const players = rosterByPosition.get(position)!;
+          return (
+            <div class="position-block">
+              <header class="position-block__header">
+                <h2 class="position-block__title">{position}</h2>
+                <span class="position-block__count">{players.length}</span>
+              </header>
+              <div class="position-block__table-wrap">
+                <table class="roster-table">
+                  <thead>
                     <tr>
-                      <td class="player-col">
-                        <div class="player-name">{player.name}</div>
-                      </td>
-                      <td class="pos-col">{player.position}</td>
-                      <td class="team-col">{player.team}</td>
-                      <td class="age-col">{player.age}</td>
-                      <td class="college-col">{player.college}</td>
-                      <td class="status-col">
-                        <span class={`status-badge status-${player.status.toLowerCase().replace('_', '-')}`}>
-                          {player.status.replace('_', ' ')}
-                        </span>
-                      </td>
+                      <th class="col-player">Player</th>
+                      <th class="col-team">NFL</th>
+                      <th class="col-age">Age</th>
+                      <th class="col-college">College</th>
+                      <th class="col-status">Status</th>
+                      {isOwner && <th class="col-actions" aria-label="Actions"></th>}
                     </tr>
-                  ))}
-                </tbody>
-              </table>
+                  </thead>
+                  <tbody>
+                    {players.map((player) => (
+                      <tr
+                        data-player-id={player.id}
+                        data-player-status={player.status}
+                        data-player-name={player.name}
+                        data-on-trade-bait={player.isOnTradeBait ? 'true' : 'false'}
+                      >
+                        <td class="col-player">
+                          <PlayerCell
+                            name={player.name}
+                            position={player.position}
+                            nflTeam={player.team}
+                            mflId={player.id}
+                            espnId={player.espn_id}
+                            playerData={buildPlayerModalData(player)}
+                            size="compact"
+                          >
+                            {player.isOnTradeBait && (
+                              <span slot="after-name" class="bait-badge" title="On trade block">TB</span>
+                            )}
+                          </PlayerCell>
+                        </td>
+                        <td class="col-team">{player.team}</td>
+                        <td class="col-age">{player.age}</td>
+                        <td class="col-college">{player.college}</td>
+                        <td class="col-status">
+                          <span
+                            class:list={[
+                              'status-badge',
+                              player.status === 'INJURED_RESERVE' && 'status-badge--ir',
+                              player.status === 'ROSTER' && 'status-badge--active',
+                            ]}
+                          >
+                            {player.status === 'INJURED_RESERVE' ? 'IR' : 'Active'}
+                          </span>
+                        </td>
+                        {isOwner && (
+                          <td class="col-actions">
+                            <button
+                              type="button"
+                              class="action-btn"
+                              data-action-trigger
+                              data-player-id={player.id}
+                              aria-label={`Manage ${player.name}`}
+                              title="Manage player"
+                            >
+                              <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+                                <circle cx="3" cy="8" r="1.5" fill="currentColor" />
+                                <circle cx="8" cy="8" r="1.5" fill="currentColor" />
+                                <circle cx="13" cy="8" r="1.5" fill="currentColor" />
+                              </svg>
+                            </button>
+                          </td>
+                        )}
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
             </div>
-          </div>
-        ))}
-    </main>
-  </div>
-</TheLeagueLayout>
+          );
+        })}
 
-<style>
-  .rosters-page {
-    display: grid;
-    gap: 2rem;
-    padding: 2rem 1rem;
-  }
+      {roster.length === 0 && (
+        <div class="empty-state">
+          <p>No roster data for this team in {selectedYear}.</p>
+        </div>
+      )}
+    </section>
 
-  .roster-hero {
-    background: #fff;
-    border-radius: 1rem;
-    box-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1);
-    padding: 2rem;
-  }
+    <!-- Analytics View (stub) -->
+    <section class="view-container" data-view-content="analytics" hidden={initialView !== 'analytics'}>
+      <div class="coming-soon">
+        <h2>Analytics</h2>
+        <p>Roster composition, age distribution, position allocation, and college / NFL-team breakdowns. Coming next.</p>
+      </div>
+    </section>
 
-  .roster-hero__content {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 2rem;
-    flex-wrap: wrap;
-    gap: 1.5rem;
-  }
+    <!-- Planner View (stub) -->
+    <section class="view-container" data-view-content="planner" hidden={initialView !== 'planner'}>
+      <div class="coming-soon">
+        <h2>Planner</h2>
+        <p>Drag-and-drop keeper selection, draft assets, and offseason planning tools. Coming next.</p>
+      </div>
+    </section>
+  </main>
 
-  .roster-hero__team {
-    display: flex;
-    align-items: center;
-    gap: 1.5rem;
-  }
+  <PlayerDetailsModal hideContract />
 
-  .team-logo {
-    width: 80px;
-    height: 80px;
-    object-fit: contain;
-    border-radius: 0.5rem;
-  }
+  <script id="afl-roster-config" type="application/json" set:html={JSON.stringify(pageConfig)}></script>
 
-  .team-name {
-    font-size: 2rem;
-    font-weight: 700;
-    margin: 0;
-    color: #1e293b;
-  }
+  <script>
+    import { initPlayerModalTrigger } from '../../utils/player-modal-trigger';
 
-  .team-abbrev {
-    font-size: 1.125rem;
-    color: #64748b;
-    margin: 0.25rem 0 0 0;
-  }
+    const configEl = document.getElementById('afl-roster-config');
+    const config = configEl ? JSON.parse(configEl.textContent || '{}') : {};
 
-  .team-selector {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-  }
+    // ── View tab switching ──
+    const tabs = document.querySelectorAll<HTMLButtonElement>('.view-tab');
+    const containers = document.querySelectorAll<HTMLElement>('[data-view-content]');
 
-  .team-selector label {
-    font-weight: 600;
-    color: #475569;
-  }
-
-  .team-selector select {
-    padding: 0.5rem 1rem;
-    border: 2px solid #dddcdc;
-    border-radius: 0.5rem;
-    font-size: 1rem;
-    background: white;
-    cursor: pointer;
-    min-width: 250px;
-  }
-
-  .team-selector select:hover {
-    border-color: #cbd5e1;
-  }
-
-  .team-selector select:focus {
-    outline: none;
-    border-color: #c41e3a;
-  }
-
-  .roster-stats {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-    gap: 1rem;
-  }
-
-  .stat-card {
-    background: linear-gradient(135deg, #c41e3a 0%, #002244 100%);
-    color: white;
-    padding: 1.5rem;
-    border-radius: 0.75rem;
-    text-align: center;
-  }
-
-  .stat-value {
-    font-size: 2rem;
-    font-weight: 700;
-    margin-bottom: 0.5rem;
-  }
-
-  .stat-label {
-    font-size: 0.875rem;
-    opacity: 0.9;
-  }
-
-  .roster-content {
-    display: grid;
-    gap: 2rem;
-  }
-
-  .position-group {
-    background: #fff;
-    border-radius: 1rem;
-    box-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1);
-    overflow: hidden;
-  }
-
-  .position-title {
-    font-size: 1.5rem;
-    font-weight: 700;
-    padding: 1.5rem 2rem;
-    margin: 0;
-    background: linear-gradient(135deg, #c41e3a 0%, #002244 100%);
-    color: white;
-  }
-
-  .roster-table {
-    overflow-x: auto;
-  }
-
-  table {
-    width: 100%;
-    border-collapse: collapse;
-  }
-
-  thead {
-    background: #f8fafc;
-    border-bottom: 2px solid #dddcdc;
-  }
-
-  th {
-    padding: 1rem;
-    text-align: left;
-    font-weight: 600;
-    color: #475569;
-    font-size: 0.875rem;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-  }
-
-  tbody tr {
-    border-bottom: 1px solid #dddcdc;
-  }
-
-  tbody tr:hover {
-    background: #f8fafc;
-  }
-
-  td {
-    padding: 1rem;
-  }
-
-  .player-col {
-    min-width: 200px;
-  }
-
-  .player-name {
-    font-weight: 600;
-    color: #1e293b;
-  }
-
-  .pos-col {
-    width: 80px;
-    text-align: center;
-    font-weight: 600;
-    color: #64748b;
-  }
-
-  .team-col {
-    width: 100px;
-    text-align: center;
-  }
-
-  .age-col {
-    width: 80px;
-    text-align: center;
-  }
-
-  .college-col {
-    min-width: 150px;
-  }
-
-  .status-col {
-    width: 120px;
-    text-align: center;
-  }
-
-  .status-badge {
-    display: inline-block;
-    padding: 0.25rem 0.75rem;
-    border-radius: 9999px;
-    font-size: 0.75rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-  }
-
-  .status-roster {
-    background: #dcfce7;
-    color: #166534;
-  }
-
-  .status-taxi-squad {
-    background: #fef3c7;
-    color: #92400e;
-  }
-
-  .status-injured-reserve {
-    background: #fee2e2;
-    color: #991b1b;
-  }
-
-  @media (max-width: 767px) {
-    .rosters-page {
-      padding: 1rem 0.5rem;
+    function switchView(viewName: string) {
+      Array.from(tabs).forEach((tab) => {
+        const isActive = tab.dataset.view === viewName;
+        tab.setAttribute('aria-selected', String(isActive));
+      });
+      Array.from(containers).forEach((container) => {
+        container.hidden = container.dataset.viewContent !== viewName;
+      });
+      const url = new URL(window.location.href);
+      if (viewName === 'roster') url.searchParams.delete('view');
+      else url.searchParams.set('view', viewName);
+      window.history.replaceState({}, '', url.toString());
     }
 
-    .roster-hero {
+    Array.from(tabs).forEach((tab) => {
+      tab.addEventListener('click', () => {
+        const viewName = tab.dataset.view;
+        if (viewName) switchView(viewName);
+      });
+    });
+
+    // ── Team / year selectors ──
+    const buildUrl = (params: Record<string, string>) => {
+      const url = new URL(window.location.href);
+      for (const [k, v] of Object.entries(params)) {
+        url.searchParams.set(k, v);
+      }
+      return url.toString();
+    };
+
+    const franchiseSelect = document.getElementById('franchise-select') as HTMLSelectElement | null;
+    if (franchiseSelect) {
+      franchiseSelect.addEventListener('change', () => {
+        window.location.href = buildUrl({ franchise: franchiseSelect.value });
+      });
+    }
+
+    const yearSelect = document.getElementById('year-select') as HTMLSelectElement | null;
+    if (yearSelect) {
+      yearSelect.addEventListener('change', () => {
+        window.location.href = buildUrl({ year: yearSelect.value });
+      });
+    }
+
+    // ── Player details modal trigger (delegated) ──
+    const rosterContainer = document.querySelector('.afl-rosters');
+    if (rosterContainer) initPlayerModalTrigger(rosterContainer as HTMLElement);
+
+    // ── Player action button (placeholder until AFLActionModal lands) ──
+    document.addEventListener('click', (e) => {
+      const target = e.target as HTMLElement;
+      const trigger = target.closest('[data-action-trigger]') as HTMLButtonElement | null;
+      if (!trigger) return;
+      e.stopPropagation();
+      const row = trigger.closest('tr');
+      const playerName = row?.dataset.playerName ?? 'this player';
+      // TODO: wire to AFLActionModal in next commit. config carries the
+      // SSR-resolved franchiseId / leagueId / isOwner that the modal needs.
+      console.debug('[afl-rosters] action triggered', {
+        player: playerName,
+        franchiseId: config.selectedFranchiseId,
+      });
+      alert(
+        `Manage ${playerName}\n\n(Action modal arrives in the next commit — Cut, IR, Trade Block, Trade.)`
+      );
+    });
+  </script>
+
+  <style>
+    /* ── Page shell ── */
+    .afl-rosters {
+      max-width: 1200px;
+      margin: 0 auto;
+      padding: 1.5rem 1rem 4rem;
+      display: grid;
+      gap: 1.25rem;
+    }
+
+    /* ── Header card ── */
+    .afl-rosters__header {
+      display: grid;
+      gap: 0.75rem;
+    }
+
+    .header-card {
+      display: flex;
+      gap: 1.5rem;
+      justify-content: space-between;
+      align-items: center;
+      flex-wrap: wrap;
+      background: #fff;
+      border-radius: 1rem;
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.06);
       padding: 1.5rem;
     }
 
-    .roster-hero__content {
-      flex-direction: column;
-      align-items: flex-start;
+    .header-card__left {
+      display: flex;
+      align-items: center;
+      gap: 1.25rem;
+      min-width: 0;
+      flex: 1 1 320px;
     }
 
-    .team-logo {
-      width: 60px;
-      height: 60px;
+    .header-card__icon {
+      width: 72px;
+      height: 72px;
+      object-fit: contain;
+      flex-shrink: 0;
     }
 
-    .team-name {
-      font-size: 1.5rem;
-    }
-
-    .team-selector {
-      width: 100%;
-    }
-
-    .team-selector select {
-      flex: 1;
+    .header-card__identity {
       min-width: 0;
     }
 
-    .position-title {
-      font-size: 1.25rem;
-      padding: 1rem 1.5rem;
+    .header-card__pills {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+      margin-bottom: 0.5rem;
     }
 
-    th, td {
-      padding: 0.75rem 0.5rem;
+    .pill {
+      display: inline-block;
+      padding: 0.125rem 0.5rem;
+      border-radius: 9999px;
+      font-size: 0.6875rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      line-height: 1.4;
     }
 
-    .college-col {
+    .pill--conf-al {
+      background: #fee2e2;
+      color: #991b1b;
+    }
+
+    .pill--conf-nl {
+      background: #dbeafe;
+      color: #1e3a8a;
+    }
+
+    .pill--division {
+      background: #f3f4f6;
+      color: #374151;
+    }
+
+    .pill--tier-premier {
+      background: #c41e3a;
+      color: #fff;
+    }
+
+    .pill--tier-dleague {
+      background: #e5e7eb;
+      color: #374151;
+    }
+
+    .pill--owner {
+      background: #fef3c7;
+      color: #92400e;
+      border: 1px solid #fbbf24;
+    }
+
+    .header-card__name {
+      font-size: 1.875rem;
+      font-weight: 700;
+      margin: 0 0 0.25rem;
+      color: #0f172a;
+      line-height: 1.1;
+    }
+
+    .header-card__profile-link {
+      font-size: 0.8125rem;
+      color: #c41e3a;
+      text-decoration: none;
+      font-weight: 600;
+    }
+
+    .header-card__profile-link:hover {
+      text-decoration: underline;
+    }
+
+    .header-card__right {
+      display: flex;
+      gap: 0.75rem;
+      flex-wrap: wrap;
+    }
+
+    .control {
+      display: flex;
+      flex-direction: column;
+      gap: 0.25rem;
+      min-width: 160px;
+    }
+
+    .control label {
+      font-size: 0.6875rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: #6b7280;
+    }
+
+    .control select {
+      padding: 0.5rem 0.75rem;
+      border: 1px solid #d1d5db;
+      border-radius: 0.5rem;
+      background: #fff;
+      font-size: 0.9375rem;
+      font-weight: 500;
+      cursor: pointer;
+    }
+
+    .control select:focus {
+      outline: 2px solid #c41e3a;
+      outline-offset: -1px;
+      border-color: #c41e3a;
+    }
+
+    /* ── View tabs ── */
+    .view-tabs {
+      display: flex;
+      gap: 0.25rem;
+      background: #fff;
+      border-radius: 0.75rem;
+      padding: 0.25rem;
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.06);
+    }
+
+    .view-tab {
+      flex: 1;
+      padding: 0.625rem 1rem;
+      border: 0;
+      background: transparent;
+      border-radius: 0.5rem;
+      font-size: 0.875rem;
+      font-weight: 600;
+      color: #6b7280;
+      cursor: pointer;
+      transition: background-color 120ms ease, color 120ms ease;
+    }
+
+    .view-tab:hover {
+      background: #f3f4f6;
+      color: #111827;
+    }
+
+    .view-tab[aria-selected="true"] {
+      background: #c41e3a;
+      color: #fff;
+    }
+
+    /* ── Summary strip ── */
+    .summary-strip {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
+      gap: 0.5rem;
+      background: #fff;
+      border-radius: 0.75rem;
+      padding: 0.75rem;
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.06);
+    }
+
+    .summary-stat {
+      text-align: center;
+      padding: 0.5rem;
+    }
+
+    .summary-stat__value {
+      display: block;
+      font-size: 1.5rem;
+      font-weight: 800;
+      color: #0f172a;
+      line-height: 1;
+    }
+
+    .summary-stat__denom {
+      font-size: 0.875rem;
+      color: #9ca3af;
+      font-weight: 600;
+    }
+
+    .summary-stat__label {
+      display: block;
+      margin-top: 0.25rem;
+      font-size: 0.6875rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: #6b7280;
+    }
+
+    .summary-stat--accent .summary-stat__value {
+      color: #c41e3a;
+    }
+
+    /* ── View containers ── */
+    .view-container {
+      display: grid;
+      gap: 1.25rem;
+    }
+
+    .view-container[hidden] {
       display: none;
     }
-  }
-</style>
+
+    /* ── Position blocks ── */
+    .position-block {
+      background: #fff;
+      border-radius: 0.75rem;
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.06);
+      overflow: hidden;
+    }
+
+    .position-block__header {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.875rem 1.25rem;
+      background: linear-gradient(135deg, #c41e3a 0%, #002244 100%);
+      color: #fff;
+    }
+
+    .position-block__title {
+      margin: 0;
+      font-size: 1rem;
+      font-weight: 700;
+      letter-spacing: 0.025em;
+      text-transform: uppercase;
+    }
+
+    .position-block__count {
+      font-size: 0.75rem;
+      font-weight: 600;
+      background: rgba(255, 255, 255, 0.2);
+      padding: 0.125rem 0.5rem;
+      border-radius: 9999px;
+    }
+
+    .position-block__table-wrap {
+      overflow-x: auto;
+    }
+
+    .roster-table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.875rem;
+    }
+
+    .roster-table thead {
+      background: #f9fafb;
+    }
+
+    .roster-table th {
+      padding: 0.625rem 1rem;
+      text-align: left;
+      font-size: 0.6875rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: #6b7280;
+      border-bottom: 1px solid #e5e7eb;
+    }
+
+    .roster-table td {
+      padding: 0.625rem 1rem;
+      border-bottom: 1px solid #f3f4f6;
+      vertical-align: middle;
+    }
+
+    .roster-table tbody tr:last-child td {
+      border-bottom: 0;
+    }
+
+    .roster-table tbody tr:hover {
+      background: #fafbfc;
+    }
+
+    .col-team,
+    .col-age,
+    .col-status,
+    .col-actions {
+      text-align: center;
+    }
+
+    .col-team {
+      width: 64px;
+      color: #6b7280;
+      font-weight: 600;
+    }
+
+    .col-age {
+      width: 56px;
+      color: #6b7280;
+    }
+
+    .col-college {
+      color: #6b7280;
+      font-size: 0.8125rem;
+    }
+
+    .col-status {
+      width: 92px;
+    }
+
+    .col-actions {
+      width: 48px;
+    }
+
+    .status-badge {
+      display: inline-block;
+      padding: 0.125rem 0.5rem;
+      border-radius: 9999px;
+      font-size: 0.6875rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      background: #e5e7eb;
+      color: #374151;
+    }
+
+    .status-badge--active {
+      background: #dcfce7;
+      color: #166534;
+    }
+
+    .status-badge--ir {
+      background: #fee2e2;
+      color: #991b1b;
+    }
+
+    .bait-badge {
+      display: inline-block;
+      margin-left: 0.375rem;
+      padding: 0 0.375rem;
+      font-size: 0.625rem;
+      font-weight: 800;
+      letter-spacing: 0.05em;
+      background: #fef3c7;
+      color: #92400e;
+      border-radius: 0.25rem;
+      vertical-align: middle;
+    }
+
+    .action-btn {
+      width: 28px;
+      height: 28px;
+      border: 0;
+      background: transparent;
+      border-radius: 0.375rem;
+      color: #6b7280;
+      cursor: pointer;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      transition: background-color 120ms ease, color 120ms ease;
+    }
+
+    .action-btn:hover {
+      background: #f3f4f6;
+      color: #111827;
+    }
+
+    .action-btn:focus-visible {
+      outline: 2px solid #c41e3a;
+      outline-offset: 1px;
+    }
+
+    /* ── Empty / coming-soon states ── */
+    .empty-state,
+    .coming-soon {
+      background: #fff;
+      border-radius: 0.75rem;
+      padding: 3rem 1.5rem;
+      text-align: center;
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.06);
+      color: #6b7280;
+    }
+
+    .coming-soon h2 {
+      margin: 0 0 0.5rem;
+      color: #111827;
+      font-size: 1.25rem;
+    }
+
+    /* ── Mobile ── */
+    @media (max-width: 720px) {
+      .afl-rosters {
+        padding: 1rem 0.5rem 3rem;
+      }
+
+      .header-card {
+        padding: 1rem;
+      }
+
+      .header-card__icon {
+        width: 56px;
+        height: 56px;
+      }
+
+      .header-card__name {
+        font-size: 1.5rem;
+      }
+
+      .header-card__right {
+        width: 100%;
+      }
+
+      .control {
+        flex: 1;
+      }
+
+      .roster-table th,
+      .roster-table td {
+        padding: 0.5rem 0.5rem;
+      }
+
+      .col-college {
+        display: none;
+      }
+    }
+  </style>
+</TheLeagueLayout>

--- a/src/pages/afl-fantasy/rosters.astro
+++ b/src/pages/afl-fantasy/rosters.astro
@@ -217,19 +217,20 @@ const positionRank = (pos: string) => {
   const idx = POSITION_ORDER.indexOf(pos);
   return idx === -1 ? POSITION_ORDER.length : idx;
 };
-const rosterByPosition = new Map<string, RosterEntry[]>();
-for (const player of roster) {
-  if (!rosterByPosition.has(player.position)) {
-    rosterByPosition.set(player.position, []);
-  }
-  rosterByPosition.get(player.position)!.push(player);
-}
-const sortedPositions = Array.from(rosterByPosition.keys()).sort(
-  (a, b) => positionRank(a) - positionRank(b)
-);
-for (const players of rosterByPosition.values()) {
-  players.sort((a, b) => a.name.localeCompare(b.name));
-}
+// Table sort: active roster first (by position then name), then IR at the
+// bottom. Mirrors TheLeague's roster page — the green left-border stripe
+// on active rows + the red stripe on IR rows makes the split obvious
+// without a dedicated Status column.
+const sortedTableRoster: RosterEntry[] = (() => {
+  const byStatus = (status: string) =>
+    roster
+      .filter((p) => p.status === status)
+      .sort((a, b) => {
+        const r = positionRank(a.position) - positionRank(b.position);
+        return r !== 0 ? r : a.name.localeCompare(b.name);
+      });
+  return [...byStatus('ROSTER'), ...byStatus('INJURED_RESERVE')];
+})();
 
 // Roster summary
 const totalPlayers = roster.length;
@@ -562,77 +563,62 @@ const pageConfig = {
                 <tr>
                   <th data-column="player">Player</th>
                   <th data-column="college">College</th>
-                  <th data-column="status">Status</th>
                   {isOwner && <th data-column="actions" aria-label="Actions"></th>}
                 </tr>
               </thead>
               <tbody>
-                {sortedPositions
-                  .flatMap((pos) => rosterByPosition.get(pos) ?? [])
-                  .map((player) => (
-                    <tr
-                      data-player-id={player.id}
-                      data-player-status={player.status}
-                      data-player-name={player.name}
-                      data-on-trade-bait={player.isOnTradeBait ? 'true' : 'false'}
-                      data-row-status={player.status === 'INJURED_RESERVE' ? 'ir' : 'active'}
-                    >
-                      <td data-column="player">
-                        <PlayerCell
-                          name={player.name}
-                          position={player.position}
-                          nflTeam={player.team}
-                          mflId={player.id}
-                          espnId={player.espn_id}
-                          playerData={buildPlayerModalData(player)}
-                          size="compact"
-                        >
-                          {player.isOnTradeBait && (
-                            <a
-                              slot="after-name"
-                              class="trade-bait-link"
-                              href={`/afl-fantasy/trade-builder?from=${selectedFranchiseId}&player=${player.id}`}
-                              title="On trade block"
-                              aria-label="On trade block"
-                            >
-                              🏷️
-                            </a>
-                          )}
-                        </PlayerCell>
-                      </td>
-                      <td data-column="college">{player.college === 'N/A' ? '—' : player.college}</td>
-                      <td data-column="status">
-                        <span
-                          class:list={[
-                            'status-pill',
-                            player.status === 'INJURED_RESERVE'
-                              ? 'status-pill--ir'
-                              : 'status-pill--active',
-                          ]}
-                        >
-                          {player.status === 'INJURED_RESERVE' ? 'IR' : 'Active'}
-                        </span>
-                      </td>
-                      {isOwner && (
-                        <td data-column="actions">
-                          <button
-                            type="button"
-                            class="ufa-action-btn"
-                            data-action-trigger
-                            data-player-id={player.id}
-                            aria-label={`Manage ${player.name}`}
-                            title="Manage player"
+                {sortedTableRoster.map((player) => (
+                  <tr
+                    data-player-id={player.id}
+                    data-player-status={player.status}
+                    data-player-name={player.name}
+                    data-on-trade-bait={player.isOnTradeBait ? 'true' : 'false'}
+                    data-row-status={player.status === 'INJURED_RESERVE' ? 'ir' : 'active'}
+                  >
+                    <td data-column="player">
+                      <PlayerCell
+                        name={player.name}
+                        position={player.position}
+                        nflTeam={player.team}
+                        mflId={player.id}
+                        espnId={player.espn_id}
+                        playerData={buildPlayerModalData(player)}
+                        size="compact"
+                      >
+                        {player.isOnTradeBait && (
+                          <a
+                            slot="after-name"
+                            class="trade-bait-link"
+                            href={`/afl-fantasy/trade-builder?from=${selectedFranchiseId}&player=${player.id}`}
+                            title="On trade block"
+                            aria-label="On trade block"
                           >
-                            <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                              <circle cx="12" cy="5" r="2"/>
-                              <circle cx="12" cy="12" r="2"/>
-                              <circle cx="12" cy="19" r="2"/>
-                            </svg>
-                          </button>
-                        </td>
-                      )}
-                    </tr>
-                  ))}
+                            🏷️
+                          </a>
+                        )}
+                      </PlayerCell>
+                    </td>
+                    <td data-column="college">{player.college === 'N/A' ? '—' : player.college}</td>
+                    {isOwner && (
+                      <td data-column="actions">
+                        <button
+                          type="button"
+                          class="ufa-action-btn"
+                          data-action-trigger
+                          data-player-id={player.id}
+                          aria-label={`Manage ${player.name}`}
+                          title="Manage player"
+                        >
+                          <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                            <circle cx="12" cy="5" r="2"/>
+                            <circle cx="12" cy="12" r="2"/>
+                            <circle cx="12" cy="19" r="2"/>
+                          </svg>
+                        </button>
+                      </td>
+                    )}
+                  </tr>
+                ))}
               </tbody>
             </table>
           </div>
@@ -1222,8 +1208,7 @@ const pageConfig = {
       padding-left: 0.75rem;
     }
 
-    .roster-table th[data-column="college"],
-    .roster-table th[data-column="status"] {
+    .roster-table th[data-column="college"] {
       text-align: left;
     }
 
@@ -1272,27 +1257,6 @@ const pageConfig = {
 
     .roster-table tbody tr:hover {
       background: var(--color-gray-50, #f9fafb);
-    }
-
-    /* Status pill (small, inline) */
-    .status-pill {
-      display: inline-block;
-      padding: 0.125rem 0.5rem;
-      border-radius: 9999px;
-      font-size: 0.65rem;
-      font-weight: 700;
-      text-transform: uppercase;
-      letter-spacing: 0.05em;
-    }
-
-    .status-pill--active {
-      background: color-mix(in srgb, var(--activity-green, #16a34a) 14%, white);
-      color: #166534;
-    }
-
-    .status-pill--ir {
-      background: color-mix(in srgb, var(--color-danger, #dc2626) 12%, white);
-      color: #991b1b;
     }
 
     /* 3-dot action button — same look TheLeague uses */

--- a/src/pages/afl-fantasy/rosters.astro
+++ b/src/pages/afl-fantasy/rosters.astro
@@ -17,6 +17,11 @@ import {
   type NflMatchup,
 } from '../../utils/nfl-matchups';
 import { normalizeTeamCode } from '../../utils/nfl-logo';
+import {
+  loadAflPlayerScores,
+  loadAflProjections,
+  aggregateScores,
+} from '../../utils/afl-player-scoring';
 import { getAuthUser } from '../../utils/auth';
 import {
   setAFLPreference,
@@ -254,10 +259,25 @@ const nflYear = new Date().getFullYear();
 const fpaData = loadFantasyPointsAllowed(nflYear) ?? loadFantasyPointsAllowed(nflYear - 1);
 const oddsMap = await fetchNflMatchups(nflWeek, { year: nflYear });
 
+// AFL per-player scoring (Avg, Last week) + projected points. Both readers
+// gracefully return empty maps when the snapshot files are absent so the
+// page still renders during offseason / before MFL produces the feed.
+const aflScores = loadAflPlayerScores(selectedYear);
+const aflProjections = loadAflProjections(selectedYear);
+
 interface PlayerMatchup {
   matchup: NflMatchup | null;
   oppRank: number | null;
+  oppAvg: number | null;
   oppCode: string | null;
+  /** Player's last-week score from playerScores.json (null if missing). */
+  lastScore: number | null;
+  /** Projected points for the week — from projectedScores.json. */
+  projected: number | null;
+  /** Sample-size of the average; renders the column as "—" when zero. */
+  scoreSampleSize: number;
+  /** Mean of all per-week scores we have on file. */
+  scoreAverage: number | null;
 }
 const matchupByPlayerId = new Map<string, PlayerMatchup>();
 for (const player of sortedTableRoster) {
@@ -265,12 +285,33 @@ for (const player of sortedTableRoster) {
   const matchup = teamCode ? oddsMap[teamCode] ?? null : null;
   const oppCode = matchup ? normalizeTeamCode(matchup.opponent) : null;
   const fpa = oppCode ? getOpponentFpa(fpaData, oppCode, player.position) : null;
+  const agg = aggregateScores(aflScores, player.id);
   matchupByPlayerId.set(player.id, {
     matchup,
     oppRank: fpa?.rank ?? null,
+    oppAvg: fpa?.avg ?? null,
     oppCode,
+    lastScore: agg.lastScore,
+    projected: aflProjections.get(player.id) ?? null,
+    scoreSampleSize: agg.sampleSize,
+    scoreAverage: agg.average,
   });
 }
+
+// Small format helpers so the JSX stays declarative
+const formatPoints = (v: number | null): string =>
+  v == null ? '—' : v.toFixed(1);
+const formatWeather = (m: NflMatchup | null): string => {
+  if (!m?.weather) return '—';
+  const t = m.weather.temperature;
+  if (typeof t === 'number') return `${Math.round(t)}°`;
+  return m.weather.displayValue ?? '—';
+};
+const formatOverUnder = (m: NflMatchup | null): string => {
+  if (!m?.overUnder) return '—';
+  const trimmed = m.overUnder.trim();
+  return trimmed && trimmed !== 'N/A' ? trimmed : '—';
+};
 
 // Roster summary
 const totalPlayers = roster.length;
@@ -604,13 +645,24 @@ const pageConfig = {
                   <th data-column="player">Player</th>
                   <th data-column="oppRank">Opp #</th>
                   <th data-column="opponent">Opponent</th>
+                  <th data-column="ou">O/U</th>
+                  <th data-column="weather">Weather</th>
+                  <th data-column="oppAvg">Opp Avg</th>
+                  <th data-column="avg">Avg</th>
+                  <th data-column="projected">Proj</th>
                   {isOwner && <th data-column="actions" aria-label="Actions"></th>}
                 </tr>
               </thead>
               <tbody>
                 {sortedTableRoster.map((player) => {
-                  const m = matchupByPlayerId.get(player.id) ?? { matchup: null, oppRank: null, oppCode: null };
-                  const tier = m.oppRank != null ? fpaTier(m.oppRank) : null;
+                  const m = matchupByPlayerId.get(player.id);
+                  const matchup = m?.matchup ?? null;
+                  const oppCode = m?.oppCode ?? null;
+                  const oppRank = m?.oppRank ?? null;
+                  const oppAvg = m?.oppAvg ?? null;
+                  const avg = m?.scoreAverage ?? null;
+                  const projected = m?.projected ?? null;
+                  const tier = oppRank != null ? fpaTier(oppRank) : null;
                   return (
                     <tr
                       data-player-id={player.id}
@@ -643,19 +695,19 @@ const pageConfig = {
                         </PlayerCell>
                       </td>
                       <td data-column="oppRank">
-                        {m.oppRank != null ? (
-                          <span class={`rank-badge rank-tier-${tier}`}>#{m.oppRank}</span>
+                        {oppRank != null ? (
+                          <span class={`rank-badge rank-tier-${tier}`}>#{oppRank}</span>
                         ) : (
                           <span class="opp-empty">—</span>
                         )}
                       </td>
                       <td data-column="opponent">
-                        {m.matchup && m.oppCode ? (
+                        {matchup && oppCode ? (
                           <span class="opponent-cell">
-                            <span class="vs-at">{m.matchup.isHome ? 'vs' : '@'}</span>
+                            <span class="vs-at">{matchup.isHome ? 'vs' : '@'}</span>
                             <img
-                              src={`/assets/nfl-logos/${m.oppCode}.svg`}
-                              alt={m.oppCode}
+                              src={`/assets/nfl-logos/${oppCode}.svg`}
+                              alt={oppCode}
                               class="opponent-logo"
                               loading="lazy"
                               onerror="this.style.display='none'"
@@ -664,6 +716,21 @@ const pageConfig = {
                         ) : (
                           <span class="opponent-bye">BYE</span>
                         )}
+                      </td>
+                      <td data-column="ou">
+                        <span class="num-cell">{formatOverUnder(matchup)}</span>
+                      </td>
+                      <td data-column="weather">
+                        <span class="num-cell">{formatWeather(matchup)}</span>
+                      </td>
+                      <td data-column="oppAvg">
+                        <span class="num-cell">{formatPoints(oppAvg)}</span>
+                      </td>
+                      <td data-column="avg">
+                        <span class="num-cell">{formatPoints(avg)}</span>
+                      </td>
+                      <td data-column="projected">
+                        <span class="num-cell num-cell--strong">{formatPoints(projected)}</span>
                       </td>
                       {isOwner && (
                         <td data-column="actions">
@@ -1251,6 +1318,7 @@ const pageConfig = {
 
     .roster-table {
       width: 100%;
+      min-width: 740px; /* keeps the 8 Coach columns readable; horizontal scrolls on phones */
       border-collapse: collapse;
     }
 
@@ -1282,17 +1350,14 @@ const pageConfig = {
       font-weight: 600;
     }
 
-    .roster-table th[data-column="oppRank"] {
-      width: 64px;
-    }
-
-    .roster-table th[data-column="opponent"] {
-      width: 96px;
-    }
-
-    .roster-table th[data-column="actions"] {
-      width: 48px;
-    }
+    .roster-table th[data-column="oppRank"] { width: 64px; }
+    .roster-table th[data-column="opponent"] { width: 96px; }
+    .roster-table th[data-column="ou"] { width: 56px; text-align: right; }
+    .roster-table th[data-column="weather"] { width: 64px; text-align: right; }
+    .roster-table th[data-column="oppAvg"] { width: 64px; text-align: right; }
+    .roster-table th[data-column="avg"] { width: 56px; text-align: right; }
+    .roster-table th[data-column="projected"] { width: 56px; text-align: right; }
+    .roster-table th[data-column="actions"] { width: 48px; }
 
     .roster-table td {
       padding: 0.65rem 0.5rem;
@@ -1310,6 +1375,26 @@ const pageConfig = {
     .roster-table td[data-column="oppRank"],
     .roster-table td[data-column="opponent"] {
       text-align: left;
+    }
+
+    .roster-table td[data-column="ou"],
+    .roster-table td[data-column="weather"],
+    .roster-table td[data-column="oppAvg"],
+    .roster-table td[data-column="avg"],
+    .roster-table td[data-column="projected"] {
+      text-align: right;
+      white-space: nowrap;
+    }
+
+    .num-cell {
+      font-variant-numeric: tabular-nums;
+      font-size: 0.85rem;
+      color: var(--color-gray-700, #374151);
+    }
+
+    .num-cell--strong {
+      font-weight: 700;
+      color: var(--color-gray-900, #111827);
     }
 
     .roster-table td[data-column="actions"] {

--- a/src/pages/afl-fantasy/rosters.astro
+++ b/src/pages/afl-fantasy/rosters.astro
@@ -2,6 +2,7 @@
 import TheLeagueLayout from '../../layouts/TheLeagueLayout.astro';
 import PlayerCell from '../../components/theleague/PlayerCell.astro';
 import PlayerDetailsModal from '../../components/theleague/PlayerDetailsModal.astro';
+import AFLActionModal from '../../components/afl-fantasy/AFLActionModal.astro';
 import { getAuthUser } from '../../utils/auth';
 import {
   setAFLPreference,
@@ -484,6 +485,7 @@ const pageConfig = {
   </main>
 
   <PlayerDetailsModal hideContract />
+  {isOwner && <AFLActionModal />}
 
   <script id="afl-roster-config" type="application/json" set:html={JSON.stringify(pageConfig)}></script>
 
@@ -545,23 +547,28 @@ const pageConfig = {
     const rosterContainer = document.querySelector('.afl-rosters');
     if (rosterContainer) initPlayerModalTrigger(rosterContainer as HTMLElement);
 
-    // ── Player action button (placeholder until AFLActionModal lands) ──
+    // ── Player action button → AFLActionModal (owner only) ──
     document.addEventListener('click', (e) => {
       const target = e.target as HTMLElement;
       const trigger = target.closest('[data-action-trigger]') as HTMLButtonElement | null;
       if (!trigger) return;
       e.stopPropagation();
-      const row = trigger.closest('tr');
-      const playerName = row?.dataset.playerName ?? 'this player';
-      // TODO: wire to AFLActionModal in next commit. config carries the
-      // SSR-resolved franchiseId / leagueId / isOwner that the modal needs.
-      console.debug('[afl-rosters] action triggered', {
-        player: playerName,
+      const row = trigger.closest('tr') as HTMLTableRowElement | null;
+      if (!row) return;
+      const opener = (window as any).openAFLActionModal as
+        | ((p: { playerId: string; playerName: string; status?: string; isOnTradeBait?: boolean; franchiseId?: string }) => void)
+        | undefined;
+      if (typeof opener !== 'function') {
+        console.warn('[afl-rosters] AFLActionModal not loaded; ignoring action.');
+        return;
+      }
+      opener({
+        playerId: row.dataset.playerId ?? '',
+        playerName: row.dataset.playerName ?? 'Player',
+        status: row.dataset.playerStatus,
+        isOnTradeBait: row.dataset.onTradeBait === 'true',
         franchiseId: config.selectedFranchiseId,
       });
-      alert(
-        `Manage ${playerName}\n\n(Action modal arrives in the next commit — Cut, IR, Trade Block, Trade.)`
-      );
     });
   </script>
 

--- a/src/pages/afl-fantasy/rosters.astro
+++ b/src/pages/afl-fantasy/rosters.astro
@@ -1024,18 +1024,46 @@ const pageConfig = {
       const row = trigger.closest('tr') as HTMLTableRowElement | null;
       if (!row) return;
       const opener = (window as any).openAFLActionModal as
-        | ((p: { playerId: string; playerName: string; status?: string; isOnTradeBait?: boolean; franchiseId?: string }) => void)
+        | ((p: {
+            playerId: string;
+            playerName: string;
+            status?: string;
+            isOnTradeBait?: boolean;
+            franchiseId?: string;
+            headshot?: string;
+            position?: string;
+            nflTeam?: string;
+          }) => void)
         | undefined;
       if (typeof opener !== 'function') {
         console.warn('[afl-rosters] AFLActionModal not loaded; ignoring action.');
         return;
       }
+
+      // Pull the player lockup details off the PlayerCell already rendered in
+      // the row. This avoids duplicating the same data into row dataset
+      // attributes server-side, and keeps the modal hero in sync with whatever
+      // PlayerCell ended up resolving (NFL-photo / college-photo / default).
+      const playerCell = row.querySelector('[data-column="player"] .player-cell');
+      const headshotImg = playerCell?.querySelector('.player-cell__avatar img') as HTMLImageElement | null;
+      const logoImg = playerCell?.querySelector('.player-meta__logo') as HTMLImageElement | null;
+      const posEl = playerCell?.querySelector('.player-meta__pos');
+      // Position label can include contract tags ("QB - RC"); strip them.
+      const positionRaw = posEl?.textContent?.trim().split('-')[0]?.trim() ?? '';
+      // Logo URL ends in `/{TEAM}.svg`; pull the code off the end.
+      const logoSrc = logoImg?.getAttribute('src') ?? '';
+      const teamCodeMatch = logoSrc.match(/\/nfl-logos\/([^/.]+)\.svg$/);
+      const teamCode = teamCodeMatch ? teamCodeMatch[1] : '';
+
       opener({
         playerId: row.dataset.playerId ?? '',
         playerName: row.dataset.playerName ?? 'Player',
         status: row.dataset.playerStatus,
         isOnTradeBait: row.dataset.onTradeBait === 'true',
         franchiseId: config.selectedFranchiseId,
+        headshot: headshotImg?.getAttribute('src') ?? undefined,
+        position: positionRaw || undefined,
+        nflTeam: teamCode || undefined,
       });
     });
   </script>

--- a/src/pages/afl-fantasy/rosters.astro
+++ b/src/pages/afl-fantasy/rosters.astro
@@ -3,6 +3,10 @@ import TheLeagueLayout from '../../layouts/TheLeagueLayout.astro';
 import PlayerCell from '../../components/theleague/PlayerCell.astro';
 import PlayerDetailsModal from '../../components/theleague/PlayerDetailsModal.astro';
 import AFLActionModal from '../../components/afl-fantasy/AFLActionModal.astro';
+import KeeperPlanner, {
+  type KeeperPlannerPlayer,
+  type KeeperPlannerDraftPick,
+} from '../../components/afl-fantasy/KeeperPlanner.astro';
 import { getAuthUser } from '../../utils/auth';
 import {
   setAFLPreference,
@@ -42,6 +46,9 @@ const playersFeeds = import.meta.glob('../../../data/afl-fantasy/mfl-feeds/*/pla
 const tradeBaitFeeds = import.meta.glob('../../../data/afl-fantasy/mfl-feeds/*/tradeBait.json', {
   eager: true,
 });
+const futurePicksFeeds = import.meta.glob('../../../data/afl-fantasy/mfl-feeds/*/futureDraftPicks.json', {
+  eager: true,
+});
 
 const getModuleData = (mod: any) =>
   mod && typeof mod === 'object' && 'default' in mod ? mod.default : mod;
@@ -74,6 +81,9 @@ const playersData = getModuleData(
 ) as any;
 const tradeBaitData = getModuleData(
   tradeBaitFeeds[`../../../data/afl-fantasy/mfl-feeds/${selectedYear}/tradeBait.json`]
+) as any;
+const futurePicksData = getModuleData(
+  futurePicksFeeds[`../../../data/afl-fantasy/mfl-feeds/${selectedYear}/futureDraftPicks.json`]
 ) as any;
 
 if (!rostersData?.rosters?.franchise || !playersData?.players?.player) {
@@ -228,6 +238,42 @@ const activeRoster = roster.filter((p) => p.status === 'ROSTER').length;
 const injuredReserve = roster.filter((p) => p.status === 'INJURED_RESERVE').length;
 const ROSTER_SIZE = 16;
 const openSlots = Math.max(0, ROSTER_SIZE - totalPlayers);
+
+// Build the KeeperPlanner inputs (only really used when isOwner is true)
+const plannerRoster: KeeperPlannerPlayer[] = roster.map((p) => ({
+  id: p.id,
+  name: p.name,
+  position: p.position,
+  team: p.team,
+  age: p.age,
+  espnId: p.espn_id,
+  status: p.status,
+}));
+
+const teamNameLookup = new Map<string, string>(
+  allTeams.map((t) => [t.franchiseId, t.nameShort || t.name])
+);
+const plannerDraftPicks: KeeperPlannerDraftPick[] = (() => {
+  const franchise = (futurePicksData?.futureDraftPicks?.franchise as any[] | undefined)?.find(
+    (f) => f?.id === selectedFranchiseId
+  );
+  const picks = franchise?.futureDraftPick;
+  if (!picks) return [];
+  const arr = Array.isArray(picks) ? picks : [picks];
+  return arr
+    .filter((p: any) => p?.year && p?.round && p?.originalPickFor)
+    .map((p: any) => ({
+      year: String(p.year),
+      round: String(p.round),
+      originalPickFor: String(p.originalPickFor),
+      originalPickForName: teamNameLookup.get(String(p.originalPickFor)),
+      isTraded: String(p.originalPickFor) !== selectedFranchiseId,
+    }))
+    .sort((a, b) => {
+      if (a.year !== b.year) return a.year.localeCompare(b.year);
+      return parseInt(a.round, 10) - parseInt(b.round, 10);
+    });
+})();
 
 // Initial view from query param
 const requestedView = Astro.url.searchParams.get('view');
@@ -475,12 +521,21 @@ const pageConfig = {
       </div>
     </section>
 
-    <!-- Planner View (stub) -->
+    <!-- Planner View -->
     <section class="view-container" data-view-content="planner" hidden={initialView !== 'planner'}>
-      <div class="coming-soon">
-        <h2>Planner</h2>
-        <p>Drag-and-drop keeper selection, draft assets, and offseason planning tools. Coming next.</p>
-      </div>
+      {isOwner ? (
+        <KeeperPlanner
+          franchiseId={selectedFranchiseId}
+          year={selectedYear}
+          roster={plannerRoster}
+          draftPicks={plannerDraftPicks}
+        />
+      ) : (
+        <div class="coming-soon">
+          <h2>Planner</h2>
+          <p>The keeper planner is private to each team owner. Sign in as {selectedTeam.name}'s owner to use it.</p>
+        </div>
+      )}
     </section>
   </main>
 

--- a/src/pages/afl-fantasy/rosters.astro
+++ b/src/pages/afl-fantasy/rosters.astro
@@ -275,6 +275,126 @@ const plannerDraftPicks: KeeperPlannerDraftPick[] = (() => {
     });
 })();
 
+// ── Analytics: simple descriptive stats for the Analytics view ──
+type AnalyticsBucket = { label: string; count: number; pct: number };
+
+function bucketize(items: string[], topN?: number): AnalyticsBucket[] {
+  const counts = new Map<string, number>();
+  for (const v of items) {
+    if (!v || v === 'N/A' || v === 'FA') continue;
+    counts.set(v, (counts.get(v) ?? 0) + 1);
+  }
+  const total = items.length;
+  let buckets = Array.from(counts.entries())
+    .map(([label, count]) => ({ label, count, pct: total ? (count / total) * 100 : 0 }))
+    .sort((a, b) => b.count - a.count || a.label.localeCompare(b.label));
+  if (topN) buckets = buckets.slice(0, topN);
+  return buckets;
+}
+
+const positionDistribution: AnalyticsBucket[] = (() => {
+  const PRIMARY_POSITIONS = ['QB', 'RB', 'WR', 'TE', 'PK'];
+  const counts = new Map<string, number>();
+  for (const p of roster) {
+    const pos = p.position;
+    const key = PRIMARY_POSITIONS.includes(pos)
+      ? pos
+      : pos === 'DEF' || pos === 'Def'
+        ? 'DEF'
+        : 'Other';
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+  const ordered = [...PRIMARY_POSITIONS, 'DEF', 'Other'];
+  return ordered
+    .map((label) => ({
+      label,
+      count: counts.get(label) ?? 0,
+      pct: roster.length ? ((counts.get(label) ?? 0) / roster.length) * 100 : 0,
+    }))
+    .filter((b) => b.count > 0);
+})();
+
+const ageBuckets: AnalyticsBucket[] = (() => {
+  const ranges: Array<{ label: string; min: number; max: number }> = [
+    { label: '≤23', min: 0, max: 23 },
+    { label: '24–26', min: 24, max: 26 },
+    { label: '27–29', min: 27, max: 29 },
+    { label: '30+', min: 30, max: 99 },
+  ];
+  const ages = roster
+    .map((p) => Number(p.age))
+    .filter((n) => Number.isFinite(n) && n > 0);
+  return ranges.map((r) => {
+    const count = ages.filter((a) => a >= r.min && a <= r.max).length;
+    return {
+      label: r.label,
+      count,
+      pct: ages.length ? (count / ages.length) * 100 : 0,
+    };
+  }).filter((b) => b.count > 0);
+})();
+
+const ageStats: { avg: number | null; oldest: { name: string; age: number } | null; youngest: { name: string; age: number } | null } =
+  (() => {
+    const withAge = roster
+      .map((p) => ({ name: p.name, age: Number(p.age) }))
+      .filter((p) => Number.isFinite(p.age) && p.age > 0);
+    if (!withAge.length) return { avg: null, oldest: null, youngest: null };
+    const sum = withAge.reduce((acc, p) => acc + p.age, 0);
+    const sortedByAge = [...withAge].sort((a, b) => a.age - b.age);
+    return {
+      avg: sum / withAge.length,
+      youngest: sortedByAge[0]!,
+      oldest: sortedByAge[sortedByAge.length - 1]!,
+    };
+  })();
+
+const nflTeamDistribution: AnalyticsBucket[] = bucketize(
+  roster.map((p) => p.team),
+  10
+);
+const collegeDistribution: AnalyticsBucket[] = bucketize(
+  roster.map((p) => p.college),
+  8
+);
+
+// Color palette for position donut chart (consistent everywhere)
+const POSITION_COLORS: Record<string, string> = {
+  QB: '#c41e3a',
+  RB: '#2563eb',
+  WR: '#16a34a',
+  TE: '#9333ea',
+  PK: '#ea580c',
+  DEF: '#0891b2',
+  Other: '#64748b',
+};
+
+// Build the SVG path string for donut chart segments
+function makeDonutSegments(buckets: AnalyticsBucket[]) {
+  const total = buckets.reduce((s, b) => s + b.count, 0);
+  if (total === 0) return [];
+  let cumulative = 0;
+  return buckets.map((b) => {
+    const startPct = cumulative / total;
+    cumulative += b.count;
+    const endPct = cumulative / total;
+    // Map to circumference; using r=42 so circumference ≈ 263.89
+    const circumference = 2 * Math.PI * 42;
+    const dashLength = (endPct - startPct) * circumference;
+    const dashOffset = -startPct * circumference;
+    return {
+      label: b.label,
+      count: b.count,
+      pct: b.pct,
+      color: POSITION_COLORS[b.label] ?? '#64748b',
+      dashArray: `${dashLength} ${circumference - dashLength}`,
+      dashOffset,
+    };
+  });
+}
+
+const donutSegments = makeDonutSegments(positionDistribution);
+
 // Initial view from query param
 const requestedView = Astro.url.searchParams.get('view');
 const initialView = ['roster', 'analytics', 'planner'].includes(requestedView ?? '')
@@ -513,12 +633,154 @@ const pageConfig = {
       )}
     </section>
 
-    <!-- Analytics View (stub) -->
+    <!-- Analytics View -->
     <section class="view-container" data-view-content="analytics" hidden={initialView !== 'analytics'}>
-      <div class="coming-soon">
-        <h2>Analytics</h2>
-        <p>Roster composition, age distribution, position allocation, and college / NFL-team breakdowns. Coming next.</p>
-      </div>
+      {roster.length === 0 ? (
+        <div class="empty-state">
+          <p>No roster data to analyze in {selectedYear}.</p>
+        </div>
+      ) : (
+        <div class="analytics-grid">
+          <!-- Position composition donut -->
+          <article class="chart-card chart-card--span-2">
+            <header class="chart-card__header">
+              <h3 class="chart-card__title">Position composition</h3>
+              <p class="chart-card__subtitle">{roster.length} players on roster</p>
+            </header>
+            <div class="donut-row">
+              <svg
+                class="donut-chart"
+                viewBox="0 0 100 100"
+                role="img"
+                aria-label="Position composition donut chart"
+              >
+                <circle cx="50" cy="50" r="42" fill="transparent" stroke="#f3f4f6" stroke-width="14" />
+                {donutSegments.map((seg) => (
+                  <circle
+                    cx="50"
+                    cy="50"
+                    r="42"
+                    fill="transparent"
+                    stroke={seg.color}
+                    stroke-width="14"
+                    stroke-dasharray={seg.dashArray}
+                    stroke-dashoffset={seg.dashOffset}
+                    transform="rotate(-90 50 50)"
+                  >
+                    <title>{seg.label}: {seg.count} ({seg.pct.toFixed(0)}%)</title>
+                  </circle>
+                ))}
+                <text x="50" y="48" text-anchor="middle" class="donut-chart__num">{roster.length}</text>
+                <text x="50" y="60" text-anchor="middle" class="donut-chart__label">PLAYERS</text>
+              </svg>
+              <ul class="donut-legend">
+                {positionDistribution.map((b) => (
+                  <li>
+                    <span
+                      class="donut-legend__swatch"
+                      style={`background:${POSITION_COLORS[b.label] ?? '#64748b'}`}
+                    ></span>
+                    <span class="donut-legend__label">{b.label}</span>
+                    <span class="donut-legend__count">{b.count}</span>
+                    <span class="donut-legend__pct">{b.pct.toFixed(0)}%</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </article>
+
+          <!-- Age stats card -->
+          <article class="chart-card">
+            <header class="chart-card__header">
+              <h3 class="chart-card__title">Age</h3>
+              <p class="chart-card__subtitle">Average / range</p>
+            </header>
+            <div class="age-stats">
+              <div class="age-stats__big">
+                <span class="age-stats__value">{ageStats.avg ? ageStats.avg.toFixed(1) : '—'}</span>
+                <span class="age-stats__label">Avg age</span>
+              </div>
+              <div class="age-stats__minmax">
+                <div class="age-stats__row">
+                  <span class="age-stats__row-label">Youngest</span>
+                  <span class="age-stats__row-name">{ageStats.youngest?.name ?? '—'}</span>
+                  <span class="age-stats__row-age">{ageStats.youngest?.age ?? '—'}</span>
+                </div>
+                <div class="age-stats__row">
+                  <span class="age-stats__row-label">Oldest</span>
+                  <span class="age-stats__row-name">{ageStats.oldest?.name ?? '—'}</span>
+                  <span class="age-stats__row-age">{ageStats.oldest?.age ?? '—'}</span>
+                </div>
+              </div>
+            </div>
+          </article>
+
+          <!-- Age distribution bars -->
+          <article class="chart-card chart-card--span-2">
+            <header class="chart-card__header">
+              <h3 class="chart-card__title">Age distribution</h3>
+              <p class="chart-card__subtitle">How your roster splits by age</p>
+            </header>
+            <ul class="bar-list">
+              {ageBuckets.map((b) => (
+                <li class="bar-row">
+                  <span class="bar-row__label">{b.label}</span>
+                  <span class="bar-row__track">
+                    <span class="bar-row__fill" style={`width:${b.pct}%`}></span>
+                  </span>
+                  <span class="bar-row__count">{b.count}</span>
+                </li>
+              ))}
+            </ul>
+          </article>
+
+          <!-- NFL team distribution -->
+          <article class="chart-card">
+            <header class="chart-card__header">
+              <h3 class="chart-card__title">NFL teams</h3>
+              <p class="chart-card__subtitle">Top {nflTeamDistribution.length} represented</p>
+            </header>
+            {nflTeamDistribution.length === 0 ? (
+              <p class="chart-card__empty">No NFL team data yet.</p>
+            ) : (
+              <ul class="bar-list bar-list--compact">
+                {nflTeamDistribution.map((b) => (
+                  <li class="bar-row">
+                    <span class="bar-row__label bar-row__label--code">{b.label}</span>
+                    <span class="bar-row__track">
+                      <span class="bar-row__fill bar-row__fill--blue" style={`width:${b.pct}%`}></span>
+                    </span>
+                    <span class="bar-row__count">{b.count}</span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </article>
+
+          <!-- College distribution -->
+          <article class="chart-card">
+            <header class="chart-card__header">
+              <h3 class="chart-card__title">Colleges</h3>
+              <p class="chart-card__subtitle">Top {collegeDistribution.length} represented</p>
+            </header>
+            {collegeDistribution.length === 0 ? (
+              <p class="chart-card__empty">No college data yet.</p>
+            ) : (
+              <ul class="bar-list bar-list--compact">
+                {collegeDistribution.map((b) => (
+                  <li class="bar-row">
+                    <span class="bar-row__label">{b.label}</span>
+                    <span class="bar-row__track">
+                      <span class="bar-row__fill bar-row__fill--green" style={`width:${b.pct}%`}></span>
+                    </span>
+                    <span class="bar-row__count">{b.count}</span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </article>
+        </div>
+      )}
     </section>
 
     <!-- Planner View -->
@@ -1026,6 +1288,258 @@ const pageConfig = {
     .action-btn:focus-visible {
       outline: 2px solid #c41e3a;
       outline-offset: 1px;
+    }
+
+    /* ── Analytics view ── */
+    .analytics-grid {
+      display: grid;
+      grid-template-columns: repeat(2, 1fr);
+      gap: 1rem;
+    }
+
+    .chart-card {
+      background: #fff;
+      border-radius: 0.75rem;
+      padding: 1.25rem;
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.06);
+    }
+
+    .chart-card--span-2 {
+      grid-column: span 2;
+    }
+
+    .chart-card__header {
+      margin-bottom: 1rem;
+    }
+
+    .chart-card__title {
+      margin: 0;
+      font-size: 0.875rem;
+      font-weight: 700;
+      color: #0f172a;
+    }
+
+    .chart-card__subtitle {
+      margin: 0.125rem 0 0;
+      font-size: 0.75rem;
+      color: #6b7280;
+    }
+
+    .chart-card__empty {
+      margin: 0;
+      font-size: 0.8125rem;
+      color: #9ca3af;
+      text-align: center;
+      padding: 1rem 0;
+    }
+
+    .donut-row {
+      display: flex;
+      align-items: center;
+      gap: 1.5rem;
+      flex-wrap: wrap;
+    }
+
+    .donut-chart {
+      width: 160px;
+      height: 160px;
+      flex-shrink: 0;
+    }
+
+    .donut-chart__num {
+      font-size: 14px;
+      font-weight: 800;
+      fill: #0f172a;
+    }
+
+    .donut-chart__label {
+      font-size: 4px;
+      letter-spacing: 0.5px;
+      fill: #6b7280;
+      font-weight: 700;
+    }
+
+    .donut-legend {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      flex: 1;
+      min-width: 160px;
+      display: grid;
+      gap: 0.375rem;
+    }
+
+    .donut-legend li {
+      display: grid;
+      grid-template-columns: 12px 1fr auto auto;
+      align-items: center;
+      gap: 0.5rem;
+      font-size: 0.8125rem;
+    }
+
+    .donut-legend__swatch {
+      display: block;
+      width: 12px;
+      height: 12px;
+      border-radius: 2px;
+    }
+
+    .donut-legend__label {
+      color: #0f172a;
+      font-weight: 600;
+    }
+
+    .donut-legend__count {
+      color: #374151;
+      font-weight: 600;
+      font-variant-numeric: tabular-nums;
+    }
+
+    .donut-legend__pct {
+      color: #6b7280;
+      font-size: 0.75rem;
+      font-variant-numeric: tabular-nums;
+    }
+
+    .age-stats {
+      display: grid;
+      gap: 1rem;
+    }
+
+    .age-stats__big {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      padding: 0.75rem;
+      background: linear-gradient(135deg, #c41e3a 0%, #002244 100%);
+      border-radius: 0.5rem;
+      color: #fff;
+    }
+
+    .age-stats__value {
+      font-size: 2.25rem;
+      font-weight: 800;
+      line-height: 1;
+    }
+
+    .age-stats__label {
+      margin-top: 0.25rem;
+      font-size: 0.6875rem;
+      font-weight: 700;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+    }
+
+    .age-stats__minmax {
+      display: grid;
+      gap: 0.5rem;
+    }
+
+    .age-stats__row {
+      display: grid;
+      grid-template-columns: 70px 1fr auto;
+      gap: 0.5rem;
+      align-items: center;
+      padding: 0.375rem 0.625rem;
+      background: #f9fafb;
+      border-radius: 0.375rem;
+      font-size: 0.8125rem;
+    }
+
+    .age-stats__row-label {
+      font-size: 0.6875rem;
+      font-weight: 700;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+      color: #6b7280;
+    }
+
+    .age-stats__row-name {
+      color: #0f172a;
+      font-weight: 600;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .age-stats__row-age {
+      font-weight: 700;
+      color: #0f172a;
+      font-variant-numeric: tabular-nums;
+    }
+
+    .bar-list {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: grid;
+      gap: 0.5rem;
+    }
+
+    .bar-list--compact {
+      gap: 0.375rem;
+    }
+
+    .bar-row {
+      display: grid;
+      grid-template-columns: 84px 1fr 36px;
+      align-items: center;
+      gap: 0.625rem;
+      font-size: 0.8125rem;
+    }
+
+    .bar-row__label {
+      color: #374151;
+      font-weight: 600;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .bar-row__label--code {
+      font-family: ui-monospace, SFMono-Regular, monospace;
+      font-size: 0.75rem;
+    }
+
+    .bar-row__track {
+      position: relative;
+      height: 12px;
+      background: #f3f4f6;
+      border-radius: 6px;
+      overflow: hidden;
+    }
+
+    .bar-row__fill {
+      position: absolute;
+      inset: 0;
+      background: #c41e3a;
+      border-radius: 6px;
+      transition: width 200ms ease;
+    }
+
+    .bar-row__fill--blue {
+      background: #2563eb;
+    }
+
+    .bar-row__fill--green {
+      background: #16a34a;
+    }
+
+    .bar-row__count {
+      color: #374151;
+      font-weight: 700;
+      font-variant-numeric: tabular-nums;
+      text-align: right;
+    }
+
+    @media (max-width: 720px) {
+      .analytics-grid {
+        grid-template-columns: 1fr;
+      }
+
+      .chart-card--span-2 {
+        grid-column: span 1;
+      }
     }
 
     /* ── Empty / coming-soon states ── */

--- a/src/pages/afl-fantasy/rosters.astro
+++ b/src/pages/afl-fantasy/rosters.astro
@@ -8,6 +8,15 @@ import KeeperPlanner, {
   type KeeperPlannerDraftPick,
 } from '../../components/afl-fantasy/KeeperPlanner.astro';
 import { spriteUrl } from '../../utils/sprite-url';
+import { getCurrentWeek } from '../../utils/current-week';
+import {
+  fetchNflMatchups,
+  loadFantasyPointsAllowed,
+  getOpponentFpa,
+  fpaTier,
+  type NflMatchup,
+} from '../../utils/nfl-matchups';
+import { normalizeTeamCode } from '../../utils/nfl-logo';
 import { getAuthUser } from '../../utils/auth';
 import {
   setAFLPreference,
@@ -231,6 +240,37 @@ const sortedTableRoster: RosterEntry[] = (() => {
       });
   return [...byStatus('ROSTER'), ...byStatus('INJURED_RESERVE')];
 })();
+
+// ── Coach-mode matchup data (matches TheLeague's roster Coach tab) ──
+//
+// For every player on the roster, look up their NFL team's matchup for the
+// current NFL week + the opponent's defensive rank against the player's
+// position. Both sources gracefully no-op outside the regular season.
+//
+// We use TheLeague's fantasyPointsAllowed.json file — it's NFL-wide data
+// (not league-specific) so the same snapshot serves both league sites.
+const nflWeek = getCurrentWeek();
+const nflYear = new Date().getFullYear();
+const fpaData = loadFantasyPointsAllowed(nflYear) ?? loadFantasyPointsAllowed(nflYear - 1);
+const oddsMap = await fetchNflMatchups(nflWeek, { year: nflYear });
+
+interface PlayerMatchup {
+  matchup: NflMatchup | null;
+  oppRank: number | null;
+  oppCode: string | null;
+}
+const matchupByPlayerId = new Map<string, PlayerMatchup>();
+for (const player of sortedTableRoster) {
+  const teamCode = player.team ? normalizeTeamCode(player.team) : '';
+  const matchup = teamCode ? oddsMap[teamCode] ?? null : null;
+  const oppCode = matchup ? normalizeTeamCode(matchup.opponent) : null;
+  const fpa = oppCode ? getOpponentFpa(fpaData, oppCode, player.position) : null;
+  matchupByPlayerId.set(player.id, {
+    matchup,
+    oppRank: fpa?.rank ?? null,
+    oppCode,
+  });
+}
 
 // Roster summary
 const totalPlayers = roster.length;
@@ -562,63 +602,90 @@ const pageConfig = {
               <thead>
                 <tr>
                   <th data-column="player">Player</th>
-                  <th data-column="college">College</th>
+                  <th data-column="oppRank">Opp #</th>
+                  <th data-column="opponent">Opponent</th>
                   {isOwner && <th data-column="actions" aria-label="Actions"></th>}
                 </tr>
               </thead>
               <tbody>
-                {sortedTableRoster.map((player) => (
-                  <tr
-                    data-player-id={player.id}
-                    data-player-status={player.status}
-                    data-player-name={player.name}
-                    data-on-trade-bait={player.isOnTradeBait ? 'true' : 'false'}
-                    data-row-status={player.status === 'INJURED_RESERVE' ? 'ir' : 'active'}
-                  >
-                    <td data-column="player">
-                      <PlayerCell
-                        name={player.name}
-                        position={player.position}
-                        nflTeam={player.team}
-                        mflId={player.id}
-                        espnId={player.espn_id}
-                        playerData={buildPlayerModalData(player)}
-                        size="compact"
-                      >
-                        {player.isOnTradeBait && (
-                          <a
-                            slot="after-name"
-                            class="trade-bait-link"
-                            href={`/afl-fantasy/trade-builder?from=${selectedFranchiseId}&player=${player.id}`}
-                            title="On trade block"
-                            aria-label="On trade block"
-                          >
-                            🏷️
-                          </a>
-                        )}
-                      </PlayerCell>
-                    </td>
-                    <td data-column="college">{player.college === 'N/A' ? '—' : player.college}</td>
-                    {isOwner && (
-                      <td data-column="actions">
-                        <button
-                          type="button"
-                          class="ufa-action-btn"
-                          data-action-trigger
-                          data-player-id={player.id}
-                          aria-label={`Manage ${player.name}`}
-                          title="Manage player"
+                {sortedTableRoster.map((player) => {
+                  const m = matchupByPlayerId.get(player.id) ?? { matchup: null, oppRank: null, oppCode: null };
+                  const tier = m.oppRank != null ? fpaTier(m.oppRank) : null;
+                  return (
+                    <tr
+                      data-player-id={player.id}
+                      data-player-status={player.status}
+                      data-player-name={player.name}
+                      data-on-trade-bait={player.isOnTradeBait ? 'true' : 'false'}
+                      data-row-status={player.status === 'INJURED_RESERVE' ? 'ir' : 'active'}
+                    >
+                      <td data-column="player">
+                        <PlayerCell
+                          name={player.name}
+                          position={player.position}
+                          nflTeam={player.team}
+                          mflId={player.id}
+                          espnId={player.espn_id}
+                          playerData={buildPlayerModalData(player)}
+                          size="compact"
                         >
-                          <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                            <circle cx="12" cy="5" r="2"/>
-                            <circle cx="12" cy="12" r="2"/>
-                            <circle cx="12" cy="19" r="2"/>
-                          </svg>
-                        </button>
+                          {player.isOnTradeBait && (
+                            <a
+                              slot="after-name"
+                              class="trade-bait-link"
+                              href={`/afl-fantasy/trade-builder?from=${selectedFranchiseId}&player=${player.id}`}
+                              title="On trade block"
+                              aria-label="On trade block"
+                            >
+                              🏷️
+                            </a>
+                          )}
+                        </PlayerCell>
                       </td>
-                    )}
-                  </tr>
-                ))}
+                      <td data-column="oppRank">
+                        {m.oppRank != null ? (
+                          <span class={`rank-badge rank-tier-${tier}`}>#{m.oppRank}</span>
+                        ) : (
+                          <span class="opp-empty">—</span>
+                        )}
+                      </td>
+                      <td data-column="opponent">
+                        {m.matchup && m.oppCode ? (
+                          <span class="opponent-cell">
+                            <span class="vs-at">{m.matchup.isHome ? 'vs' : '@'}</span>
+                            <img
+                              src={`/assets/nfl-logos/${m.oppCode}.svg`}
+                              alt={m.oppCode}
+                              class="opponent-logo"
+                              loading="lazy"
+                              onerror="this.style.display='none'"
+                            />
+                          </span>
+                        ) : (
+                          <span class="opponent-bye">BYE</span>
+                        )}
+                      </td>
+                      {isOwner && (
+                        <td data-column="actions">
+                          <button
+                            type="button"
+                            class="ufa-action-btn"
+                            data-action-trigger
+                            data-player-id={player.id}
+                            aria-label={`Manage ${player.name}`}
+                            title="Manage player"
+                          >
+                            <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                              <circle cx="12" cy="5" r="2"/>
+                              <circle cx="12" cy="12" r="2"/>
+                              <circle cx="12" cy="19" r="2"/>
+                            </svg>
+                          </button>
+                        </td>
+                      )}
+                    </tr>
+                  );
+                })}
               </tbody>
             </table>
           </div>
@@ -1208,8 +1275,18 @@ const pageConfig = {
       padding-left: 0.75rem;
     }
 
-    .roster-table th[data-column="college"] {
+    .roster-table th[data-column="oppRank"],
+    .roster-table th[data-column="opponent"] {
       text-align: left;
+      font-weight: 600;
+    }
+
+    .roster-table th[data-column="oppRank"] {
+      width: 64px;
+    }
+
+    .roster-table th[data-column="opponent"] {
+      width: 96px;
     }
 
     .roster-table th[data-column="actions"] {
@@ -1229,18 +1306,62 @@ const pageConfig = {
       padding-left: 0.75rem;
     }
 
-    .roster-table td[data-column="college"] {
-      color: var(--color-gray-500, #6b7280);
-      font-size: 0.8rem;
-      max-width: 180px;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
+    .roster-table td[data-column="oppRank"],
+    .roster-table td[data-column="opponent"] {
+      text-align: left;
     }
 
     .roster-table td[data-column="actions"] {
       text-align: right;
       padding-right: 0.5rem;
+    }
+
+    /* OPP # rank badge — color-tiered by FPA rank
+       (1-8 = red / tough; 25-32 = green / good matchup) */
+    .rank-badge {
+      display: inline-block;
+      padding: 0.12rem 0.55rem;
+      border-radius: 0.5rem;
+      font-weight: 700;
+      font-size: 0.75rem;
+      font-variant-numeric: tabular-nums;
+      line-height: 1.4;
+    }
+
+    .rank-tier-4 { background: #d1fae5; color: #047857; border: 1px solid #a7f3d0; }
+    .rank-tier-3 { background: #ecfdf5; color: #047857; border: 1px solid #d1fae5; }
+    .rank-tier-2 { background: #fef2f2; color: #b91c1c; border: 1px solid #fee2e2; }
+    .rank-tier-1 { background: #fee2e2; color: #b91c1c; border: 1px solid #fecaca; }
+
+    .opp-empty {
+      color: var(--color-gray-400, #9ca3af);
+    }
+
+    /* Opponent cell — vs/@ + NFL logo, matches TheLeague's Coach tab */
+    .opponent-cell {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4rem;
+    }
+
+    .vs-at {
+      font-size: 0.75rem;
+      color: var(--color-gray-500, #64748b);
+      font-weight: 500;
+      width: 1.25rem;
+      text-align: center;
+    }
+
+    .opponent-logo {
+      width: 22px;
+      height: 22px;
+      object-fit: contain;
+    }
+
+    .opponent-bye {
+      color: var(--color-gray-400, #9ca3af);
+      font-style: italic;
+      font-size: 0.8rem;
     }
 
     .roster-table tbody tr {
@@ -1293,14 +1414,6 @@ const pageConfig = {
       display: inline-block;
       cursor: pointer;
       text-decoration: none;
-    }
-
-    /* Hide college column on narrow screens (no horizontal scroll needed) */
-    @media (max-width: 560px) {
-      .roster-table th[data-column="college"],
-      .roster-table td[data-column="college"] {
-        display: none;
-      }
     }
 
     /* ── Analytics view ── */

--- a/src/pages/afl-fantasy/rosters.astro
+++ b/src/pages/afl-fantasy/rosters.astro
@@ -643,6 +643,7 @@ const pageConfig = {
               <thead>
                 <tr>
                   <th data-column="player">Player</th>
+                  {isOwner && <th data-column="actions" aria-label="Actions"></th>}
                   <th data-column="oppRank">Opp #</th>
                   <th data-column="opponent">Opponent</th>
                   <th data-column="ou">O/U</th>
@@ -650,7 +651,6 @@ const pageConfig = {
                   <th data-column="oppAvg">Opp Avg</th>
                   <th data-column="avg">Avg</th>
                   <th data-column="projected">Proj</th>
-                  {isOwner && <th data-column="actions" aria-label="Actions"></th>}
                 </tr>
               </thead>
               <tbody>
@@ -694,6 +694,24 @@ const pageConfig = {
                           )}
                         </PlayerCell>
                       </td>
+                      {isOwner && (
+                        <td data-column="actions">
+                          <button
+                            type="button"
+                            class="ufa-action-btn"
+                            data-action-trigger
+                            data-player-id={player.id}
+                            aria-label={`Manage ${player.name}`}
+                            title="Manage player"
+                          >
+                            <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                              <circle cx="12" cy="5" r="2"/>
+                              <circle cx="12" cy="12" r="2"/>
+                              <circle cx="12" cy="19" r="2"/>
+                            </svg>
+                          </button>
+                        </td>
+                      )}
                       <td data-column="oppRank">
                         {oppRank != null ? (
                           <span class={`rank-badge rank-tier-${tier}`}>#{oppRank}</span>
@@ -732,24 +750,6 @@ const pageConfig = {
                       <td data-column="projected">
                         <span class="num-cell num-cell--strong">{formatPoints(projected)}</span>
                       </td>
-                      {isOwner && (
-                        <td data-column="actions">
-                          <button
-                            type="button"
-                            class="ufa-action-btn"
-                            data-action-trigger
-                            data-player-id={player.id}
-                            aria-label={`Manage ${player.name}`}
-                            title="Manage player"
-                          >
-                            <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                              <circle cx="12" cy="5" r="2"/>
-                              <circle cx="12" cy="12" r="2"/>
-                              <circle cx="12" cy="19" r="2"/>
-                            </svg>
-                          </button>
-                        </td>
-                      )}
                     </tr>
                   );
                 })}
@@ -1397,9 +1397,13 @@ const pageConfig = {
       color: var(--color-gray-900, #111827);
     }
 
+    /* Actions column now sits immediately after the player name; align the
+       button to the left so it reads as part of the row's identity block
+       rather than a right-edge afterthought. */
     .roster-table td[data-column="actions"] {
-      text-align: right;
-      padding-right: 0.5rem;
+      text-align: left;
+      padding-left: 0.25rem;
+      padding-right: 0.25rem;
     }
 
     /* OPP # rank badge — color-tiered by FPA rank

--- a/src/pages/afl-fantasy/trade-builder.astro
+++ b/src/pages/afl-fantasy/trade-builder.astro
@@ -1,0 +1,987 @@
+---
+import TheLeagueLayout from '../../layouts/TheLeagueLayout.astro';
+import PlayerCell from '../../components/theleague/PlayerCell.astro';
+import { getAuthUser } from '../../utils/auth';
+import {
+  getAllTeams,
+  getTeam,
+  getConferenceTeams,
+  getConferenceShort,
+  type AFLTeam,
+  type ConferenceId,
+} from '../../utils/afl-conference';
+
+export const prerender = false;
+
+const FALLBACK_YEAR = 2025;
+
+// Data — pull rosters + players + ADP for the current AFL season
+const rostersFeeds = import.meta.glob('../../../data/afl-fantasy/mfl-feeds/*/rosters.json', { eager: true });
+const playersFeeds = import.meta.glob('../../../data/afl-fantasy/mfl-feeds/*/players.json', { eager: true });
+const adpFeeds = import.meta.glob('../../../data/afl-fantasy/mfl-feeds/*/adp-dynasty.json', { eager: true });
+const picksFeeds = import.meta.glob('../../../data/afl-fantasy/mfl-feeds/*/futureDraftPicks.json', { eager: true });
+
+const getModuleData = (mod: any) => (mod && typeof mod === 'object' && 'default' in mod ? mod.default : mod);
+
+const availableYears = Object.entries(rostersFeeds)
+  .map(([path, mod]) => {
+    const match = path.match(/\/(\d{4})\/rosters\.json$/);
+    if (!match) return null;
+    const data = getModuleData(mod) as any;
+    return data?.rosters?.franchise ? parseInt(match[1], 10) : null;
+  })
+  .filter((y): y is number => y !== null)
+  .sort((a, b) => b - a);
+
+const selectedYear = availableYears[0] ?? FALLBACK_YEAR;
+
+const rostersData = getModuleData(rostersFeeds[`../../../data/afl-fantasy/mfl-feeds/${selectedYear}/rosters.json`]) as any;
+const playersData = getModuleData(playersFeeds[`../../../data/afl-fantasy/mfl-feeds/${selectedYear}/players.json`]) as any;
+const adpData = getModuleData(adpFeeds[`../../../data/afl-fantasy/mfl-feeds/${selectedYear}/adp-dynasty.json`]) as any;
+const picksData = getModuleData(picksFeeds[`../../../data/afl-fantasy/mfl-feeds/${selectedYear}/futureDraftPicks.json`]) as any;
+
+// Auth — must be an AFL owner
+const authUser = getAuthUser(Astro.request);
+const isAflOwner = !!authUser && authUser.leagueId === '19621' && !!authUser.franchiseId;
+
+const allTeams = getAllTeams();
+
+// Derive "from" and "to" from query params (?from=0001&to=0002&player=12345)
+const queryFrom = Astro.url.searchParams.get('from');
+const queryTo = Astro.url.searchParams.get('to');
+const queryPlayer = Astro.url.searchParams.get('player');
+
+const fromFranchiseId =
+  isAflOwner && (!queryFrom || queryFrom === authUser!.franchiseId)
+    ? authUser!.franchiseId!
+    : (queryFrom && allTeams.some((t) => t.franchiseId === queryFrom)
+        ? queryFrom
+        : authUser?.franchiseId ?? '0001');
+
+const fromTeam: AFLTeam | undefined = getTeam(fromFranchiseId);
+const fromConference: ConferenceId | null = fromTeam?.conference ?? null;
+const sameConferenceTeams = fromConference
+  ? getConferenceTeams(fromConference).filter((t) => t.franchiseId !== fromFranchiseId)
+  : [];
+
+const toFranchiseId =
+  queryTo && sameConferenceTeams.some((t) => t.franchiseId === queryTo)
+    ? queryTo
+    : sameConferenceTeams[0]?.franchiseId ?? null;
+const toTeam: AFLTeam | undefined = toFranchiseId ? getTeam(toFranchiseId) : undefined;
+
+// Build player info map
+type PlayerLite = {
+  id: string;
+  name: string;
+  position: string;
+  team: string;
+  age: string;
+  espnId?: string;
+  adp?: number;
+  adpRank?: number;
+};
+const playerMap = new Map<string, PlayerLite>();
+for (const p of (playersData?.players?.player ?? []) as any[]) {
+  playerMap.set(p.id, {
+    id: p.id,
+    name: p.name || `Player ${p.id}`,
+    position: p.position || 'N/A',
+    team: p.team || 'FA',
+    age: p.age || 'N/A',
+    espnId: p.espn_id,
+  });
+}
+
+// Enrich with ADP
+for (const a of (adpData?.adp?.player ?? []) as any[]) {
+  const info = playerMap.get(a.id);
+  if (info) {
+    info.adp = parseFloat(a.averagePick);
+    info.adpRank = parseInt(a.rank, 10);
+  }
+}
+
+// Get rosters
+function rosterFor(franchiseId: string): PlayerLite[] {
+  const f = (rostersData?.rosters?.franchise as any[] | undefined)?.find((fr) => fr.id === franchiseId);
+  if (!f?.player) return [];
+  const arr = Array.isArray(f.player) ? f.player : [f.player];
+  return arr
+    .map((p: any) => playerMap.get(p.id))
+    .filter((p: PlayerLite | undefined): p is PlayerLite => !!p)
+    .sort((a: PlayerLite, b: PlayerLite) => {
+      // ADP rank first (lower = more valuable), unranked players at the end
+      const aRank = a.adpRank ?? 9999;
+      const bRank = b.adpRank ?? 9999;
+      return aRank - bRank;
+    });
+}
+
+const fromRoster = rosterFor(fromFranchiseId);
+const toRoster = toFranchiseId ? rosterFor(toFranchiseId) : [];
+
+// Pre-selected player from query param
+const preSelectedPlayer =
+  queryPlayer && fromRoster.some((p) => p.id === queryPlayer) ? queryPlayer : null;
+
+// Future draft picks for both teams
+type DraftPickAsset = {
+  token: string;
+  label: string;
+  year: string;
+  round: number;
+  originalPickFor: string;
+  isOriginal: boolean;
+};
+const teamNameLookup = new Map<string, string>(allTeams.map((t) => [t.franchiseId, t.nameShort || t.name]));
+function picksFor(franchiseId: string): DraftPickAsset[] {
+  const f = (picksData?.futureDraftPicks?.franchise as any[] | undefined)?.find((fr) => fr.id === franchiseId);
+  if (!f?.futureDraftPick) return [];
+  const arr = Array.isArray(f.futureDraftPick) ? f.futureDraftPick : [f.futureDraftPick];
+  return arr
+    .map((p: any) => ({
+      year: String(p.year),
+      round: parseInt(p.round, 10),
+      originalPickFor: String(p.originalPickFor),
+      isOriginal: String(p.originalPickFor) === franchiseId,
+      token: `FP_${String(p.originalPickFor)}_${String(p.year)}_${String(p.round)}`,
+      label: `${p.year} R${p.round}${String(p.originalPickFor) !== franchiseId ? ` (via ${teamNameLookup.get(String(p.originalPickFor)) ?? p.originalPickFor})` : ''}`,
+    }))
+    .sort((a: DraftPickAsset, b: DraftPickAsset) => {
+      if (a.year !== b.year) return a.year.localeCompare(b.year);
+      return a.round - b.round;
+    });
+}
+const fromPicks = fromFranchiseId ? picksFor(fromFranchiseId) : [];
+const toPicks = toFranchiseId ? picksFor(toFranchiseId) : [];
+
+// Page-level config for client JS
+const pageConfig = {
+  fromFranchiseId,
+  toFranchiseId,
+  selectedYear,
+  preSelectedPlayer,
+  isAflOwner,
+  // Tag map so the client can pretty-print player info from IDs without re-fetching
+  playerLookup: Object.fromEntries(
+    Array.from(playerMap.values()).map((p) => [
+      p.id,
+      { name: p.name, position: p.position, team: p.team, adp: p.adp ?? null, adpRank: p.adpRank ?? null },
+    ])
+  ),
+  // Pick lookup keyed by token for fairness math
+  pickLookup: Object.fromEntries(
+    [...fromPicks, ...toPicks].map((pick) => [
+      pick.token,
+      { label: pick.label, year: pick.year, round: pick.round, originalPickFor: pick.originalPickFor },
+    ])
+  ),
+};
+
+---
+
+<TheLeagueLayout title="AFL Trade Builder">
+  <main class="trade-builder">
+    {!isAflOwner ? (
+      <section class="tb-gate">
+        <h1>Trade Builder</h1>
+        <p>Sign in as an AFL Fantasy owner to draft trade proposals.</p>
+        <a href="/login" class="tb-btn tb-btn--primary">Sign in</a>
+      </section>
+    ) : !toTeam ? (
+      <section class="tb-gate">
+        <h1>Trade Builder</h1>
+        <p>No same-conference trade partners are available right now.</p>
+      </section>
+    ) : (
+      <>
+        <header class="tb-header">
+          <div class="tb-header__crumbs">
+            <a href={`/afl-fantasy/rosters?franchise=${fromFranchiseId}`}>← Back to roster</a>
+          </div>
+          <h1 class="tb-header__title">Trade Builder</h1>
+          <p class="tb-header__sub">
+            Same-conference trades only ({getConferenceShort(fromConference!)})
+          </p>
+        </header>
+
+        <div class="tb-panels">
+          <!-- LEFT: My side -->
+          <section class="tb-side tb-side--mine" aria-label="Your offering">
+            <header class="tb-side__header">
+              {fromTeam?.icon && <img class="tb-side__icon" src={fromTeam.icon} alt="" />}
+              <div>
+                <h2 class="tb-side__team">{fromTeam?.name}</h2>
+                <p class="tb-side__role">You give</p>
+              </div>
+            </header>
+
+            <ul class="tb-zone" data-zone="from" id="zone-from">
+              <li class="tb-empty">Pick players or picks from your roster below.</li>
+            </ul>
+
+            <div class="tb-section">
+              <h3 class="tb-section__title">Your players · ranked by ADP</h3>
+              <ul class="tb-picker">
+                {fromRoster.map((p) => (
+                  <li class="tb-picker__item" data-asset-type="player" data-asset-id={p.id} data-side="from">
+                    <span class="tb-picker__cell">
+                      <PlayerCell
+                        name={p.name}
+                        position={p.position}
+                        nflTeam={p.team}
+                        mflId={p.id}
+                        espnId={p.espnId}
+                        size="compact"
+                      />
+                    </span>
+                    <span class="tb-picker__adp">{p.adp != null ? `ADP ${p.adp.toFixed(1)}` : '—'}</span>
+                    <button type="button" class="tb-picker__add" aria-label={`Add ${p.name} to offer`}>+</button>
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+            {fromPicks.length > 0 && (
+              <div class="tb-section">
+                <h3 class="tb-section__title">Your {Number(selectedYear) + 1} picks</h3>
+                <ul class="tb-picker">
+                  {fromPicks.map((pick) => (
+                    <li class="tb-picker__item tb-picker__item--pick" data-asset-type="pick" data-asset-id={pick.token} data-side="from" data-pick-label={pick.label}>
+                      <span class="tb-picker__pick-label">{pick.label}</span>
+                      <button type="button" class="tb-picker__add" aria-label={`Add ${pick.label} to offer`}>+</button>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </section>
+
+          <!-- CENTER: Fairness -->
+          <section class="tb-center" aria-label="Trade summary">
+            <div class="tb-fairness">
+              <h3 class="tb-center__title">Trade balance</h3>
+              <div class="tb-balance" id="tb-balance">
+                <div class="tb-balance__row">
+                  <span class="tb-balance__label">Your offer ADP sum</span>
+                  <span class="tb-balance__value" id="tb-from-sum">0</span>
+                </div>
+                <div class="tb-balance__row">
+                  <span class="tb-balance__label">Their offer ADP sum</span>
+                  <span class="tb-balance__value" id="tb-to-sum">0</span>
+                </div>
+                <div class="tb-balance__bar">
+                  <div class="tb-balance__bar-fill" id="tb-balance-fill"></div>
+                </div>
+                <p class="tb-balance__verdict" id="tb-balance-verdict">Add assets to see a fairness read.</p>
+              </div>
+
+              <label class="tb-comments-label" for="tb-comments">Note (optional)</label>
+              <textarea id="tb-comments" class="tb-comments" rows="3" placeholder="Add a message for the receiving owner..."></textarea>
+
+              <button
+                id="tb-submit"
+                type="button"
+                class="tb-btn tb-btn--primary tb-submit"
+                disabled
+              >
+                Send proposal
+              </button>
+              <p class="tb-submit-hint" id="tb-submit-hint"></p>
+            </div>
+          </section>
+
+          <!-- RIGHT: Their side -->
+          <section class="tb-side tb-side--theirs" aria-label="Their offering">
+            <header class="tb-side__header">
+              {toTeam.icon && <img class="tb-side__icon" src={toTeam.icon} alt="" />}
+              <div>
+                <h2 class="tb-side__team">
+                  <select id="tb-to-select" class="tb-to-select">
+                    {sameConferenceTeams
+                      .sort((a, b) => a.name.localeCompare(b.name))
+                      .map((t) => (
+                        <option value={t.franchiseId} selected={t.franchiseId === toFranchiseId}>
+                          {t.name}
+                        </option>
+                      ))}
+                  </select>
+                </h2>
+                <p class="tb-side__role">They give</p>
+              </div>
+            </header>
+
+            <ul class="tb-zone" data-zone="to" id="zone-to">
+              <li class="tb-empty">Pick what you want from their roster.</li>
+            </ul>
+
+            <div class="tb-section">
+              <h3 class="tb-section__title">Their players · ranked by ADP</h3>
+              <ul class="tb-picker">
+                {toRoster.map((p) => (
+                  <li class="tb-picker__item" data-asset-type="player" data-asset-id={p.id} data-side="to">
+                    <span class="tb-picker__cell">
+                      <PlayerCell
+                        name={p.name}
+                        position={p.position}
+                        nflTeam={p.team}
+                        mflId={p.id}
+                        espnId={p.espnId}
+                        size="compact"
+                      />
+                    </span>
+                    <span class="tb-picker__adp">{p.adp != null ? `ADP ${p.adp.toFixed(1)}` : '—'}</span>
+                    <button type="button" class="tb-picker__add" aria-label={`Add ${p.name} to ask`}>+</button>
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+            {toPicks.length > 0 && (
+              <div class="tb-section">
+                <h3 class="tb-section__title">Their {Number(selectedYear) + 1} picks</h3>
+                <ul class="tb-picker">
+                  {toPicks.map((pick) => (
+                    <li class="tb-picker__item tb-picker__item--pick" data-asset-type="pick" data-asset-id={pick.token} data-side="to" data-pick-label={pick.label}>
+                      <span class="tb-picker__pick-label">{pick.label}</span>
+                      <button type="button" class="tb-picker__add" aria-label={`Add ${pick.label} to ask`}>+</button>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </section>
+        </div>
+      </>
+    )}
+  </main>
+
+  <script id="tb-config" type="application/json" set:html={JSON.stringify(pageConfig)}></script>
+
+  <script>
+    const cfgEl = document.getElementById('tb-config');
+    if (cfgEl) {
+      const config = JSON.parse(cfgEl.textContent || '{}');
+      const { fromFranchiseId, preSelectedPlayer, isAflOwner, playerLookup, pickLookup } = config;
+
+      const zoneFrom = document.getElementById('zone-from');
+      const zoneTo = document.getElementById('zone-to');
+      const fromSumEl = document.getElementById('tb-from-sum');
+      const toSumEl = document.getElementById('tb-to-sum');
+      const balanceFill = document.getElementById('tb-balance-fill');
+      const verdictEl = document.getElementById('tb-balance-verdict');
+      const submitBtn = document.getElementById('tb-submit') as HTMLButtonElement | null;
+      const hintEl = document.getElementById('tb-submit-hint');
+      const commentsEl = document.getElementById('tb-comments') as HTMLTextAreaElement | null;
+      const toSelect = document.getElementById('tb-to-select') as HTMLSelectElement | null;
+
+      type Asset = { type: 'player' | 'pick'; id: string };
+      const offer: { from: Asset[]; to: Asset[] } = { from: [], to: [] };
+
+      // ADP-to-points scale: low ADP = high value. Player worth = max(0, 200 - rank).
+      // Picks worth: derived from average ADP at that round position
+      // (1st = 180, 2nd = 130, 3rd = 90, 4th = 60, 5th+ = 30 each).
+      const PICK_VALUES: Record<number, number> = {
+        1: 180, 2: 130, 3: 90, 4: 60, 5: 40, 6: 30, 7: 25, 8: 20, 9: 15, 10: 10,
+      };
+
+      function playerValue(playerId: string): number {
+        const p = playerLookup[playerId];
+        if (!p) return 0;
+        if (p.adpRank == null) return 5; // un-ranked rookies / depth
+        return Math.max(5, 200 - p.adpRank);
+      }
+
+      function pickValue(token: string): number {
+        const pick = pickLookup[token];
+        if (!pick) return 0;
+        return PICK_VALUES[pick.round] ?? 5;
+      }
+
+      function assetValue(a: Asset): number {
+        return a.type === 'player' ? playerValue(a.id) : pickValue(a.id);
+      }
+
+      function assetLabel(a: Asset): string {
+        if (a.type === 'player') {
+          const p = playerLookup[a.id];
+          return p ? `${p.name} (${p.position}${p.adp != null ? ` · ADP ${p.adp.toFixed(0)}` : ''})` : a.id;
+        }
+        return pickLookup[a.id]?.label ?? a.id;
+      }
+
+      function renderZone(side: 'from' | 'to') {
+        const zone = side === 'from' ? zoneFrom : zoneTo;
+        if (!zone) return;
+        const assets = offer[side];
+        if (assets.length === 0) {
+          zone.innerHTML = `<li class="tb-empty">${side === 'from' ? 'Pick players or picks from your roster below.' : "Pick what you want from their roster."}</li>`;
+          return;
+        }
+        zone.innerHTML = assets
+          .map(
+            (a) => `
+              <li class="tb-asset" data-asset-type="${a.type}" data-asset-id="${a.id}" data-side="${side}">
+                <span class="tb-asset__label">${assetLabel(a)}</span>
+                <button type="button" class="tb-asset__remove" aria-label="Remove">×</button>
+              </li>
+            `
+          )
+          .join('');
+      }
+
+      function updateFairness() {
+        const fromSum = offer.from.reduce((s, a) => s + assetValue(a), 0);
+        const toSum = offer.to.reduce((s, a) => s + assetValue(a), 0);
+        if (fromSumEl) fromSumEl.textContent = String(fromSum);
+        if (toSumEl) toSumEl.textContent = String(toSum);
+
+        const max = Math.max(fromSum, toSum, 1);
+        if (balanceFill) {
+          // Fill direction: 50% center = even, >50% = "your side worth more"
+          const total = fromSum + toSum || 1;
+          const fromPct = (fromSum / total) * 100;
+          balanceFill.style.width = `${fromPct}%`;
+        }
+
+        const diff = fromSum - toSum;
+        const ratio = max ? Math.abs(diff) / max : 0;
+
+        if (verdictEl) {
+          if (fromSum === 0 && toSum === 0) {
+            verdictEl.textContent = 'Add assets to see a fairness read.';
+            verdictEl.dataset.kind = '';
+          } else if (ratio < 0.1) {
+            verdictEl.textContent = 'Looks fair on both sides.';
+            verdictEl.dataset.kind = 'ok';
+          } else if (diff > 0) {
+            verdictEl.textContent = `You're sending ${Math.round(ratio * 100)}% more value.`;
+            verdictEl.dataset.kind = 'warn';
+          } else {
+            verdictEl.textContent = `You're receiving ${Math.round(ratio * 100)}% more value.`;
+            verdictEl.dataset.kind = 'good';
+          }
+        }
+
+        // Submit gating: both sides must have at least one asset
+        const ready = offer.from.length > 0 && offer.to.length > 0 && isAflOwner;
+        if (submitBtn) submitBtn.disabled = !ready;
+        if (hintEl) {
+          if (!ready) {
+            hintEl.textContent = offer.from.length === 0 || offer.to.length === 0 ? 'Add at least one asset on each side.' : '';
+          } else {
+            hintEl.textContent = '';
+          }
+        }
+      }
+
+      function add(side: 'from' | 'to', type: 'player' | 'pick', id: string) {
+        if (offer[side].some((a) => a.id === id && a.type === type)) return;
+        offer[side].push({ type, id });
+        renderZone(side);
+        updateFairness();
+        // Visually mark the row as added
+        const row = document.querySelector(
+          `[data-side="${side}"][data-asset-type="${type}"][data-asset-id="${id}"]`
+        );
+        row?.classList.add('is-selected');
+      }
+
+      function remove(side: 'from' | 'to', type: 'player' | 'pick', id: string) {
+        offer[side] = offer[side].filter((a) => !(a.id === id && a.type === type));
+        renderZone(side);
+        updateFairness();
+        const row = document.querySelector(
+          `[data-side="${side}"][data-asset-type="${type}"][data-asset-id="${id}"]`
+        );
+        row?.classList.remove('is-selected');
+      }
+
+      // Wire picker buttons
+      document.querySelectorAll<HTMLLIElement>('.tb-picker__item').forEach((item) => {
+        const btn = item.querySelector<HTMLButtonElement>('.tb-picker__add');
+        btn?.addEventListener('click', () => {
+          const type = (item.dataset.assetType as 'player' | 'pick') || 'player';
+          const id = item.dataset.assetId || '';
+          const side = (item.dataset.side as 'from' | 'to') || 'from';
+          if (!id) return;
+          if (item.classList.contains('is-selected')) {
+            remove(side, type, id);
+          } else {
+            add(side, type, id);
+          }
+        });
+      });
+
+      // Wire zone removal
+      document.addEventListener('click', (e) => {
+        const target = e.target as HTMLElement;
+        const rm = target.closest<HTMLElement>('.tb-asset__remove');
+        if (!rm) return;
+        const asset = rm.closest<HTMLElement>('.tb-asset');
+        if (!asset) return;
+        const side = asset.dataset.side as 'from' | 'to';
+        const type = asset.dataset.assetType as 'player' | 'pick';
+        const id = asset.dataset.assetId || '';
+        remove(side, type, id);
+      });
+
+      // Wire team switch
+      toSelect?.addEventListener('change', () => {
+        const url = new URL(window.location.href);
+        url.searchParams.set('from', fromFranchiseId);
+        url.searchParams.set('to', toSelect.value);
+        url.searchParams.delete('player');
+        window.location.href = url.toString();
+      });
+
+      // Pre-select player from query param
+      if (preSelectedPlayer) {
+        add('from', 'player', preSelectedPlayer);
+      }
+
+      // Submit handler
+      submitBtn?.addEventListener('click', async () => {
+        if (offer.from.length === 0 || offer.to.length === 0) return;
+        const toFranchise = toSelect?.value;
+        if (!toFranchise) return;
+
+        const willGiveUp = offer.from.map((a) => a.id).join(',');
+        const willReceive = offer.to.map((a) => a.id).join(',');
+        const comments = commentsEl?.value.trim() || '';
+
+        const summary =
+          `Send this trade to ${toSelect.options[toSelect.selectedIndex].text}?\n\n` +
+          `You give:\n  ${offer.from.map(assetLabel).join('\n  ')}\n\n` +
+          `You receive:\n  ${offer.to.map(assetLabel).join('\n  ')}`;
+        if (!confirm(summary)) return;
+
+        submitBtn.disabled = true;
+        submitBtn.textContent = 'Sending…';
+        if (hintEl) hintEl.textContent = '';
+
+        try {
+          const res = await fetch('/api/trades/submit', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              offeredTo: toFranchise,
+              willGiveUp,
+              willReceive,
+              comments,
+            }),
+          });
+          const data = await res.json().catch(() => ({}));
+          if (!res.ok || !data?.success) {
+            throw new Error(data?.message || `HTTP ${res.status}`);
+          }
+          if (hintEl) {
+            hintEl.textContent = 'Trade proposal sent. Redirecting to your roster…';
+            hintEl.dataset.kind = 'ok';
+          }
+          setTimeout(() => {
+            window.location.href = `/afl-fantasy/rosters?franchise=${fromFranchiseId}`;
+          }, 1200);
+        } catch (err: any) {
+          submitBtn.disabled = false;
+          submitBtn.textContent = 'Send proposal';
+          if (hintEl) {
+            hintEl.textContent = err?.message || 'Submit failed. Please try again.';
+            hintEl.dataset.kind = 'err';
+          }
+        }
+      });
+
+      renderZone('from');
+      renderZone('to');
+      updateFairness();
+    }
+  </script>
+
+  <style>
+    .trade-builder {
+      max-width: 1240px;
+      margin: 0 auto;
+      padding: 1.5rem 1rem 4rem;
+    }
+
+    .tb-gate {
+      max-width: 480px;
+      margin: 4rem auto;
+      text-align: center;
+      background: #fff;
+      padding: 2rem;
+      border-radius: 0.75rem;
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.06);
+    }
+
+    .tb-header {
+      margin-bottom: 1.25rem;
+    }
+
+    .tb-header__crumbs {
+      font-size: 0.8125rem;
+      margin-bottom: 0.25rem;
+    }
+
+    .tb-header__crumbs a {
+      color: #c41e3a;
+      text-decoration: none;
+      font-weight: 600;
+    }
+
+    .tb-header__crumbs a:hover {
+      text-decoration: underline;
+    }
+
+    .tb-header__title {
+      margin: 0;
+      font-size: 1.75rem;
+      font-weight: 800;
+      color: #0f172a;
+    }
+
+    .tb-header__sub {
+      margin: 0.25rem 0 0;
+      color: #6b7280;
+      font-size: 0.875rem;
+    }
+
+    .tb-panels {
+      display: grid;
+      grid-template-columns: 1fr 320px 1fr;
+      gap: 1rem;
+      align-items: start;
+    }
+
+    .tb-side {
+      background: #fff;
+      border-radius: 0.75rem;
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.06);
+      padding: 1.25rem;
+      display: grid;
+      gap: 1rem;
+    }
+
+    .tb-side__header {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+    }
+
+    .tb-side__icon {
+      width: 44px;
+      height: 44px;
+      object-fit: contain;
+    }
+
+    .tb-side__team {
+      margin: 0;
+      font-size: 1.125rem;
+      font-weight: 700;
+      color: #0f172a;
+    }
+
+    .tb-side__role {
+      margin: 0;
+      font-size: 0.6875rem;
+      font-weight: 700;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+      color: #6b7280;
+    }
+
+    .tb-to-select {
+      font-size: 1.125rem;
+      font-weight: 700;
+      color: #0f172a;
+      padding: 0.125rem 0.375rem;
+      border: 1px solid #e5e7eb;
+      border-radius: 0.375rem;
+      background: #fff;
+      cursor: pointer;
+      max-width: 100%;
+    }
+
+    .tb-zone {
+      list-style: none;
+      margin: 0;
+      padding: 0.75rem;
+      min-height: 80px;
+      background: #f9fafb;
+      border-radius: 0.5rem;
+      border: 2px dashed #e5e7eb;
+      display: grid;
+      gap: 0.375rem;
+    }
+
+    .tb-empty {
+      color: #9ca3af;
+      font-size: 0.8125rem;
+      text-align: center;
+      padding: 0.625rem;
+    }
+
+    .tb-asset {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 0.5rem;
+      padding: 0.5rem 0.625rem;
+      background: #fff;
+      border: 1px solid #e5e7eb;
+      border-radius: 0.375rem;
+    }
+
+    .tb-asset__label {
+      font-size: 0.8125rem;
+      font-weight: 600;
+      color: #0f172a;
+    }
+
+    .tb-asset__remove {
+      width: 22px;
+      height: 22px;
+      border: 0;
+      border-radius: 0.25rem;
+      background: #fee2e2;
+      color: #991b1b;
+      font-size: 1rem;
+      font-weight: 800;
+      line-height: 1;
+      cursor: pointer;
+    }
+
+    .tb-asset__remove:hover {
+      background: #fecaca;
+    }
+
+    .tb-section {
+      display: grid;
+      gap: 0.375rem;
+    }
+
+    .tb-section__title {
+      margin: 0;
+      font-size: 0.6875rem;
+      font-weight: 700;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+      color: #6b7280;
+    }
+
+    .tb-picker {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      max-height: 380px;
+      overflow-y: auto;
+      display: grid;
+      gap: 0.25rem;
+    }
+
+    .tb-picker__item {
+      display: grid;
+      grid-template-columns: 1fr auto 28px;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.375rem 0.5rem;
+      border-radius: 0.375rem;
+      border: 1px solid #f3f4f6;
+    }
+
+    .tb-picker__item:hover {
+      background: #f9fafb;
+    }
+
+    .tb-picker__item.is-selected {
+      background: #fef2f2;
+      border-color: #fecaca;
+    }
+
+    .tb-picker__item--pick {
+      grid-template-columns: 1fr 28px;
+    }
+
+    .tb-picker__cell {
+      min-width: 0;
+    }
+
+    .tb-picker__adp {
+      font-size: 0.75rem;
+      color: #6b7280;
+      font-weight: 600;
+      font-variant-numeric: tabular-nums;
+    }
+
+    .tb-picker__pick-label {
+      font-size: 0.8125rem;
+      color: #0f172a;
+      font-weight: 600;
+    }
+
+    .tb-picker__add {
+      width: 24px;
+      height: 24px;
+      border: 0;
+      border-radius: 0.25rem;
+      background: #dcfce7;
+      color: #166534;
+      font-size: 1rem;
+      font-weight: 800;
+      line-height: 1;
+      cursor: pointer;
+    }
+
+    .tb-picker__add:hover {
+      background: #bbf7d0;
+    }
+
+    .tb-picker__item.is-selected .tb-picker__add {
+      background: #fee2e2;
+      color: #991b1b;
+    }
+
+    /* Center fairness panel */
+    .tb-center {
+      position: sticky;
+      top: 1rem;
+    }
+
+    .tb-fairness {
+      background: #fff;
+      border-radius: 0.75rem;
+      padding: 1.25rem;
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.06);
+      display: grid;
+      gap: 0.75rem;
+    }
+
+    .tb-center__title {
+      margin: 0;
+      font-size: 0.8125rem;
+      font-weight: 700;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+      color: #6b7280;
+    }
+
+    .tb-balance {
+      display: grid;
+      gap: 0.5rem;
+    }
+
+    .tb-balance__row {
+      display: flex;
+      justify-content: space-between;
+      font-size: 0.8125rem;
+      color: #374151;
+    }
+
+    .tb-balance__label {
+      color: #6b7280;
+    }
+
+    .tb-balance__value {
+      font-weight: 800;
+      color: #0f172a;
+      font-variant-numeric: tabular-nums;
+    }
+
+    .tb-balance__bar {
+      position: relative;
+      height: 10px;
+      background: #fee2e2;
+      border-radius: 5px;
+      overflow: hidden;
+    }
+
+    .tb-balance__bar-fill {
+      position: absolute;
+      inset: 0 auto 0 0;
+      width: 0%;
+      background: #dcfce7;
+      transition: width 200ms ease;
+    }
+
+    .tb-balance__verdict {
+      margin: 0.25rem 0 0;
+      font-size: 0.8125rem;
+      text-align: center;
+      color: #6b7280;
+    }
+
+    .tb-balance__verdict[data-kind="ok"] { color: #166534; }
+    .tb-balance__verdict[data-kind="warn"] { color: #991b1b; }
+    .tb-balance__verdict[data-kind="good"] { color: #0369a1; }
+
+    .tb-comments-label {
+      font-size: 0.6875rem;
+      font-weight: 700;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+      color: #6b7280;
+    }
+
+    .tb-comments {
+      width: 100%;
+      padding: 0.5rem 0.625rem;
+      border: 1px solid #e5e7eb;
+      border-radius: 0.375rem;
+      font-size: 0.875rem;
+      font-family: inherit;
+      resize: vertical;
+    }
+
+    .tb-comments:focus {
+      outline: 2px solid #c41e3a;
+      outline-offset: -1px;
+      border-color: #c41e3a;
+    }
+
+    .tb-btn {
+      padding: 0.625rem 1rem;
+      border-radius: 0.375rem;
+      border: 1px solid transparent;
+      font-size: 0.875rem;
+      font-weight: 700;
+      cursor: pointer;
+    }
+
+    .tb-btn:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+
+    .tb-btn--primary {
+      background: #c41e3a;
+      color: #fff;
+    }
+
+    .tb-btn--primary:hover:not(:disabled) {
+      background: #a31a31;
+    }
+
+    .tb-submit-hint {
+      margin: 0;
+      font-size: 0.75rem;
+      color: #6b7280;
+      text-align: center;
+    }
+
+    .tb-submit-hint[data-kind="ok"] { color: #166534; }
+    .tb-submit-hint[data-kind="err"] { color: #991b1b; }
+
+    @media (max-width: 1024px) {
+      .tb-panels {
+        grid-template-columns: 1fr;
+      }
+
+      .tb-center {
+        position: static;
+        order: -1;
+      }
+    }
+  </style>
+</TheLeagueLayout>

--- a/src/pages/afl-fantasy/trade-builder.astro
+++ b/src/pages/afl-fantasy/trade-builder.astro
@@ -187,7 +187,7 @@ const pageConfig = {
       <section class="tb-gate">
         <h1>Trade Builder</h1>
         <p>Sign in as an AFL Fantasy owner to draft trade proposals.</p>
-        <a href="/login" class="tb-btn tb-btn--primary">Sign in</a>
+        <a href="/afl-fantasy/login?next=/afl-fantasy/trade-builder" class="tb-btn tb-btn--primary">Sign in</a>
       </section>
     ) : !toTeam ? (
       <section class="tb-gate">

--- a/src/pages/api/afl-keepers.ts
+++ b/src/pages/api/afl-keepers.ts
@@ -1,0 +1,139 @@
+/**
+ * GET    /api/afl-keepers?franchise=0001&year=2025
+ * POST   /api/afl-keepers   body: { year: 2025, franchise: "0001", keepers: ["12345", ...] }
+ * DELETE /api/afl-keepers?franchise=0001&year=2025
+ *
+ * Per-franchise keeper plan persistence for AFL Fantasy. Scoped to the
+ * authenticated user's franchise — owners can only read/write their own
+ * plan. The plan is private (no public read) since it's a strategic
+ * scratchpad.
+ *
+ * Keeper plans are NOT a formal MFL construct in AFL — this is purely a
+ * client-side / server-side scratchpad. The actual roster mutations
+ * happen when the owner clicks "Finalize keepers", which triggers a
+ * sequence of /api/cut-player calls for the non-keepers.
+ */
+
+import type { APIRoute } from 'astro';
+import { getAuthUser } from '../../utils/auth';
+import {
+  KEEPER_LIMIT,
+  getKeeperPlan,
+  saveKeeperPlan,
+  deleteKeeperPlan,
+  sanitizeKeeperIds,
+} from '../../utils/afl-keepers-storage';
+
+const JSON_HEADERS = { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' };
+
+const AFL_LEAGUE_ID = '19621';
+
+function unauthorized(message: string) {
+  return new Response(JSON.stringify({ success: false, message }), {
+    status: 401,
+    headers: JSON_HEADERS,
+  });
+}
+
+function forbidden(message: string) {
+  return new Response(JSON.stringify({ success: false, message }), {
+    status: 403,
+    headers: JSON_HEADERS,
+  });
+}
+
+function badRequest(message: string) {
+  return new Response(JSON.stringify({ success: false, message }), {
+    status: 400,
+    headers: JSON_HEADERS,
+  });
+}
+
+export const GET: APIRoute = async ({ request, url }) => {
+  const user = getAuthUser(request);
+  if (!user) return unauthorized('Sign in to view your keeper plan.');
+
+  const franchiseId = url.searchParams.get('franchise');
+  const yearStr = url.searchParams.get('year');
+  if (!franchiseId || !/^\d{4}$/.test(franchiseId)) {
+    return badRequest('Missing or invalid franchise.');
+  }
+  const year = Number(yearStr);
+  if (!Number.isInteger(year) || year < 2020 || year > 2100) {
+    return badRequest('Missing or invalid year.');
+  }
+
+  // Owners only see their own plan.
+  if (user.leagueId !== AFL_LEAGUE_ID || user.franchiseId !== franchiseId) {
+    return forbidden('You can only view your own keeper plan.');
+  }
+
+  const plan = await getKeeperPlan(AFL_LEAGUE_ID, year, franchiseId);
+  return new Response(
+    JSON.stringify({
+      success: true,
+      plan: plan ?? { leagueId: AFL_LEAGUE_ID, year, franchiseId, keepers: [], lastUpdated: null, version: 1 },
+      limit: KEEPER_LIMIT,
+    }),
+    { status: 200, headers: JSON_HEADERS }
+  );
+};
+
+export const POST: APIRoute = async ({ request }) => {
+  const user = getAuthUser(request);
+  if (!user) return unauthorized('Sign in to save your keeper plan.');
+
+  let body: any;
+  try {
+    body = await request.json();
+  } catch {
+    return badRequest('Invalid JSON body.');
+  }
+
+  const franchiseId = body?.franchise;
+  const year = Number(body?.year);
+  if (!franchiseId || !/^\d{4}$/.test(String(franchiseId))) {
+    return badRequest('Missing or invalid franchise.');
+  }
+  if (!Number.isInteger(year) || year < 2020 || year > 2100) {
+    return badRequest('Missing or invalid year.');
+  }
+
+  // Owners only save their own plan.
+  if (user.leagueId !== AFL_LEAGUE_ID || user.franchiseId !== franchiseId) {
+    return forbidden('You can only save your own keeper plan.');
+  }
+
+  const keepers = sanitizeKeeperIds(body?.keepers);
+  const plan = await saveKeeperPlan(AFL_LEAGUE_ID, year, franchiseId, keepers);
+
+  return new Response(JSON.stringify({ success: true, plan, limit: KEEPER_LIMIT }), {
+    status: 200,
+    headers: JSON_HEADERS,
+  });
+};
+
+export const DELETE: APIRoute = async ({ request, url }) => {
+  const user = getAuthUser(request);
+  if (!user) return unauthorized('Sign in to reset your keeper plan.');
+
+  const franchiseId = url.searchParams.get('franchise');
+  const yearStr = url.searchParams.get('year');
+  if (!franchiseId || !/^\d{4}$/.test(franchiseId)) {
+    return badRequest('Missing or invalid franchise.');
+  }
+  const year = Number(yearStr);
+  if (!Number.isInteger(year) || year < 2020 || year > 2100) {
+    return badRequest('Missing or invalid year.');
+  }
+
+  if (user.leagueId !== AFL_LEAGUE_ID || user.franchiseId !== franchiseId) {
+    return forbidden('You can only reset your own keeper plan.');
+  }
+
+  await deleteKeeperPlan(AFL_LEAGUE_ID, year, franchiseId);
+  return new Response(JSON.stringify({ success: true }), {
+    status: 200,
+    headers: JSON_HEADERS,
+  });
+};

--- a/src/pages/api/auth/login.ts
+++ b/src/pages/api/auth/login.ts
@@ -6,7 +6,7 @@ import { setTheLeaguePreference } from '../../../utils/team-preferences';
 export const POST: APIRoute = async ({ request, cookies }) => {
   try {
     const body = await request.json();
-    const { username, password, leagueId } = body;
+    const { username, password, leagueId, year } = body;
 
     // Validate inputs
     if (!username || !password) {
@@ -16,8 +16,10 @@ export const POST: APIRoute = async ({ request, cookies }) => {
       );
     }
 
-    // Authenticate with MFL
-    const mflResponse = await authenticateWithMFL(username, password, leagueId);
+    // Authenticate with MFL — year override lets AFL pass 2025 because
+    // the AFL 2026 league hasn't been created on MFL yet.
+    const seasonYear = Number.isInteger(Number(year)) ? Number(year) : undefined;
+    const mflResponse = await authenticateWithMFL(username, password, leagueId, seasonYear);
 
     if (!mflResponse.success) {
       return new Response(
@@ -30,10 +32,15 @@ export const POST: APIRoute = async ({ request, cookies }) => {
     }
 
     if (!mflResponse.franchiseId) {
+      // Forward the more specific error from the MFL resolver so the user
+      // gets a useful message ("not a member of league X", "no leagues
+      // found", etc.) instead of a generic "contact the commissioner".
       return new Response(
         JSON.stringify({
           success: false,
-          message: 'Login succeeded but your franchise could not be determined. Contact the commissioner.',
+          message:
+            mflResponse.error ||
+            'Login succeeded but your franchise could not be determined. Contact the commissioner.',
         }),
         { status: 401, headers: { 'Content-Type': 'application/json' } }
       );

--- a/src/pages/api/trade-bait.ts
+++ b/src/pages/api/trade-bait.ts
@@ -73,11 +73,15 @@ export const POST: APIRoute = async ({ request }) => {
 
     // 3. Create MFL API client with the USER's cookie (not the server env var)
     const leagueYear = getCurrentLeagueYear();
+    const leagueId = user.leagueId || '13522';
     const mflClient = createMFLApiClient({
-      leagueId: user.leagueId || '13522',
+      leagueId,
       year: String(leagueYear),
       mflUserId: user.id, // Per-user auth — the user's MFL cookie
     });
+    // Local cache directory matches the league we're writing for so AFL
+    // updates don't overwrite TheLeague's tradeBait.json (or vice versa).
+    const cacheLeagueDir = leagueId === '19621' ? 'afl-fantasy' : 'theleague';
 
     // 4. SECURITY: Verify the player belongs to the user's roster
     //    This prevents any user from adding players they don't own to trade bait,
@@ -106,7 +110,7 @@ export const POST: APIRoute = async ({ request }) => {
         try {
           const cachePath = path.resolve(
             process.cwd(),
-            `data/theleague/mfl-feeds/${leagueYear}/tradeBait.json`,
+            `data/${cacheLeagueDir}/mfl-feeds/${leagueYear}/tradeBait.json`,
           );
           fs.writeFileSync(cachePath, JSON.stringify(result.allPlayerIds, null, 2), 'utf8');
         } catch (cacheErr) {

--- a/src/pages/theleague/rosters.astro
+++ b/src/pages/theleague/rosters.astro
@@ -2313,12 +2313,12 @@ const defaultLastSeenText = formatLastSeen(defaultLastSeen);
 
               <!-- GM Mode Columns -->
               <th scope="col" data-column="rank" class="gm-col ranking-col" data-sortable data-sort-key="topRanking" id="rankColHeader">Rank <span class="sort-arrow"></span></th>
-              <th scope="col" data-column="years" class="gm-col" data-sortable data-sort-key="contractYears">Yrs <span class="sort-arrow"></span></th>
               <th scope="col" data-column="actions" class="actions-column gm-col" title="Contract Actions">
                 <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-label="Actions" style="opacity:0.5;vertical-align:middle;">
                   <circle cx="12" cy="5" r="2"/><circle cx="12" cy="12" r="2"/><circle cx="12" cy="19" r="2"/>
                 </svg>
               </th>
+              <th scope="col" data-column="years" class="gm-col" data-sortable data-sort-key="contractYears">Yrs <span class="sort-arrow"></span></th>
               {SALARY_YEARS.map((year, index) => (
                 <th scope="col" data-column={`year${index + 1}`} class="gm-col" data-sortable data-sort-key={`salary_${index}`}>{year} <span class="sort-arrow"></span></th>
               ))}
@@ -2328,8 +2328,8 @@ const defaultLastSeenText = formatLastSeen(defaultLastSeen);
             <tr class="roster-totals roster-totals--dead gm-row">
               <td data-column="player" class="roster-totals__label">Dead Money</td>
               <td data-column="rank" class="gm-col ranking-col"></td>
-              <td data-column="years" class="gm-col"></td>
               <td data-column="actions" class="gm-col"></td>
+              <td data-column="years" class="gm-col"></td>
               {SALARY_YEARS.map((year, index) => (
                 <td data-column={`dm${index + 1}`} id={`dmTotal${index + 1}`} class="gm-col">
                   {formatCurrency(initialDeadMoney[index] ?? 0)}
@@ -2339,8 +2339,8 @@ const defaultLastSeenText = formatLastSeen(defaultLastSeen);
             <tr class="roster-totals gm-row">
               <td data-column="player" class="roster-totals__label">Total Salary</td>
               <td data-column="rank" class="gm-col ranking-col"></td>
-              <td data-column="years" class="gm-col"></td>
               <td data-column="actions" class="gm-col"></td>
+              <td data-column="years" class="gm-col"></td>
               {SALARY_YEARS.map((year, index) => (
                 <td data-column={`year${index + 1}`} id={`yearTotal${index + 1}`} class="gm-col">
                   {formatCurrency((initialYearTotals[index] ?? 0) + (initialDeadMoney[index] ?? 0))}
@@ -2350,8 +2350,8 @@ const defaultLastSeenText = formatLastSeen(defaultLastSeen);
             <tr class="roster-totals roster-totals--cap gm-row">
               <td data-column="player" class="roster-totals__label">Salary Cap</td>
               <td data-column="rank" class="gm-col ranking-col"></td>
-              <td data-column="years" class="gm-col"></td>
               <td data-column="actions" class="gm-col"></td>
+              <td data-column="years" class="gm-col"></td>
               {SALARY_YEARS.map((year, index) => (
                 <td data-column={`cap${index + 1}`} id={`capLimit${index + 1}`} class="gm-col">
                   {formatCurrency(initialCapLimit)}
@@ -2361,8 +2361,8 @@ const defaultLastSeenText = formatLastSeen(defaultLastSeen);
             <tr class="roster-totals roster-totals--space gm-row">
               <td data-column="player" class="roster-totals__label">Cap Space</td>
               <td data-column="rank" class="gm-col ranking-col"></td>
-              <td data-column="years" class="gm-col"></td>
               <td data-column="actions" class="gm-col"></td>
+              <td data-column="years" class="gm-col"></td>
               {SALARY_YEARS.map((year, index) => (
                 <td data-column={`space${index + 1}`} id={`capSpaceTotal${index + 1}`} class="gm-col">
                   {formatCurrency(
@@ -2558,7 +2558,6 @@ const defaultLastSeenText = formatLastSeen(defaultLastSeen);
 
                 {/* GM Mode Cells */}
                 <td data-label="Rank" data-column="rank" class="gm-col ranking-col ranking-cell"></td>
-                <td data-label="Yrs" data-column="years" class="gm-col years-cell" data-player-id={player.id}>{player.contractYears || 0}</td>
                 <td data-label="Actions" data-column="actions" class="actions-cell gm-col">
                   <button
                     class="ufa-action-btn"
@@ -2581,6 +2580,7 @@ const defaultLastSeenText = formatLastSeen(defaultLastSeen);
                     </svg>
                   </button>
                 </td>
+                <td data-label="Yrs" data-column="years" class="gm-col years-cell" data-player-id={player.id}>{player.contractYears || 0}</td>
                 {SALARY_YEARS.map((year, index) => {
                   const isUfa = !(player.contractYears > index);
                   const isFirstYearUfa = isUfa && player.contractYears === index;
@@ -7057,8 +7057,8 @@ const defaultLastSeenText = formatLastSeen(defaultLastSeen);
 
             ${/* GM Mode Cells */ ''}
             <td data-label="Rank" data-column="rank" class="gm-col ranking-col ranking-cell"></td>
-            <td data-label="Yrs" data-column="years" class="gm-col years-cell" data-player-id="${player.id}">${buildYearsCellContent(player.id, displayYears, currentTeam)}</td>
             ${actionsCell}
+            <td data-label="Yrs" data-column="years" class="gm-col years-cell" data-player-id="${player.id}">${buildYearsCellContent(player.id, displayYears, currentTeam)}</td>
             ${salaryCells}
           </tr>`;
         })

--- a/src/pages/theleague/rosters.astro
+++ b/src/pages/theleague/rosters.astro
@@ -3847,13 +3847,17 @@ const defaultLastSeenText = formatLastSeen(defaultLastSeen);
   text-align: center;
 }
 
-  :global(.roster-table td[data-column^='year']) {
+/* Salary year columns (year1, year2, ...) — right-align the dollar amounts.
+   :not([data-column='years']) explicitly excludes the Yrs column above, which
+   otherwise gets caught by this prefix selector and ends up right-aligned
+   instead of centered (same specificity → source-order wins → bug). */
+  :global(.roster-table td[data-column^='year']:not([data-column='years'])) {
     font-size: var(--table-cell-font-size, 0.75rem);
     text-align: right;
     padding-right: 0.5rem;
   }
 
-:global(.roster-table th[data-column^='year']) {
+:global(.roster-table th[data-column^='year']:not([data-column='years'])) {
   text-align: right;
   padding-right: 0.5rem;
 }

--- a/src/styles/player-cell.css
+++ b/src/styles/player-cell.css
@@ -107,6 +107,15 @@
   color: #111;
   font-size: var(--player-name-size);
   line-height: 1.3;
+  /* Keep the lockup tight: "Lastname, Firstname" must stay on one line so
+     the table doesn't grow a second row of cell-height to host an awkward
+     orphan word. The column itself widens to fit (tables auto-size column
+     width to content unless capped); on extremely narrow viewports the
+     ellipsis kicks in instead of wrapping. */
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
 }
 
 .player-cell__name--clickable {

--- a/src/utils/afl-conference.ts
+++ b/src/utils/afl-conference.ts
@@ -1,0 +1,119 @@
+/**
+ * AFL Conference helpers.
+ *
+ * MFL stores conferences as numeric IDs ('00', '01'); the league names them
+ * "American League" and "National League". Keep the IDs at the API boundary
+ * and use the user-facing names everywhere in UI.
+ *
+ * Cross-conference (AL <-> NL) trades are not allowed.
+ */
+
+import aflConfig from '../../data/afl-fantasy/afl.config.json';
+
+export type ConferenceId = '00' | '01';
+export type ConferenceName = 'American League' | 'National League';
+export type ConferenceShort = 'AL' | 'NL';
+
+export interface AFLTeam {
+  franchiseId: string;
+  name: string;
+  nameMedium: string;
+  nameShort: string;
+  abbrev: string;
+  aliases: string[];
+  conference: ConferenceId;
+  division: string;
+  tier: string;
+  icon: string;
+  banner: string;
+}
+
+const CONFERENCE_NAMES: Record<ConferenceId, ConferenceName> = {
+  '00': 'American League',
+  '01': 'National League',
+};
+
+const CONFERENCE_SHORT: Record<ConferenceId, ConferenceShort> = {
+  '00': 'AL',
+  '01': 'NL',
+};
+
+const NAME_TO_ID: Record<ConferenceName, ConferenceId> = {
+  'American League': '00',
+  'National League': '01',
+};
+
+const ALL_TEAMS: AFLTeam[] = (aflConfig.teams as AFLTeam[]).slice();
+
+const FRANCHISE_INDEX = new Map<string, AFLTeam>(
+  ALL_TEAMS.map((t) => [t.franchiseId, t])
+);
+
+export function getConferenceName(id: ConferenceId): ConferenceName {
+  return CONFERENCE_NAMES[id];
+}
+
+export function getConferenceShort(id: ConferenceId): ConferenceShort {
+  return CONFERENCE_SHORT[id];
+}
+
+export function getConferenceIdByName(name: ConferenceName): ConferenceId {
+  return NAME_TO_ID[name];
+}
+
+export function isValidConferenceId(value: string): value is ConferenceId {
+  return value === '00' || value === '01';
+}
+
+export function getTeam(franchiseId: string): AFLTeam | undefined {
+  return FRANCHISE_INDEX.get(franchiseId);
+}
+
+export function getFranchiseConference(franchiseId: string): ConferenceId | null {
+  return FRANCHISE_INDEX.get(franchiseId)?.conference ?? null;
+}
+
+export function getConferenceTeams(id: ConferenceId): AFLTeam[] {
+  return ALL_TEAMS.filter((t) => t.conference === id);
+}
+
+export function getAllTeams(): AFLTeam[] {
+  return ALL_TEAMS.slice();
+}
+
+export function sameConference(a: string, b: string): boolean {
+  const ca = getFranchiseConference(a);
+  const cb = getFranchiseConference(b);
+  return ca !== null && cb !== null && ca === cb;
+}
+
+/**
+ * Group teams by conference for UI dropdowns / lists.
+ * Returns AL first, then NL.
+ */
+export function getTeamsGroupedByConference(): Array<{
+  conferenceId: ConferenceId;
+  conferenceName: ConferenceName;
+  teams: AFLTeam[];
+}> {
+  return (['00', '01'] as ConferenceId[]).map((id) => ({
+    conferenceId: id,
+    conferenceName: CONFERENCE_NAMES[id],
+    teams: getConferenceTeams(id),
+  }));
+}
+
+/**
+ * Filter a generic list of items that have a franchise ID to a single
+ * conference. Useful for tradeBait / freeAgents / rosters when we only
+ * want one conference's worth.
+ */
+export function filterByConference<T extends { franchiseId?: string; id?: string }>(
+  items: T[],
+  conferenceId: ConferenceId
+): T[] {
+  return items.filter((item) => {
+    const fid = item.franchiseId ?? item.id;
+    return fid != null && getFranchiseConference(fid) === conferenceId;
+  });
+}

--- a/src/utils/afl-keepers-storage.ts
+++ b/src/utils/afl-keepers-storage.ts
@@ -1,0 +1,189 @@
+/**
+ * AFL Keeper Plan Storage.
+ *
+ * AFL doesn't have a formal "keeper" league construct on MFL — the
+ * offseason auction wipes the slate every year. But owners want a
+ * private scratchpad: drag 7 players above the line, see who's getting
+ * cut, finalize when they're ready and watch the bulk-cut go.
+ *
+ * One plan per franchise per year, scoped to leagueId so test leagues
+ * never collide with production AFL. Stored in Upstash Redis in
+ * production (Vercel) with a filesystem fallback for local dev.
+ */
+
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+
+export const KEEPER_LIMIT = 7;
+
+export interface KeeperPlan {
+  leagueId: string;
+  year: number;
+  franchiseId: string;
+  /** Ordered list of MFL player IDs the owner intends to keep. Capped at KEEPER_LIMIT. */
+  keepers: string[];
+  /** ISO 8601 timestamp of the last write. */
+  lastUpdated: string;
+  /** Schema version — bump when the shape changes. */
+  version: 1;
+}
+
+const REDIS_KEY = 'afl-keepers';
+
+type RedisClient = {
+  hget: <T>(key: string, field: string) => Promise<T | null>;
+  hset: (key: string, fieldValues: Record<string, unknown>) => Promise<number>;
+  hdel: (key: string, ...fields: string[]) => Promise<number>;
+};
+
+let _redis: RedisClient | null | undefined;
+
+async function getRedis(): Promise<RedisClient | null> {
+  if (_redis !== undefined) return _redis;
+  const url =
+    process.env.UPSTASH_REDIS_REST_URL ||
+    process.env.KV_REST_API_URL ||
+    process.env.STORAGE_REST_API_URL;
+  const token =
+    process.env.UPSTASH_REDIS_REST_TOKEN ||
+    process.env.KV_REST_API_TOKEN ||
+    process.env.STORAGE_REST_API_TOKEN;
+  if (!url || !token) {
+    _redis = null;
+    return null;
+  }
+  try {
+    const { Redis } = await import('@upstash/redis');
+    _redis = new Redis({ url, token }) as unknown as RedisClient;
+    return _redis;
+  } catch (err) {
+    console.warn('[afl-keepers] Redis unavailable:', err);
+    _redis = null;
+    return null;
+  }
+}
+
+/** Hash field key — keeps every (league, year, franchise) tuple distinct. */
+function planKey(leagueId: string, year: number, franchiseId: string): string {
+  return `${leagueId}:${year}:${franchiseId}`;
+}
+
+// --- Filesystem fallback (dev) ---
+const DEV_PATH = join(
+  process.cwd(),
+  'data/afl-fantasy/keeper-plans.json'
+);
+
+interface DevFile {
+  version: 1;
+  plans: Record<string, KeeperPlan>;
+}
+
+function readDevFile(): DevFile {
+  try {
+    return JSON.parse(readFileSync(DEV_PATH, 'utf-8'));
+  } catch {
+    return { version: 1, plans: {} };
+  }
+}
+
+function writeDevFile(file: DevFile): void {
+  const dir = dirname(DEV_PATH);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  writeFileSync(DEV_PATH, JSON.stringify(file, null, 2), 'utf-8');
+}
+
+function useRedis(): boolean {
+  return !!process.env.VERCEL || !!process.env.UPSTASH_REDIS_REST_URL;
+}
+
+/** Sanitize/cap a list of player IDs to KEEPER_LIMIT, dedupe, drop non-numeric. */
+export function sanitizeKeeperIds(ids: unknown): string[] {
+  if (!Array.isArray(ids)) return [];
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const id of ids) {
+    const str = String(id ?? '').trim();
+    if (!/^\d+$/.test(str)) continue;
+    if (seen.has(str)) continue;
+    seen.add(str);
+    out.push(str);
+    if (out.length >= KEEPER_LIMIT) break;
+  }
+  return out;
+}
+
+/** Read a single franchise's plan. Returns null if no plan saved yet. */
+export async function getKeeperPlan(
+  leagueId: string,
+  year: number,
+  franchiseId: string
+): Promise<KeeperPlan | null> {
+  const key = planKey(leagueId, year, franchiseId);
+
+  if (useRedis()) {
+    const redis = await getRedis();
+    if (!redis) return null;
+    try {
+      const plan = await redis.hget<KeeperPlan>(REDIS_KEY, key);
+      return plan ?? null;
+    } catch (err) {
+      console.error('[afl-keepers] Redis read error:', err);
+      return null;
+    }
+  }
+
+  const file = readDevFile();
+  return file.plans[key] ?? null;
+}
+
+/** Save a franchise's plan. The plan replaces any existing one. */
+export async function saveKeeperPlan(
+  leagueId: string,
+  year: number,
+  franchiseId: string,
+  keepers: string[]
+): Promise<KeeperPlan> {
+  const plan: KeeperPlan = {
+    leagueId,
+    year,
+    franchiseId,
+    keepers: sanitizeKeeperIds(keepers),
+    lastUpdated: new Date().toISOString(),
+    version: 1,
+  };
+
+  const key = planKey(leagueId, year, franchiseId);
+
+  if (useRedis()) {
+    const redis = await getRedis();
+    if (!redis) throw new Error('Redis not available');
+    await redis.hset(REDIS_KEY, { [key]: plan });
+    return plan;
+  }
+
+  const file = readDevFile();
+  file.plans[key] = plan;
+  writeDevFile(file);
+  return plan;
+}
+
+/** Delete a franchise's plan (used by Reset). */
+export async function deleteKeeperPlan(
+  leagueId: string,
+  year: number,
+  franchiseId: string
+): Promise<void> {
+  const key = planKey(leagueId, year, franchiseId);
+
+  if (useRedis()) {
+    const redis = await getRedis();
+    if (!redis) return;
+    await redis.hdel(REDIS_KEY, key);
+    return;
+  }
+
+  const file = readDevFile();
+  delete file.plans[key];
+  writeDevFile(file);
+}

--- a/src/utils/afl-player-scoring.ts
+++ b/src/utils/afl-player-scoring.ts
@@ -1,0 +1,145 @@
+/**
+ * AFL player-scoring helpers.
+ *
+ * Surfaces per-player weekly scoring data for the Coach-mode columns on
+ * the AFL roster page. Mirrors how TheLeague's roster page computes
+ * Avg / Projected, but reads the AFL feeds (data/afl-fantasy/mfl-feeds/...).
+ *
+ * The committed snapshots vary in coverage: most seasons only have the
+ * latest week of scores plus a (sometimes empty) projection. Helpers
+ * here are defensive — every getter returns null when data is missing,
+ * so the caller can render an em dash.
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+interface ScoreEntry {
+  id: string;
+  week: string;
+  score: string;
+}
+
+interface PlayerScoresFile {
+  playerScores?: { week?: string; playerScore?: ScoreEntry | ScoreEntry[] };
+}
+
+interface ProjectedScoresFile {
+  projectedScores?: { week?: string; playerScore?: ScoreEntry | ScoreEntry[] };
+}
+
+export interface PlayerScoreAggregate {
+  /** Most recent week's score for this player, if available. */
+  lastScore: number | null;
+  /** Week number that lastScore came from. */
+  lastWeek: number | null;
+  /** Mean of every recorded weekly score (null when no entries). */
+  average: number | null;
+  /** Number of weeks the average is computed across. */
+  sampleSize: number;
+}
+
+const playerScoresCache = new Map<string, Map<string, ScoreEntry[]>>();
+const projectionsCache = new Map<string, Map<string, number>>();
+
+function readJson<T>(path: string): T | null {
+  try {
+    return JSON.parse(readFileSync(path, 'utf-8')) as T;
+  } catch {
+    return null;
+  }
+}
+
+function ensureArray<T>(v: T | T[] | undefined | null): T[] {
+  if (v == null) return [];
+  return Array.isArray(v) ? v : [v];
+}
+
+/**
+ * Load every available playerScores.json for the given AFL season and
+ * fold them into a {playerId → score entries} map. Cached per year.
+ */
+export function loadAflPlayerScores(year: number): Map<string, ScoreEntry[]> {
+  const cacheKey = String(year);
+  const hit = playerScoresCache.get(cacheKey);
+  if (hit) return hit;
+
+  const path = resolve(
+    process.cwd(),
+    `data/afl-fantasy/mfl-feeds/${year}/playerScores.json`
+  );
+  const file = readJson<PlayerScoresFile>(path);
+  const entries = ensureArray(file?.playerScores?.playerScore);
+
+  const map = new Map<string, ScoreEntry[]>();
+  for (const entry of entries) {
+    if (!entry?.id || !entry?.week) continue;
+    const list = map.get(entry.id) ?? [];
+    list.push(entry);
+    map.set(entry.id, list);
+  }
+  // Newest-first within each player's list so the "last week" pull is O(1)
+  for (const list of map.values()) {
+    list.sort((a, b) => Number(b.week) - Number(a.week));
+  }
+  playerScoresCache.set(cacheKey, map);
+  return map;
+}
+
+/**
+ * Load the projectedScores.json snapshot for the given AFL season as a
+ * {playerId → projected points} map. Cached per year.
+ */
+export function loadAflProjections(year: number): Map<string, number> {
+  const cacheKey = String(year);
+  const hit = projectionsCache.get(cacheKey);
+  if (hit) return hit;
+
+  const path = resolve(
+    process.cwd(),
+    `data/afl-fantasy/mfl-feeds/${year}/projectedScores.json`
+  );
+  const file = readJson<ProjectedScoresFile>(path);
+  const entries = ensureArray(file?.projectedScores?.playerScore);
+  const map = new Map<string, number>();
+  for (const entry of entries) {
+    if (!entry?.id) continue;
+    const n = parseFloat(entry.score);
+    if (Number.isFinite(n) && n > 0) {
+      map.set(entry.id, n);
+    }
+  }
+  projectionsCache.set(cacheKey, map);
+  return map;
+}
+
+/**
+ * Compute the per-player aggregate (last score, week, average) from a
+ * pre-loaded scoreboard map. Returns nulls when no entries exist.
+ */
+export function aggregateScores(
+  scoresByPlayer: Map<string, ScoreEntry[]>,
+  playerId: string
+): PlayerScoreAggregate {
+  const entries = scoresByPlayer.get(playerId);
+  if (!entries || entries.length === 0) {
+    return { lastScore: null, lastWeek: null, average: null, sampleSize: 0 };
+  }
+  let total = 0;
+  let count = 0;
+  for (const e of entries) {
+    const n = parseFloat(e.score);
+    if (Number.isFinite(n)) {
+      total += n;
+      count += 1;
+    }
+  }
+  const first = entries[0]; // already newest-first
+  const last = parseFloat(first.score);
+  return {
+    lastScore: Number.isFinite(last) ? last : null,
+    lastWeek: first.week ? parseInt(first.week, 10) : null,
+    average: count > 0 ? total / count : null,
+    sampleSize: count,
+  };
+}

--- a/src/utils/mfl-login.ts
+++ b/src/utils/mfl-login.ts
@@ -58,19 +58,24 @@ function parseMFLLoginXML(xml: string): { cookie?: string; error?: string } {
  * @param username - MFL username
  * @param password - MFL password
  * @param leagueId - League ID to match against (e.g. "13522")
+ * @param year - Override the season year used when calling MFL. Defaults to
+ *   the current calendar year. AFL passes the last completed season here
+ *   because the 2026 AFL league hasn't been created on MFL yet, so calling
+ *   `2026/myleagues` returns nothing for league 19621.
  */
 export async function authenticateWithMFL(
   username: string,
   password: string,
-  leagueId?: string
+  leagueId?: string,
+  year?: number,
 ): Promise<MFLLoginResponse> {
   try {
-    const year = new Date().getFullYear();
+    const seasonYear = year ?? new Date().getFullYear();
 
     // ── Step 1: Login to get MFL_USER_ID cookie ─────────────────────
     // Try POST first (MFL-recommended), fall back to GET if POST returns
     // empty body (MFL redirects POST→GET on some hosts, losing the body).
-    const loginUrl = `https://api.myfantasyleague.com/${year}/login`;
+    const loginUrl = `https://api.myfantasyleague.com/${seasonYear}/login`;
     const loginParams = new URLSearchParams({
       USERNAME: username,
       PASSWORD: password,
@@ -78,7 +83,7 @@ export async function authenticateWithMFL(
     });
 
     if (process.env.NODE_ENV !== 'production') {
-      console.log('[mfl-login] Step 1: calling /login (year:', year, ')');
+      console.log('[mfl-login] Step 1: calling /login (year:', seasonYear, ')');
     }
 
     // Use manual redirect handling to capture Set-Cookie headers from ALL hops.
@@ -212,7 +217,7 @@ export async function authenticateWithMFL(
     // Authenticate with the MFL_USER_ID cookie from Step 1.
     // Returns {"leagues":{}} when unauth'd, or {"leagues":{"league":[...]}}
     // with franchise_id when authenticated.
-    const mlUrl = `https://api.myfantasyleague.com/${year}/export?TYPE=myleagues&JSON=1`;
+    const mlUrl = `https://api.myfantasyleague.com/${seasonYear}/export?TYPE=myleagues&JSON=1`;
 
     console.log('[mfl-login] Step 2: calling export?TYPE=myleagues with cookie');
 

--- a/src/utils/nfl-matchups.ts
+++ b/src/utils/nfl-matchups.ts
@@ -18,6 +18,8 @@
 
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
+import { getCurrentLeagueYear, getCurrentSeasonYear } from './league-year';
+import liveOddsFallbackData from '../data/nfl/live-odds.json';
 
 export interface NflMatchup {
   /** Opponent NFL team code (e.g. "BUF") */
@@ -55,14 +57,41 @@ function normalizeNflCode(code: string): string {
 }
 
 /**
+ * Materialize the static src/data/nfl/live-odds.json fallback into an
+ * OddsMap. The fallback file is a snapshot of the most recent real NFL
+ * week (or the upcoming Week 1 once it's generated) so the Coach-tab
+ * columns render something useful during the offseason instead of "BYE"
+ * for every player.
+ */
+function fallbackOddsMap(): OddsMap {
+  const map: OddsMap = {};
+  for (const [code, record] of Object.entries(liveOddsFallbackData as Record<string, any>)) {
+    if (!record?.opponent) continue;
+    map[normalizeNflCode(code)] = {
+      opponent: normalizeNflCode(record.opponent),
+      isHome: !!record.isHome,
+    };
+  }
+  return map;
+}
+
+/**
  * Fetch the ESPN scoreboard for a given week and build a {teamCode → matchup}
- * map. Returns an empty map if the fetch fails (offseason, network blip,
- * timeout) so callers can render "BYE" rather than crash.
+ * map. During the offseason — when MFL has rolled into the new league year
+ * but the previous NFL season hasn't been replaced yet — we skip ESPN and
+ * return the static fallback so the page never renders all-BYE. Outside of
+ * that window we still fall back to the snapshot on any ESPN failure.
  */
 export async function fetchNflMatchups(
   week: number,
   options: { signal?: AbortSignal; year?: number } = {}
 ): Promise<OddsMap> {
+  // Offseason short-circuit: leagueYear ahead of seasonYear means we're
+  // past Feb 14 but before Labor Day — no live NFL games to fetch.
+  if (getCurrentLeagueYear() > getCurrentSeasonYear()) {
+    return fallbackOddsMap();
+  }
+
   const cacheKey = `${options.year ?? new Date().getFullYear()}-${week}`;
   const cached = oddsCache.get(cacheKey);
   if (cached && Date.now() - cached.fetchedAt < ODDS_TTL_MS) {
@@ -80,9 +109,10 @@ export async function fetchNflMatchups(
       signal: options.signal ?? AbortSignal.timeout(5000),
     });
     if (!res.ok) {
-      console.warn(`[nfl-matchups] ESPN returned ${res.status} for week ${week}`);
-      oddsCache.set(cacheKey, { data: {}, fetchedAt: Date.now() });
-      return {};
+      console.warn(`[nfl-matchups] ESPN returned ${res.status} for week ${week}; using fallback`);
+      const fb = fallbackOddsMap();
+      oddsCache.set(cacheKey, { data: fb, fetchedAt: Date.now() });
+      return fb;
     }
     const data = await res.json();
     const map: OddsMap = {};
@@ -97,12 +127,20 @@ export async function fetchNflMatchups(
       map[homeCode] = { opponent: awayCode, isHome: true };
       map[awayCode] = { opponent: homeCode, isHome: false };
     }
+    // Empty ESPN response (between weeks, schedule not yet published) →
+    // use the fallback snapshot so the table still renders something.
+    if (Object.keys(map).length === 0) {
+      const fb = fallbackOddsMap();
+      oddsCache.set(cacheKey, { data: fb, fetchedAt: Date.now() });
+      return fb;
+    }
     oddsCache.set(cacheKey, { data: map, fetchedAt: Date.now() });
     return map;
   } catch (err) {
-    console.warn('[nfl-matchups] ESPN fetch failed:', err);
-    oddsCache.set(cacheKey, { data: {}, fetchedAt: Date.now() });
-    return {};
+    console.warn('[nfl-matchups] ESPN fetch failed; using fallback:', err);
+    const fb = fallbackOddsMap();
+    oddsCache.set(cacheKey, { data: fb, fetchedAt: Date.now() });
+    return fb;
   }
 }
 

--- a/src/utils/nfl-matchups.ts
+++ b/src/utils/nfl-matchups.ts
@@ -1,0 +1,180 @@
+/**
+ * NFL matchup helper — used by AFL roster page (and reusable by anything
+ * else that wants to surface "this week's NFL opponent" data alongside
+ * fantasy players.
+ *
+ * Two pieces of data feed the Coach-mode columns:
+ *
+ *   1. ESPN scoreboard for the current NFL week — gives each NFL team's
+ *      opponent for the week + home/away.
+ *
+ *   2. fantasyPointsAllowed.json (committed under data/theleague/mfl-feeds/
+ *      because the data is NFL-wide, not league-specific) — gives each NFL
+ *      team's defensive rank by position so we can color the OPP # pill.
+ *
+ * Both are cached in-process for 5 minutes so multiple page renders during
+ * a single dev session (or repeated SSR hits) don't hammer ESPN.
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+export interface NflMatchup {
+  /** Opponent NFL team code (e.g. "BUF") */
+  opponent: string;
+  /** True when the player's NFL team is hosting */
+  isHome: boolean;
+}
+
+export interface PositionFpa {
+  rank: number; // 1 (worst defense) to 32 (best defense)
+  avg: number;
+}
+
+export interface FpaData {
+  /** Map of NFL team code to per-position FPA stats */
+  byTeam: Record<string, Record<string, PositionFpa>>;
+  /** Number of completed weeks the FPA was computed across */
+  completedWeeks?: number;
+}
+
+const ODDS_TTL_MS = 5 * 60 * 1000;
+type OddsMap = Record<string, NflMatchup>;
+const oddsCache = new Map<string, { data: OddsMap; fetchedAt: number }>();
+const fpaCache = new Map<number, FpaData | null>();
+
+/** ESPN sometimes uses a different code than MFL/our NFL logos. */
+function normalizeNflCode(code: string): string {
+  if (!code) return '';
+  const map: Record<string, string> = {
+    JAC: 'JAX',
+    WAS: 'WSH',
+  };
+  const upper = code.toUpperCase();
+  return map[upper] ?? upper;
+}
+
+/**
+ * Fetch the ESPN scoreboard for a given week and build a {teamCode → matchup}
+ * map. Returns an empty map if the fetch fails (offseason, network blip,
+ * timeout) so callers can render "BYE" rather than crash.
+ */
+export async function fetchNflMatchups(
+  week: number,
+  options: { signal?: AbortSignal; year?: number } = {}
+): Promise<OddsMap> {
+  const cacheKey = `${options.year ?? new Date().getFullYear()}-${week}`;
+  const cached = oddsCache.get(cacheKey);
+  if (cached && Date.now() - cached.fetchedAt < ODDS_TTL_MS) {
+    return cached.data;
+  }
+
+  // ESPN: regular season = seasontype 2 (weeks 1-18), playoffs = seasontype 3 (weeks 1-4)
+  const isPlayoffs = week > 18;
+  const seasonType = isPlayoffs ? 3 : 2;
+  const espnWeek = isPlayoffs ? week - 18 : week;
+  const url = `https://site.api.espn.com/apis/site/v2/sports/football/nfl/scoreboard?week=${espnWeek}&seasontype=${seasonType}`;
+
+  try {
+    const res = await fetch(url, {
+      signal: options.signal ?? AbortSignal.timeout(5000),
+    });
+    if (!res.ok) {
+      console.warn(`[nfl-matchups] ESPN returned ${res.status} for week ${week}`);
+      oddsCache.set(cacheKey, { data: {}, fetchedAt: Date.now() });
+      return {};
+    }
+    const data = await res.json();
+    const map: OddsMap = {};
+    for (const event of data?.events ?? []) {
+      const competition = event?.competitions?.[0];
+      if (!competition) continue;
+      const home = competition.competitors?.find((t: any) => t.homeAway === 'home');
+      const away = competition.competitors?.find((t: any) => t.homeAway === 'away');
+      if (!home?.team?.abbreviation || !away?.team?.abbreviation) continue;
+      const homeCode = normalizeNflCode(home.team.abbreviation);
+      const awayCode = normalizeNflCode(away.team.abbreviation);
+      map[homeCode] = { opponent: awayCode, isHome: true };
+      map[awayCode] = { opponent: homeCode, isHome: false };
+    }
+    oddsCache.set(cacheKey, { data: map, fetchedAt: Date.now() });
+    return map;
+  } catch (err) {
+    console.warn('[nfl-matchups] ESPN fetch failed:', err);
+    oddsCache.set(cacheKey, { data: {}, fetchedAt: Date.now() });
+    return {};
+  }
+}
+
+/**
+ * Load FPA data for a season from the committed JSON file. Cached per year
+ * so we only hit disk once. Returns null when the file doesn't exist (early
+ * in a season, missing snapshot).
+ */
+export function loadFantasyPointsAllowed(year: number): FpaData | null {
+  if (fpaCache.has(year)) return fpaCache.get(year) ?? null;
+
+  const path = resolve(
+    process.cwd(),
+    `data/theleague/mfl-feeds/${year}/fantasyPointsAllowed.json`
+  );
+  try {
+    const raw = readFileSync(path, 'utf-8');
+    const parsed = JSON.parse(raw);
+    const result: FpaData = {
+      byTeam: parsed.fantasyPointsAllowed ?? {},
+      completedWeeks: parsed.completedWeeks,
+    };
+    fpaCache.set(year, result);
+    return result;
+  } catch {
+    fpaCache.set(year, null);
+    return null;
+  }
+}
+
+/**
+ * Reverse mapping for FPA lookup: ESPN-style codes ↔ MFL-style codes.
+ * The committed FPA file uses MFL codes (JAC, WAS); ESPN scoreboard
+ * returns ESPN codes (JAX, WSH). Try both at lookup time.
+ */
+const FPA_LOOKUP_FALLBACKS: Record<string, string> = {
+  JAX: 'JAC',
+  WSH: 'WAS',
+  JAC: 'JAX',
+  WAS: 'WSH',
+};
+
+/**
+ * Look up the FPA stats for a given (opponent team, player position) pair.
+ * Returns null when either the team or the position isn't in the data.
+ * Defenses (DEF/Def) and kickers (PK) typically don't have FPA — caller
+ * decides whether to show "—".
+ */
+export function getOpponentFpa(
+  fpa: FpaData | null,
+  opponentCode: string,
+  position: string
+): PositionFpa | null {
+  if (!fpa || !opponentCode) return null;
+  const upper = opponentCode.toUpperCase();
+  const teamStats =
+    fpa.byTeam[upper] ??
+    fpa.byTeam[FPA_LOOKUP_FALLBACKS[upper] ?? ''];
+  if (!teamStats) return null;
+  return teamStats[position] ?? null;
+}
+
+/**
+ * Bucket an FPA rank into one of four tiers for color coding.
+ *   tier 4 = ranks 25-32 (worst defense → green / good matchup)
+ *   tier 3 = ranks 17-24
+ *   tier 2 = ranks  9-16
+ *   tier 1 = ranks  1- 8 (best defense → red / tough matchup)
+ */
+export function fpaTier(rank: number): 1 | 2 | 3 | 4 {
+  if (rank >= 25) return 4;
+  if (rank >= 17) return 3;
+  if (rank >= 9) return 2;
+  return 1;
+}

--- a/src/utils/nfl-matchups.ts
+++ b/src/utils/nfl-matchups.ts
@@ -26,6 +26,20 @@ export interface NflMatchup {
   opponent: string;
   /** True when the player's NFL team is hosting */
   isHome: boolean;
+  /**
+   * Point spread as ESPN reports it ("BUF -2.5", "PHI -7", etc.) Caller
+   * decides how to display. Empty string when ESPN hasn't priced the game.
+   */
+  spread: string;
+  /** Over/Under for the game ("47.5", "N/A", or empty). */
+  overUnder: string;
+  /** Game time in ISO 8601 (helps callers detect "BYE" vs "not yet scheduled") */
+  date: string;
+  /**
+   * Stadium weather snapshot from ESPN. null when ESPN doesn't include it
+   * (dome games, indoor venues, future games before forecast lands).
+   */
+  weather: { temperature?: number; displayValue?: string } | null;
 }
 
 export interface PositionFpa {
@@ -70,6 +84,17 @@ function fallbackOddsMap(): OddsMap {
     map[normalizeNflCode(code)] = {
       opponent: normalizeNflCode(record.opponent),
       isHome: !!record.isHome,
+      spread: typeof record.spread === 'string' ? record.spread : '',
+      overUnder: typeof record.overUnder === 'string' ? record.overUnder : '',
+      date: typeof record.date === 'string' ? record.date : '',
+      weather: record.weather && typeof record.weather === 'object'
+        ? {
+            temperature:
+              typeof record.weather.temperature === 'number' ? record.weather.temperature : undefined,
+            displayValue:
+              typeof record.weather.displayValue === 'string' ? record.weather.displayValue : undefined,
+          }
+        : null,
     };
   }
   return map;
@@ -124,8 +149,25 @@ export async function fetchNflMatchups(
       if (!home?.team?.abbreviation || !away?.team?.abbreviation) continue;
       const homeCode = normalizeNflCode(home.team.abbreviation);
       const awayCode = normalizeNflCode(away.team.abbreviation);
-      map[homeCode] = { opponent: awayCode, isHome: true };
-      map[awayCode] = { opponent: homeCode, isHome: false };
+      const odds = competition.odds?.[0] ?? {};
+      const spread = typeof odds.details === 'string' ? odds.details : '';
+      const overUnder = odds.overUnder != null ? String(odds.overUnder) : '';
+      const weather = competition.weather
+        ? {
+            temperature:
+              typeof competition.weather.temperature === 'number'
+                ? competition.weather.temperature
+                : undefined,
+            displayValue:
+              typeof competition.weather.displayValue === 'string'
+                ? competition.weather.displayValue
+                : undefined,
+          }
+        : null;
+      const date = typeof event.date === 'string' ? event.date : '';
+      const base = { spread, overUnder, weather, date };
+      map[homeCode] = { opponent: awayCode, isHome: true, ...base };
+      map[awayCode] = { opponent: homeCode, isHome: false, ...base };
     }
     // Empty ESPN response (between weeks, schedule not yet published) →
     // use the fallback snapshot so the table still renders something.

--- a/tests/afl-conference.test.ts
+++ b/tests/afl-conference.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getConferenceName,
+  getConferenceShort,
+  getConferenceIdByName,
+  isValidConferenceId,
+  getFranchiseConference,
+  getConferenceTeams,
+  getAllTeams,
+  sameConference,
+  getTeamsGroupedByConference,
+  filterByConference,
+} from '../src/utils/afl-conference';
+
+describe('afl-conference', () => {
+  it('maps 00 to American League and 01 to National League', () => {
+    expect(getConferenceName('00')).toBe('American League');
+    expect(getConferenceName('01')).toBe('National League');
+    expect(getConferenceShort('00')).toBe('AL');
+    expect(getConferenceShort('01')).toBe('NL');
+  });
+
+  it('round-trips conference name <-> id', () => {
+    expect(getConferenceIdByName('American League')).toBe('00');
+    expect(getConferenceIdByName('National League')).toBe('01');
+  });
+
+  it('isValidConferenceId only accepts 00 / 01', () => {
+    expect(isValidConferenceId('00')).toBe(true);
+    expect(isValidConferenceId('01')).toBe(true);
+    expect(isValidConferenceId('02')).toBe(false);
+    expect(isValidConferenceId('')).toBe(false);
+    expect(isValidConferenceId('AL')).toBe(false);
+  });
+
+  it('returns conference for a known franchise', () => {
+    // Smokane FC (0001) is in the American League per afl.config.json
+    expect(getFranchiseConference('0001')).toBe('00');
+    // Muck Juggling Micks (0013) is in the National League
+    expect(getFranchiseConference('0013')).toBe('01');
+  });
+
+  it('returns null for unknown franchise', () => {
+    expect(getFranchiseConference('9999')).toBeNull();
+  });
+
+  it('splits the league exactly 12/12', () => {
+    expect(getConferenceTeams('00')).toHaveLength(12);
+    expect(getConferenceTeams('01')).toHaveLength(12);
+    expect(getAllTeams()).toHaveLength(24);
+  });
+
+  it('sameConference is true within and false across leagues', () => {
+    expect(sameConference('0001', '0002')).toBe(true); // both AL
+    expect(sameConference('0013', '0014')).toBe(true); // both NL
+    expect(sameConference('0001', '0013')).toBe(false); // AL vs NL
+  });
+
+  it('sameConference returns false when either franchise is unknown', () => {
+    expect(sameConference('0001', '9999')).toBe(false);
+    expect(sameConference('9999', '9998')).toBe(false);
+  });
+
+  it('groups teams AL first then NL', () => {
+    const groups = getTeamsGroupedByConference();
+    expect(groups).toHaveLength(2);
+    expect(groups[0].conferenceId).toBe('00');
+    expect(groups[0].conferenceName).toBe('American League');
+    expect(groups[1].conferenceId).toBe('01');
+    expect(groups[1].conferenceName).toBe('National League');
+  });
+
+  it('filterByConference filters items keyed by franchiseId or id', () => {
+    const items = [
+      { franchiseId: '0001', n: 'a' },
+      { franchiseId: '0013', n: 'b' },
+      { franchiseId: '0014', n: 'c' },
+    ];
+    expect(filterByConference(items, '00')).toEqual([{ franchiseId: '0001', n: 'a' }]);
+    expect(filterByConference(items, '01')).toHaveLength(2);
+
+    const itemsById = [{ id: '0001' }, { id: '0014' }];
+    expect(filterByConference(itemsById, '00')).toEqual([{ id: '0001' }]);
+  });
+});


### PR DESCRIPTION
Centralizes the American League / National League <-> MFL conference ID
('00'/'01') mapping in a single utility so the trade builder, roster
filters, and team selectors all agree. Cross-conference trades are not
allowed in this league, so callers can use sameConference() to gate the
trade target picker.

Also fixes two AFL papercuts in shared code:

- trade-bait.ts wrote its post-update cache to data/theleague/ regardless
  of which league the user belonged to, so an AFL owner adding a player
  to their trade block would silently corrupt TheLeague's cache. Cache
  dir now follows the user's leagueId.

- PlayerDetailsModal hard-coded a Contract metric and a Contract detail
  row that fell back to a "Free Agent" badge when salary was null. AFL
  has no salaries at all, so every AFL player rendered as "FA". Added a
  hideContract prop so AFL pages can suppress the section.