### PR TITLE
revert: afl(rosters) banner + keeper-context strip + kept-7 stat (#227)

### DIFF
--- a/src/pages/afl-fantasy/rosters.astro
+++ b/src/pages/afl-fantasy/rosters.astro
@@ -515,18 +515,6 @@ const pageConfig = {
 
 <TheLeagueLayout title={`AFL Fantasy — ${selectedTeam.name} Roster`}>
   <section class="roster-page" data-initial-view={initialView}>
-    <!-- Team banner: full-width above the hero card, matching the
-         franchises detail page treatment. Renders only when the team
-         config has a banner URL; otherwise skipped silently. -->
-    {selectedTeam.banner && (
-      <img
-        class="team-banner"
-        src={selectedTeam.banner}
-        alt=""
-        loading="lazy"
-      />
-    )}
-
     <!-- Team Header Card -->
     <div class="team-card" data-team-identity>
       {selectedTeam.icon && (
@@ -622,17 +610,6 @@ const pageConfig = {
         Franchise profile →
       </a>
     </div>
-
-    <!-- AFL keeper context strip: anchors the page in the league's
-         one rule a salary-cap reader needs to know up front, with a
-         deep link to the keepers surface (and planner). Top-level so it
-         shows across roster / analytics / planner views. -->
-    <aside class="afl-keeper-context">
-      <strong>AFL Fantasy keeps 7.</strong>
-      Each franchise picks 7 players to retain next season — no salary
-      cap, no contracts. Build the list on
-      <a href={`/keepers?franchise=${selectedTeam.franchiseId}`}>the keepers page</a>.
-    </aside>
 
     <!-- Roster View -->
     <section class="view-container" data-view-content="roster" hidden={initialView !== 'roster'}>
@@ -802,10 +779,6 @@ const pageConfig = {
             <article>
               <p>Open active slots</p>
               <strong>{Math.max(0, ROSTER_SIZE - activeRoster)}</strong>
-            </article>
-            <article class="roster-summary__keep">
-              <p>Kept next year</p>
-              <strong>7</strong>
             </article>
           </div>
         </Fragment>
@@ -1134,40 +1107,6 @@ const pageConfig = {
       padding: var(--padding-md, 1rem) var(--padding-md, 1rem) var(--padding-xxl, 3rem);
       display: grid;
       gap: var(--padding-md, 1rem);
-    }
-
-    /* ── Team banner (above hero) ── */
-    .team-banner {
-      display: block;
-      width: 100%;
-      height: auto;
-      max-height: 240px;
-      object-fit: contain;
-      background: var(--color-gray-100, #f3f4f6);
-      border-radius: var(--radius-lg, 1rem);
-      border: 1px solid var(--color-gray-200, #e5e7eb);
-    }
-
-    /* ── AFL keeper context strip ── */
-    .afl-keeper-context {
-      background: #fff7ed;
-      border: 1px solid #fdba74;
-      color: #7c2d12;
-      border-radius: var(--radius-md, 0.75rem);
-      padding: 0.75rem 1rem;
-      font-size: 0.9375rem;
-      line-height: 1.5;
-    }
-
-    .afl-keeper-context a {
-      color: var(--color-primary, #c41e3a);
-      font-weight: 600;
-    }
-
-    /* Highlight the keep-7 summary stat so the AFL-specific number
-       reads at a glance among the standard roster counts. */
-    .roster-summary__keep strong {
-      color: #92400e;
     }
 
     /* ── Team-card hero ── */


### PR DESCRIPTION
## Summary

Reverts [commit 32a8a41](https://github.com/braven112/mfl.football.v2/commit/32a8a41cb10df12cd66710296cc97a8feb766653) ([#227](https://github.com/braven112/mfl.football.v2/pull/227)) at the user's request.

Removes the three additions to [src/pages/afl-fantasy/rosters.astro](src/pages/afl-fantasy/rosters.astro):

- Full-width team banner above the team-card hero
- AFL keeper context strip (`<aside class="afl-keeper-context">`)
- "Kept next year — 7" roster-summary stat

…along with their associated CSS (`.team-banner`, `.afl-keeper-context`, `.roster-summary__keep`).

Clean revert — no conflicts, no other commits had touched the file since.

## Test plan

- [ ] `/afl-fantasy/rosters` renders the team-card hero, roster summary, and keeper strip-free layout as it did prior to #227
- [ ] No leftover references to `team-banner`, `afl-keeper-context`, or `roster-summary__keep` selectors anywhere in the page
- [ ] No build/type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)