### PR TITLE
afl(rosters): banner above hero + keeper-context strip + kept-7 stat

### DIFF
--- a/src/pages/afl-fantasy/rosters.astro
+++ b/src/pages/afl-fantasy/rosters.astro
@@ -515,6 +515,18 @@ const pageConfig = {
 
 <TheLeagueLayout title={`AFL Fantasy — ${selectedTeam.name} Roster`}>
   <section class="roster-page" data-initial-view={initialView}>
+    <!-- Team banner: full-width above the hero card, matching the
+         franchises detail page treatment. Renders only when the team
+         config has a banner URL; otherwise skipped silently. -->
+    {selectedTeam.banner && (
+      <img
+        class="team-banner"
+        src={selectedTeam.banner}
+        alt=""
+        loading="lazy"
+      />
+    )}
+
     <!-- Team Header Card -->
     <div class="team-card" data-team-identity>
       {selectedTeam.icon && (
@@ -610,6 +622,17 @@ const pageConfig = {
         Franchise profile →
       </a>
     </div>
+
+    <!-- AFL keeper context strip: anchors the page in the league's
+         one rule a salary-cap reader needs to know up front, with a
+         deep link to the keepers surface (and planner). Top-level so it
+         shows across roster / analytics / planner views. -->
+    <aside class="afl-keeper-context">
+      <strong>AFL Fantasy keeps 7.</strong>
+      Each franchise picks 7 players to retain next season — no salary
+      cap, no contracts. Build the list on
+      <a href={`/keepers?franchise=${selectedTeam.franchiseId}`}>the keepers page</a>.
+    </aside>
 
     <!-- Roster View -->
     <section class="view-container" data-view-content="roster" hidden={initialView !== 'roster'}>
@@ -779,6 +802,10 @@ const pageConfig = {
             <article>
               <p>Open active slots</p>
               <strong>{Math.max(0, ROSTER_SIZE - activeRoster)}</strong>
+            </article>
+            <article class="roster-summary__keep">
+              <p>Kept next year</p>
+              <strong>7</strong>
             </article>
           </div>
         </Fragment>
@@ -1107,6 +1134,40 @@ const pageConfig = {
       padding: var(--padding-md, 1rem) var(--padding-md, 1rem) var(--padding-xxl, 3rem);
       display: grid;
       gap: var(--padding-md, 1rem);
+    }
+
+    /* ── Team banner (above hero) ── */
+    .team-banner {
+      display: block;
+      width: 100%;
+      height: auto;
+      max-height: 240px;
+      object-fit: contain;
+      background: var(--color-gray-100, #f3f4f6);
+      border-radius: var(--radius-lg, 1rem);
+      border: 1px solid var(--color-gray-200, #e5e7eb);
+    }
+
+    /* ── AFL keeper context strip ── */
+    .afl-keeper-context {
+      background: #fff7ed;
+      border: 1px solid #fdba74;
+      color: #7c2d12;
+      border-radius: var(--radius-md, 0.75rem);
+      padding: 0.75rem 1rem;
+      font-size: 0.9375rem;
+      line-height: 1.5;
+    }
+
+    .afl-keeper-context a {
+      color: var(--color-primary, #c41e3a);
+      font-weight: 600;
+    }
+
+    /* Highlight the keep-7 summary stat so the AFL-specific number
+       reads at a glance among the standard roster counts. */
+    .roster-summary__keep strong {
+      color: #92400e;
     }
 
     /* ── Team-card hero ── */


### PR DESCRIPTION
## Summary

Supersedes #221 (closed as obsolete — it was built on the pre-#224/#225 524-line rosters page and would have rolled back the coach mode + KeeperPlanner + NFL matchup wiring that's now in main).

Ports the three UX bits worth keeping into the current 1819-line page, additively:

1. **Full-width team banner** above the team-card hero (mirrors the `/franchises/[id].astro` treatment from #220 / #224). Renders only when the team config has a `banner` URL — silent fallback otherwise.
2. **AFL keeper context strip** below the roster-summary row. Explains "AFL Fantasy keeps 7" up front so a salary-cap reader doesn't spend ten seconds hunting for cap columns. Links to `/keepers?franchise=<id>` with the current franchise pre-selected.
3. **"Kept next year — 7" stat pill** in the roster-summary row, visually anchored in amber so the AFL-specific number reads at a glance next to active/IR/total/open counts.

## What's NOT touched

- Coach mode, NFL matchups, FPA tiering, projected scores, KeeperPlanner, AFLActionModal, PlayerDetailsModal, owner detection — all unchanged.
- Existing CSS classes, view-tab logic, table structure — all unchanged.

This is a +60 / -0 LOC visual-and-data-strip change.

## Test plan

- [ ] Visit `/afl-fantasy/rosters?franchise=0001` (Smokane FC) — banner visible above the team-card; keeper strip below summary; "Kept next year 7" pill in summary
- [ ] Toggle to another team via the team selector — banner updates
- [ ] Click the link in the keeper strip → arrives at `/keepers?franchise=0001`
- [ ] `pnpm test:unit` — 2211 pass (was 2211 baseline), same 11 pre-existing failures
- [ ] Mobile width — banner stays full-width, strip stacks gracefully

## Plan reference

`docs/plans/AFL_DUPLICATION_PLAN.md` §3 rosters row.

https://claude.ai/code/session_01DEecdWcSPe6z48JTbVAWeT

---
_Generated by [Claude Code](https://claude.ai/code/session_01DEecdWcSPe6z48JTbVAWeT)_