### PR TITLE
fix(afl): set correct preference cookie on login + JWT fallback for nav

### DIFF
--- a/src/layouts/TheLeagueLayout.astro
+++ b/src/layouts/TheLeagueLayout.astro
@@ -74,18 +74,25 @@ if (myteamParam) {
 	});
 }
 
+// JWT session is the canonical auth state — used as a fallback when the
+// league-specific preference cookie is missing (e.g., older login sessions
+// from before the cookie write was fixed, or after a manual cookie clear).
+const layoutAuthUser = getAuthUser(Astro.request);
+
 // Get team preference based on current league context
 let myteam: string | null = null;
 let teamInfo: NavTeamInfo | null = null;
 
 if (league === 'afl') {
-	// AFL: Check AFL-specific preference cookie first
+	// AFL: Check AFL-specific preference cookie first, fall back to JWT
 	const aflPref = getAFLPreference(Astro.cookies);
-	myteam = myteamParam || aflPref?.franchiseId || null;
+	const aflJwtFranchiseId =
+		layoutAuthUser?.leagueId === '19621' ? layoutAuthUser.franchiseId : null;
+	myteam = myteamParam || aflPref?.franchiseId || aflJwtFranchiseId || null;
 
-	// Only populate nav teamInfo from authenticated sources (AFL preference cookie),
-	// not from ?myteam= query param which doesn't require login
-	const navTeamId = aflPref?.franchiseId || null;
+	// Only populate nav teamInfo from authenticated sources (AFL preference cookie
+	// or JWT session), not from ?myteam= query param which doesn't require login
+	const navTeamId = aflPref?.franchiseId || aflJwtFranchiseId || null;
 
 	if (navTeamId) {
 		// Dynamic import AFL config only when needed
@@ -156,8 +163,7 @@ const hideLeaguePrefix = Astro.locals.hideLeaguePrefix ?? false;
 const adminFranchiseIds = getAdminFranchiseIds();
 
 // Commissioner mode: use JWT session auth as the single source of truth
-const authUser = getAuthUser(Astro.request);
-const isCommissioner = !!authUser && isCommissionerOrAdmin(authUser);
+const isCommissioner = !!layoutAuthUser && isCommissionerOrAdmin(layoutAuthUser);
 const isCommishMode = isCommissioner && Astro.cookies.get('commish-mode')?.value === 'true';
 
 // Get visible navigation sections

--- a/src/pages/api/auth/login.ts
+++ b/src/pages/api/auth/login.ts
@@ -1,7 +1,9 @@
 import type { APIRoute } from 'astro';
 import { authenticateWithMFL } from '../../../utils/mfl-login';
 import { createSessionToken, createSessionCookie, createMFLCookies } from '../../../utils/session';
-import { setTheLeaguePreference } from '../../../utils/team-preferences';
+import { setTheLeaguePreference, setAFLPreference, getAFLTeamData } from '../../../utils/team-preferences';
+
+const AFL_LEAGUE_ID = '19621';
 
 export const POST: APIRoute = async ({ request, cookies }) => {
   try {
@@ -59,8 +61,16 @@ export const POST: APIRoute = async ({ request, cookies }) => {
     const isDev = import.meta.env.DEV;
     const sessionCookie = createSessionCookie(sessionToken, isDev);
 
-    // Set team preference cookie
-    setTheLeaguePreference(cookies, mflResponse.franchiseId);
+    // Set team preference cookie for the league the user logged into
+    const resolvedLeagueId = mflResponse.leagueId || leagueId || '';
+    if (resolvedLeagueId === AFL_LEAGUE_ID) {
+      const teamData = getAFLTeamData(mflResponse.franchiseId);
+      if (teamData) {
+        setAFLPreference(cookies, mflResponse.franchiseId, teamData.conference, teamData.tier);
+      }
+    } else {
+      setTheLeaguePreference(cookies, mflResponse.franchiseId);
+    }
 
     // Build all Set-Cookie headers: session + MFL credentials
     const setCookieHeaders = [sessionCookie];


### PR DESCRIPTION
## Summary

- AFL login flow writes the wrong preference cookie — `setTheLeaguePreference()` was called unconditionally regardless of which league the user signed into, leaving AFL owners with a valid JWT but no `afl_team_pref` cookie
- The split caused the AFL rosters page to render the \"Your team\" badge + action buttons (driven by the JWT via `getAuthUser()`) while the nav drawer simultaneously showed the \"Verify Your Team / Link your MFL account\" CTA (driven by the missing preference cookie)
- Login route now branches on the resolved `leagueId`: AFL (19621) writes `afl_team_pref` via `setAFLPreference()` with conference + tier looked up from `getAFLTeamData()`; everything else continues to use `setTheLeaguePreference()`
- Layout adds a JWT fallback for AFL nav `teamInfo` so users already logged in via the broken flow see the correct team in the drawer immediately on deploy without needing to re-login. Also consolidates a duplicate `getAuthUser()` call into a single `layoutAuthUser` variable

## Files changed

- `src/pages/api/auth/login.ts` — branch cookie write on `leagueId`
- `src/layouts/TheLeagueLayout.astro` — JWT fallback for AFL `teamInfo`, consolidate `getAuthUser()`

## Test plan

- [x] Type-check passes on changed files (`pnpm exec tsc --noEmit`)
- [x] Manually verified: with a valid AFL session JWT and no `afl_team_pref` cookie, the nav drawer footer renders Smokane FC logo + name instead of \"Verify Your Team\"
- [x] Manually verified: `/api/auth/me` returns `authenticated: true` with `leagueId: 19621`
- [ ] Post-deploy: log into AFL fresh — confirm `afl_team_pref` cookie is set and nav drawer shows team immediately
- [ ] Post-deploy: existing AFL sessions (broken cookie state) — confirm nav drawer recovers via JWT fallback without forcing re-login
- [ ] Post-deploy: confirm Set Lineup / Add/drop actions now succeed end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)