### PR TITLE
fix(rosters): remove absolute positioning from view-tabs

### DIFF
--- a/src/pages/theleague/rosters.astro
+++ b/src/pages/theleague/rosters.astro
@@ -3298,10 +3298,6 @@ const defaultLastSeenText = formatLastSeen(defaultLastSeen);
 
   /* View Tabs */
   .view-tabs {
-    position: absolute;
-    right: var(--padding-lg);
-    top: var(--padding-lg);
-    transform: none;
     display: flex;
     gap: 0.5rem;
   }
@@ -3309,8 +3305,6 @@ const defaultLastSeenText = formatLastSeen(defaultLastSeen);
   /* Mobile: Stack tabs below team info */
   @media (max-width: 767px) {
     .view-tabs {
-      position: static;
-      transform: none;
       width: 100%;
       justify-content: center;
       margin-top: var(--padding-md);


### PR DESCRIPTION
## Summary

- The `.view-tabs` container on the rosters page had `position: absolute` with `top` / `right` offsets, which fought the natural flex layout of its parent `.team-card__actions` (already uses `margin-left: auto` to push content right).
- Removed the absolute positioning so the parent flex layout places the tabs naturally on desktop.
- Dropped the now-redundant `position: static` reset in the mobile media query.

## Why

The absolute positioning caused the Roster / Analytics / Planner tabs to float out of the team card's natural document flow, producing misaligned layout against the parent card chrome.

## Test plan

- [x] Verified on desktop (1280×800) at `/theleague/rosters` — tabs sit on the right edge of the team card via flex, `position: static`
- [x] Mobile media query still stacks tabs full-width below team info
- [ ] Reviewer: confirm no regression on AFL rosters page (same `.view-tabs` class is also used in `src/pages/afl-fantasy/rosters.astro`, but with its own scoped CSS — this PR only touches TheLeague's copy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)