### PR TITLE
fix(afl-rosters): align team header and split active vs IR tables

### DIFF
--- a/src/pages/afl-fantasy/rosters.astro
+++ b/src/pages/afl-fantasy/rosters.astro
@@ -235,16 +235,17 @@ const positionRank = (pos: string) => {
 // bottom. Mirrors TheLeague's roster page — the green left-border stripe
 // on active rows + the red stripe on IR rows makes the split obvious
 // without a dedicated Status column.
-const sortedTableRoster: RosterEntry[] = (() => {
-  const byStatus = (status: string) =>
-    roster
-      .filter((p) => p.status === status)
-      .sort((a, b) => {
-        const r = positionRank(a.position) - positionRank(b.position);
-        return r !== 0 ? r : a.name.localeCompare(b.name);
-      });
-  return [...byStatus('ROSTER'), ...byStatus('INJURED_RESERVE')];
-})();
+const byPositionThenName = (a: RosterEntry, b: RosterEntry) => {
+  const r = positionRank(a.position) - positionRank(b.position);
+  return r !== 0 ? r : a.name.localeCompare(b.name);
+};
+const activeRosterPlayers: RosterEntry[] = roster
+  .filter((p) => p.status === 'ROSTER')
+  .sort(byPositionThenName);
+const irRosterPlayers: RosterEntry[] = roster
+  .filter((p) => p.status === 'INJURED_RESERVE')
+  .sort(byPositionThenName);
+const sortedTableRoster: RosterEntry[] = [...activeRosterPlayers, ...irRosterPlayers];
 
 // ── Coach-mode matchup data (matches TheLeague's roster Coach tab) ──
 //
@@ -610,26 +611,6 @@ const pageConfig = {
       </a>
     </div>
 
-    <!-- Roster summary -->
-    <div class="roster-summary">
-      <article>
-        <p>Active roster</p>
-        <strong>{activeRoster}<span class="roster-summary__denom">/{ROSTER_SIZE}</span></strong>
-      </article>
-      <article>
-        <p>Injured reserve</p>
-        <strong>{injuredReserve}</strong>
-      </article>
-      <article>
-        <p>Total players</p>
-        <strong>{totalPlayers}</strong>
-      </article>
-      <article>
-        <p>Open active slots</p>
-        <strong>{Math.max(0, ROSTER_SIZE - activeRoster)}</strong>
-      </article>
-    </div>
-
     <!-- Roster View -->
     <section class="view-container" data-view-content="roster" hidden={initialView !== 'roster'}>
       {roster.length === 0 ? (
@@ -637,24 +618,45 @@ const pageConfig = {
           <p>No roster data for this team in {selectedYear}.</p>
         </div>
       ) : (
-        <div class="roster-table-card">
-          <div class="roster-table-wrapper">
-            <table class="roster-table roster-table--afl">
-              <thead>
-                <tr>
-                  <th data-column="player">Player</th>
-                  {isOwner && <th data-column="actions" aria-label="Actions"></th>}
-                  <th data-column="oppRank">Opp #</th>
-                  <th data-column="opponent">Opponent</th>
-                  <th data-column="ou">O/U</th>
-                  <th data-column="weather">Weather</th>
-                  <th data-column="oppAvg">Opp Avg</th>
-                  <th data-column="avg">Avg</th>
-                  <th data-column="projected">Proj</th>
-                </tr>
-              </thead>
-              <tbody>
-                {sortedTableRoster.map((player) => {
+        <Fragment>
+        {[
+          {
+            title: 'Active Roster',
+            players: activeRosterPlayers,
+            statusClass: 'active',
+            alwaysShow: true,
+          },
+          {
+            title: 'Injured Reserve',
+            players: irRosterPlayers,
+            statusClass: 'ir',
+            alwaysShow: false,
+          },
+        ]
+          .filter((group) => group.alwaysShow || group.players.length > 0)
+          .map((group) => (
+            <div class="roster-section" data-roster-section={group.statusClass}>
+              {group.statusClass !== 'active' && (
+                <h3 class="roster-section__title">{group.title}</h3>
+              )}
+              <div class="roster-table-card">
+                <div class="roster-table-wrapper">
+                  <table class="roster-table roster-table--afl">
+                    <thead>
+                      <tr>
+                        <th data-column="player">Player</th>
+                        {isOwner && <th data-column="actions" aria-label="Actions"></th>}
+                        <th data-column="oppRank">Opp #</th>
+                        <th data-column="opponent">Opponent</th>
+                        <th data-column="ou">O/U</th>
+                        <th data-column="weather">Weather</th>
+                        <th data-column="oppAvg">Opp Avg</th>
+                        <th data-column="avg">Avg</th>
+                        <th data-column="projected">Proj</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {group.players.map((player) => {
                   const m = matchupByPlayerId.get(player.id);
                   const matchup = m?.matchup ?? null;
                   const oppCode = m?.oppCode ?? null;
@@ -753,10 +755,33 @@ const pageConfig = {
                     </tr>
                   );
                 })}
-              </tbody>
-            </table>
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            </div>
+          ))}
+
+          <!-- Roster summary cards -->
+          <div class="roster-summary">
+            <article>
+              <p>Active roster</p>
+              <strong>{activeRoster}<span class="roster-summary__denom">/{ROSTER_SIZE}</span></strong>
+            </article>
+            <article>
+              <p>Injured reserve</p>
+              <strong>{injuredReserve}</strong>
+            </article>
+            <article>
+              <p>Total players</p>
+              <strong>{totalPlayers}</strong>
+            </article>
+            <article>
+              <p>Open active slots</p>
+              <strong>{Math.max(0, ROSTER_SIZE - activeRoster)}</strong>
+            </article>
           </div>
-        </div>
+        </Fragment>
       )}
     </section>
 
@@ -1172,6 +1197,7 @@ const pageConfig = {
     @media (min-width: 480px) {
       .team-card__actions {
         width: auto;
+        margin-left: auto;
       }
     }
 
@@ -1283,6 +1309,27 @@ const pageConfig = {
     }
 
     .roster-controls-bar__profile:hover { text-decoration: underline; }
+
+    /* ── Roster section header ── */
+    .roster-section {
+      display: grid;
+      gap: var(--padding-md, 1rem);
+    }
+
+    .roster-section__title {
+      margin: 0;
+      padding-bottom: 0.25rem;
+      font-size: 1rem;
+      font-weight: 700;
+      color: var(--color-gray-900, #111827);
+      line-height: 1.2;
+    }
+
+    /* IR section: slightly de-emphasized table card to make it visually
+       obvious these players are NOT on the active roster. */
+    .roster-section[data-roster-section='ir'] .roster-table-card {
+      background: var(--color-gray-50, #f9fafb);
+    }
 
     /* ── Roster summary cards (matches TheLeague's .roster-summary) ── */
     .roster-summary {


### PR DESCRIPTION
## Summary

Three small UX fixes to the AFL Fantasy rosters page:

- **Team header alignment.** On desktop, `.team-card__actions` was missing the `margin-left: auto` that TheLeague's roster page uses. The empty actions box now consumes the free space on the right, pushing the team identity (avatar + name + meta) to the left so the tabs no longer leave a visible empty band beside the team info.
- **IR is now its own table.** The combined roster table was split into two tables — Active Roster on top, Injured Reserve below — so it's immediately clear which players aren't on the active roster. The IR section gets its own "Injured Reserve" headline and a subtly gray-50 tinted card; the active section is unlabeled (no headline needed since it's the default view).
- **Summary cards moved to the bottom.** The four stat cards (Active roster, Injured reserve, Total players, Open active slots) now sit beneath the IR table as a footer summary instead of stacked above the table.

## Implementation notes

- The combined `sortedTableRoster` array still exists (kept for the `matchupByPlayerId` lookup loop), but the JSX now iterates over a `[activeGroup, irGroup]` array and filters out the IR group when there are no IR players. This means the row template is defined exactly once — both tables share the same column structure and row markup.
- IR section uses `data-roster-section="ir"` on its wrapper so the table card gets a `gray-50` background. Each tbody row already has `data-row-status="ir"` for the red left-border accent, so individual IR rows still get their stripe inside the IR table.

## Test plan

- [x] Desktop (1280px): team identity left-aligned, tabs on right, no empty band on the left
- [x] Active Roster table renders all 16 players with no headline
- [x] Injured Reserve table renders below with "Injured Reserve" headline and gray-tinted card
- [x] Four summary stat cards render at the bottom
- [x] IR section only renders when there are IR players (verified via `alwaysShow` filter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)