### PR TITLE
afl(rosters): remove team banner and keep-7 context strip

### DIFF
--- a/src/pages/afl-fantasy/rosters.astro
+++ b/src/pages/afl-fantasy/rosters.astro
@@ -515,18 +515,6 @@ const pageConfig = {
 
 <TheLeagueLayout title={`AFL Fantasy — ${selectedTeam.name} Roster`}>
   <section class="roster-page" data-initial-view={initialView}>
-    <!-- Team banner: full-width above the hero card, matching the
-         franchises detail page treatment. Renders only when the team
-         config has a banner URL; otherwise skipped silently. -->
-    {selectedTeam.banner && (
-      <img
-        class="team-banner"
-        src={selectedTeam.banner}
-        alt=""
-        loading="lazy"
-      />
-    )}
-
     <!-- Team Header Card -->
     <div class="team-card" data-team-identity>
       {selectedTeam.icon && (
@@ -622,17 +610,6 @@ const pageConfig = {
         Franchise profile →
       </a>
     </div>
-
-    <!-- AFL keeper context strip: anchors the page in the league's
-         one rule a salary-cap reader needs to know up front, with a
-         deep link to the keepers surface (and planner). Top-level so it
-         shows across roster / analytics / planner views. -->
-    <aside class="afl-keeper-context">
-      <strong>AFL Fantasy keeps 7.</strong>
-      Each franchise picks 7 players to retain next season — no salary
-      cap, no contracts. Build the list on
-      <a href={`/keepers?franchise=${selectedTeam.franchiseId}`}>the keepers page</a>.
-    </aside>
 
     <!-- Roster View -->
     <section class="view-container" data-view-content="roster" hidden={initialView !== 'roster'}>
@@ -1134,34 +1111,6 @@ const pageConfig = {
       padding: var(--padding-md, 1rem) var(--padding-md, 1rem) var(--padding-xxl, 3rem);
       display: grid;
       gap: var(--padding-md, 1rem);
-    }
-
-    /* ── Team banner (above hero) ── */
-    .team-banner {
-      display: block;
-      width: 100%;
-      height: auto;
-      max-height: 240px;
-      object-fit: contain;
-      background: var(--color-gray-100, #f3f4f6);
-      border-radius: var(--radius-lg, 1rem);
-      border: 1px solid var(--color-gray-200, #e5e7eb);
-    }
-
-    /* ── AFL keeper context strip ── */
-    .afl-keeper-context {
-      background: #fff7ed;
-      border: 1px solid #fdba74;
-      color: #7c2d12;
-      border-radius: var(--radius-md, 0.75rem);
-      padding: 0.75rem 1rem;
-      font-size: 0.9375rem;
-      line-height: 1.5;
-    }
-
-    .afl-keeper-context a {
-      color: var(--color-primary, #c41e3a);
-      font-weight: 600;
     }
 
     /* Highlight the keep-7 summary stat so the AFL-specific number


### PR DESCRIPTION
## Summary
- Removes the full-width team banner image that sat above the team-card hero on the AFL rosters page
- Removes the yellow "AFL Fantasy keeps 7" keeper-context aside and its CSS
- Roster page now lands directly on the team-card hero → controls bar → roster table

## Test plan
- [x] Verified in dev preview: `.team-banner` and `.afl-keeper-context` no longer render on `/afl-fantasy/rosters`
- [x] Team-card hero, team/year switcher, and roster table render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)