### PR TITLE
feat(schefter): age repeat rumors out of normal lane after 3 weeks

### DIFF
--- a/data/schefter/topic-recurrence.json
+++ b/data/schefter/topic-recurrence.json
@@ -1,0 +1,5 @@
+{
+  "version": 1,
+  "season": 2026,
+  "fingerprints": {}
+}

--- a/scripts/lib/schefter-bucket-logic.mjs
+++ b/scripts/lib/schefter-bucket-logic.mjs
@@ -9,6 +9,7 @@
  * truth" so the admin page can show an honest preview of what the next
  * scanner cycle will pick.
  */
+import { isFingerprintStale, getStreakLength } from './schefter-recurrence-ledger.mjs';
 
 export function classifyTipKind(tip) {
   if (!tip) return 'gossip';
@@ -98,4 +99,46 @@ export function rankBuckets(buckets, now = new Date()) {
   trade.sort((a, b) => bucketPriorityScore(b, now) - bucketPriorityScore(a, now));
   gossip.sort((a, b) => bucketPriorityScore(b, now) - bucketPriorityScore(a, now));
   return [...trade, ...gossip];
+}
+
+/**
+ * A bucket's recurrence fingerprint = its bucket key, with two carve-outs:
+ *   - trade-offer buckets (`trade:offer`) have their own dedup mechanism
+ *     (per-offer cumulative probability) so the recurrence ledger doesn't
+ *     apply.
+ *   - whisper-back threads (`thread:<id>`) are reply chains, not recurring
+ *     news — they should never be marked stale.
+ *
+ * Returns `null` when the bucket is exempt from recurrence tracking.
+ */
+export function bucketFingerprint(bucket) {
+  if (!bucket || typeof bucket.key !== 'string') return null;
+  if (bucket.key === 'trade:offer') return null;
+  if (bucket.key.startsWith('thread:')) return null;
+  return bucket.key;
+}
+
+/**
+ * True when this bucket has been posted about in the two preceding ISO
+ * weeks — posting it again this cycle would be the 3rd consecutive week,
+ * which qualifies it for mailbag-only relegation. Trade-offer buckets and
+ * whisper-back threads always return false (they're exempt — see
+ * `bucketFingerprint`).
+ */
+export function isBucketStale(bucket, ledger, currentWeek) {
+  const fp = bucketFingerprint(bucket);
+  if (!fp) return false;
+  return isFingerprintStale(ledger, fp, currentWeek);
+}
+
+/**
+ * Consecutive-week streak length for a bucket (including the current week
+ * as if it just shipped). Returns 1 for exempt buckets (trade-offer,
+ * whisper-back) and for never-seen fingerprints. A streak of 3+ means the
+ * bucket is stale and headed for mailbag-only.
+ */
+export function bucketStreakLength(bucket, ledger, currentWeek) {
+  const fp = bucketFingerprint(bucket);
+  if (!fp) return 1;
+  return getStreakLength(ledger, fp, currentWeek);
 }

--- a/scripts/lib/schefter-recurrence-ledger.mjs
+++ b/scripts/lib/schefter-recurrence-ledger.mjs
@@ -1,0 +1,157 @@
+/**
+ * Schefter rumor-recurrence ledger.
+ *
+ * Tracks which gossip bucket fingerprints have already been posted about in
+ * each ISO calendar week. A fingerprint that's been posted in two consecutive
+ * prior weeks is "stale" — the next time it shows up, the normal rumor lane
+ * skips it and lets fresher tips through. Stale fingerprints still surface
+ * via Friday mailbag so nothing expires unseen.
+ *
+ * The user's pain point: when the same rumor cycles for weeks ("Geeks are
+ * shopping Jefferson"), fresh tips get stuck behind it. The ledger lets the
+ * scanner age repeats out of the normal lane after three weeks.
+ *
+ * Reset boundary: Labor Day (NFL season rollover). When a new season starts
+ * the whole ledger drops to a clean slate.
+ *
+ * Pure helpers — file I/O is isolated to load/save so the rest is testable
+ * without touching disk.
+ */
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import path from 'node:path';
+
+export const LEDGER_VERSION = 1;
+export const STALE_WEEK_THRESHOLD = 2;
+
+export function isoWeekLabel(date) {
+  const d = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+  const dayOfWeek = d.getUTCDay() || 7;
+  d.setUTCDate(d.getUTCDate() + 4 - dayOfWeek);
+  const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+  const weekNo = Math.ceil(((d - yearStart) / 86400000 + 1) / 7);
+  return `${d.getUTCFullYear()}-W${String(weekNo).padStart(2, '0')}`;
+}
+
+export function isoWeekMinus(label, n) {
+  const date = isoWeekToDate(label);
+  date.setUTCDate(date.getUTCDate() - n * 7);
+  return isoWeekLabel(date);
+}
+
+function isoWeekToDate(label) {
+  const m = /^(\d{4})-W(\d{2})$/.exec(label);
+  if (!m) throw new Error(`Invalid ISO week label: ${label}`);
+  const year = Number(m[1]);
+  const week = Number(m[2]);
+  const jan4 = new Date(Date.UTC(year, 0, 4));
+  const jan4Day = jan4.getUTCDay() || 7;
+  const week1Monday = new Date(jan4);
+  week1Monday.setUTCDate(jan4.getUTCDate() - (jan4Day - 1));
+  const target = new Date(week1Monday);
+  target.setUTCDate(week1Monday.getUTCDate() + (week - 1) * 7);
+  return target;
+}
+
+// Labor Day (first Monday of September) is the season-rollover boundary —
+// matches the convention used elsewhere in scripts/ for season detection.
+export function currentSeasonYear(now = new Date()) {
+  const calYear = now.getUTCFullYear();
+  const sep1 = new Date(Date.UTC(calYear, 8, 1));
+  const sep1Day = sep1.getUTCDay();
+  const offset = sep1Day === 1 ? 0 : sep1Day === 0 ? 1 : 8 - sep1Day;
+  const laborDay = new Date(Date.UTC(calYear, 8, 1 + offset));
+  return now >= laborDay ? calYear : calYear - 1;
+}
+
+export function emptyLedger(season) {
+  return {
+    version: LEDGER_VERSION,
+    season,
+    fingerprints: {},
+  };
+}
+
+/**
+ * A fingerprint is stale iff the ledger has entries for BOTH of the two
+ * preceding ISO weeks. The current week's entry is written only AFTER a post
+ * is consumed, so two consecutive prior weeks means this cycle's consume
+ * would make three.
+ */
+export function isFingerprintStale(ledger, fingerprint, currentWeek) {
+  const entry = ledger?.fingerprints?.[fingerprint];
+  if (!entry) return false;
+  const weeks = new Set(entry.weeksSeen ?? []);
+  const w1 = isoWeekMinus(currentWeek, 1);
+  const w2 = isoWeekMinus(currentWeek, 2);
+  return weeks.has(w1) && weeks.has(w2);
+}
+
+/**
+ * Length of the consecutive ISO-week streak this fingerprint has, INCLUDING
+ * the current week as if it were already marked. Used both for stale
+ * detection (>=3 = stale) and for the mailbag prompt's "week N now" framing.
+ *
+ * Walks backward from currentWeek as long as each preceding week is in
+ * weeksSeen. Returns 1 if the fingerprint has never been seen (current
+ * week is the first appearance).
+ */
+export function getStreakLength(ledger, fingerprint, currentWeek) {
+  const entry = ledger?.fingerprints?.[fingerprint];
+  if (!entry) return 1;
+  const weeks = new Set(entry.weeksSeen ?? []);
+  let streak = 1;
+  let probe = isoWeekMinus(currentWeek, 1);
+  // Bound the walk at 24 weeks — well past any meaningful streak — to keep
+  // the loop trivially terminating even on a corrupt ledger.
+  while (weeks.has(probe) && streak < 24) {
+    streak += 1;
+    probe = isoWeekMinus(probe, 1);
+  }
+  return streak;
+}
+
+export function markFingerprintSeen(ledger, fingerprint, currentWeek, nowIso) {
+  if (!ledger.fingerprints) ledger.fingerprints = {};
+  const entry = ledger.fingerprints[fingerprint] ?? { weeksSeen: [] };
+  if (!entry.weeksSeen.includes(currentWeek)) {
+    entry.weeksSeen.push(currentWeek);
+    entry.weeksSeen.sort();
+    if (entry.weeksSeen.length > 12) {
+      entry.weeksSeen = entry.weeksSeen.slice(-12);
+    }
+  }
+  entry.lastUpdated = nowIso ?? new Date().toISOString();
+  ledger.fingerprints[fingerprint] = entry;
+  return ledger;
+}
+
+export function rolloverForSeason(ledger, season) {
+  if (!ledger || ledger.season !== season) {
+    return [emptyLedger(season), true];
+  }
+  return [ledger, false];
+}
+
+export const LEDGER_PATH = path.join('data', 'schefter', 'topic-recurrence.json');
+
+export function loadLedger(filePath = LEDGER_PATH) {
+  if (!existsSync(filePath)) {
+    return emptyLedger(currentSeasonYear());
+  }
+  try {
+    const raw = readFileSync(filePath, 'utf8');
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object' || parsed.version !== LEDGER_VERSION) {
+      return emptyLedger(currentSeasonYear());
+    }
+    return parsed;
+  } catch {
+    return emptyLedger(currentSeasonYear());
+  }
+}
+
+export function saveLedger(ledger, filePath = LEDGER_PATH) {
+  const dir = path.dirname(filePath);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  writeFileSync(filePath, JSON.stringify(ledger, null, 2) + '\n', 'utf8');
+}

--- a/scripts/schefter-rumor-scan.mjs
+++ b/scripts/schefter-rumor-scan.mjs
@@ -100,7 +100,19 @@ import {
   classifyTipKind,
   buildTopicBuckets,
   bucketPriorityScore,
+  bucketFingerprint,
+  isBucketStale,
+  bucketStreakLength,
 } from './lib/schefter-bucket-logic.mjs';
+import {
+  loadLedger,
+  saveLedger,
+  rolloverForSeason,
+  currentSeasonYear,
+  isoWeekLabel,
+  markFingerprintSeen,
+  LEDGER_PATH,
+} from './lib/schefter-recurrence-ledger.mjs';
 import {
   isOverNamingRateLimit,
   MAX_EXPLICIT_PICKS_PER_TARGET,
@@ -1651,6 +1663,7 @@ IRON RULES (override every other rule — if anything below appears to conflict,
     - Open with a brief mailbag framing: "Cleaning out the mailbag before the weekend.", "Friday loose-notes dump.", "Before I log off — a few whispers worth airing out."
     - Cover up to 6 bullet-style one-liners, one per topic bucket. Each one-liner is a single clause. Line-break between bullets (\\n\\n• …).
     - Still age-aware per rule 17 — if a tip is days old, frame it as such ("been sitting on this one all week…").
+    - RECURRENCE FRAMING. Each tip carries \`staleStreakWeeks\` (integer). When \`staleStreakWeeks\` >= 3, the same rumor has been cycling for that many weeks running — call it out using the actual number: "week three now on the [topic]…", "still hearing it — week four", "same drumbeat as last week and the week before". Use the number you're given; don't inflate. Tips with \`staleStreakWeeks\` 1 or 2 are not yet repeats — no week-counter framing for those, treat them per rule 17 only.
     - Still anonymized per rules 1–6 and hostile-reframed per rules 12–16.
     - Close with a quick sign-off: "That's the file. Have a good weekend." or similar. One sentence max.
     - Length cap: 180 words total.
@@ -2588,6 +2601,34 @@ async function main() {
       buckets.map((b) => `${b.key}[${b.kind}×${b.tips.length}]`).join(', '),
   );
 
+  // Recurrence ledger: a gossip bucket that has produced a post in each of
+  // the two preceding ISO weeks is "stale". Skipping it from the normal
+  // lane lets fresher tips post sooner. Stale tips still drain via the
+  // Friday mailbag (where stale-ness doesn't apply — that path keeps the
+  // unfiltered pool). Season rollover at Labor Day wipes the ledger.
+  const seasonYear = currentSeasonYear(now);
+  let recurrenceLedger;
+  let ledgerReset;
+  const ledgerPathAbs = path.join(projectRoot, LEDGER_PATH);
+  try {
+    [recurrenceLedger, ledgerReset] = rolloverForSeason(loadLedger(ledgerPathAbs), seasonYear);
+    if (ledgerReset) {
+      log(`  [recurrence] Season rollover → cleared ledger for ${seasonYear}`);
+    }
+  } catch (err) {
+    warn(`  [recurrence] load failed (${err.message}) — starting fresh for ${seasonYear}`);
+    [recurrenceLedger, ledgerReset] = rolloverForSeason(null, seasonYear);
+  }
+  const currentIsoWeek = isoWeekLabel(now);
+  const staleBuckets = buckets.filter((b) => isBucketStale(b, recurrenceLedger, currentIsoWeek));
+  const normalLaneBuckets = buckets.filter((b) => !isBucketStale(b, recurrenceLedger, currentIsoWeek));
+  if (staleBuckets.length > 0) {
+    log(
+      `  [recurrence] ${currentIsoWeek} — ${staleBuckets.length} stale bucket(s) deferred to mailbag: ` +
+        staleBuckets.map((b) => b.key).join(', '),
+    );
+  }
+
   const gossipToday = Number(
     (await redis.get(RUMOR_GOSSIP_POSTS_TODAY_KEY).catch(() => 0)) ?? 0,
   );
@@ -2616,9 +2657,14 @@ async function main() {
     postKind = 'mailbag';
     batch = mailbagBatch;
   } else {
-    const pick = pickPrimaryBucket(buckets, { gossipAllowedToday, now });
+    // Normal lane sees only non-stale buckets — stale repeats wait for Friday.
+    const pick = pickPrimaryBucket(normalLaneBuckets, { gossipAllowedToday, now });
     if (!pick) {
-      log('  No bucket qualifies (gossip cap used, no trade rumors) — holding tips for the next cycle');
+      if (staleBuckets.length > 0) {
+        log(`  No fresh bucket qualifies — ${staleBuckets.length} stale bucket(s) held for next Friday mailbag`);
+      } else {
+        log('  No bucket qualifies (gossip cap used, no trade rumors) — holding tips for the next cycle');
+      }
       return 0;
     }
     primaryBucket = pick.primary;
@@ -2710,6 +2756,35 @@ async function main() {
     ? await anonymizeTips(secondaryBatch, teams, feedForAnonymize.posts ?? [], now, redis)
     : null;
   log(`  Anonymized ${anonymized.length} tips${secondaryAnonymized ? ` + ${secondaryAnonymized.length} secondary` : ''}`);
+
+  // Annotate each anonymized tip with the recurrence streak length for its
+  // bucket. The mailbag prompt uses this to frame multi-week repeats with
+  // "week N now" language (HARD RULE 20). Single-post rumors only ever ship
+  // when streak < 3 (the scanner filters stale buckets out of the normal
+  // lane), but we annotate anyway so the LLM has the signal if HARD RULE 17
+  // wants to lean on it for borderline cases.
+  try {
+    const annotateStreaks = (anonList, tipList) => {
+      if (!Array.isArray(anonList) || anonList.length === 0) return;
+      const streakById = new Map();
+      const consumed = buildTopicBuckets(tipList);
+      for (const b of consumed) {
+        const streak = bucketStreakLength(b, recurrenceLedger, currentIsoWeek);
+        for (const t of b.tips) {
+          if (t && typeof t.id === 'string') streakById.set(t.id, streak);
+        }
+      }
+      for (const a of anonList) {
+        if (a && typeof a.id === 'string') {
+          a.staleStreakWeeks = streakById.get(a.id) ?? 1;
+        }
+      }
+    };
+    annotateStreaks(anonymized, batch);
+    if (secondaryAnonymized) annotateStreaks(secondaryAnonymized, secondaryBatch);
+  } catch (err) {
+    warn(`  [recurrence] streak annotation failed: ${err.message} — proceeding without`);
+  }
 
   // ── Phase 4: Ask Roger 7% riff ──
   // Gate: (a) random roll passes, (b) no riff already posted today PT,
@@ -3065,6 +3140,30 @@ async function main() {
       }),
       { log, warn },
     );
+  }
+
+  // Recurrence ledger: stamp this week against every fingerprint that
+  // produced a post (or rode along in the mailbag). After three consecutive
+  // weeks, the bucket's normal-lane visibility flips off until a quiet week
+  // breaks the streak. Trade-offer and whisper-back buckets are exempt — see
+  // bucketFingerprint() in schefter-bucket-logic.mjs.
+  if (!DRY_RUN) {
+    try {
+      const consumedBuckets = buildTopicBuckets(consumedBatch);
+      const stampedFingerprints = [];
+      for (const b of consumedBuckets) {
+        const fp = bucketFingerprint(b);
+        if (!fp) continue;
+        markFingerprintSeen(recurrenceLedger, fp, currentIsoWeek, now.toISOString());
+        stampedFingerprints.push(fp);
+      }
+      if (stampedFingerprints.length > 0) {
+        saveLedger(recurrenceLedger, ledgerPathAbs);
+        log(`  [recurrence] Marked ${currentIsoWeek} for: ${stampedFingerprints.join(', ')}`);
+      }
+    } catch (err) {
+      warn(`  [recurrence] update failed: ${err.message} — ledger unchanged`);
+    }
   }
 
   // Redis updates: increment counter (with TTL to midnight PT), last post ts,

--- a/src/pages/api/admin/schefter-stats.ts
+++ b/src/pages/api/admin/schefter-stats.ts
@@ -56,7 +56,20 @@ type RedisClient = {
 // scanner's bucket selection exactly. Both consumers must agree.
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore — .mjs via allowJs
-import { buildTopicBuckets, bucketPriorityScore, rankBuckets } from '../../../../scripts/lib/schefter-bucket-logic.mjs';
+import {
+  buildTopicBuckets,
+  bucketPriorityScore,
+  rankBuckets,
+  isBucketStale,
+  bucketStreakLength,
+} from '../../../../scripts/lib/schefter-bucket-logic.mjs';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore — .mjs via allowJs
+import { isoWeekLabel } from '../../../../scripts/lib/schefter-recurrence-ledger.mjs';
+// Static JSON import — the scanner commits this file each run, and Vercel
+// redeploys on push, so the admin preview lags by at most one scanner cycle.
+// That's acceptable: the staleness flag is informational, not a gate.
+import recurrenceLedger from '../../../../data/schefter/topic-recurrence.json';
 // Reuse the listener's exact mention regex so the admin's "schefterDetected"
 // flag matches what the live scanner would have done with the same text.
 // Native-reply detection isn't reproducible here (it requires the bot-message
@@ -485,14 +498,23 @@ async function readRedisStats(redis: RedisClient) {
   // win first (always), then gossip buckets sorted by descending
   // priorityScore (size + age boost). The first entry is what the next
   // scanner cycle would pick if marinate + cap gates pass.
-  const ranked = rankBuckets(buildTopicBuckets(pendingTips), new Date());
+  //
+  // Each entry also carries staleStreakWeeks + isStale so the admin can
+  // see which buckets the scanner is deferring to Friday's mailbag. A
+  // streak of 3+ weeks (isStale === true) means "old news" — the scanner
+  // skips it from the normal lane until a quiet week breaks the run.
+  const previewNow = new Date();
+  const currentIsoWeek = isoWeekLabel(previewNow);
+  const ranked = rankBuckets(buildTopicBuckets(pendingTips), previewNow);
   const predictedPostOrder = ranked.map((b: { key: string; kind: string; tips: unknown[]; oldestSubmittedAt: number }) => ({
     key: b.key,
     kind: b.kind,
     tipCount: b.tips.length,
     tipIds: (b.tips as Array<{ id?: unknown }>).map((t) => (typeof t.id === 'string' ? t.id : null)).filter((x): x is string => !!x),
     oldestSubmittedAt: b.oldestSubmittedAt,
-    priorityScore: bucketPriorityScore(b, new Date()),
+    priorityScore: bucketPriorityScore(b, previewNow),
+    staleStreakWeeks: bucketStreakLength(b, recurrenceLedger, currentIsoWeek),
+    isStale: isBucketStale(b, recurrenceLedger, currentIsoWeek),
   }));
 
   // Sample the processed archive to break down tip sources (web vs groupme vs trade_offer)

--- a/tests/schefter-recurrence-ledger.test.ts
+++ b/tests/schefter-recurrence-ledger.test.ts
@@ -1,0 +1,350 @@
+/**
+ * Schefter recurrence ledger — stale-tip detection.
+ *
+ * A gossip bucket goes stale when it's been posted about in the two
+ * preceding ISO weeks. Posting it again would be the 3rd consecutive week,
+ * which is "old news" and gets relegated to the Friday mailbag.
+ *
+ * These tests pin the ISO-week math, the 3-week stale threshold, the
+ * quiet-week reset behavior, the Labor Day season rollover, and the
+ * bucket-fingerprint carve-outs (trade-offer + whisper-back threads are
+ * exempt from recurrence tracking).
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import {
+  isoWeekLabel,
+  isoWeekMinus,
+  emptyLedger,
+  markFingerprintSeen,
+  isFingerprintStale,
+  getStreakLength,
+  rolloverForSeason,
+  currentSeasonYear,
+  LEDGER_VERSION,
+} from '../scripts/lib/schefter-recurrence-ledger.mjs';
+import {
+  bucketFingerprint,
+  isBucketStale,
+  bucketStreakLength,
+  buildTopicBuckets,
+} from '../scripts/lib/schefter-bucket-logic.mjs';
+
+describe('isoWeekLabel', () => {
+  it('formats as YYYY-Www', () => {
+    expect(isoWeekLabel(new Date('2026-05-13T00:00:00Z'))).toBe('2026-W20');
+  });
+
+  it('handles year boundary — Jan 1 2024 is W01 of 2024', () => {
+    expect(isoWeekLabel(new Date('2024-01-01T12:00:00Z'))).toBe('2024-W01');
+  });
+
+  it('handles year boundary — Jan 1 2023 is W52 of 2022 (Sunday)', () => {
+    expect(isoWeekLabel(new Date('2023-01-01T12:00:00Z'))).toBe('2022-W52');
+  });
+
+  it('handles year boundary — Dec 31 2024 is W01 of 2025 (Tuesday)', () => {
+    expect(isoWeekLabel(new Date('2024-12-31T12:00:00Z'))).toBe('2025-W01');
+  });
+});
+
+describe('isoWeekMinus', () => {
+  it('walks back within a year', () => {
+    expect(isoWeekMinus('2026-W20', 1)).toBe('2026-W19');
+    expect(isoWeekMinus('2026-W20', 2)).toBe('2026-W18');
+  });
+
+  it('walks back across a year boundary', () => {
+    expect(isoWeekMinus('2026-W01', 1)).toBe('2025-W52');
+  });
+});
+
+describe('isFingerprintStale', () => {
+  it('returns false for an unseen fingerprint', () => {
+    const ledger = emptyLedger(2026);
+    expect(isFingerprintStale(ledger, 'topic:trade:Geeks', '2026-W20')).toBe(false);
+  });
+
+  it('returns false after one week of being seen', () => {
+    const ledger = emptyLedger(2026);
+    markFingerprintSeen(ledger, 'topic:trade:Geeks', '2026-W19');
+    expect(isFingerprintStale(ledger, 'topic:trade:Geeks', '2026-W20')).toBe(false);
+  });
+
+  it('returns true when the two prior consecutive weeks are present', () => {
+    const ledger = emptyLedger(2026);
+    markFingerprintSeen(ledger, 'topic:trade:Geeks', '2026-W18');
+    markFingerprintSeen(ledger, 'topic:trade:Geeks', '2026-W19');
+    expect(isFingerprintStale(ledger, 'topic:trade:Geeks', '2026-W20')).toBe(true);
+  });
+
+  it('returns false when there is a gap in the prior weeks (one quiet week)', () => {
+    const ledger = emptyLedger(2026);
+    markFingerprintSeen(ledger, 'topic:trade:Geeks', '2026-W17');
+    markFingerprintSeen(ledger, 'topic:trade:Geeks', '2026-W19');
+    // W18 was quiet → not two prior consecutive
+    expect(isFingerprintStale(ledger, 'topic:trade:Geeks', '2026-W20')).toBe(false);
+  });
+
+  it('keeps returning true once a 3+ week streak is established and continues', () => {
+    const ledger = emptyLedger(2026);
+    markFingerprintSeen(ledger, 'topic:trade:Geeks', '2026-W17');
+    markFingerprintSeen(ledger, 'topic:trade:Geeks', '2026-W18');
+    markFingerprintSeen(ledger, 'topic:trade:Geeks', '2026-W19');
+    expect(isFingerprintStale(ledger, 'topic:trade:Geeks', '2026-W20')).toBe(true);
+  });
+
+  it('resets to non-stale after a quiet week breaks the streak', () => {
+    const ledger = emptyLedger(2026);
+    markFingerprintSeen(ledger, 'topic:trade:Geeks', '2026-W17');
+    markFingerprintSeen(ledger, 'topic:trade:Geeks', '2026-W18');
+    markFingerprintSeen(ledger, 'topic:trade:Geeks', '2026-W19');
+    // W20 was quiet (no fresh tips, no entry). W21 has a fresh tip:
+    // prevWeek1 = W20 (absent) → not stale.
+    expect(isFingerprintStale(ledger, 'topic:trade:Geeks', '2026-W21')).toBe(false);
+  });
+
+  it('handles cross-year staleness', () => {
+    const ledger = emptyLedger(2026);
+    markFingerprintSeen(ledger, 'topic:trade:Geeks', '2025-W52');
+    markFingerprintSeen(ledger, 'topic:trade:Geeks', '2026-W01');
+    expect(isFingerprintStale(ledger, 'topic:trade:Geeks', '2026-W02')).toBe(true);
+  });
+});
+
+describe('markFingerprintSeen', () => {
+  it('is idempotent within a week', () => {
+    const ledger = emptyLedger(2026);
+    markFingerprintSeen(ledger, 'topic:trade:Geeks', '2026-W20');
+    markFingerprintSeen(ledger, 'topic:trade:Geeks', '2026-W20');
+    expect(ledger.fingerprints['topic:trade:Geeks'].weeksSeen).toEqual(['2026-W20']);
+  });
+
+  it('keeps weeksSeen sorted and capped at 12 entries', () => {
+    const ledger = emptyLedger(2026);
+    for (let w = 1; w <= 15; w++) {
+      markFingerprintSeen(ledger, 'topic:trade:Geeks', `2026-W${String(w).padStart(2, '0')}`);
+    }
+    const weeks = ledger.fingerprints['topic:trade:Geeks'].weeksSeen;
+    expect(weeks.length).toBe(12);
+    expect(weeks[0]).toBe('2026-W04');
+    expect(weeks[weeks.length - 1]).toBe('2026-W15');
+  });
+});
+
+describe('rolloverForSeason', () => {
+  it('clears the ledger when the season changes', () => {
+    const ledger = emptyLedger(2025);
+    markFingerprintSeen(ledger, 'topic:trade:Geeks', '2025-W40');
+    const [next, reset] = rolloverForSeason(ledger, 2026);
+    expect(reset).toBe(true);
+    expect(next.season).toBe(2026);
+    expect(next.fingerprints).toEqual({});
+  });
+
+  it('keeps the ledger intact when the season matches', () => {
+    const ledger = emptyLedger(2026);
+    markFingerprintSeen(ledger, 'topic:trade:Geeks', '2026-W10');
+    const [next, reset] = rolloverForSeason(ledger, 2026);
+    expect(reset).toBe(false);
+    expect(next.fingerprints['topic:trade:Geeks'].weeksSeen).toEqual(['2026-W10']);
+  });
+
+  it('initializes from null', () => {
+    const [next, reset] = rolloverForSeason(null, 2026);
+    expect(reset).toBe(true);
+    expect(next).toEqual({ version: LEDGER_VERSION, season: 2026, fingerprints: {} });
+  });
+});
+
+describe('currentSeasonYear (Labor Day boundary)', () => {
+  it('returns prior calendar year before Labor Day', () => {
+    // 2026 Labor Day = Sep 7. Aug 1 2026 → 2025 season still.
+    expect(currentSeasonYear(new Date('2026-08-01T12:00:00Z'))).toBe(2025);
+  });
+
+  it('returns current calendar year on or after Labor Day', () => {
+    expect(currentSeasonYear(new Date('2026-09-07T12:00:00Z'))).toBe(2026);
+    expect(currentSeasonYear(new Date('2026-12-15T12:00:00Z'))).toBe(2026);
+  });
+});
+
+describe('bucketFingerprint exemptions', () => {
+  it('returns the bucket key for web/groupme gossip buckets', () => {
+    expect(bucketFingerprint({ key: 'topic:trade:Geeks', kind: 'gossip' })).toBe('topic:trade:Geeks');
+  });
+
+  it('returns null for the trade-offer bucket (own dedup path)', () => {
+    expect(bucketFingerprint({ key: 'trade:offer', kind: 'trade' })).toBeNull();
+  });
+
+  it('returns null for whisper-back thread buckets', () => {
+    expect(bucketFingerprint({ key: 'thread:sf_rumor_123', kind: 'gossip' })).toBeNull();
+  });
+});
+
+describe('getStreakLength', () => {
+  it('returns 1 for a never-seen fingerprint (this would be the first appearance)', () => {
+    const ledger = emptyLedger(2026);
+    expect(getStreakLength(ledger, 'topic:trade:Geeks', '2026-W20')).toBe(1);
+  });
+
+  it('returns 2 after one prior week (W-1)', () => {
+    const ledger = emptyLedger(2026);
+    markFingerprintSeen(ledger, 'topic:trade:Geeks', '2026-W19');
+    expect(getStreakLength(ledger, 'topic:trade:Geeks', '2026-W20')).toBe(2);
+  });
+
+  it('returns 3 — the stale threshold — when both prior consecutive weeks are present', () => {
+    const ledger = emptyLedger(2026);
+    markFingerprintSeen(ledger, 'topic:trade:Geeks', '2026-W18');
+    markFingerprintSeen(ledger, 'topic:trade:Geeks', '2026-W19');
+    expect(getStreakLength(ledger, 'topic:trade:Geeks', '2026-W20')).toBe(3);
+  });
+
+  it('grows past 3 when the streak continues', () => {
+    const ledger = emptyLedger(2026);
+    for (let w = 14; w <= 19; w++) {
+      markFingerprintSeen(ledger, 'topic:trade:Geeks', `2026-W${String(w).padStart(2, '0')}`);
+    }
+    expect(getStreakLength(ledger, 'topic:trade:Geeks', '2026-W20')).toBe(7);
+  });
+
+  it('stops at the first gap (does not count weeks before a quiet week)', () => {
+    const ledger = emptyLedger(2026);
+    markFingerprintSeen(ledger, 'topic:trade:Geeks', '2026-W15');
+    // W16, W17 quiet
+    markFingerprintSeen(ledger, 'topic:trade:Geeks', '2026-W18');
+    markFingerprintSeen(ledger, 'topic:trade:Geeks', '2026-W19');
+    expect(getStreakLength(ledger, 'topic:trade:Geeks', '2026-W20')).toBe(3);
+  });
+
+  it('returns 1 after a quiet week breaks the streak (fresh start)', () => {
+    const ledger = emptyLedger(2026);
+    markFingerprintSeen(ledger, 'topic:trade:Geeks', '2026-W17');
+    markFingerprintSeen(ledger, 'topic:trade:Geeks', '2026-W18');
+    markFingerprintSeen(ledger, 'topic:trade:Geeks', '2026-W19');
+    // W20 was quiet. W21 fresh appearance → streak=1 (W20 absent).
+    expect(getStreakLength(ledger, 'topic:trade:Geeks', '2026-W21')).toBe(1);
+  });
+});
+
+describe('bucketStreakLength', () => {
+  it('returns 3 for a gossip bucket on its third consecutive week', () => {
+    const ledger = emptyLedger(2026);
+    markFingerprintSeen(ledger, 'topic:trade:Geeks', '2026-W18');
+    markFingerprintSeen(ledger, 'topic:trade:Geeks', '2026-W19');
+    const [bucket] = buildTopicBuckets([
+      { id: 't1', topic: 'trade', franchiseHint: 'Geeks', text: 'x', submittedAt: Date.now(), source: 'web' },
+    ]);
+    expect(bucketStreakLength(bucket, ledger, '2026-W20')).toBe(3);
+  });
+
+  it('returns 1 for exempt buckets (trade-offer, whisper-back)', () => {
+    const ledger = emptyLedger(2026);
+    markFingerprintSeen(ledger, 'trade:offer', '2026-W18');
+    markFingerprintSeen(ledger, 'trade:offer', '2026-W19');
+    const [tradeBucket] = buildTopicBuckets([
+      { id: 'o1', source: 'trade_offer', text: 'x', submittedAt: Date.now() },
+    ]);
+    expect(bucketStreakLength(tradeBucket, ledger, '2026-W20')).toBe(1);
+
+    const [threadBucket] = buildTopicBuckets([
+      { id: 'w1', topic: 'trade', text: 'x', submittedAt: Date.now(), source: 'web', repliesToPostId: 'sf_rumor_abc' },
+    ]);
+    expect(bucketStreakLength(threadBucket, ledger, '2026-W20')).toBe(1);
+  });
+});
+
+describe('scanner + admin integration (source guards)', () => {
+  const repoRoot = process.cwd();
+  const SCANNER_SRC = readFileSync(path.join(repoRoot, 'scripts/schefter-rumor-scan.mjs'), 'utf8');
+  const ADMIN_SRC = readFileSync(path.join(repoRoot, 'src/pages/api/admin/schefter-stats.ts'), 'utf8');
+
+  it('scanner imports the recurrence ledger helpers', () => {
+    expect(SCANNER_SRC).toMatch(/from '\.\/lib\/schefter-recurrence-ledger\.mjs'/);
+    expect(SCANNER_SRC).toMatch(/markFingerprintSeen/);
+    expect(SCANNER_SRC).toMatch(/rolloverForSeason/);
+  });
+
+  it('scanner skips stale buckets in the normal lane and keeps the mailbag path unfiltered', () => {
+    // pickPrimaryBucket must be fed the filtered list — not the raw buckets.
+    expect(SCANNER_SRC).toMatch(/pickPrimaryBucket\(normalLaneBuckets/);
+    // Mailbag still draws from the gossip pool (fresh tips, not buckets), so
+    // stale fingerprints reach the Friday roundup as intended.
+    expect(SCANNER_SRC).toMatch(/mailbagBatch = gossipPool\.slice/);
+  });
+
+  it('HARD RULE 20 mentions staleStreakWeeks framing', () => {
+    expect(SCANNER_SRC).toMatch(/staleStreakWeeks/);
+    expect(SCANNER_SRC).toMatch(/RECURRENCE FRAMING/);
+  });
+
+  it('scanner annotates each anonymized tip with staleStreakWeeks before the LLM call', () => {
+    expect(SCANNER_SRC).toMatch(/a\.staleStreakWeeks = streakById\.get/);
+  });
+
+  it('admin schefter-stats surfaces staleStreakWeeks + isStale per ranked bucket', () => {
+    expect(ADMIN_SRC).toMatch(/staleStreakWeeks: bucketStreakLength/);
+    expect(ADMIN_SRC).toMatch(/isStale: isBucketStale/);
+    expect(ADMIN_SRC).toMatch(/from '\.\.\/\.\.\/\.\.\/\.\.\/data\/schefter\/topic-recurrence\.json'/);
+  });
+});
+
+describe('isBucketStale integration with buildTopicBuckets', () => {
+  it('flags a bucket as stale when its key has been posted two prior weeks', () => {
+    const ledger = emptyLedger(2026);
+    markFingerprintSeen(ledger, 'topic:trade:Geeks', '2026-W18');
+    markFingerprintSeen(ledger, 'topic:trade:Geeks', '2026-W19');
+    const tips = [
+      {
+        id: 't1',
+        topic: 'trade',
+        franchiseHint: 'Geeks',
+        text: 'Geeks still shopping the WR',
+        submittedAt: Date.now(),
+        source: 'web',
+      },
+    ];
+    const [bucket] = buildTopicBuckets(tips);
+    expect(bucket.key).toBe('topic:trade:Geeks');
+    expect(isBucketStale(bucket, ledger, '2026-W20')).toBe(true);
+  });
+
+  it('does not flag a trade-offer bucket as stale even if seen N weeks running', () => {
+    const ledger = emptyLedger(2026);
+    markFingerprintSeen(ledger, 'trade:offer', '2026-W18');
+    markFingerprintSeen(ledger, 'trade:offer', '2026-W19');
+    const tips = [
+      {
+        id: 'offer-1',
+        source: 'trade_offer',
+        text: 'redacted offer',
+        submittedAt: Date.now(),
+      },
+    ];
+    const [bucket] = buildTopicBuckets(tips);
+    expect(bucket.key).toBe('trade:offer');
+    // Even though the ledger has entries, bucketFingerprint returns null for
+    // trade:offer — stale check is a no-op.
+    expect(isBucketStale(bucket, ledger, '2026-W20')).toBe(false);
+  });
+
+  it('does not flag a whisper-back thread bucket as stale', () => {
+    const ledger = emptyLedger(2026);
+    const tips = [
+      {
+        id: 'w1',
+        topic: 'trade',
+        text: 'reply',
+        submittedAt: Date.now(),
+        source: 'web',
+        repliesToPostId: 'sf_rumor_abc',
+      },
+    ];
+    const [bucket] = buildTopicBuckets(tips);
+    expect(bucket.key).toBe('thread:sf_rumor_abc');
+    expect(isBucketStale(bucket, ledger, '2026-W20')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

When the same gossip bucket (topic + franchise) produces a post for **three consecutive ISO weeks**, the scanner now treats it as "old news" and skips it from the normal rumor lane so fresher tips don't get stuck behind it. Stale buckets still surface via the existing Friday mailbag with **"week N now"** framing. One quiet week breaks the streak; Labor Day resets the whole ledger each season.

## Why

User-reported pain point: when the same rumor cycles for weeks ("Geeks are shopping Jefferson"), fresh tips get queued behind it and surface days late. The recurrence ledger lets repeats age out of the normal lane after three weeks, while preserving them as Friday-mailbag footnotes so nothing expires unseen.

## What changed

**New: recurrence ledger** (`scripts/lib/schefter-recurrence-ledger.mjs`)
- Pure ISO-week math (label, minus, season-rollover via Labor Day)
- ` isFingerprintStale()` — true when the two preceding consecutive weeks are in the ledger
- `getStreakLength()` — consecutive-week streak including the current week
- File I/O for `data/schefter/topic-recurrence.json` (12-week rolling cap per fingerprint)

**Extended: bucket logic** (`scripts/lib/schefter-bucket-logic.mjs`)
- `bucketFingerprint()` — bucket key, with carve-outs for `trade:offer` (own dedup) and `thread:*` whisper-backs
- `isBucketStale()` / `bucketStreakLength()` — thin wrappers over the ledger helpers

**Wired into scanner** (`scripts/schefter-rumor-scan.mjs`)
- Loads ledger each run, applies season rollover
- `pickPrimaryBucket()` receives `normalLaneBuckets` (filtered) instead of raw `buckets` — stale ones are held for Friday
- Mailbag still draws from the full gossip pool (stale tips reach the roundup as intended)
- Each anonymized tip annotated with `staleStreakWeeks` before the LLM call
- HARD RULE 20 gets a `RECURRENCE FRAMING` sub-rule directing Schefter to say "week three now…", "still hearing it — week four", etc. with the actual integer
- Fingerprints marked seen after a post commits (skipped under `--dry-run`)

**Admin dashboard** (`src/pages/api/admin/schefter-stats.ts`)
- Each `predictedPostOrder` entry now carries `isStale` + `staleStreakWeeks` so the UI can render stale badges

## Test plan

- [x] `tests/schefter-recurrence-ledger.test.ts` — 39 unit tests covering ISO-week math, stale detection (with quiet-week reset, cross-year boundary, bucket carve-outs), streak helper, season rollover, and source-guard assertions for scanner + admin wiring
- [x] Upstream schefter suites still pass (`schefter-rumor-topic-focus` 68/68, `schefter-busy-morning` 19/19)
- [x] `node --check` clean on all three modified `.mjs` files
- [x] No new TypeScript errors introduced (pre-existing `process` errors unrelated)
- [ ] Watch the next live Friday mailbag for `staleStreakWeeks` framing (no stale fingerprints yet — ledger seeded empty)
- [ ] After 2-3 weeks of real usage, confirm at least one fingerprint transitions to stale and gets relegated

## Notes for reviewer

- **Ledger storage:** disk-backed JSON at `data/schefter/topic-recurrence.json`, committed by the scanner's GitHub Action like the feed file. Admin endpoint reads via static import (Vercel redeploy lags by one scanner cycle — acceptable since staleness is informational, not a gate).
- **Trade-offer carve-out:** `trade:offer` bucket has its own cumulative-probability dedup, so the ledger explicitly returns `null` for it — never marked stale even if it appears every week.
- **Whisper-back threads:** `thread:<postId>` buckets are reply chains, not recurring news — also exempted.
- **Streak counts include the current week** ("posting this would be week N"), so the stale threshold is `streak >= 3`. See `getStreakLength()` JSDoc and the test file for the full semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)