### PR TITLE
feat(afl): AFL homepage parity with TheLeague

### DIFF
--- a/src/components/afl/AflChampionshipHero.astro
+++ b/src/components/afl/AflChampionshipHero.astro
@@ -1,0 +1,260 @@
+---
+/**
+ * AflChampionshipHero — World Championship matchup hero (Week 16).
+ *
+ * Shows AL champion vs NL champion. Without live bracket data we fall back to
+ * the #1 seed of each conference; once the playoffs feed publishes winners,
+ * those override the seeds.
+ */
+import { chooseTeamName } from '../../utils/team-names';
+import { getConferenceStandings } from '../../utils/standings';
+
+interface Team {
+  franchiseId: string;
+  name: string;
+  nameMedium?: string;
+  nameShort?: string;
+  abbrev?: string;
+  icon?: string;
+  banner?: string;
+}
+
+interface Props {
+  teams: Team[];
+  standings: any[];
+  config: any;
+  userFranchiseId?: string;
+}
+
+const { teams, standings, config, userFranchiseId } = Astro.props;
+const teamMap = new Map(teams.map(t => [t.franchiseId, t]));
+
+interface ChampionEntry {
+  franchiseId: string;
+  name: string;
+  icon?: string;
+  banner?: string;
+  seed: number;
+  record: string;
+  isUser: boolean;
+}
+
+function topSeed(code: '00' | '01'): ChampionEntry | null {
+  try {
+    const result = getConferenceStandings(standings, config, code);
+    const top = (result.allTeams ?? [])[0];
+    if (!top) return null;
+    const team = teamMap.get(top.id);
+    return {
+      franchiseId: top.id,
+      name: team
+        ? chooseTeamName({
+            fullName: team.name,
+            nameMedium: team.nameMedium,
+            nameShort: team.nameShort,
+            abbrev: team.abbrev,
+          }, 'default')
+        : top.teamName ?? top.id,
+      icon: team?.icon,
+      banner: team?.banner,
+      seed: top.conferenceSeed,
+      record: top.h2hwlt ?? '0-0-0',
+      isUser: top.id === userFranchiseId,
+    };
+  } catch {
+    return null;
+  }
+}
+
+const al = topSeed('00');
+const nl = topSeed('01');
+
+function formatRecord(wlt: string): string {
+  const parts = wlt.split('-');
+  return parts.length === 3 && parts[2] === '0' ? `${parts[0]}-${parts[1]}` : wlt;
+}
+---
+
+<section class="afl-champ-hero" aria-label="World Championship matchup">
+  <div class="afl-champ-hero__head">
+    <span class="afl-champ-hero__kicker">World Championship · Week 16</span>
+    <h2 class="afl-champ-hero__title">One Game. One Trophy.</h2>
+    <p class="afl-champ-hero__sub">The AL champion and NL champion meet to crown the AFL world champion.</p>
+  </div>
+
+  <div class="afl-champ-hero__matchup">
+    {al ? (
+      <div class:list={['afl-champ-hero__side afl-champ-hero__side--al', { 'afl-champ-hero__side--user': al.isUser }]}>
+        <span class="afl-champ-hero__conf">American League</span>
+        {al.icon && <img src={al.icon} alt="" class="afl-champ-hero__icon" loading="lazy" />}
+        <span class="afl-champ-hero__name">{al.name}</span>
+        <span class="afl-champ-hero__record">{formatRecord(al.record)}</span>
+      </div>
+    ) : (
+      <div class="afl-champ-hero__side afl-champ-hero__side--tbd">
+        <span class="afl-champ-hero__conf">American League</span>
+        <span class="afl-champ-hero__name">TBD</span>
+      </div>
+    )}
+
+    <div class="afl-champ-hero__vs" aria-hidden="true">vs</div>
+
+    {nl ? (
+      <div class:list={['afl-champ-hero__side afl-champ-hero__side--nl', { 'afl-champ-hero__side--user': nl.isUser }]}>
+        <span class="afl-champ-hero__conf">National League</span>
+        {nl.icon && <img src={nl.icon} alt="" class="afl-champ-hero__icon" loading="lazy" />}
+        <span class="afl-champ-hero__name">{nl.name}</span>
+        <span class="afl-champ-hero__record">{formatRecord(nl.record)}</span>
+      </div>
+    ) : (
+      <div class="afl-champ-hero__side afl-champ-hero__side--tbd">
+        <span class="afl-champ-hero__conf">National League</span>
+        <span class="afl-champ-hero__name">TBD</span>
+      </div>
+    )}
+  </div>
+
+  <a href="/afl-fantasy/playoffs" class="afl-champ-hero__cta">
+    View bracket
+    <span aria-hidden="true">→</span>
+  </a>
+</section>
+
+<style>
+  .afl-champ-hero {
+    --afl-accent: var(--color-primary, #c41e3a);
+    --afl-gold: #d97706;
+    background:
+      radial-gradient(ellipse at top, color-mix(in srgb, var(--afl-gold) 8%, transparent), transparent 70%),
+      var(--content-bg, #fff);
+    border: 1px solid var(--afl-gold);
+    border-radius: var(--radius-lg, 0.75rem);
+    box-shadow: var(--shadow-md);
+    padding: 2rem 1.75rem;
+  }
+
+  .afl-champ-hero__head {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.375rem;
+    text-align: center;
+    margin-bottom: 1.5rem;
+  }
+
+  .afl-champ-hero__kicker {
+    font-size: 0.6875rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--afl-gold);
+  }
+
+  .afl-champ-hero__title {
+    margin: 0;
+    font-size: 1.5rem;
+    font-weight: 800;
+    color: var(--color-gray-900, #111827);
+    line-height: 1.15;
+  }
+
+  .afl-champ-hero__sub {
+    margin: 0;
+    font-size: 0.875rem;
+    color: var(--color-gray-500, #6b7280);
+    max-width: 38ch;
+  }
+
+  .afl-champ-hero__matchup {
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
+    align-items: center;
+    gap: 1rem;
+  }
+
+  .afl-champ-hero__side {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.375rem;
+    padding: 1rem 0.75rem;
+    background: var(--color-gray-50, #f9fafb);
+    border: 1px solid var(--content-border, #e2e8f0);
+    border-radius: var(--radius-md, 0.5rem);
+    text-align: center;
+  }
+
+  .afl-champ-hero__side--user {
+    border-color: var(--afl-accent);
+    background: color-mix(in srgb, var(--afl-accent) 5%, var(--content-bg, #fff));
+  }
+
+  .afl-champ-hero__side--tbd {
+    opacity: 0.6;
+  }
+
+  .afl-champ-hero__conf {
+    font-size: 0.5625rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--color-gray-400, #9ca3af);
+  }
+
+  .afl-champ-hero__icon {
+    width: 3rem;
+    height: 3rem;
+    border-radius: 50%;
+    object-fit: cover;
+  }
+
+  .afl-champ-hero__name {
+    font-size: 1rem;
+    font-weight: 700;
+    color: var(--color-gray-800, #1f2937);
+    line-height: 1.2;
+  }
+
+  .afl-champ-hero__side--user .afl-champ-hero__name {
+    color: var(--afl-accent);
+  }
+
+  .afl-champ-hero__record {
+    font-size: 0.75rem;
+    color: var(--color-gray-500, #6b7280);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .afl-champ-hero__vs {
+    font-size: 0.875rem;
+    font-weight: 800;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--afl-gold);
+  }
+
+  .afl-champ-hero__cta {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    margin-top: 1.25rem;
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: var(--afl-accent);
+    text-decoration: none;
+    transition: gap 0.15s ease;
+  }
+
+  .afl-champ-hero__cta:hover {
+    gap: 0.5rem;
+  }
+
+  @media (max-width: 560px) {
+    .afl-champ-hero__matchup {
+      grid-template-columns: 1fr;
+    }
+    .afl-champ-hero__vs {
+      padding: 0.25rem 0;
+    }
+  }
+</style>

--- a/src/components/afl/AflHero.astro
+++ b/src/components/afl/AflHero.astro
@@ -1,0 +1,202 @@
+---
+/**
+ * AflHero — Renders the AFL homepage hero from an AflHeroState.
+ *
+ * Routes to specialty hero components for high-stakes phases (trade deadline
+ * countdown, playoffs bracket, championship matchup) and falls back to the
+ * shared editorial HeroBanner for everything else.
+ */
+import HeroBanner from '../theleague/HeroBanner.astro';
+import TradeDeadlineHero from '../theleague/TradeDeadlineHero';
+import AflPlayoffsHero from './AflPlayoffsHero.astro';
+import AflChampionshipHero from './AflChampionshipHero.astro';
+import '../../styles/trade-deadline-hero.css';
+import type { AflHeroState } from '../../utils/afl-hero-resolver';
+
+interface Props {
+  state: AflHeroState;
+  /** AFL league config — required when rendering playoffs/championship heroes that need bracket data. */
+  config?: any;
+  /** Standings data from the AFL feed — same. */
+  standings?: any[];
+  /** User's franchise id, for highlighting in playoff brackets. */
+  userFranchiseId?: string;
+}
+
+const { state, config, standings, userFranchiseId } = Astro.props;
+const { content } = state;
+
+const fmtTime = (d: Date) =>
+  d.toLocaleString('en-US', { weekday: 'short', month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit', timeZoneName: 'short' });
+---
+
+{state.kind === 'trade-deadline' ? (
+  <TradeDeadlineHero
+    client:idle
+    deadlineMidnightPT={state.deadlineMidnightPT}
+  />
+) : state.kind === 'playoffs' && config && standings ? (
+  <AflPlayoffsHero
+    teams={config.teams}
+    standings={standings}
+    config={config}
+    userFranchiseId={userFranchiseId}
+  />
+) : state.kind === 'championship' && config && standings ? (
+  <AflChampionshipHero
+    teams={config.teams}
+    standings={standings}
+    config={config}
+    userFranchiseId={userFranchiseId}
+  />
+) : (
+  <HeroBanner
+    title={content.title}
+    summary={content.summary}
+    link={content.link}
+    linkLabel={content.linkLabel ?? 'Learn more'}
+    icon={content.icon}
+    accentColor={content.accentColor}
+    variant="editorial"
+    isActive={content.isActive}
+    isUrgent={content.isUrgent}
+    isExternal={content.isExternal}
+    image={content.image}
+    imageAlt={content.imageAlt}
+    kicker={content.kicker}
+    kickerDate={content.kickerDate}
+  />
+)}
+
+{state.kind === 'conference-draft' && (
+  <div class="afl-draft-pills" aria-label="Conference draft details">
+    <div class:list={['afl-draft-pill', { 'afl-draft-pill--live': state.al.live, 'afl-draft-pill--mine': state.userConference === '00' }]}>
+      <span class="afl-draft-pill__label">American League</span>
+      <span class="afl-draft-pill__date">{fmtTime(state.al.date)}</span>
+      <span class="afl-draft-pill__status">{state.al.live ? 'Live now' : 'Live draft'}</span>
+    </div>
+    <div class:list={['afl-draft-pill', { 'afl-draft-pill--live': state.nl.live, 'afl-draft-pill--mine': state.userConference === '01' }]}>
+      <span class="afl-draft-pill__label">National League</span>
+      <span class="afl-draft-pill__date">{fmtTime(state.nl.date)}</span>
+      <span class="afl-draft-pill__status">{state.nl.live ? 'Live now' : 'Email draft'}</span>
+    </div>
+  </div>
+)}
+
+{state.kind === 'keeper-deadline' && (
+  <div class="afl-countdown-strip" aria-label="Keeper deadline countdown">
+    <span class="afl-countdown-strip__label">Keeper Deadline</span>
+    <span class="afl-countdown-strip__value">
+      {state.daysUntil === 0
+        ? 'Today, 8pm PT'
+        : state.daysUntil === 1
+          ? 'Tomorrow, 8pm PT'
+          : `${state.daysUntil} days · July 15`}
+    </span>
+    <a class="afl-countdown-strip__link" href="/afl-fantasy/keepers">Manage keepers →</a>
+  </div>
+)}
+
+<style>
+  .afl-draft-pills {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.75rem;
+    margin-top: 0.75rem;
+  }
+
+  .afl-draft-pill {
+    display: flex;
+    flex-direction: column;
+    gap: 0.125rem;
+    padding: 0.875rem 1rem;
+    background: var(--content-bg, #fff);
+    border: 1px solid var(--content-border, #e2e8f0);
+    border-left: 3px solid var(--cat-draft, #7c3aed);
+    border-radius: var(--radius-md, 0.5rem);
+    box-shadow: var(--shadow-sm);
+  }
+
+  .afl-draft-pill--mine {
+    border-left-color: var(--color-primary, #c41e3a);
+    background: color-mix(in srgb, var(--color-primary, #c41e3a) 4%, var(--content-bg, #fff));
+  }
+
+  .afl-draft-pill--live {
+    border-left-color: var(--color-error, #dc2626);
+    box-shadow: 0 0 0 1px var(--color-error, #dc2626);
+  }
+
+  .afl-draft-pill__label {
+    font-size: 0.625rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--color-gray-400, #9ca3af);
+  }
+
+  .afl-draft-pill__date {
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: var(--color-gray-800, #1f2937);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .afl-draft-pill__status {
+    font-size: 0.75rem;
+    color: var(--color-gray-500, #6b7280);
+  }
+
+  .afl-draft-pill--live .afl-draft-pill__status {
+    color: var(--color-error, #dc2626);
+    font-weight: 600;
+  }
+
+  .afl-countdown-strip {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-top: 0.75rem;
+    padding: 0.75rem 1rem;
+    background: var(--color-gray-50, #f9fafb);
+    border: 1px solid var(--content-border, #e2e8f0);
+    border-radius: var(--radius-md, 0.5rem);
+    flex-wrap: wrap;
+  }
+
+  .afl-countdown-strip__label {
+    font-size: 0.625rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--color-gray-400, #9ca3af);
+  }
+
+  .afl-countdown-strip__value {
+    font-size: 0.875rem;
+    font-weight: 700;
+    color: var(--color-gray-800, #1f2937);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .afl-countdown-strip__link {
+    margin-left: auto;
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--color-primary, #c41e3a);
+    text-decoration: none;
+  }
+
+  .afl-countdown-strip__link:hover {
+    text-decoration: underline;
+  }
+
+  @media (max-width: 640px) {
+    .afl-draft-pills {
+      grid-template-columns: 1fr;
+    }
+    .afl-countdown-strip__link {
+      margin-left: 0;
+    }
+  }
+</style>

--- a/src/components/afl/AflPlayoffsHero.astro
+++ b/src/components/afl/AflPlayoffsHero.astro
@@ -1,0 +1,280 @@
+---
+/**
+ * AflPlayoffsHero — Hero variant for the conference playoff weeks (Week 14-15).
+ *
+ * Shows both conference brackets side-by-side: 4 seeds per conference with
+ * matchups (1v4, 2v3). User's franchise is highlighted in whichever bracket
+ * they belong to.
+ */
+import { chooseTeamName } from '../../utils/team-names';
+import { getConferenceStandings } from '../../utils/standings';
+
+interface Team {
+  franchiseId: string;
+  name: string;
+  nameMedium?: string;
+  nameShort?: string;
+  abbrev?: string;
+  icon?: string;
+}
+
+interface Props {
+  teams: Team[];
+  standings: any[];
+  config: any;
+  userFranchiseId?: string;
+}
+
+const { teams, standings, config, userFranchiseId } = Astro.props;
+const teamMap = new Map(teams.map(t => [t.franchiseId, t]));
+
+interface SeedEntry {
+  franchiseId: string;
+  name: string;
+  icon?: string;
+  seed: number;
+  record: string;
+  isUser: boolean;
+}
+
+function buildConference(code: '00' | '01'): { name: string; seeds: SeedEntry[] } | null {
+  try {
+    const result = getConferenceStandings(standings, config, code);
+    const top4 = (result.allTeams ?? []).slice(0, 4).map((t: any) => {
+      const team = teamMap.get(t.id);
+      return {
+        franchiseId: t.id,
+        name: team
+          ? chooseTeamName({
+              fullName: team.name,
+              nameMedium: team.nameMedium,
+              nameShort: team.nameShort,
+              abbrev: team.abbrev,
+            }, 'short')
+          : t.teamName ?? t.id,
+        icon: team?.icon,
+        seed: t.conferenceSeed,
+        record: t.h2hwlt ?? '0-0-0',
+        isUser: t.id === userFranchiseId,
+      };
+    });
+    return { name: result.conference.name, seeds: top4 };
+  } catch {
+    return null;
+  }
+}
+
+const al = buildConference('00');
+const nl = buildConference('01');
+
+function formatRecord(wlt: string): string {
+  const parts = wlt.split('-');
+  return parts.length === 3 && parts[2] === '0' ? `${parts[0]}-${parts[1]}` : wlt;
+}
+---
+
+<section class="afl-playoffs-hero" aria-label="Conference playoff brackets">
+  <div class="afl-playoffs-hero__head">
+    <span class="afl-playoffs-hero__kicker">Conference Playoffs · Week 14</span>
+    <h2 class="afl-playoffs-hero__title">Conference Brackets</h2>
+    <p class="afl-playoffs-hero__sub">
+      AL and NL seeds 1–4 face off. Conference champions meet in the World Championship Week 16.
+    </p>
+  </div>
+
+  <div class="afl-playoffs-hero__grid">
+    {[al, nl].filter((c): c is { name: string; seeds: SeedEntry[] } => !!c).map((conf) => (
+      <div class="afl-playoffs-hero__bracket">
+        <h3 class="afl-playoffs-hero__bracket-title">{conf.name}</h3>
+        {[
+          { home: conf.seeds[0], away: conf.seeds[3], label: 'Game 1' },
+          { home: conf.seeds[1], away: conf.seeds[2], label: 'Game 2' },
+        ].filter(m => m.home && m.away).map(({ home, away, label }) => (
+          <article class="afl-playoffs-hero__matchup">
+            <div class="afl-playoffs-hero__matchup-label">{label}</div>
+            <div class:list={['afl-playoffs-hero__team', { 'afl-playoffs-hero__team--user': home.isUser }]}>
+              <span class="afl-playoffs-hero__seed">{home.seed}</span>
+              {home.icon && <img src={home.icon} alt="" class="afl-playoffs-hero__icon" loading="lazy" />}
+              <span class="afl-playoffs-hero__name">{home.name}</span>
+              <span class="afl-playoffs-hero__record">{formatRecord(home.record)}</span>
+            </div>
+            <div class="afl-playoffs-hero__vs" aria-hidden="true">vs</div>
+            <div class:list={['afl-playoffs-hero__team', { 'afl-playoffs-hero__team--user': away.isUser }]}>
+              <span class="afl-playoffs-hero__seed">{away.seed}</span>
+              {away.icon && <img src={away.icon} alt="" class="afl-playoffs-hero__icon" loading="lazy" />}
+              <span class="afl-playoffs-hero__name">{away.name}</span>
+              <span class="afl-playoffs-hero__record">{formatRecord(away.record)}</span>
+            </div>
+          </article>
+        ))}
+      </div>
+    ))}
+  </div>
+
+  <a href="/afl-fantasy/playoffs" class="afl-playoffs-hero__cta">
+    Full bracket
+    <span aria-hidden="true">→</span>
+  </a>
+</section>
+
+<style>
+  .afl-playoffs-hero {
+    --afl-accent: var(--color-primary, #c41e3a);
+    background: var(--content-bg, #fff);
+    border: 1px solid var(--content-border, #e2e8f0);
+    border-radius: var(--radius-lg, 0.75rem);
+    box-shadow: var(--shadow-md);
+    padding: 1.75rem;
+  }
+
+  .afl-playoffs-hero__head {
+    display: flex;
+    flex-direction: column;
+    gap: 0.375rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .afl-playoffs-hero__kicker {
+    font-size: 0.6875rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--cat-regular-season, #1c497c);
+  }
+
+  .afl-playoffs-hero__title {
+    margin: 0;
+    font-size: 1.35rem;
+    font-weight: 700;
+    color: var(--color-gray-800, #1f2937);
+    line-height: 1.2;
+  }
+
+  .afl-playoffs-hero__sub {
+    margin: 0;
+    font-size: 0.875rem;
+    color: var(--color-gray-500, #6b7280);
+  }
+
+  .afl-playoffs-hero__grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1.25rem;
+  }
+
+  .afl-playoffs-hero__bracket {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .afl-playoffs-hero__bracket-title {
+    margin: 0 0 0.25rem;
+    font-size: 0.6875rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--color-gray-500, #6b7280);
+  }
+
+  .afl-playoffs-hero__matchup {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    padding: 0.625rem 0.75rem;
+    background: var(--color-gray-50, #f9fafb);
+    border-left: 3px solid var(--cat-regular-season, #1c497c);
+    border-radius: var(--radius-md, 0.5rem);
+  }
+
+  .afl-playoffs-hero__matchup-label {
+    font-size: 0.5625rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--color-gray-400, #9ca3af);
+  }
+
+  .afl-playoffs-hero__team {
+    display: grid;
+    grid-template-columns: 1.5rem 1.25rem 1fr auto;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.8125rem;
+  }
+
+  .afl-playoffs-hero__team--user {
+    font-weight: 700;
+    color: var(--afl-accent);
+  }
+
+  .afl-playoffs-hero__seed {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.25rem;
+    height: 1.25rem;
+    border-radius: 999px;
+    background: var(--cat-regular-season, #1c497c);
+    color: #fff;
+    font-size: 0.625rem;
+    font-weight: 700;
+  }
+
+  .afl-playoffs-hero__team--user .afl-playoffs-hero__seed {
+    background: var(--afl-accent);
+  }
+
+  .afl-playoffs-hero__icon {
+    width: 1.25rem;
+    height: 1.25rem;
+    border-radius: 50%;
+    object-fit: cover;
+  }
+
+  .afl-playoffs-hero__name {
+    color: var(--color-gray-800, #1f2937);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .afl-playoffs-hero__record {
+    font-size: 0.6875rem;
+    color: var(--color-gray-500, #6b7280);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .afl-playoffs-hero__vs {
+    font-size: 0.5625rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--color-gray-400, #9ca3af);
+    text-align: center;
+    padding: 0.125rem 0;
+  }
+
+  .afl-playoffs-hero__cta {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    margin-top: 1.25rem;
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: var(--afl-accent);
+    text-decoration: none;
+    transition: gap 0.15s ease;
+  }
+
+  .afl-playoffs-hero__cta:hover {
+    gap: 0.5rem;
+  }
+
+  @media (max-width: 720px) {
+    .afl-playoffs-hero__grid {
+      grid-template-columns: 1fr;
+      gap: 1rem;
+    }
+  }
+</style>

--- a/src/components/afl/hp-sections/AflConferenceDraftPreview.astro
+++ b/src/components/afl/hp-sections/AflConferenceDraftPreview.astro
@@ -1,0 +1,238 @@
+---
+/**
+ * AflConferenceDraftPreview — AL + NL draft readiness card.
+ *
+ * Surfaces in the run-up to Labor Day weekend. Shows each conference's
+ * draft format, date/time, and status (countdown, live, complete).
+ */
+import { spriteUrl } from '../../../utils/sprite-url';
+
+interface Props {
+  alDate: Date;
+  nlDate: Date;
+  referenceDate: Date;
+  userConferenceId?: '00' | '01';
+}
+
+const { alDate, nlDate, referenceDate, userConferenceId } = Astro.props;
+
+function daysBetween(later: Date, earlier: Date): number {
+  const day = 1000 * 60 * 60 * 24;
+  const a = new Date(later);
+  a.setHours(0, 0, 0, 0);
+  const b = new Date(earlier);
+  b.setHours(0, 0, 0, 0);
+  return Math.round((a.getTime() - b.getTime()) / day);
+}
+
+function fmt(d: Date): string {
+  return d.toLocaleString('en-US', {
+    weekday: 'long',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    timeZoneName: 'short',
+  });
+}
+
+function statusFor(date: Date, durationHours: number): { label: string; tone: 'upcoming' | 'live' | 'complete' } {
+  const end = new Date(date.getTime() + durationHours * 60 * 60 * 1000);
+  if (referenceDate < date) {
+    const d = daysBetween(date, referenceDate);
+    return {
+      label: d === 0 ? 'Today' : d === 1 ? 'Tomorrow' : `In ${d} days`,
+      tone: 'upcoming',
+    };
+  }
+  if (referenceDate < end) return { label: 'Live now', tone: 'live' };
+  return { label: 'Complete', tone: 'complete' };
+}
+
+const al = {
+  name: 'American League',
+  date: alDate,
+  format: 'Live draft · 1 minute per pick',
+  status: statusFor(alDate, 8),
+  isMine: userConferenceId === '00',
+};
+const nl = {
+  name: 'National League',
+  date: nlDate,
+  format: 'Email draft · slow clock',
+  status: statusFor(nlDate, 48),
+  isMine: userConferenceId === '01',
+};
+---
+
+<section class="afl-cdraft" aria-label="Conference draft preview">
+  <div class="afl-cdraft__header">
+    <h3 class="afl-cdraft__title">Conference Drafts</h3>
+    <a href="/afl-fantasy/draft-predictor" class="afl-cdraft__cta">
+      Draft predictor
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" aria-hidden="true">
+        <path d="M5 12h14M12 5l7 7-7 7"/>
+      </svg>
+    </a>
+  </div>
+  <div class="afl-cdraft__grid">
+    {[al, nl].map(conf => (
+      <article class:list={['afl-cdraft__card', `afl-cdraft__card--${conf.status.tone}`, { 'afl-cdraft__card--mine': conf.isMine }]}>
+        <div class="afl-cdraft__card-head">
+          <svg class="afl-cdraft__icon" width="20" height="20" aria-hidden="true">
+            <use href={`${spriteUrl}#icon-draft-podium`} />
+          </svg>
+          <div class="afl-cdraft__card-titles">
+            <p class="afl-cdraft__card-eyebrow">{conf.name}{conf.isMine ? ' · Yours' : ''}</p>
+            <h4 class="afl-cdraft__card-title">{conf.format}</h4>
+          </div>
+          <span class:list={['afl-cdraft__pill', `afl-cdraft__pill--${conf.status.tone}`]}>
+            {conf.status.label}
+          </span>
+        </div>
+        <p class="afl-cdraft__when">{fmt(conf.date)}</p>
+      </article>
+    ))}
+  </div>
+</section>
+
+<style>
+  .afl-cdraft {
+    --afl-accent: var(--color-primary, #c41e3a);
+    background: var(--content-bg, #fff);
+    border: 1px solid var(--content-border, #e2e8f0);
+    border-radius: var(--radius-md, 0.5rem);
+    box-shadow: var(--shadow-md);
+    padding: 1.5rem;
+  }
+
+  .afl-cdraft__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 1rem;
+    gap: 1rem;
+  }
+
+  .afl-cdraft__title {
+    font-size: 0.75rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    padding-left: 0.625rem;
+    border-left: 2px solid var(--afl-accent);
+    margin: 0;
+    line-height: 1;
+    color: var(--color-gray-700, #374151);
+  }
+
+  .afl-cdraft__cta {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--afl-accent);
+    text-decoration: none;
+  }
+
+  .afl-cdraft__cta:hover {
+    gap: 0.5rem;
+  }
+
+  .afl-cdraft__grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.75rem;
+  }
+
+  .afl-cdraft__card {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    padding: 1rem;
+    background: var(--color-gray-50, #f9fafb);
+    border: 1px solid transparent;
+    border-radius: var(--radius-md, 0.5rem);
+  }
+
+  .afl-cdraft__card--live {
+    background: color-mix(in srgb, var(--color-error, #dc2626) 5%, var(--content-bg, #fff));
+    border-color: var(--color-error, #dc2626);
+  }
+
+  .afl-cdraft__card--mine {
+    border-color: var(--afl-accent);
+    background: color-mix(in srgb, var(--afl-accent) 6%, var(--content-bg, #fff));
+  }
+
+  .afl-cdraft__card-head {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.75rem;
+  }
+
+  .afl-cdraft__icon {
+    color: var(--cat-draft, #7c3aed);
+    flex-shrink: 0;
+    margin-top: 0.125rem;
+  }
+
+  .afl-cdraft__card-titles {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .afl-cdraft__card-eyebrow {
+    margin: 0;
+    font-size: 0.625rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--color-gray-400, #9ca3af);
+  }
+
+  .afl-cdraft__card-title {
+    margin: 0.125rem 0 0;
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: var(--color-gray-800, #1f2937);
+    line-height: 1.3;
+  }
+
+  .afl-cdraft__pill {
+    font-size: 0.625rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    padding: 0.25rem 0.5rem;
+    border-radius: 999px;
+    background: var(--color-gray-100, #f3f4f6);
+    color: var(--color-gray-600, #4b5563);
+    white-space: nowrap;
+    flex-shrink: 0;
+  }
+
+  .afl-cdraft__pill--live {
+    background: var(--color-error, #dc2626);
+    color: #fff;
+  }
+
+  .afl-cdraft__pill--complete {
+    background: var(--color-gray-200, #e5e7eb);
+    color: var(--color-gray-600, #4b5563);
+  }
+
+  .afl-cdraft__when {
+    margin: 0;
+    font-size: 0.8125rem;
+    color: var(--color-gray-600, #4b5563);
+    font-variant-numeric: tabular-nums;
+  }
+
+  @media (max-width: 640px) {
+    .afl-cdraft__grid {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/src/components/afl/hp-sections/AflConferencePlayoffPreview.astro
+++ b/src/components/afl/hp-sections/AflConferencePlayoffPreview.astro
@@ -1,0 +1,336 @@
+---
+/**
+ * AflConferencePlayoffPreview — AL or NL playoff seeding preview.
+ *
+ * Each AFL conference seeds 4 teams for the head-to-head playoffs:
+ *   - Seeds 1–2: Division winners (sorted by record)
+ *   - Seeds 3–4: Top 2 wild cards
+ * Everyone else competes in the NIT-style consolation bracket.
+ *
+ * Picks the user's conference (AL or NL) when known; falls back to AL.
+ * Renders seeds 1–6 so you can see who's in the playoffs and who's chasing.
+ */
+import { chooseTeamName } from '../../../utils/team-names';
+import { getConferenceStandings } from '../../../utils/standings';
+
+interface Team {
+  franchiseId: string;
+  name: string;
+  nameMedium?: string;
+  nameShort?: string;
+  abbrev?: string;
+  icon?: string;
+  conference?: string;
+  division?: string;
+}
+
+interface Props {
+  teams: Team[];
+  standings: any[];
+  /** AFL league config (needed by getConferenceStandings). */
+  config: any;
+  userFranchiseId?: string;
+  /** Pick which conference to show: '00' = AL, '01' = NL. Defaults to AL. */
+  conferenceCode?: '00' | '01';
+  /** Number of teams that make the playoffs. */
+  playoffSlots?: number;
+}
+
+const {
+  teams,
+  standings,
+  config,
+  userFranchiseId,
+  conferenceCode = '00',
+  playoffSlots = 4,
+} = Astro.props;
+
+const teamMap = new Map(teams.map(t => [t.franchiseId, t]));
+const hasGames = standings.some(f => parseFloat(f.pf ?? '0') > 0);
+
+let confResult: { conference: any; allTeams: Array<any> } | null = null;
+try {
+  confResult = getConferenceStandings(standings, config, conferenceCode);
+} catch {
+  confResult = null;
+}
+
+if (!confResult) {
+  // If standings aren't ready, render nothing
+}
+
+const conferenceName = confResult?.conference?.name ?? (conferenceCode === '00' ? 'American League' : 'National League');
+
+interface PreviewRow {
+  franchiseId: string;
+  name: string;
+  seed: number;
+  record: string;
+  pf: number;
+  division: string;
+  isDivisionWinner: boolean;
+  isUser: boolean;
+}
+
+const allConfTeams = (confResult?.allTeams ?? []) as any[];
+
+const rows: PreviewRow[] = allConfTeams.map((t: any) => {
+  const team = teamMap.get(t.id);
+  const displayName = team
+    ? chooseTeamName({
+        fullName: team.name,
+        nameMedium: team.nameMedium,
+        nameShort: team.nameShort,
+        abbrev: team.abbrev,
+      }, 'default')
+    : t.teamName ?? t.id;
+  return {
+    franchiseId: t.id,
+    name: displayName,
+    seed: t.conferenceSeed,
+    record: t.h2hwlt ?? '0-0-0',
+    pf: parseFloat(t.pf ?? '0'),
+    division: t.division,
+    isDivisionWinner: t.conferenceSeed <= 2,
+    isUser: t.id === userFranchiseId,
+  };
+});
+
+const visible = rows.slice(0, 6);
+---
+
+{rows.length > 0 && (
+  <section class="afl-conf" aria-label={`${conferenceName} playoff preview`}>
+    <div class="afl-conf__header">
+      <div class="afl-conf__section-header">
+        <h3 class="afl-conf__title">{conferenceName} Playoff Standings</h3>
+        <p class="afl-conf__sub">Top {playoffSlots} clinch playoff seeds. Division winners take seeds 1–2.</p>
+      </div>
+      <a href={`/afl-fantasy/standings?view=conference&conf=${conferenceCode}`} class="afl-conf__cta">
+        Full bracket
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" aria-hidden="true">
+          <path d="M5 12h14M12 5l7 7-7 7"/>
+        </svg>
+      </a>
+    </div>
+
+    <table class="afl-conf__table">
+      <thead>
+        <tr>
+          <th class="afl-conf__th afl-conf__th--seed">Seed</th>
+          <th class="afl-conf__th afl-conf__th--team">Team</th>
+          <th class="afl-conf__th afl-conf__th--div">Div</th>
+          {hasGames && <th class="afl-conf__th afl-conf__th--record">Record</th>}
+          <th class="afl-conf__th afl-conf__th--pf">PF</th>
+        </tr>
+      </thead>
+      <tbody>
+        {visible.map((row) => (
+          <>
+            {row.seed === playoffSlots + 1 && (
+              <tr class="afl-conf__cutline" aria-hidden="true">
+                <td colspan={hasGames ? 5 : 4}>Playoff line ↓</td>
+              </tr>
+            )}
+            <tr class:list={[
+              'afl-conf__row',
+              { 'afl-conf__row--user': row.isUser, 'afl-conf__row--out': row.seed > playoffSlots },
+            ]}>
+              <td class="afl-conf__td afl-conf__td--seed">
+                <span class:list={['afl-conf__seed-badge', { 'afl-conf__seed-badge--in': row.seed <= playoffSlots }]}>
+                  {row.seed}
+                </span>
+              </td>
+              <td class="afl-conf__td afl-conf__td--team">
+                <span class={row.isUser ? 'afl-conf__team-name--bold' : ''}>{row.name}</span>
+                {row.isDivisionWinner && <span class="afl-conf__chip" aria-label="Division winner">Div</span>}
+              </td>
+              <td class="afl-conf__td afl-conf__td--div">{row.division}</td>
+              {hasGames && <td class="afl-conf__td afl-conf__td--record">{row.record}</td>}
+              <td class="afl-conf__td afl-conf__td--pf">{row.pf.toLocaleString('en-US', { maximumFractionDigits: 0 })}</td>
+            </tr>
+          </>
+        ))}
+      </tbody>
+    </table>
+  </section>
+)}
+
+<style>
+  .afl-conf {
+    --afl-accent: var(--color-primary, #c41e3a);
+    --afl-highlight-bg: color-mix(in srgb, var(--afl-accent) 6%, transparent);
+    background: var(--content-bg, #fff);
+    border: 1px solid var(--content-border, #e2e8f0);
+    border-radius: var(--radius-md, 0.5rem);
+    box-shadow: var(--shadow-md);
+    padding: 1.5rem;
+  }
+
+  .afl-conf__header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 1rem;
+  }
+
+  .afl-conf__section-header {
+    padding-left: 0.625rem;
+    border-left: 2px solid var(--afl-accent);
+  }
+
+  .afl-conf__title {
+    font-size: 0.75rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    margin: 0;
+    line-height: 1;
+    color: var(--color-gray-700, #374151);
+  }
+
+  .afl-conf__sub {
+    margin: 0.375rem 0 0;
+    font-size: 0.8125rem;
+    color: var(--color-gray-500, #6b7280);
+  }
+
+  .afl-conf__cta {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--afl-accent);
+    text-decoration: none;
+    transition: gap 0.15s ease;
+    white-space: nowrap;
+  }
+
+  .afl-conf__cta:hover {
+    gap: 0.5rem;
+  }
+
+  .afl-conf__table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.8125rem;
+  }
+
+  .afl-conf__th {
+    font-size: 0.625rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--color-gray-400, #9ca3af);
+    padding: 0 0.5rem 0.5rem;
+    text-align: left;
+    border-bottom: 1px solid var(--color-gray-50, #f9fafb);
+    white-space: nowrap;
+  }
+
+  .afl-conf__th--seed { width: 2.5rem; text-align: center; }
+  .afl-conf__th--record,
+  .afl-conf__th--pf { text-align: right; }
+  .afl-conf__th--div { text-align: center; width: 3rem; }
+
+  .afl-conf__row {
+    transition: background 0.1s ease;
+  }
+
+  .afl-conf__row:hover {
+    background: var(--color-gray-50, #f9fafb);
+  }
+
+  .afl-conf__row--user {
+    background: var(--afl-highlight-bg);
+  }
+
+  .afl-conf__row--user .afl-conf__td:first-child {
+    box-shadow: inset 3px 0 0 var(--afl-accent);
+  }
+
+  .afl-conf__row--out .afl-conf__td {
+    color: var(--color-gray-500, #6b7280);
+  }
+
+  .afl-conf__td {
+    padding: 0.4375rem 0.5rem;
+    border-bottom: 1px solid var(--color-gray-50, #f9fafb);
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+  }
+
+  .afl-conf__td--seed {
+    text-align: center;
+  }
+
+  .afl-conf__seed-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 1.5rem;
+    height: 1.5rem;
+    padding: 0 0.375rem;
+    border-radius: 999px;
+    background: var(--color-gray-100, #f3f4f6);
+    color: var(--color-gray-500, #6b7280);
+    font-size: 0.6875rem;
+    font-weight: 700;
+  }
+
+  .afl-conf__seed-badge--in {
+    background: var(--cat-regular-season, #1c497c);
+    color: #fff;
+  }
+
+  .afl-conf__td--team {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-weight: 500;
+    color: var(--color-gray-800, #1f2937);
+    overflow: hidden;
+  }
+
+  .afl-conf__team-name--bold {
+    font-weight: 700;
+  }
+
+  .afl-conf__chip {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.0625rem 0.375rem;
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--cat-regular-season, #1c497c) 14%, transparent);
+    color: var(--cat-regular-season, #1c497c);
+    font-size: 0.5625rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+
+  .afl-conf__td--div {
+    text-align: center;
+    color: var(--color-gray-500, #6b7280);
+    font-size: 0.75rem;
+  }
+
+  .afl-conf__td--record,
+  .afl-conf__td--pf {
+    text-align: right;
+    color: var(--color-gray-700, #374151);
+  }
+
+  .afl-conf__cutline td {
+    padding: 0.25rem 0.5rem;
+    font-size: 0.5625rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--color-error, #dc2626);
+    background: color-mix(in srgb, var(--color-error, #dc2626) 6%, transparent);
+    text-align: center;
+  }
+</style>

--- a/src/components/afl/hp-sections/AflQuickLinks.astro
+++ b/src/components/afl/hp-sections/AflQuickLinks.astro
@@ -1,0 +1,175 @@
+---
+/**
+ * AflQuickLinks — Discovery grid for AFL homepage.
+ *
+ * Filters page-directory.json to AFL routes (paths starting with /afl-fantasy/),
+ * sorted by popularity. Mirrors TheLeague's HpQuickLinks structure so the
+ * editorial design stays consistent.
+ */
+import { spriteUrl } from '../../../utils/sprite-url';
+
+interface PageEntry {
+  id: string;
+  title: string;
+  description: string;
+  path: string;
+  icon: string;
+  category: string;
+  visibility: string;
+  popularity: number;
+}
+
+import pageDirectory from '../../../data/page-directory.json';
+const allPages: PageEntry[] = pageDirectory as PageEntry[];
+
+// Filter to AFL routes only and exclude the homepage itself + admin pages.
+const aflPages = allPages
+  .filter(p => p.visibility === 'all')
+  .filter(p => p.path.startsWith('/afl-fantasy/') || p.path === '/afl-fantasy')
+  .filter(p => p.id !== 'afl-homepage' && p.id !== 'homepage');
+
+// Sort by popularity, take up to 8.
+const pages = [...aflPages].sort((a, b) => b.popularity - a.popularity).slice(0, 8);
+---
+
+<section class="afl-links" aria-label="Quick links">
+  <div class="afl-links__header">
+    <h3 class="afl-links__title">Explore</h3>
+    <a href="/afl-fantasy" class="afl-links__cta">
+      All pages
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" aria-hidden="true">
+        <path d="M5 12h14M12 5l7 7-7 7"/>
+      </svg>
+    </a>
+  </div>
+  {pages.length === 0 ? (
+    <p class="afl-links__empty">No AFL pages registered in the directory yet.</p>
+  ) : (
+    <div class="afl-links__grid">
+      {pages.map(page => (
+        <a href={page.path} class="afl-links__card">
+          <svg class="afl-links__icon" width="20" height="20" aria-hidden="true">
+            <use href={`${spriteUrl}#icon-${page.icon}`} />
+          </svg>
+          <div class="afl-links__text">
+            <span class="afl-links__name">{page.title}</span>
+            <span class="afl-links__desc">{page.description}</span>
+          </div>
+        </a>
+      ))}
+    </div>
+  )}
+</section>
+
+<style>
+  .afl-links {
+    --afl-accent: var(--color-primary, #c41e3a);
+    background: var(--content-bg, #fff);
+    border: 1px solid var(--content-border, #e2e8f0);
+    border-radius: var(--radius-md, 0.5rem);
+    box-shadow: var(--shadow-md);
+    padding: 1.5rem;
+  }
+
+  .afl-links__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 1rem;
+  }
+
+  .afl-links__title {
+    font-size: 0.75rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    padding-left: 0.625rem;
+    border-left: 2px solid var(--afl-accent);
+    margin: 0;
+    line-height: 1;
+    color: var(--color-gray-700, #374151);
+  }
+
+  .afl-links__cta {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--afl-accent);
+    text-decoration: none;
+    transition: gap 0.15s ease;
+  }
+
+  .afl-links__cta:hover {
+    gap: 0.5rem;
+  }
+
+  .afl-links__empty {
+    margin: 0;
+    font-size: 0.8125rem;
+    color: var(--color-gray-500, #6b7280);
+  }
+
+  .afl-links__grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 0.5rem;
+  }
+
+  .afl-links__card {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.75rem;
+    padding: 0.75rem;
+    border-radius: var(--radius-md, 0.5rem);
+    background: var(--color-gray-50, #f9fafb);
+    text-decoration: none;
+    transition: background 0.15s ease, transform 0.15s ease;
+  }
+
+  .afl-links__card:hover {
+    background: var(--color-gray-100, #f3f4f6);
+    transform: translateY(-1px);
+  }
+
+  .afl-links__icon {
+    flex-shrink: 0;
+    color: var(--afl-accent);
+    margin-top: 0.125rem;
+  }
+
+  .afl-links__text {
+    display: flex;
+    flex-direction: column;
+    gap: 0.125rem;
+    min-width: 0;
+  }
+
+  .afl-links__name {
+    font-size: 0.8125rem;
+    font-weight: 600;
+    color: var(--color-gray-800, #1f2937);
+    line-height: 1.3;
+  }
+
+  .afl-links__desc {
+    font-size: 0.6875rem;
+    color: var(--color-gray-500, #6b7280);
+    line-height: 1.4;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  @media (max-width: 640px) {
+    .afl-links {
+      padding: 1.25rem;
+    }
+
+    .afl-links__grid {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/src/components/afl/hp-sections/AflStandingsCompact.astro
+++ b/src/components/afl/hp-sections/AflStandingsCompact.astro
@@ -1,0 +1,374 @@
+---
+/**
+ * AflStandingsCompact — Single-tier standings preview centered on the user.
+ *
+ * Renders only the tier the user belongs to (Premier League or D-League).
+ * Shows a tight 5-row window: 2 above + the user + 2 below. The window
+ * clamps at the top/bottom of the tier, and inserts the promotion/
+ * relegation cutline if it falls inside the visible window.
+ *
+ * If no user is selected, falls back to the cutline neighborhood of
+ * Premier League.
+ */
+import { chooseTeamName } from '../../../utils/team-names';
+
+interface Team {
+  franchiseId: string;
+  name: string;
+  nameMedium?: string;
+  nameShort?: string;
+  abbrev?: string;
+  tier?: string;
+  icon?: string;
+}
+
+interface StandingRow {
+  franchiseId: string;
+  name: string;
+  rank: number;
+  allPlayRecord: string;
+  allPlayPct: number;
+  pf: number;
+  tier: 'Premier League' | 'D-League';
+  isUser: boolean;
+}
+
+interface Props {
+  teams: Team[];
+  standings: any[];
+  userFranchiseId?: string;
+  /** Number of teams promoted from D-League / relegated from Premier each year. */
+  relegationCount?: number;
+}
+
+const { teams, standings, userFranchiseId, relegationCount = 4 } = Astro.props;
+
+const teamMap = new Map(teams.map(t => [t.franchiseId, t]));
+const hasGames = standings.some(f => parseFloat(f.pf ?? '0') > 0);
+
+function makeRows(): StandingRow[] {
+  return standings.map(f => {
+    const team = teamMap.get(f.id);
+    const tier = (team?.tier === 'Premier League' ? 'Premier League' : 'D-League') as StandingRow['tier'];
+    const displayName = team
+      ? chooseTeamName({
+          fullName: team.name,
+          nameMedium: team.nameMedium,
+          nameShort: team.nameShort,
+          abbrev: team.abbrev,
+        }, 'default')
+      : f.fname ?? f.id;
+    return {
+      franchiseId: f.id,
+      name: displayName,
+      rank: 0,
+      allPlayRecord: f.all_play_wlt ?? '0-0-0',
+      allPlayPct: parseFloat(f.all_play_pct ?? '0'),
+      pf: parseFloat(f.pf ?? '0'),
+      tier,
+      isUser: f.id === userFranchiseId,
+    };
+  });
+}
+
+/** Format a "W-L-T" record string, dropping the "-0" ties suffix when there are no ties. */
+function formatRecord(wlt: string): string {
+  const parts = wlt.split('-');
+  if (parts.length === 3 && parts[2] === '0') return `${parts[0]}-${parts[1]}`;
+  return wlt;
+}
+
+function sortRows(rows: StandingRow[]): StandingRow[] {
+  return [...rows].sort((a, b) => {
+    if (hasGames) {
+      if (b.allPlayPct !== a.allPlayPct) return b.allPlayPct - a.allPlayPct;
+      return b.pf - a.pf;
+    }
+    return b.pf - a.pf;
+  });
+}
+
+const allRows = makeRows();
+const premierRows = sortRows(allRows.filter(r => r.tier === 'Premier League'));
+const dLeagueRows = sortRows(allRows.filter(r => r.tier === 'D-League'));
+premierRows.forEach((r, i) => { r.rank = i + 1; });
+dLeagueRows.forEach((r, i) => { r.rank = i + 1; });
+
+// Pick the user's tier (default to Premier if no user)
+const userRow = userFranchiseId ? allRows.find(r => r.isUser) : undefined;
+const userTier = userRow?.tier ?? 'Premier League';
+const tierRows = userTier === 'Premier League' ? premierRows : dLeagueRows;
+
+// Cutline index (first row past the cutoff): Premier = bottom N relegated,
+// D-League = top N promoted.
+const cutIdx = userTier === 'Premier League'
+  ? Math.max(0, tierRows.length - relegationCount)
+  : relegationCount;
+
+const cutLabel = userTier === 'Premier League' ? 'Relegation line ↓' : 'Promotion line ↑';
+
+// Build a 5-row window centered on the user (or cutline if no user).
+const WINDOW_SIZE = 5;
+const half = Math.floor(WINDOW_SIZE / 2); // 2
+const total = tierRows.length;
+
+const focalIdx = userRow
+  ? tierRows.findIndex(r => r.franchiseId === userFranchiseId)
+  : Math.max(0, cutIdx - 1); // place the cutline near the middle when no user
+
+let startIdx = Math.max(0, focalIdx - half);
+let endIdx = Math.min(total, startIdx + WINDOW_SIZE);
+// Clamp to bottom: if we hit the bottom, walk start back so we still show 5.
+if (endIdx - startIdx < WINDOW_SIZE) {
+  startIdx = Math.max(0, endIdx - WINDOW_SIZE);
+}
+
+const windowRows = tierRows.slice(startIdx, endIdx).map((row) => ({
+  ...row,
+  // Mark this row so we render the cutline ABOVE it (i.e., it's the first
+  // row past the cutoff and the row above it is also visible).
+  cutBefore: row.rank === cutIdx + 1 && row.rank > 1 && startIdx <= cutIdx - 1,
+}));
+
+// Subtitle: user's position + clearance to/from the cutline
+function ordinal(n: number): string {
+  const m100 = n % 100;
+  if (m100 >= 11 && m100 <= 13) return `${n}th`;
+  const m10 = n % 10;
+  if (m10 === 1) return `${n}st`;
+  if (m10 === 2) return `${n}nd`;
+  if (m10 === 3) return `${n}rd`;
+  return `${n}th`;
+}
+
+let subtitle = '';
+if (userRow) {
+  const rank = focalIdx + 1;
+  if (userTier === 'Premier League') {
+    const safeBy = cutIdx - focalIdx;
+    subtitle = safeBy > 0
+      ? `You're ${ordinal(rank)} of ${total} in Premier — ${safeBy} clear of relegation.`
+      : `You're ${ordinal(rank)} of ${total} in Premier — in the relegation zone.`;
+  } else {
+    const promoBy = cutIdx - focalIdx;
+    subtitle = promoBy > 0
+      ? `You're ${ordinal(rank)} of ${total} in D-League — in promotion position.`
+      : `You're ${ordinal(rank)} of ${total} in D-League — ${-promoBy + 1} short of promotion.`;
+  }
+} else {
+  subtitle = userTier === 'Premier League'
+    ? `Premier League — bottom ${relegationCount} drop to D-League at season end.`
+    : `D-League — top ${relegationCount} promote to Premier.`;
+}
+---
+
+<section class="afl-tiers" aria-label={`${userTier} standings`}>
+  <div class="afl-tiers__header">
+    <div class="afl-tiers__section-header">
+      <h3 class="afl-tiers__title">{userTier} Standings</h3>
+      <p class="afl-tiers__sub">{subtitle}</p>
+    </div>
+    <a href="/afl-fantasy/standings?view=tier" class="afl-tiers__cta">
+      Full standings
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" aria-hidden="true">
+        <path d="M5 12h14M12 5l7 7-7 7"/>
+      </svg>
+    </a>
+  </div>
+
+  <table class="afl-tiers__table">
+    <thead>
+      <tr>
+        <th class="afl-tiers__th afl-tiers__th--rank">#</th>
+        <th class="afl-tiers__th afl-tiers__th--team">Team</th>
+        {hasGames && <th class="afl-tiers__th afl-tiers__th--ap">All-Play</th>}
+        <th class="afl-tiers__th afl-tiers__th--pf">PF</th>
+      </tr>
+    </thead>
+    <tbody>
+      {windowRows.map((row) => (
+        <>
+          {row.cutBefore && (
+            <tr class="afl-tiers__cutline" aria-hidden="true">
+              <td colspan={hasGames ? 4 : 3}>{cutLabel}</td>
+            </tr>
+          )}
+          <tr class:list={['afl-tiers__row', { 'afl-tiers__row--user': row.isUser }]}>
+            <td class="afl-tiers__td afl-tiers__td--rank">{row.rank}</td>
+            <td class="afl-tiers__td afl-tiers__td--team">
+              <span class={row.isUser ? 'afl-tiers__team-name--bold' : ''}>{row.name}</span>
+            </td>
+            {hasGames && (
+              <td class="afl-tiers__td afl-tiers__td--ap">
+                <span class="afl-tiers__ap-record">{formatRecord(row.allPlayRecord)}</span>
+                <span class="afl-tiers__ap-pct">{(row.allPlayPct * 100).toFixed(1)}%</span>
+              </td>
+            )}
+            <td class="afl-tiers__td afl-tiers__td--pf">{row.pf.toLocaleString('en-US', { maximumFractionDigits: 0 })}</td>
+          </tr>
+        </>
+      ))}
+    </tbody>
+  </table>
+</section>
+
+<style>
+  .afl-tiers {
+    --afl-accent: var(--color-primary, #c41e3a);
+    --afl-highlight-bg: color-mix(in srgb, var(--afl-accent) 6%, transparent);
+    background: var(--content-bg, #fff);
+    border: 1px solid var(--content-border, #e2e8f0);
+    border-radius: var(--radius-md, 0.5rem);
+    box-shadow: var(--shadow-md);
+    padding: 1.5rem;
+  }
+
+  .afl-tiers__header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 1rem;
+  }
+
+  .afl-tiers__section-header {
+    padding-left: 0.625rem;
+    border-left: 2px solid var(--afl-accent);
+  }
+
+  .afl-tiers__title {
+    font-size: 0.75rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    margin: 0;
+    line-height: 1;
+    color: var(--color-gray-700, #374151);
+  }
+
+  .afl-tiers__sub {
+    margin: 0.375rem 0 0;
+    font-size: 0.8125rem;
+    color: var(--color-gray-500, #6b7280);
+  }
+
+  .afl-tiers__cta {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--afl-accent);
+    text-decoration: none;
+    transition: gap 0.15s ease;
+    white-space: nowrap;
+  }
+
+  .afl-tiers__cta:hover {
+    gap: 0.5rem;
+  }
+
+  .afl-tiers__table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.8125rem;
+  }
+
+  .afl-tiers__th {
+    font-size: 0.625rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--color-gray-400, #9ca3af);
+    padding: 0 0.5rem 0.5rem;
+    text-align: left;
+    border-bottom: 1px solid var(--color-gray-50, #f9fafb);
+    white-space: nowrap;
+  }
+
+  .afl-tiers__th--rank { width: 2rem; text-align: center; }
+  .afl-tiers__th--ap,
+  .afl-tiers__th--pf { text-align: right; }
+
+  .afl-tiers__row {
+    transition: background 0.1s ease;
+  }
+
+  .afl-tiers__row:hover {
+    background: var(--color-gray-50, #f9fafb);
+  }
+
+  .afl-tiers__row--user {
+    background: var(--afl-highlight-bg);
+  }
+
+  .afl-tiers__row--user .afl-tiers__td:first-child {
+    box-shadow: inset 3px 0 0 var(--afl-accent);
+  }
+
+  .afl-tiers__td {
+    padding: 0.4375rem 0.5rem;
+    border-bottom: 1px solid var(--color-gray-50, #f9fafb);
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+  }
+
+  .afl-tiers__td--rank {
+    text-align: center;
+    color: var(--color-gray-400, #9ca3af);
+    font-size: 0.6875rem;
+    font-weight: 600;
+  }
+
+  .afl-tiers__td--team {
+    font-weight: 500;
+    color: var(--color-gray-800, #1f2937);
+  }
+
+  .afl-tiers__team-name--bold {
+    font-weight: 700;
+  }
+
+  .afl-tiers__td--ap,
+  .afl-tiers__td--pf {
+    text-align: right;
+    color: var(--color-gray-700, #374151);
+  }
+
+  /* All-Play column — the headline metric for tier promotion/relegation.
+     Show the W-L-T record big and the % small underneath. */
+  .afl-tiers__td--ap {
+    line-height: 1.15;
+  }
+
+  .afl-tiers__ap-record {
+    display: block;
+    font-size: 0.875rem;
+    font-weight: 700;
+    color: var(--color-gray-800, #1f2937);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .afl-tiers__ap-pct {
+    display: block;
+    margin-top: 0.0625rem;
+    font-size: 0.625rem;
+    color: var(--color-gray-400, #9ca3af);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .afl-tiers__row--user .afl-tiers__ap-record {
+    color: var(--afl-accent);
+  }
+
+  .afl-tiers__cutline td {
+    padding: 0.25rem 0.5rem;
+    font-size: 0.5625rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--color-error, #dc2626);
+    background: color-mix(in srgb, var(--color-error, #dc2626) 6%, transparent);
+    text-align: center;
+  }
+</style>

--- a/src/components/afl/hp-sections/AflTeamSnapshot.astro
+++ b/src/components/afl/hp-sections/AflTeamSnapshot.astro
@@ -1,0 +1,363 @@
+---
+/**
+ * AflTeamSnapshot — Personal team card for the AFL homepage.
+ *
+ * Shows the AFL team's tier (Premier / D-League), conference, current record,
+ * and roster count. During the regular season, also surfaces the next matchup;
+ * during the offseason, surfaces keeper status. Guests see a team picker prompt.
+ */
+import { spriteUrl } from '../../../utils/sprite-url';
+
+interface Team {
+  franchiseId: string;
+  name: string;
+  nameMedium?: string;
+  nameShort?: string;
+  conference?: string;
+  division?: string;
+  tier?: string;
+  icon?: string;
+}
+
+interface Props {
+  userTeam?: Team;
+  userConferenceName?: string;
+  record?: { wins: number; losses: number; ties: number };
+  nextOpponent?: { name?: string; icon?: string };
+  rosterCount?: number;
+  keeperCount?: number;
+  /** Total keepers allowed per franchise. */
+  keeperLimit: number;
+  /** Active roster target (used to surface "X of N" slot fill). */
+  rosterLimit?: number;
+  /** Render variant — defaults to "in-season" when record exists, "offseason" otherwise */
+  variant?: 'in-season' | 'offseason';
+}
+
+const {
+  userTeam,
+  userConferenceName,
+  record,
+  nextOpponent,
+  rosterCount,
+  keeperCount,
+  keeperLimit,
+  rosterLimit,
+  variant,
+} = Astro.props;
+
+const inferredVariant: 'in-season' | 'offseason' = variant ?? (record ? 'in-season' : 'offseason');
+
+interface MetricDef {
+  label: string;
+  value: string;
+  sub: string;
+  href: string;
+  icon?: string;
+  alert?: boolean;
+}
+
+const metrics: MetricDef[] = inferredVariant === 'in-season'
+  ? [
+      {
+        label: 'Record',
+        value: record ? `${record.wins}-${record.losses}${record.ties ? `-${record.ties}` : ''}` : '—',
+        sub: userConferenceName ? `${userConferenceName} conf.` : 'in conference',
+        href: '/afl-fantasy/standings',
+        icon: 'star',
+      },
+      {
+        label: 'Tier',
+        value: userTeam?.tier === 'Premier League' ? 'Premier' : userTeam?.tier === 'D-League' ? 'D-League' : '—',
+        sub: 'this season',
+        href: '/afl-fantasy/standings?view=tier',
+        icon: 'trophy',
+      },
+      {
+        label: 'Roster',
+        value: rosterCount != null ? `${rosterCount}` : '—',
+        sub: rosterLimit ? `of ${rosterLimit} slots` : 'players',
+        href: '/afl-fantasy/rosters',
+        icon: 'users',
+        alert: rosterLimit ? (rosterCount ?? 0) > rosterLimit : false,
+      },
+      {
+        label: 'Next Up',
+        value: nextOpponent?.name ? 'vs.' : 'TBD',
+        sub: nextOpponent?.name ?? 'check schedule',
+        href: '/afl-fantasy/standings',
+        icon: 'exchange',
+      },
+    ]
+  : [
+      {
+        label: 'Tier',
+        value: userTeam?.tier === 'Premier League' ? 'Premier' : userTeam?.tier === 'D-League' ? 'D-League' : '—',
+        sub: 'this season',
+        href: '/afl-fantasy/standings?view=tier',
+        icon: 'trophy',
+      },
+      {
+        label: 'Conference',
+        value: userTeam?.conference === '00' ? 'AL' : userTeam?.conference === '01' ? 'NL' : '—',
+        sub: userTeam?.division ?? '',
+        href: '/afl-fantasy/standings',
+        icon: 'star',
+      },
+      {
+        label: 'Keepers',
+        value: keeperCount != null ? `${keeperCount}` : '—',
+        sub: `of ${keeperLimit} protected`,
+        href: '/afl-fantasy/keepers',
+        icon: 'bookmark',
+        alert: keeperCount != null && keeperCount < keeperLimit,
+      },
+      {
+        label: 'Roster',
+        value: rosterCount != null ? `${rosterCount}` : '—',
+        sub: 'players',
+        href: '/afl-fantasy/rosters',
+        icon: 'users',
+      },
+    ];
+---
+
+{userTeam ? (
+  <section class="afl-snapshot" aria-label="My team snapshot">
+    <div class="afl-snapshot__header">
+      <div class="afl-snapshot__team">
+        {userTeam.icon && (
+          <img src={userTeam.icon} alt="" class="afl-snapshot__team-icon" width="28" height="28" loading="lazy" />
+        )}
+        <div class="afl-snapshot__name">
+          <h3 class="afl-snapshot__title">My Team</h3>
+          <p class="afl-snapshot__sub">{userTeam.nameMedium ?? userTeam.name}</p>
+        </div>
+      </div>
+      <a href="/afl-fantasy/rosters" class="afl-snapshot__cta">
+        Full roster
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" aria-hidden="true">
+          <path d="M5 12h14M12 5l7 7-7 7"/>
+        </svg>
+      </a>
+    </div>
+    <div class="afl-snapshot__grid">
+      {metrics.map(m => (
+        <a href={m.href} class="afl-snapshot__card">
+          {m.icon && (
+            <svg class="afl-snapshot__card-icon" width="14" height="14" aria-hidden="true">
+              <use href={`${spriteUrl}#icon-${m.icon}`} />
+            </svg>
+          )}
+          <span class:list={['afl-snapshot__card-value', { 'afl-snapshot__card-value--alert': m.alert }]}>{m.value}</span>
+          <span class="afl-snapshot__card-label">{m.label}</span>
+          <span class="afl-snapshot__card-sub">{m.sub}</span>
+        </a>
+      ))}
+    </div>
+  </section>
+) : (
+  <section class="afl-snapshot afl-snapshot--guest" aria-label="Team selector prompt">
+    <div class="afl-snapshot__guest-inner">
+      <svg class="afl-snapshot__guest-icon" width="24" height="24" aria-hidden="true">
+        <use href={`${spriteUrl}#icon-shield`} />
+      </svg>
+      <div class="afl-snapshot__guest-text">
+        <p class="afl-snapshot__guest-heading">Pick your franchise</p>
+        <p class="afl-snapshot__guest-desc">Choose your team to personalize standings, keepers, and the rotating hero.</p>
+      </div>
+      <a href="/afl-fantasy/standings" class="afl-snapshot__guest-btn">Choose team</a>
+    </div>
+  </section>
+)}
+
+<style>
+  .afl-snapshot {
+    --afl-accent: var(--color-primary, #c41e3a);
+    background: var(--content-bg, #fff);
+    border: 1px solid var(--content-border, #e2e8f0);
+    border-radius: var(--radius-md, 0.5rem);
+    box-shadow: var(--shadow-md);
+    padding: 1.5rem;
+  }
+
+  .afl-snapshot__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 1rem;
+    gap: 1rem;
+  }
+
+  .afl-snapshot__team {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    min-width: 0;
+  }
+
+  .afl-snapshot__team-icon {
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    object-fit: cover;
+    flex-shrink: 0;
+  }
+
+  .afl-snapshot__name {
+    display: flex;
+    flex-direction: column;
+    gap: 0.125rem;
+    min-width: 0;
+  }
+
+  .afl-snapshot__title {
+    font-size: 0.75rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    padding-left: 0.625rem;
+    border-left: 2px solid var(--afl-accent);
+    margin: 0;
+    line-height: 1;
+    color: var(--color-gray-700, #374151);
+  }
+
+  .afl-snapshot__sub {
+    margin: 0 0 0 0.625rem;
+    font-size: 0.8125rem;
+    color: var(--color-gray-500, #6b7280);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .afl-snapshot__cta {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--afl-accent);
+    text-decoration: none;
+    transition: gap 0.15s ease;
+  }
+
+  .afl-snapshot__cta:hover {
+    gap: 0.5rem;
+  }
+
+  .afl-snapshot__grid {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 0.5rem;
+  }
+
+  .afl-snapshot__card {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.125rem;
+    padding: 0.875rem 0.5rem;
+    background: var(--color-gray-50, #f9fafb);
+    border-radius: var(--radius-md, 0.5rem);
+    text-decoration: none;
+    text-align: center;
+    transition: background 0.15s ease;
+  }
+
+  .afl-snapshot__card:hover {
+    background: var(--color-gray-100, #f3f4f6);
+  }
+
+  .afl-snapshot__card-icon {
+    color: var(--color-gray-400, #9ca3af);
+  }
+
+  .afl-snapshot__card-value {
+    font-size: 1.25rem;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+    color: var(--color-gray-800, #1f2937);
+    line-height: 1.2;
+  }
+
+  .afl-snapshot__card-value--alert {
+    color: var(--color-error, #dc2626);
+  }
+
+  .afl-snapshot__card-label {
+    font-size: 0.625rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--color-gray-400, #9ca3af);
+  }
+
+  .afl-snapshot__card-sub {
+    font-size: 0.6875rem;
+    color: var(--color-gray-500, #6b7280);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .afl-snapshot--guest {
+    padding: 1.25rem 1.5rem;
+  }
+
+  .afl-snapshot__guest-inner {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+  }
+
+  .afl-snapshot__guest-icon {
+    flex-shrink: 0;
+    color: var(--color-gray-300, #d1d5db);
+  }
+
+  .afl-snapshot__guest-text {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .afl-snapshot__guest-heading {
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: var(--color-gray-700, #374151);
+    margin: 0;
+  }
+
+  .afl-snapshot__guest-desc {
+    font-size: 0.75rem;
+    color: var(--color-gray-500, #6b7280);
+    margin: 0.25rem 0 0;
+  }
+
+  .afl-snapshot__guest-btn {
+    flex-shrink: 0;
+    padding: 0.4375rem 0.875rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: #fff;
+    background: var(--afl-accent);
+    border: 1px solid var(--afl-accent);
+    border-radius: var(--radius-md, 0.5rem);
+    box-shadow: var(--shadow-sm);
+    text-decoration: none;
+    white-space: nowrap;
+  }
+
+  @media (max-width: 640px) {
+    .afl-snapshot__grid {
+      grid-template-columns: repeat(2, 1fr);
+    }
+    .afl-snapshot__guest-inner {
+      flex-wrap: wrap;
+    }
+    .afl-snapshot__guest-btn {
+      width: 100%;
+      text-align: center;
+      box-sizing: border-box;
+    }
+  }
+</style>

--- a/src/components/afl/hp-sections/AflWhatsNext.astro
+++ b/src/components/afl/hp-sections/AflWhatsNext.astro
@@ -1,0 +1,110 @@
+---
+/**
+ * AflWhatsNext — League events timeline for the AFL homepage.
+ *
+ * Reuses the shared WhatsNextCard component but sources its timeline from
+ * the AFL events JSON (via getAflWhatsNextTimeline).
+ */
+import WhatsNextCard from '../../theleague/WhatsNextCard.astro';
+import { getAflWhatsNextTimeline } from '../../../utils/league-event-resolver';
+
+interface Props {
+  /** Override date for demo/testing purposes (?testDate=YYYY-MM-DD). */
+  demoDate?: Date;
+  /** Maximum number of event cards to show (default: 2). */
+  maxCards?: number;
+  /** Optional event ID to hide (when already shown in the hero banner). */
+  excludeEventId?: string;
+}
+
+const { demoDate, maxCards = 2, excludeEventId } = Astro.props;
+
+const timeline = getAflWhatsNextTimeline(demoDate);
+
+let { current, next, upcoming } = timeline;
+if (excludeEventId) {
+  if (current?.definition.id === excludeEventId) current = null;
+  if (next?.definition.id === excludeEventId) next = null;
+  if (upcoming?.definition.id === excludeEventId) upcoming = null;
+}
+
+const hasEvents = current || next || upcoming;
+---
+
+{hasEvents && (
+  <section class="afl-next" aria-label="Upcoming AFL events">
+    <div class="afl-next__header">
+      <h2 class="afl-next__heading">What's Next</h2>
+      <a href="/afl-fantasy/calendar" class="afl-next__calendar-link">
+        Full calendar
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" aria-hidden="true">
+          <path d="M5 12h14M12 5l7 7-7 7"/>
+        </svg>
+      </a>
+    </div>
+    <div class:list={['afl-next__grid', { 'afl-next__grid--2col': maxCards === 2 }]}>
+      {current && <WhatsNextCard event={current} position="current" />}
+      {maxCards >= 2 && next && <WhatsNextCard event={next} position="next" />}
+      {maxCards >= 3 && upcoming && <WhatsNextCard event={upcoming} position="upcoming" />}
+    </div>
+  </section>
+)}
+
+<style>
+  .afl-next {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .afl-next__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+  }
+
+  .afl-next__heading {
+    font-size: 0.75rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    padding-left: 0.625rem;
+    border-left: 2px solid var(--color-primary, #c41e3a);
+    margin: 0;
+    line-height: 1;
+    color: var(--color-gray-700, #374151);
+  }
+
+  .afl-next__calendar-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--color-primary, #c41e3a);
+    text-decoration: none;
+    white-space: nowrap;
+    transition: gap 0.15s ease;
+  }
+
+  .afl-next__calendar-link:hover {
+    gap: 0.5rem;
+  }
+
+  .afl-next__grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 1.5rem;
+  }
+
+  .afl-next__grid--2col {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  @media (max-width: 768px) {
+    .afl-next__grid {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/src/components/nav/LeagueSwitcher.astro
+++ b/src/components/nav/LeagueSwitcher.astro
@@ -2,7 +2,7 @@
 /**
  * LeagueSwitcher Component
  *
- * Toggle component for switching between AFL Fantasy and TheLeague.
+ * Toggle component for switching between AFL and TheLeague.
  * Implements smart routing to navigate to the equivalent page in the other league.
  *
  * Features:
@@ -77,7 +77,7 @@ const isAflActive = currentLeague === 'afl';
     <a
       href={aflUrl}
       class:list={['league-switcher__option', { 'league-switcher__option--active': isAflActive }]}
-      aria-label={isAflActive ? 'AFL Fantasy (current)' : 'Switch to AFL Fantasy'}
+      aria-label={isAflActive ? 'AFL (current)' : 'Switch to AFL'}
       aria-current={isAflActive ? 'page' : undefined}
     >
       <span class="league-switcher__abbrev">AFL</span>

--- a/src/components/nav/NavHeader.astro
+++ b/src/components/nav/NavHeader.astro
@@ -46,14 +46,14 @@ const canSwitchLeagues = hasTeamInBothLeagues(franchiseId, league);
 const leagueHome = resolveLeaguePath(league === 'afl' ? '/afl-fantasy' : '/theleague', hideLeaguePrefix);
 
 // Determine league display name for screen readers
-const leagueName = league === 'afl' ? 'AFL Fantasy' : 'TheLeague';
+const leagueName = league === 'afl' ? 'AFL' : 'TheLeague';
 
 // Logo alt text
-const logoAlt = league === 'afl' ? 'AFL Fantasy Logo' : 'TheLeague Logo';
+const logoAlt = league === 'afl' ? 'AFL Logo' : 'TheLeague Logo';
 
 // Target league for switching
 const targetLeague = league === 'afl' ? 'theleague' : 'afl';
-const targetLeagueName = league === 'afl' ? 'TheLeague' : 'AFL Fantasy';
+const targetLeagueName = league === 'afl' ? 'TheLeague' : 'AFL';
 
 // Equivalent-route logic lives in src/utils/nav-utils.ts and is shared with
 // LeagueSwitcher. nav-utils consults the route-equivalence map first and
@@ -80,7 +80,7 @@ const switchUrl = resolveLeaguePath(getEquivalentRoute(currentPath, targetLeague
       />
       <span class="nav-header__league-name">
         {league === 'afl' ? (
-          <span class="nav-header__league-name--afl">AFL Fantasy</span>
+          <span class="nav-header__league-name--afl">AFL</span>
         ) : (
           <>
             <span class="nav-header__league-name--the">The</span>

--- a/src/components/theleague/Header.astro
+++ b/src/components/theleague/Header.astro
@@ -96,7 +96,7 @@ const liveScoringUrl = `https://${league.host}/${year}/home/${league.leagueId}?M
           <div class="league_logo" id="league_logo">
             {isAFL ? (
               <!-- AFL Logo -->
-              <img src="/assets/logos/afl-logo.svg" alt="AFL Fantasy Logo" class="header-logo-img" />
+              <img src="/assets/logos/afl-logo.svg" alt="AFL Logo" class="header-logo-img" />
             ) : (
               <!-- The League Logo -->
               <img src="/assets/logos/theleague-logo.svg" alt="The League Logo" class="header-logo-img" />
@@ -105,7 +105,7 @@ const liveScoringUrl = `https://${league.host}/${year}/home/${league.leagueId}?M
           <div class="leaguename">
             {isAFL ? (
               <>
-                <span class="leaguename--afl-name">AFL Fantasy</span>
+                <span class="leaguename--afl-name">AFL</span>
               </>
             ) : (
               <>

--- a/src/data/afl-fantasy/league-events.json
+++ b/src/data/afl-fantasy/league-events.json
@@ -1,76 +1,96 @@
 {
-  "$comment": "AFL Fantasy league calendar events. Each entry has either a fixed date (month + day, optional time) or a computed rule (relative to NFL Labor Day). dates_per_year overrides the computed/fixed values for specific years (e.g. when the league moves auction night). The calendar page renders these grouped by category. Update this file as the AFL league office sets dates each year.",
-  "$todo": "Most dates below are placeholders inferred from typical AFL cadence. Brandon: replace with actual AFL deadlines from the AFL constitution, and switch to dates_per_year overrides where helpful.",
+  "$comment": "AFL league calendar events. Mirrors TheLeague's shape (see src/data/theleague/league-events.ts and src/types/league-events.ts). Custom computed rules used here: 'saturday-before-labor-day' (AL Live Draft), 'sunday-before-labor-day' (NL Email Draft, 9am PT). Keeper deadline is fixed July 15.",
   "events": [
     {
+      "id": "afl-new-season-starts",
+      "name": "New Season Starts",
+      "description": "AFL league year rolls over and rosters lock for the new season.",
+      "category": "preseason",
+      "icon": "star",
+      "startDate": { "type": "fixed", "month": 2, "day": 15 },
+      "sortOrder": 1
+    },
+    {
       "id": "afl-keeper-deadline",
-      "name": "Keeper List Deadline",
-      "description": "Each franchise must declare its 7 kept players. Players not declared as keepers are released into the auction pool.",
+      "name": "Keeper Deadline",
+      "description": "Final day to declare your 7 keepers. Anyone not protected enters the draft pool.",
       "category": "preseason",
       "icon": "bookmark",
-      "startDate": { "type": "fixed", "month": 7, "day": 1, "time": "20:00" },
-      "urgencyDays": 14,
-      "sortOrder": 1,
+      "startDate": { "type": "fixed", "month": 7, "day": 15, "time": "20:00" },
       "actionLinks": [
-        { "label": "Manage Keepers", "url": "/afl-fantasy/keepers/manage", "external": false }
-      ]
-    },
-    {
-      "id": "afl-auction",
-      "name": "AFL Auction",
-      "description": "Live auction for all non-keeper players. Free agency follows after the auction closes.",
-      "category": "preseason",
-      "icon": "dollar",
-      "startDate": { "type": "fixed", "month": 8, "day": 15, "time": "19:00" },
+        { "label": "Manage Keepers", "url": "/afl-fantasy/keepers", "external": false }
+      ],
       "urgencyDays": 7,
-      "sortOrder": 2
-    },
-    {
-      "id": "afl-season-start",
-      "name": "Regular Season Kickoff",
-      "description": "Week 1 of the AFL Fantasy regular season begins with the NFL kickoff Thursday.",
-      "category": "in-season",
-      "icon": "star",
-      "startDate": { "type": "computed", "rule": "nfl-kickoff" },
       "sortOrder": 3
     },
     {
-      "id": "afl-trade-deadline",
-      "name": "Trade Deadline",
-      "description": "Final day to submit trades for the regular season.",
-      "category": "in-season",
-      "icon": "clock",
-      "startDate": { "type": "computed", "rule": "friday-before-week-11" },
+      "id": "afl-al-draft",
+      "name": "American League Draft",
+      "description": "AL teams meet live for the conference draft — veterans and rookies on the same board.",
+      "category": "draft",
+      "icon": "draft-podium",
+      "startDate": { "type": "computed", "rule": "saturday-before-labor-day", "time": "09:00" },
       "urgencyDays": 7,
       "sortOrder": 4
     },
     {
-      "id": "afl-allplay-locks",
-      "name": "All-Play Cutoff Locks",
-      "description": "Final week of all-play scoring. After this week the Premier/D-League promotion-relegation cutoff is locked.",
-      "category": "in-season",
-      "icon": "swap",
-      "startDate": { "type": "computed", "rule": "after-week-16" },
+      "id": "afl-nl-draft",
+      "name": "National League Draft",
+      "description": "NL teams begin the email draft at 9am PT Sunday. Slow draft, but the clock matters.",
+      "category": "draft",
+      "icon": "draft-podium",
+      "startDate": { "type": "computed", "rule": "sunday-before-labor-day", "time": "09:00" },
       "urgencyDays": 7,
       "sortOrder": 5
     },
     {
-      "id": "afl-conference-playoffs-start",
-      "name": "Conference Playoffs Start",
-      "description": "AL and NL conference seeds 1-4 begin head-to-head playoffs. NIT bracket (seeds 5-12) also begins.",
-      "category": "playoffs",
-      "icon": "trophy",
-      "startDate": { "type": "computed", "rule": "playoffs-start" },
+      "id": "afl-season-start",
+      "name": "NFL Season Starts",
+      "description": "NFL kickoff and the start of weekly fantasy matchups across both conferences.",
+      "category": "regular-season",
+      "icon": "nfl",
+      "startDate": { "type": "computed", "rule": "nfl-kickoff" },
       "sortOrder": 6
     },
     {
-      "id": "afl-championship-week",
-      "name": "Championship Week",
-      "description": "AL champion vs. NL champion in the AFL Fantasy championship game.",
-      "category": "playoffs",
-      "icon": "trophy",
-      "startDate": { "type": "computed", "rule": "championship-week" },
+      "id": "afl-trade-deadline",
+      "name": "Trade Deadline",
+      "description": "Final day to submit trades. Deadline is the Wednesday between Week 10 and Week 11.",
+      "category": "regular-season",
+      "icon": "exchange",
+      "startDate": { "type": "computed", "rule": "afl-trade-deadline" },
+      "urgencyDays": 7,
       "sortOrder": 7
+    },
+    {
+      "id": "afl-regular-season-ends",
+      "name": "Regular Season Ends",
+      "description": "Week 13 closes the regular season. Premier/D-League cutoff and conference seeds lock.",
+      "category": "regular-season",
+      "icon": "gavel",
+      "startDate": { "type": "computed", "rule": "after-week-16" },
+      "urgencyDays": 7,
+      "sortOrder": 8
+    },
+    {
+      "id": "afl-conference-playoffs",
+      "name": "Conference Playoffs",
+      "description": "Week 14 — conference seeds 1-4 begin head-to-head playoffs.",
+      "category": "regular-season",
+      "icon": "playoff",
+      "startDate": { "type": "computed", "rule": "afl-playoffs-start" },
+      "urgencyDays": 7,
+      "sortOrder": 9
+    },
+    {
+      "id": "afl-championship-week",
+      "name": "World Championship",
+      "description": "Week 16 — AL champion vs. NL champion in the World Championship.",
+      "category": "regular-season",
+      "icon": "champ",
+      "startDate": { "type": "computed", "rule": "afl-championship-week" },
+      "urgencyDays": 7,
+      "sortOrder": 10
     }
   ]
 }

--- a/src/data/page-directory.json
+++ b/src/data/page-directory.json
@@ -458,5 +458,137 @@
     "tags": ["tip", "tips", "rumor", "rumors", "rumor mill", "schefter", "anonymous", "gossip", "leak", "leaks", "whisper", "source", "informant", "intel", "scoop", "hot take", "prediction", "submit", "form", "trade rumor", "commish beef"],
     "visibility": "all",
     "popularity": 30
+  },
+  {
+    "id": "afl-rosters",
+    "title": "Rosters",
+    "description": "All 24 AFL franchise rosters across both conferences — players, status, contracts. Switch teams with the picker.",
+    "path": "/afl-fantasy/rosters",
+    "icon": "users",
+    "category": "popular",
+    "tags": ["afl", "roster", "rosters", "team", "teams", "players", "lineup", "squad", "depth chart", "premier league", "d-league", "american league", "national league", "al", "nl", "conference", "division", "starters", "bench", "ir", "injured reserve", "keeper"],
+    "visibility": "all",
+    "popularity": 90
+  },
+  {
+    "id": "afl-standings",
+    "title": "Standings",
+    "description": "AFL standings by conference, division, tier, and all-play — track promotion/relegation between Premier League and D-League.",
+    "path": "/afl-fantasy/standings",
+    "icon": "trophy",
+    "category": "popular",
+    "tags": ["afl", "standings", "rankings", "rank", "record", "wins", "losses", "ties", "all-play", "allplay", "tier", "premier league", "d-league", "promotion", "relegation", "conference", "division", "american league", "national league", "al", "nl", "playoff race", "playoff seeding", "pf", "pa", "points for", "points against"],
+    "visibility": "all",
+    "popularity": 88
+  },
+  {
+    "id": "afl-lineup",
+    "title": "Set Lineup",
+    "description": "Set your weekly starting lineup — pick from your bench, swap into FLEX slots, and submit to MFL without leaving the site.",
+    "path": "/afl-fantasy/lineup",
+    "icon": "clipboard",
+    "category": "my-team",
+    "tags": ["afl", "lineup", "lineups", "set lineup", "submit lineup", "starters", "starting", "bench", "start", "sit", "flex", "weekly", "qb", "rb", "wr", "te", "pk", "def", "kicker", "defense", "swap", "slot", "game day", "matchup"],
+    "visibility": "all",
+    "popularity": 80
+  },
+  {
+    "id": "afl-keepers",
+    "title": "Keepers",
+    "description": "Declare your 7 protected players before the July 15 deadline. Players left undeclared get released into the draft pool.",
+    "path": "/afl-fantasy/keepers",
+    "icon": "bookmark",
+    "category": "my-team",
+    "tags": ["afl", "keeper", "keepers", "keep", "protect", "protected", "declare", "declaration", "deadline", "july 15", "preseason", "offseason", "auction pool", "draft pool", "release", "released", "core", "retain", "save", "lock in", "7 keepers"],
+    "visibility": "all",
+    "popularity": 75
+  },
+  {
+    "id": "afl-playoffs",
+    "title": "Playoffs",
+    "description": "Conference playoff brackets — AL and NL race through head-to-head matchups to crown champions before the AFL title game.",
+    "path": "/afl-fantasy/playoffs",
+    "icon": "playoff",
+    "category": "popular",
+    "tags": ["afl", "playoff", "playoffs", "bracket", "brackets", "championship", "title", "trophy", "champion", "head to head", "h2h", "conference", "al", "nl", "american league", "national league", "seed", "seeding", "round", "semifinal", "final", "matchup", "nit", "consolation"],
+    "visibility": "all",
+    "popularity": 70
+  },
+  {
+    "id": "afl-news",
+    "title": "Schefter Report",
+    "description": "AFL news feed — transactions, trades, draft buzz, and weekly recaps. Schefter covers both conferences.",
+    "path": "/afl-fantasy/news",
+    "icon": "news",
+    "category": "popular",
+    "tags": ["afl", "news", "feed", "schefter", "report", "transactions", "trades", "trade", "free agent", "free agency", "waivers", "rumors", "hot take", "analysis", "recap", "weekly", "breaking", "moves", "activity", "timeline", "commentary"],
+    "visibility": "all",
+    "popularity": 72
+  },
+  {
+    "id": "afl-trade-builder",
+    "title": "Trade Builder",
+    "description": "Build and propose AFL trades — pick assets, evaluate fairness, and send the offer when the package looks right.",
+    "path": "/afl-fantasy/trade-builder",
+    "icon": "exchange",
+    "category": "my-team",
+    "tags": ["afl", "trade", "trades", "trading", "trade builder", "swap", "exchange", "propose", "offer", "send trade", "fairness", "value", "package", "players", "draft picks", "futures", "deal", "deals", "trading block"],
+    "visibility": "all",
+    "popularity": 60
+  },
+  {
+    "id": "afl-draft-predictor",
+    "title": "Draft Predictor",
+    "description": "Projected AFL draft order for the upcoming season — based on standings, tiebreakers, and current league results.",
+    "path": "/afl-fantasy/draft-predictor",
+    "icon": "draft-podium",
+    "category": "tools",
+    "tags": ["afl", "draft", "predictor", "draft predictor", "draft order", "order", "pick", "picks", "round", "rounds", "rookie", "rookies", "veteran", "projection", "next year", "upcoming", "future", "1.01", "first round", "conference draft", "al draft", "nl draft"],
+    "visibility": "all",
+    "popularity": 55
+  },
+  {
+    "id": "afl-calendar",
+    "title": "Calendar",
+    "description": "Important AFL dates — keeper deadline, conference draft weekend, trade deadline, playoffs, and championship week.",
+    "path": "/afl-fantasy/calendar",
+    "icon": "calendar",
+    "category": "info",
+    "tags": ["afl", "calendar", "dates", "deadlines", "schedule", "events", "timeline", "keeper deadline", "draft", "trade deadline", "playoffs", "championship", "kickoff", "labor day", "season", "year", "important dates", "when", "july 15"],
+    "visibility": "all",
+    "popularity": 35
+  },
+  {
+    "id": "afl-rules",
+    "title": "Constitution",
+    "description": "The AFL constitution — scoring, roster rules, keeper rules, draft format, playoffs, tier promotion/relegation, and dues.",
+    "path": "/afl-fantasy/rules",
+    "icon": "scroll",
+    "category": "info",
+    "tags": ["afl", "rules", "constitution", "bylaws", "scoring", "format", "roster rules", "keeper rules", "draft rules", "playoff rules", "tier", "promotion", "relegation", "dues", "payouts", "commissioner", "league rules", "guidelines", "policy", "policies"],
+    "visibility": "all",
+    "popularity": 30
+  },
+  {
+    "id": "afl-about",
+    "title": "About AFL",
+    "description": "About the American Football League — history, structure, franchises, and how AFL differs from TheLeague.",
+    "path": "/afl-fantasy/about",
+    "icon": "shield",
+    "category": "info",
+    "tags": ["afl", "about", "american football league", "history", "franchises", "league", "info", "information", "intro", "overview", "structure", "conferences", "tiers", "format", "background", "how it works", "explainer", "what is"],
+    "visibility": "all",
+    "popularity": 20
+  },
+  {
+    "id": "afl-whats-new",
+    "title": "What's New",
+    "description": "Changelog of new AFL features, page launches, enhancements, and bug fixes — filtered to AFL-tagged updates only.",
+    "path": "/afl-fantasy/whats-new",
+    "icon": "star",
+    "category": "info",
+    "tags": ["afl", "whats new", "what's new", "changelog", "updates", "new", "features", "release notes", "release", "notes", "announcements", "history", "blog", "log", "added", "shipped", "launched", "fixed", "polish", "enhancement"],
+    "visibility": "all",
+    "popularity": 25
   }
 ]

--- a/src/data/whats-new.json
+++ b/src/data/whats-new.json
@@ -14,7 +14,10 @@
     "linkLabel": "Run a mock draft",
     "icon": "draft-podium",
     "image": "mock-draft.webp",
-    "imageAlt": "The Mock Draft lobby — Start a Mock Draft form with timer chips (1, 3, 10, 15 sec), round selector, draft order toggle, and a Board Settings card showing the per-team ranking source list. The Pigskins row is highlighted with a YOU badge and defaults to My Rank; every other team is set to Default."
+    "imageAlt": "The Mock Draft lobby — Start a Mock Draft form with timer chips (1, 3, 10, 15 sec), round selector, draft order toggle, and a Board Settings card showing the per-team ranking source list. The Pigskins row is highlighted with a YOU badge and defaults to My Rank; every other team is set to Default.",
+    "leagues": [
+      "theleague"
+    ]
   },
   {
     "id": "tip-schefter-gets-louder",
@@ -31,7 +34,10 @@
     "linkLabel": "Tip Schefter",
     "icon": "commenting",
     "image": "tip-schefter-engagement.webp",
-    "imageAlt": "The Tip Schefter page with the new tipster scorecard, top-tipsters leaderboard, live cooker timeline, hot topics chips, and a rumor card in the feed showing the four-verdict anonymous reaction bar"
+    "imageAlt": "The Tip Schefter page with the new tipster scorecard, top-tipsters leaderboard, live cooker timeline, hot topics chips, and a rumor card in the feed showing the four-verdict anonymous reaction bar",
+    "leagues": [
+      "theleague"
+    ]
   },
   {
     "id": "weekly-rollup-2026-03-30",
@@ -46,7 +52,10 @@
     "link": "/theleague/whats-new",
     "linkLabel": "See all updates",
     "icon": "wrench",
-    "excludeFromHero": true
+    "excludeFromHero": true,
+    "leagues": [
+      "theleague"
+    ]
   },
   {
     "id": "submit-lineup",
@@ -63,7 +72,10 @@
     "linkLabel": "Set your lineup",
     "icon": "clipboard",
     "image": "submit-lineup.webp",
-    "imageAlt": "The Set Lineup page showing nine starter slots with player photos, projections, and opponent matchup data, with the player selection drawer open on the right"
+    "imageAlt": "The Set Lineup page showing nine starter slots with player photos, projections, and opponent matchup data, with the player selection drawer open on the right",
+    "leagues": [
+      "theleague"
+    ]
   },
   {
     "id": "2026-auction-recap",
@@ -80,7 +92,10 @@
     "linkLabel": "Read the recap",
     "icon": "commenting",
     "image": "schefter-report.webp",
-    "imageAlt": "The Schefter Report auction recap article showing Claude Schefter's analysis of the 2026 auction results"
+    "imageAlt": "The Schefter Report auction recap article showing Claude Schefter's analysis of the 2026 auction results",
+    "leagues": [
+      "theleague"
+    ]
   },
   {
     "id": "schefter-report",
@@ -97,7 +112,10 @@
     "linkLabel": "Read the feed",
     "icon": "commenting",
     "image": "schefter-report.webp",
-    "imageAlt": "The Schefter Report feed page showing Claude Schefter's persona header with avatar and bio, followed by a social feed of auction wins and trade reports with filter pills for All, Trades, Free Agency, and Auction"
+    "imageAlt": "The Schefter Report feed page showing Claude Schefter's persona header with avatar and bio, followed by a social feed of auction wins and trade reports with filter pills for All, Trades, Free Agency, and Auction",
+    "leagues": [
+      "theleague"
+    ]
   },
   {
     "id": "the-board",
@@ -114,7 +132,10 @@
     "linkLabel": "Visit The Board",
     "icon": "commenting",
     "image": "the-board.webp",
-    "imageAlt": "The Board page showing league discussion posts with emoji reactions and comment counts, category filter pills, and a sidebar with posting guidelines and an Ask Roger promo"
+    "imageAlt": "The Board page showing league discussion posts with emoji reactions and comment counts, category filter pills, and a sidebar with posting guidelines and an Ask Roger promo",
+    "leagues": [
+      "theleague"
+    ]
   },
   {
     "id": "ask-roger",
@@ -131,7 +152,10 @@
     "linkLabel": "Ask Roger a question",
     "icon": "gavel",
     "image": "ask-roger.webp",
-    "imageAlt": "Ask Roger page showing a two-column layout with AI-answered rules Q&A cards on the left and Roger's personality card on the right"
+    "imageAlt": "Ask Roger page showing a two-column layout with AI-answered rules Q&A cards on the left and Roger's personality card on the right",
+    "leagues": [
+      "theleague"
+    ]
   },
   {
     "id": "projected-free-agents",
@@ -148,7 +172,10 @@
     "linkLabel": "View the report",
     "icon": "binoculars",
     "image": "projected-free-agents.webp",
-    "imageAlt": "Projected Free Agents report showing a sortable table of players in their final contract year with salary, projected points, and position filter pills"
+    "imageAlt": "Projected Free Agents report showing a sortable table of players in their final contract year with salary, projected points, and position filter pills",
+    "leagues": [
+      "theleague"
+    ]
   },
   {
     "id": "search-page",
@@ -165,7 +192,10 @@
     "linkLabel": "Try the search",
     "icon": "search",
     "image": "search-page.webp",
-    "imageAlt": "Search page showing a searchable grid of page cards with category filter chips and search input"
+    "imageAlt": "Search page showing a searchable grid of page cards with category filter chips and search input",
+    "leagues": [
+      "theleague"
+    ]
   },
   {
     "id": "owner-activity",
@@ -182,7 +212,10 @@
     "linkLabel": "Check who's active",
     "icon": "activity",
     "image": "owner-activity.webp",
-    "imageAlt": "Owner Activity page showing a 30-day line chart of daily page views per owner with 16 color-coded team lines, legend, and popular pages section"
+    "imageAlt": "Owner Activity page showing a 30-day line chart of daily page views per owner with 16 color-coded team lines, legend, and popular pages section",
+    "leagues": [
+      "theleague"
+    ]
   },
   {
     "id": "auction-view",
@@ -200,7 +233,10 @@
     "linkLabel": "Open auction view",
     "icon": "binoculars",
     "image": "auction-view.webp",
-    "imageAlt": "Free Agent page showing the Auction view with live bid amounts, countdown timers, and Place Bid buttons"
+    "imageAlt": "Free Agent page showing the Auction view with live bid amounts, countdown timers, and Place Bid buttons",
+    "leagues": [
+      "theleague"
+    ]
   },
   {
     "id": "weekly-rollup-2026-03-16",
@@ -216,7 +252,10 @@
     "link": "/theleague/whats-new",
     "linkLabel": "See all updates",
     "icon": "wrench",
-    "excludeFromHero": true
+    "excludeFromHero": true,
+    "leagues": [
+      "theleague"
+    ]
   },
   {
     "id": "salary-analytics-redesign",
@@ -233,7 +272,10 @@
     "linkLabel": "Check salary thresholds",
     "icon": "bar-chart",
     "image": "salary-analytics-redesign.webp",
-    "imageAlt": "Salary Analytics page showing editorial-styled position cards with metric grids, detail rows, and top earner tables"
+    "imageAlt": "Salary Analytics page showing editorial-styled position cards with metric grids, detail rows, and top earner tables",
+    "leagues": [
+      "theleague"
+    ]
   },
   {
     "id": "salary-history-redesign",
@@ -250,7 +292,10 @@
     "linkLabel": "View salary trends",
     "icon": "standings-2",
     "image": "salary-history-redesign.webp",
-    "imageAlt": "Salary history page showing a styled line chart with Franchise Tag trends, segmented control tabs, custom legend, and collapsible data table"
+    "imageAlt": "Salary history page showing a styled line chart with Franchise Tag trends, segmented control tabs, custom legend, and collapsible data table",
+    "leagues": [
+      "theleague"
+    ]
   },
   {
     "id": "auction-command-center",
@@ -267,7 +312,10 @@
     "linkLabel": "Visit the homepage",
     "icon": "gavel",
     "image": "auction-hero.webp",
-    "imageAlt": "Homepage showing the Auction Command Center with Place Auction Bid button, quick rules, and eight quick links for auction tools"
+    "imageAlt": "Homepage showing the Auction Command Center with Place Auction Bid button, quick rules, and eight quick links for auction tools",
+    "leagues": [
+      "theleague"
+    ]
   },
   {
     "id": "trade-submission",
@@ -284,7 +332,10 @@
     "linkLabel": "Open the Trade Builder",
     "icon": "transactions-2",
     "image": "trade-submission.webp",
-    "imageAlt": "Trade builder showing the trade confirmation modal with both sides of a proposed trade, cap impact metrics, and a submit button"
+    "imageAlt": "Trade builder showing the trade confirmation modal with both sides of a proposed trade, cap impact metrics, and a submit button",
+    "leagues": [
+      "theleague"
+    ]
   },
   {
     "id": "login-redesign",
@@ -302,7 +353,10 @@
     "icon": "lock",
     "image": "login-redesign.webp",
     "imageAlt": "Redesigned login page with editorial-style uppercase labels, clean input fields, and a prominent Sign In button following the site's design language",
-    "excludeFromHero": true
+    "excludeFromHero": true,
+    "leagues": [
+      "theleague"
+    ]
   },
   {
     "id": "weekly-rollup-2026-03-09",
@@ -319,7 +373,10 @@
     "icon": "wrench",
     "image": "weekly-rollup-2026-03-09.webp",
     "imageAlt": "Free Agents page showing broadcast-style diagonal player photo, editorial table headers, and position filter tabs",
-    "excludeFromHero": true
+    "excludeFromHero": true,
+    "leagues": [
+      "theleague"
+    ]
   },
   {
     "id": "contract-declarations",
@@ -393,7 +450,10 @@
     "icon": "clipboard",
     "image": "contracts-hero-modal.webp",
     "imageAlt": "Contract declaration modal for DeAndre Hopkins showing salary, deadline countdown, and year selection options over the roster page",
-    "pinToHero": true
+    "pinToHero": true,
+    "leagues": [
+      "theleague"
+    ]
   },
   {
     "id": "weekly-rollup-2026-03-02",
@@ -412,7 +472,10 @@
     "icon": "wrench",
     "excludeFromHero": true,
     "image": "weekly-rollup-2026-03-03.webp",
-    "imageAlt": "Fernando Mendoza's player details modal showing his Indiana college headshot loaded via the new college headshot fallback"
+    "imageAlt": "Fernando Mendoza's player details modal showing his Indiana college headshot loaded via the new college headshot fallback",
+    "leagues": [
+      "theleague"
+    ]
   },
   {
     "id": "free-agents-redesign",
@@ -429,7 +492,10 @@
     "linkLabel": "Scout some free agents",
     "icon": "binoculars",
     "image": "free-agents-redesign.webp",
-    "imageAlt": "Redesigned Free Agents page with broadcast-style diagonal photo hero, editorial position filters, and sortable stats table showing top available players"
+    "imageAlt": "Redesigned Free Agents page with broadcast-style diagonal photo hero, editorial position filters, and sortable stats table showing top available players",
+    "leagues": [
+      "theleague"
+    ]
   },
   {
     "id": "player-details-modal-redesign",
@@ -447,7 +513,10 @@
     "icon": "user",
     "excludeFromHero": true,
     "image": "player-details-modal.webp",
-    "imageAlt": "Redesigned player details modal showing Joe Burrow's profile with hero section, metric cards, and weekly results table"
+    "imageAlt": "Redesigned player details modal showing Joe Burrow's profile with hero section, metric cards, and weekly results table",
+    "leagues": [
+      "theleague"
+    ]
   },
   {
     "id": "dead-money-awards",
@@ -464,7 +533,10 @@
     "linkLabel": "See who made the list",
     "icon": "tombstone",
     "image": "dead-money-awards.webp",
-    "imageAlt": "Dead Money Awards page showing the league's worst contracts and overpays by season"
+    "imageAlt": "Dead Money Awards page showing the league's worst contracts and overpays by season",
+    "leagues": [
+      "theleague"
+    ]
   },
   {
     "id": "pwa-app",
@@ -481,7 +553,10 @@
     "linkLabel": "Read more",
     "icon": "home",
     "image": "pwa-app.webp",
-    "imageAlt": "The League installed as a Progressive Web App on a mobile home screen"
+    "imageAlt": "The League installed as a Progressive Web App on a mobile home screen",
+    "leagues": [
+      "theleague"
+    ]
   },
   {
     "id": "weekly-rollup-2026-02-24",
@@ -505,7 +580,10 @@
     "icon": "wrench",
     "excludeFromHero": true,
     "image": "weekly-rollup-2026-02-24.webp",
-    "imageAlt": "Free Agents page showing defense player avatars, ranking color badges, and table header gradient styling"
+    "imageAlt": "Free Agents page showing defense player avatars, ranking color badges, and table header gradient styling",
+    "leagues": [
+      "theleague"
+    ]
   },
   {
     "id": "league-planner",
@@ -522,7 +600,10 @@
     "linkLabel": "Open League Planner",
     "icon": "chalkboard",
     "image": "league-planner.webp",
-    "imageAlt": "League Planner showing offseason phase-aware roster tools with free agent targets and draft picks"
+    "imageAlt": "League Planner showing offseason phase-aware roster tools with free agent targets and draft picks",
+    "leagues": [
+      "theleague"
+    ]
   },
   {
     "id": "frozen-salary-averages-fix",
@@ -535,7 +616,10 @@
     ],
     "category": "bug-fix",
     "icon": "wrench",
-    "excludeFromHero": true
+    "excludeFromHero": true,
+    "leagues": [
+      "theleague"
+    ]
   },
   {
     "id": "composite-my-rank",
@@ -552,7 +636,10 @@
     "linkLabel": "Set up My Rank",
     "icon": "star",
     "image": "composite-my-rank.webp",
-    "imageAlt": "Import Rankings page showing ranking source selection with weight controls for building a My Rank composite"
+    "imageAlt": "Import Rankings page showing ranking source selection with weight controls for building a My Rank composite",
+    "leagues": [
+      "theleague"
+    ]
   },
   {
     "id": "whats-new-redesign",
@@ -570,7 +657,10 @@
     "icon": "star",
     "excludeFromHero": true,
     "image": "whats-new-redesign.webp",
-    "imageAlt": "What's New page with category filter tabs, featured entry cards, and timeline sidebar"
+    "imageAlt": "What's New page with category filter tabs, featured entry cards, and timeline sidebar",
+    "leagues": [
+      "theleague"
+    ]
   },
   {
     "id": "salary-archive",
@@ -587,7 +677,10 @@
     "linkLabel": "View the archive",
     "icon": "history",
     "image": "salary-archive.webp",
-    "imageAlt": "Salary Archive page listing historical salary spreadsheets from 2009 to 2025"
+    "imageAlt": "Salary Archive page listing historical salary spreadsheets from 2009 to 2025",
+    "leagues": [
+      "theleague"
+    ]
   },
   {
     "id": "roster-ranking-source-label",
@@ -604,7 +697,10 @@
     "icon": "clipboard",
     "excludeFromHero": true,
     "image": "roster-ranking-source-label.webp",
-    "imageAlt": "Roster page showing ranking source abbreviation in the column header"
+    "imageAlt": "Roster page showing ranking source abbreviation in the column header",
+    "leagues": [
+      "theleague"
+    ]
   },
   {
     "id": "salary-analytics",
@@ -621,7 +717,10 @@
     "linkLabel": "View Salary Analytics",
     "icon": "bar-chart",
     "image": "salary-analytics.webp",
-    "imageAlt": "Salary Analytics page with position benchmarks, starter averages, and player salary breakdowns"
+    "imageAlt": "Salary Analytics page with position benchmarks, starter averages, and player salary breakdowns",
+    "leagues": [
+      "theleague"
+    ]
   },
   {
     "id": "import-rankings",
@@ -638,7 +737,10 @@
     "linkLabel": "Import rankings now",
     "icon": "clipboard",
     "image": "import-rankings.webp",
-    "imageAlt": "Import Rankings page with bookmarklet instructions and draggable ranking source list"
+    "imageAlt": "Import Rankings page with bookmarklet instructions and draggable ranking source list",
+    "leagues": [
+      "theleague"
+    ]
   },
   {
     "id": "free-agent-scouting",
@@ -655,7 +757,10 @@
     "linkLabel": "Scout Free Agents",
     "icon": "users",
     "image": "free-agent-scouting.webp",
-    "imageAlt": "Free Agents scouting table with player rankings, snap counts, and position filters"
+    "imageAlt": "Free Agents scouting table with player rankings, snap counts, and position filters",
+    "leagues": [
+      "theleague"
+    ]
   },
   {
     "id": "whats-new-page",
@@ -671,7 +776,10 @@
     "linkLabel": "See all updates",
     "icon": "star",
     "image": "whats-new-page.webp",
-    "imageAlt": "What's New changelog page showing feature entries with dates and category badges"
+    "imageAlt": "What's New changelog page showing feature entries with dates and category badges",
+    "leagues": [
+      "theleague"
+    ]
   },
   {
     "id": "gm-coach-mode",
@@ -688,7 +796,10 @@
     "linkLabel": "Try Coach Mode",
     "icon": "submit",
     "image": "gm-coach-mode.webp",
-    "imageAlt": "Roster page in Coach Mode showing matchup data and start/sit columns"
+    "imageAlt": "Roster page in Coach Mode showing matchup data and start/sit columns",
+    "leagues": [
+      "theleague"
+    ]
   },
   {
     "id": "trade-bait-marketplace",
@@ -705,7 +816,10 @@
     "linkLabel": "Open Trade Builder",
     "icon": "transactions-2",
     "image": "trade-bait-marketplace.webp",
-    "imageAlt": "Trade Builder page showing the Trade Bait Marketplace with available players"
+    "imageAlt": "Trade Builder page showing the Trade Bait Marketplace with available players",
+    "leagues": [
+      "theleague"
+    ]
   },
   {
     "id": "weekly-rollup-2026-02-17",
@@ -729,7 +843,10 @@
     "icon": "wrench",
     "excludeFromHero": true,
     "image": "weekly-rollup-2026-02-17.webp",
-    "imageAlt": "League calendar showing NFL logo icons, corrected dates, and color-coded event categories"
+    "imageAlt": "League calendar showing NFL logo icons, corrected dates, and color-coded event categories",
+    "leagues": [
+      "theleague"
+    ]
   },
   {
     "id": "league-summary",
@@ -746,7 +863,10 @@
     "linkLabel": "View League Summary",
     "icon": "standings-2",
     "image": "league-summary.webp",
-    "imageAlt": "League Summary dashboard comparing all 16 teams across salary cap and roster metrics"
+    "imageAlt": "League Summary dashboard comparing all 16 teams across salary cap and roster metrics",
+    "leagues": [
+      "theleague"
+    ]
   },
   {
     "id": "trade-builder",
@@ -763,7 +883,10 @@
     "linkLabel": "Build a Trade",
     "icon": "transactions-2",
     "image": "trade-builder.webp",
-    "imageAlt": "Trade Builder showing two-team player selection with salary cap impact analysis"
+    "imageAlt": "Trade Builder showing two-team player selection with salary cap impact analysis",
+    "leagues": [
+      "theleague"
+    ]
   },
   {
     "id": "whats-next-timeline",
@@ -780,7 +903,10 @@
     "linkLabel": "View Homepage",
     "icon": "calendar",
     "image": "whats-next-timeline.webp",
-    "imageAlt": "Homepage showing the What's Next timeline with three upcoming league event cards"
+    "imageAlt": "Homepage showing the What's Next timeline with three upcoming league event cards",
+    "leagues": [
+      "theleague"
+    ]
   },
   {
     "id": "league-calendar",
@@ -797,7 +923,10 @@
     "linkLabel": "View Calendar",
     "icon": "calendar",
     "image": "league-calendar.webp",
-    "imageAlt": "League Calendar page with color-coded events and countdown timers"
+    "imageAlt": "League Calendar page with color-coded events and countdown timers",
+    "leagues": [
+      "theleague"
+    ]
   },
   {
     "id": "espn-headshots",
@@ -813,7 +942,10 @@
     "linkLabel": "View Rosters",
     "icon": "helmet",
     "image": "espn-headshots.webp",
-    "imageAlt": "Player cards displaying real ESPN headshot photos instead of placeholder silhouettes"
+    "imageAlt": "Player cards displaying real ESPN headshot photos instead of placeholder silhouettes",
+    "leagues": [
+      "theleague"
+    ]
   },
   {
     "id": "custom-football-icons",
@@ -829,7 +961,10 @@
     "linkLabel": "View Icon Set",
     "icon": "shield",
     "image": "custom-football-icons.webp",
-    "imageAlt": "Navigation drawer showcasing custom-designed SVG football icons for each page"
+    "imageAlt": "Navigation drawer showcasing custom-designed SVG football icons for each page",
+    "leagues": [
+      "theleague"
+    ]
   },
   {
     "id": "nav-drawer-redesign",
@@ -846,7 +981,10 @@
     "linkLabel": "View The League",
     "icon": "home",
     "image": "nav-drawer-redesign.webp",
-    "imageAlt": "Redesigned navigation drawer with grouped sections, league switching, and team info"
+    "imageAlt": "Redesigned navigation drawer with grouped sections, league switching, and team info",
+    "leagues": [
+      "theleague"
+    ]
   },
   {
     "id": "weekly-rollup-2026-01-27",
@@ -866,7 +1004,10 @@
     "icon": "wrench",
     "excludeFromHero": true,
     "image": "weekly-rollup-2026-01-27.webp",
-    "imageAlt": "Rosters page showing polished navigation drawer, updated box shadows, and alternating row backgrounds"
+    "imageAlt": "Rosters page showing polished navigation drawer, updated box shadows, and alternating row backgrounds",
+    "leagues": [
+      "theleague"
+    ]
   },
   {
     "id": "weekly-rollup-2026-01-13",
@@ -886,7 +1027,10 @@
     "icon": "wrench",
     "excludeFromHero": true,
     "image": "weekly-rollup-2026-01-13.webp",
-    "imageAlt": "Playoff bracket showing champion draft pick improvements and more robust bracket data loading"
+    "imageAlt": "Playoff bracket showing champion draft pick improvements and more robust bracket data loading",
+    "leagues": [
+      "theleague"
+    ]
   },
   {
     "id": "weekly-rollup-2025-12-29",
@@ -906,7 +1050,10 @@
     "icon": "wrench",
     "excludeFromHero": true,
     "image": "weekly-rollup-2025-12-29.webp",
-    "imageAlt": "Playoff bracket showing corrected champion logic, conference names, and NIT seeding display"
+    "imageAlt": "Playoff bracket showing corrected champion logic, conference names, and NIT seeding display",
+    "leagues": [
+      "theleague"
+    ]
   },
   {
     "id": "weekly-rollup-2025-12-22",
@@ -926,7 +1073,10 @@
     "icon": "wrench",
     "excludeFromHero": true,
     "image": "weekly-rollup-2025-12-22.webp",
-    "imageAlt": "MVP tracking page showing all-time MVP data and Team of the Year standings"
+    "imageAlt": "MVP tracking page showing all-time MVP data and Team of the Year standings",
+    "leagues": [
+      "theleague"
+    ]
   },
   {
     "id": "weekly-rollup-2025-12-08",
@@ -934,8 +1084,8 @@
     "title": "Weekly Fixes & Polish (Dec 1-7)",
     "summary": "10 bug fixes and style improvements across AFL setup, infrastructure, and builds.",
     "description": [
-      "First week of December focused on AFL Fantasy support and infrastructure:",
-      "<strong>AFL Fantasy</strong> — AFL theme styles and build script added. Division standings rules implemented. Both leagues now update independently. Salary processing correctly skipped for AFL. Icons enabled across AFL pages.",
+      "First week of December focused on AFL support and infrastructure:",
+      "<strong>AFL</strong> — AFL theme styles and build script added. Division standings rules implemented. Both leagues now update independently. Salary processing correctly skipped for AFL. Icons enabled across AFL pages.",
       "<strong>Infrastructure</strong> — Vercel config simplified to run Astro build directly. Asset domain updated to use correct Vercel deployment URL. Incorrect monorepo Vercel config removed. Syncing workflow split by league for reliability.",
       "<strong>Other</strong> — pnpm lockfile refreshed. JS build system for MFL site established."
     ],
@@ -945,7 +1095,10 @@
     "icon": "wrench",
     "excludeFromHero": true,
     "image": "weekly-rollup-2025-12-08.webp",
-    "imageAlt": "AFL Fantasy standings page showing the newly launched AFL league support with division standings"
+    "imageAlt": "AFL standings page showing the newly launched AFL league support with division standings",
+    "leagues": [
+      "theleague"
+    ]
   },
   {
     "id": "weekly-rollup-2025-12-01",
@@ -966,7 +1119,10 @@
     "icon": "wrench",
     "excludeFromHero": true,
     "image": "weekly-rollup-2025-12-01.webp",
-    "imageAlt": "Standings page showing improved tiebreaker display, larger table fonts, and tab icon fixes"
+    "imageAlt": "Standings page showing improved tiebreaker display, larger table fonts, and tab icon fixes",
+    "leagues": [
+      "theleague"
+    ]
   },
   {
     "id": "weekly-rollup-2025-11-24",
@@ -987,7 +1143,10 @@
     "icon": "wrench",
     "excludeFromHero": true,
     "image": "weekly-rollup-2025-11-24.webp",
-    "imageAlt": "League Summary page showing donut charts with legends, salary cap breakdowns, and position pie charts"
+    "imageAlt": "League Summary page showing donut charts with legends, salary cap breakdowns, and position pie charts",
+    "leagues": [
+      "theleague"
+    ]
   },
   {
     "id": "weekly-rollup-2025-11-17",
@@ -1009,7 +1168,10 @@
     "icon": "wrench",
     "excludeFromHero": true,
     "image": "weekly-rollup-2025-11-17.webp",
-    "imageAlt": "Standings page from the first week of site polish, showing improved alignment, button styles, and icon support"
+    "imageAlt": "Standings page from the first week of site polish, showing improved alignment, button styles, and icon support",
+    "leagues": [
+      "theleague"
+    ]
   },
   {
     "id": "rules-constitution",
@@ -1026,7 +1188,10 @@
     "linkLabel": "Read the Rules",
     "icon": "clipboard",
     "image": "rules-constitution.webp",
-    "imageAlt": "League Rules and Constitution page with searchable rule sections"
+    "imageAlt": "League Rules and Constitution page with searchable rule sections",
+    "leagues": [
+      "theleague"
+    ]
   },
   {
     "id": "playoffs",
@@ -1043,7 +1208,10 @@
     "linkLabel": "View Playoffs",
     "icon": "champ",
     "image": "playoffs.webp",
-    "imageAlt": "Playoff bracket page showing tournament matchups and winners bracket"
+    "imageAlt": "Playoff bracket page showing tournament matchups and winners bracket",
+    "leagues": [
+      "theleague"
+    ]
   },
   {
     "id": "draft-predictor",
@@ -1060,7 +1228,10 @@
     "linkLabel": "View Draft Order",
     "icon": "draft-podium",
     "image": "draft-predictor.webp",
-    "imageAlt": "Draft Order Predictor showing projected pick order based on current standings"
+    "imageAlt": "Draft Order Predictor showing projected pick order based on current standings",
+    "leagues": [
+      "theleague"
+    ]
   },
   {
     "id": "standings",
@@ -1077,7 +1248,10 @@
     "linkLabel": "View Standings",
     "icon": "shield",
     "image": "standings.webp",
-    "imageAlt": "Standings page showing division standings with win-loss records and points"
+    "imageAlt": "Standings page showing division standings with win-loss records and points",
+    "leagues": [
+      "theleague"
+    ]
   },
   {
     "id": "rosters",
@@ -1094,7 +1268,10 @@
     "linkLabel": "View Rosters",
     "icon": "banknote",
     "image": "rosters.webp",
-    "imageAlt": "Team Roster page showing player salaries, contract lengths, and position details"
+    "imageAlt": "Team Roster page showing player salaries, contract lengths, and position details",
+    "leagues": [
+      "theleague"
+    ]
   },
   {
     "id": "salary-history",
@@ -1111,7 +1288,10 @@
     "linkLabel": "View Salary History",
     "icon": "history",
     "image": "salary-history.webp",
-    "imageAlt": "Salary History page with interactive charts showing cap spending trends across seasons"
+    "imageAlt": "Salary History page with interactive charts showing cap spending trends across seasons",
+    "leagues": [
+      "theleague"
+    ]
   },
   {
     "id": "mvp-rankings",
@@ -1128,7 +1308,10 @@
     "linkLabel": "View MVPs",
     "icon": "star",
     "image": "mvp-rankings.webp",
-    "imageAlt": "MVP Rankings page showing salary-adjusted value rankings for top performers"
+    "imageAlt": "MVP Rankings page showing salary-adjusted value rankings for top performers",
+    "leagues": [
+      "theleague"
+    ]
   },
   {
     "id": "salary-benchmarks",
@@ -1145,7 +1328,10 @@
     "linkLabel": "View Benchmarks",
     "icon": "bar-chart",
     "image": "salary-benchmarks.webp",
-    "imageAlt": "Salary Benchmarks page comparing team spending against league averages by position"
+    "imageAlt": "Salary Benchmarks page comparing team spending against league averages by position",
+    "leagues": [
+      "theleague"
+    ]
   },
   {
     "id": "extension-calculator",
@@ -1162,7 +1348,10 @@
     "linkLabel": "Open Calculator",
     "icon": "dollar",
     "image": "extension-calculator.webp",
-    "imageAlt": "Extension Calculator showing projected contract costs with 10% annual escalation"
+    "imageAlt": "Extension Calculator showing projected contract costs with 10% annual escalation",
+    "leagues": [
+      "theleague"
+    ]
   },
   {
     "id": "asset-library",
@@ -1179,6 +1368,9 @@
     "linkLabel": "Browse Assets",
     "icon": "eye",
     "image": "asset-library.webp",
-    "imageAlt": "Asset Library gallery showing team logos, banners, and brand graphics"
+    "imageAlt": "Asset Library gallery showing team logos, banners, and brand graphics",
+    "leagues": [
+      "theleague"
+    ]
   }
 ]

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -14,7 +14,7 @@ import TheLeagueLayout from '../layouts/TheLeagueLayout.astro';
           Go to The League
         </a>
         <a href="/afl-fantasy" class="btn btn--secondary">
-          Go to AFL Fantasy
+          Go to AFL
         </a>
       </div>
     </div>

--- a/src/pages/afl-fantasy/about.astro
+++ b/src/pages/afl-fantasy/about.astro
@@ -21,11 +21,11 @@ const mostRecentChamp = championships[0];
 const yearsRecorded = championships.length;
 ---
 
-<TheLeagueLayout title="About AFL Fantasy | American Football League">
+<TheLeagueLayout title="About AFL | American Football League">
   <main class="about-page">
     <header class="about-hero">
       <div class="about-hero__eyebrow">
-        <span class="about-tag">AFL Fantasy</span>
+        <span class="about-tag">AFL</span>
         <span class="about-dot">·</span>
         <span class="about-hero__date">Since 2003</span>
       </div>
@@ -35,7 +35,7 @@ const yearsRecorded = championships.length;
       </h1>
 
       <p class="about-hero__deck">
-        AFL Fantasy is a 24-team dynasty league that's been running since 2003.
+        AFL is a 24-team dynasty league that's been running since 2003.
         It runs on top of MyFantasyLeague but adds something most fantasy
         leagues don't: <strong>a side competition that decides who plays in
         Premier League next year</strong>. Win-loss records still matter for

--- a/src/pages/afl-fantasy/assets.astro
+++ b/src/pages/afl-fantasy/assets.astro
@@ -85,10 +85,10 @@ const getConferenceName = (code: string) => {
 // Division names are now stored directly on teams, no transformation needed
 ---
 
-<TheLeagueLayout title="AFL Fantasy Asset Library">
+<TheLeagueLayout title="AFL Asset Library">
   <main class="league-gallery">
     <header class="gallery-header">
-      <h1>AFL Fantasy Asset Library</h1>
+      <h1>AFL Asset Library</h1>
       <p>Team logos, banners, and graphics for all {leagueConfig.teams.length} teams</p>
     </header>
     {teamList.length === 0 ? (

--- a/src/pages/afl-fantasy/calendar.astro
+++ b/src/pages/afl-fantasy/calendar.astro
@@ -1,144 +1,18 @@
 ---
 import TheLeagueLayout from '../../layouts/TheLeagueLayout.astro';
-import eventsConfig from '../../data/afl-fantasy/league-events.json';
+import { getAllResolvedAflEvents } from '../../utils/league-event-resolver';
+import { getCurrentLeagueYear } from '../../utils/league-year';
+import { spriteUrl } from '../../utils/sprite-url';
+import type { ResolvedLeagueEvent } from '../../types/league-events';
 
 export const prerender = false;
 
-interface FixedDate {
-  type: 'fixed';
-  month: number; // 1-12
-  day: number;
-  time?: string;
-}
+const testDateParam = Astro.url.searchParams.get('testDate');
+const today = testDateParam ? new Date(testDateParam + 'T12:00:00') : new Date();
+const leagueYear = getCurrentLeagueYear(today);
 
-interface ComputedDate {
-  type: 'computed';
-  rule:
-    | 'nfl-kickoff'
-    | 'friday-before-week-11'
-    | 'after-week-16'
-    | 'playoffs-start'
-    | 'championship-week'
-    | 'third-thursday-march'
-    | 'third-sunday-august';
-}
-
-interface AflEvent {
-  id: string;
-  name: string;
-  description: string;
-  category: 'preseason' | 'in-season' | 'playoffs' | 'offseason';
-  icon: string;
-  startDate: FixedDate | ComputedDate;
-  urgencyDays?: number;
-  sortOrder: number;
-  actionLinks?: Array<{ label: string; url: string; external?: boolean }>;
-}
-
-const events = (eventsConfig.events as AflEvent[]).slice().sort(
-  (a, b) => a.sortOrder - b.sortOrder
-);
-
-// --- Date resolution -----------------------------------------------------
-
-function getNthDayOfMonth(year: number, month: number, dayOfWeek: number, nth: number): Date {
-  const first = new Date(year, month, 1);
-  const firstDow = first.getDay();
-  let diff = dayOfWeek - firstDow;
-  if (diff < 0) diff += 7;
-  return new Date(year, month, 1 + diff + (nth - 1) * 7);
-}
-
-function getLaborDay(year: number): Date {
-  return getNthDayOfMonth(year, 8, 1, 1); // Sept (idx 8), Monday (1), 1st
-}
-
-function resolveDate(date: FixedDate | ComputedDate, year: number): Date {
-  if (date.type === 'fixed') {
-    const [hh, mm] = (date.time ?? '00:00').split(':').map(Number);
-    return new Date(year, date.month - 1, date.day, hh ?? 0, mm ?? 0);
-  }
-  switch (date.rule) {
-    case 'third-thursday-march':
-      return getNthDayOfMonth(year, 2, 4, 3);
-    case 'third-sunday-august':
-      return getNthDayOfMonth(year, 7, 0, 3);
-    case 'nfl-kickoff': {
-      const ld = getLaborDay(year);
-      return new Date(ld.getFullYear(), ld.getMonth(), ld.getDate() + 3);
-    }
-    case 'friday-before-week-11': {
-      const ld = getLaborDay(year);
-      const kickoff = new Date(ld.getFullYear(), ld.getMonth(), ld.getDate() + 3);
-      // Week 11 starts ~10 weeks after kickoff; "Friday before" = -6 days from week-start
-      return new Date(
-        kickoff.getFullYear(),
-        kickoff.getMonth(),
-        kickoff.getDate() + 10 * 7 - 6
-      );
-    }
-    case 'after-week-16': {
-      const ld = getLaborDay(year);
-      const kickoff = new Date(ld.getFullYear(), ld.getMonth(), ld.getDate() + 3);
-      return new Date(
-        kickoff.getFullYear(),
-        kickoff.getMonth(),
-        kickoff.getDate() + 16 * 7
-      );
-    }
-    case 'playoffs-start': {
-      const ld = getLaborDay(year);
-      const kickoff = new Date(ld.getFullYear(), ld.getMonth(), ld.getDate() + 3);
-      return new Date(
-        kickoff.getFullYear(),
-        kickoff.getMonth(),
-        kickoff.getDate() + 14 * 7
-      );
-    }
-    case 'championship-week': {
-      const ld = getLaborDay(year);
-      const kickoff = new Date(ld.getFullYear(), ld.getMonth(), ld.getDate() + 3);
-      return new Date(
-        kickoff.getFullYear(),
-        kickoff.getMonth(),
-        kickoff.getDate() + 16 * 7
-      );
-    }
-  }
-}
-
-function calendarDaysUntil(target: Date, today: Date): number {
-  const a = new Date(target.getFullYear(), target.getMonth(), target.getDate());
-  const b = new Date(today.getFullYear(), today.getMonth(), today.getDate());
-  return Math.round((a.getTime() - b.getTime()) / (1000 * 60 * 60 * 24));
-}
-
-const today = new Date();
-const calendarYear = today.getFullYear();
-
-interface ResolvedEvent {
-  def: AflEvent;
-  date: Date;
-  daysUntil: number;
-  isPast: boolean;
-  urgent: boolean;
-}
-
-const resolveYear = (year: number): ResolvedEvent[] =>
-  events.map((def) => {
-    const date = resolveDate(def.startDate, year);
-    const daysUntil = calendarDaysUntil(date, today);
-    return {
-      def,
-      date,
-      daysUntil,
-      isPast: daysUntil < 0,
-      urgent: daysUntil >= 0 && daysUntil <= (def.urgencyDays ?? 0),
-    };
-  });
-
-const currentYearEvents = resolveYear(calendarYear);
-const nextYearEvents = resolveYear(calendarYear + 1);
+const currentYearEvents = getAllResolvedAflEvents({ leagueYear, referenceDate: today });
+const nextYearEvents = getAllResolvedAflEvents({ leagueYear: leagueYear + 1, referenceDate: today });
 
 const upcomingThisYear = currentYearEvents.filter((e) => !e.isPast);
 const pastThisYear = currentYearEvents.filter((e) => e.isPast);
@@ -150,6 +24,20 @@ const fmt = (d: Date) =>
     day: 'numeric',
     year: 'numeric',
   });
+
+function daysFromNow(target: Date): number {
+  const a = new Date(target.getFullYear(), target.getMonth(), target.getDate());
+  const b = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+  return Math.round((a.getTime() - b.getTime()) / (1000 * 60 * 60 * 24));
+}
+
+function countdownLabel(daysUntil: number): string {
+  if (daysUntil === 0) return 'Today';
+  if (daysUntil === 1) return 'Tomorrow';
+  if (daysUntil > 0) return `In ${daysUntil} days`;
+  if (daysUntil === -1) return 'Yesterday';
+  return `${-daysUntil} days ago`;
+}
 ---
 
 <TheLeagueLayout title="AFL Calendar | American Football League">
@@ -157,60 +45,77 @@ const fmt = (d: Date) =>
     <header class="afl-calendar__hero">
       <h1>AFL Calendar</h1>
       <p>
-        Important dates for the AFL Fantasy {calendarYear} league year. Times
-        are local. Some dates below are placeholder cadences pending the
-        official AFL constitution; flag any wrong ones and they'll move into
-        <code>src/data/afl-fantasy/league-events.json</code>.
+        Important dates for the AFL {leagueYear} league year. All dates
+        are resolved from the league constitution
+        (<code>src/pages/afl-fantasy/docs/rules.html</code>) and shared with
+        the homepage What's Next timeline.
       </p>
     </header>
 
     {upcomingThisYear.length > 0 && (
       <section class="afl-calendar__section">
-        <h2>Coming up — {calendarYear}</h2>
+        <h2>Coming up — {leagueYear}</h2>
         <div class="afl-calendar__grid">
-          {upcomingThisYear.map(({ def, date, daysUntil, urgent }) => (
-            <article class:list={['event-card', { 'event-card--urgent': urgent }]}>
-              <div class="event-card__category">{def.category}</div>
-              <h3 class="event-card__title">{def.name}</h3>
-              <div class="event-card__date">{fmt(date)}</div>
-              <div class="event-card__until">
-                {daysUntil === 0
-                  ? 'Today'
-                  : daysUntil === 1
-                  ? 'Tomorrow'
-                  : `In ${daysUntil} days`}
-              </div>
-              <p class="event-card__desc">{def.description}</p>
-              {def.actionLinks?.length ? (
-                <div class="event-card__links">
-                  {def.actionLinks.map((link) => (
-                    <a
-                      href={link.url}
-                      class="event-card__link"
-                      target={link.external ? '_blank' : undefined}
-                      rel={link.external ? 'noopener noreferrer' : undefined}
-                    >
-                      {link.label}
-                    </a>
-                  ))}
+          {upcomingThisYear.map((event: ResolvedLeagueEvent) => {
+            const daysUntil = daysFromNow(event.startDate);
+            return (
+              <article class:list={[
+                'event-card',
+                event.isActive && 'event-card--active',
+                event.isUrgent && 'event-card--urgent',
+              ]}>
+                <div class="event-card__head">
+                  {event.definition.icon && (
+                    <svg class="event-card__icon" width="18" height="18" aria-hidden="true">
+                      <use href={`${spriteUrl}#icon-${event.definition.icon}`} />
+                    </svg>
+                  )}
+                  <span class="event-card__category">{event.definition.category}</span>
                 </div>
-              ) : null}
-            </article>
-          ))}
+                <h3 class="event-card__title">{event.definition.name}</h3>
+                <div class="event-card__date">{fmt(event.startDate)}</div>
+                <div class="event-card__until">
+                  {event.isActive ? 'Happening now' : countdownLabel(daysUntil)}
+                </div>
+                <p class="event-card__desc">{event.definition.description}</p>
+                {event.actionLinks.length > 0 && (
+                  <div class="event-card__links">
+                    {event.actionLinks.map((link) => (
+                      <a
+                        href={link.url}
+                        class="event-card__link"
+                        target={link.external ? '_blank' : undefined}
+                        rel={link.external ? 'noopener noreferrer' : undefined}
+                      >
+                        {link.label}
+                      </a>
+                    ))}
+                  </div>
+                )}
+              </article>
+            );
+          })}
         </div>
       </section>
     )}
 
     {pastThisYear.length > 0 && (
       <section class="afl-calendar__section afl-calendar__section--past">
-        <h2>Already happened — {calendarYear}</h2>
+        <h2>Already happened — {leagueYear}</h2>
         <div class="afl-calendar__grid">
-          {pastThisYear.map(({ def, date }) => (
+          {pastThisYear.map((event: ResolvedLeagueEvent) => (
             <article class="event-card event-card--past">
-              <div class="event-card__category">{def.category}</div>
-              <h3 class="event-card__title">{def.name}</h3>
-              <div class="event-card__date">{fmt(date)}</div>
-              <p class="event-card__desc">{def.description}</p>
+              <div class="event-card__head">
+                {event.definition.icon && (
+                  <svg class="event-card__icon" width="18" height="18" aria-hidden="true">
+                    <use href={`${spriteUrl}#icon-${event.definition.icon}`} />
+                  </svg>
+                )}
+                <span class="event-card__category">{event.definition.category}</span>
+              </div>
+              <h3 class="event-card__title">{event.definition.name}</h3>
+              <div class="event-card__date">{fmt(event.startDate)}</div>
+              <p class="event-card__desc">{event.definition.description}</p>
             </article>
           ))}
         </div>
@@ -218,15 +123,21 @@ const fmt = (d: Date) =>
     )}
 
     <section class="afl-calendar__section">
-      <h2>Next year — {calendarYear + 1}</h2>
+      <h2>Next year — {leagueYear + 1}</h2>
       <div class="afl-calendar__grid">
-        {nextYearEvents.map(({ def, date, daysUntil }) => (
+        {nextYearEvents.map((event: ResolvedLeagueEvent) => (
           <article class="event-card event-card--future">
-            <div class="event-card__category">{def.category}</div>
-            <h3 class="event-card__title">{def.name}</h3>
-            <div class="event-card__date">{fmt(date)}</div>
-            <div class="event-card__until">In {daysUntil} days</div>
-            <p class="event-card__desc">{def.description}</p>
+            <div class="event-card__head">
+              {event.definition.icon && (
+                <svg class="event-card__icon" width="18" height="18" aria-hidden="true">
+                  <use href={`${spriteUrl}#icon-${event.definition.icon}`} />
+                </svg>
+              )}
+              <span class="event-card__category">{event.definition.category}</span>
+            </div>
+            <h3 class="event-card__title">{event.definition.name}</h3>
+            <div class="event-card__date">{fmt(event.startDate)}</div>
+            <p class="event-card__desc">{event.definition.description}</p>
           </article>
         ))}
       </div>
@@ -294,6 +205,11 @@ const fmt = (d: Date) =>
     gap: var(--spacing-xs, 4px);
   }
 
+  .event-card--active {
+    border-color: var(--color-success, #16a34a);
+    box-shadow: 0 0 0 1px var(--color-success, #16a34a);
+  }
+
   .event-card--urgent {
     border-color: var(--primary-color, #c41e3a);
     box-shadow: 0 0 0 1px var(--primary-color, #c41e3a);
@@ -307,13 +223,24 @@ const fmt = (d: Date) =>
     background: var(--bg-muted, #f9fafb);
   }
 
+  .event-card__head {
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
+    margin-bottom: var(--spacing-xs, 4px);
+  }
+
+  .event-card__icon {
+    color: var(--primary-color, #c41e3a);
+    flex-shrink: 0;
+  }
+
   .event-card__category {
     font-size: 0.6875rem;
     font-weight: 700;
     text-transform: uppercase;
     letter-spacing: 0.1em;
     color: var(--text-muted, #6b7280);
-    margin-bottom: var(--spacing-xs, 4px);
   }
 
   .event-card--urgent .event-card__category {
@@ -340,6 +267,10 @@ const fmt = (d: Date) =>
 
   .event-card--urgent .event-card__until {
     color: var(--primary-color, #c41e3a);
+  }
+
+  .event-card--active .event-card__until {
+    color: var(--color-success, #16a34a);
   }
 
   .event-card__desc {

--- a/src/pages/afl-fantasy/draft-predictor.astro
+++ b/src/pages/afl-fantasy/draft-predictor.astro
@@ -16,7 +16,7 @@ import path from 'path';
 // Note: This page is server-rendered (not prerendered) to support team preferences
 // export const prerender = true;
 
-// Load AFL Fantasy data - use current season year (updates Labor Day)
+// Load AFL data - use current season year (updates Labor Day)
 const currentYear = getCurrentSeasonYear();
 const standingsPath = path.join(process.cwd(), 'data', 'afl-fantasy', 'mfl-feeds', currentYear.toString(), 'standings.json');
 const playoffBracketsPath = path.join(process.cwd(), 'data', 'afl-fantasy', 'mfl-feeds', currentYear.toString(), 'playoff-brackets.json');
@@ -94,7 +94,7 @@ const alOrder = draftOrders.find(order => order.conference === 'American League'
 const nlOrder = draftOrders.find(order => order.conference === 'National League');
 ---
 
-<TheLeagueLayout title={`AFL Fantasy - ${nextYear} Draft Predictor`}>
+<TheLeagueLayout title={`AFL - ${nextYear} Draft Predictor`}>
   <script is:inline define:vars={{ preferredConference }}>
     // Set preferred conference on body for client-side script
     document.body.setAttribute('data-preferred-conference', preferredConference === '00' ? 'AL' : 'NL');

--- a/src/pages/afl-fantasy/franchises/index.astro
+++ b/src/pages/afl-fantasy/franchises/index.astro
@@ -34,7 +34,7 @@ const premierCount = teams.filter(t => t.tier === 'Premier League').length;
 const dLeagueCount = teams.filter(t => t.tier === 'D-League').length;
 ---
 
-<TheLeagueLayout title="Franchises | AFL Fantasy">
+<TheLeagueLayout title="Franchises | AFL">
   <main class="franchises-page">
     <header class="franchises-hero">
       <h1>AFL Franchises</h1>

--- a/src/pages/afl-fantasy/index.astro
+++ b/src/pages/afl-fantasy/index.astro
@@ -1,238 +1,306 @@
 ---
-import TheLeagueLayout from '../../layouts/TheLeagueLayout.astro';
-import aflConfig from '../../../data/afl-fantasy/afl.config.json';
-import {
-  setAFLPreference,
-  getAFLTeamData,
-} from '../../utils/team-preferences';
-
-// Server-render to support team preferences
+/**
+ * AFL Homepage
+ *
+ * 2-column layout mirroring TheLeague's homepage:
+ *   Left  — rotating hero (calendar-driven), team snapshot, conference-draft
+ *           preview (in season), tiered standings preview, What's Next
+ *           timeline, quick links.
+ *   Right — Schefter Report news feed (sticky sidebar).
+ *
+ * The hero rotation is driven by `resolveAflHeroState` which encodes AFL's
+ * calendar cadence: long quiet offseason → keeper window in June/July →
+ * conference draft weekend before Labor Day → regular season → playoffs →
+ * championship. What's New entries tagged `leagues: ['afl']` (or untagged)
+ * surface during quiet periods.
+ */
 export const prerender = false;
 
-// Team Preference Cookie Integration
-const myTeamParam = Astro.url.searchParams.get('myteam');
+import TheLeagueLayout from '../../layouts/TheLeagueLayout.astro';
+import SchefterFeedCompact from '../../components/shared/SchefterFeedCompact.astro';
+import AflHero from '../../components/afl/AflHero.astro';
+import AflTeamSnapshot from '../../components/afl/hp-sections/AflTeamSnapshot.astro';
+import AflStandingsCompact from '../../components/afl/hp-sections/AflStandingsCompact.astro';
+import AflConferencePlayoffPreview from '../../components/afl/hp-sections/AflConferencePlayoffPreview.astro';
+import AflConferenceDraftPreview from '../../components/afl/hp-sections/AflConferenceDraftPreview.astro';
+import AflWhatsNext from '../../components/afl/hp-sections/AflWhatsNext.astro';
+import AflQuickLinks from '../../components/afl/hp-sections/AflQuickLinks.astro';
 
-// If myteam parameter is provided, update the cookie preference
+import aflConfig from '../../../data/afl-fantasy/afl.config.json';
+import feedData from '../../../data/afl-fantasy/schefter-feed.json';
+import whatsNewData from '../../data/whats-new.json';
+
+import { entryAppliesToLeague } from '../../types/whats-new';
+import type { WhatsNewEntry } from '../../types/whats-new';
+import type { SchefterFeed as FeedType } from '../../types/schefter';
+import { parseTestDate } from '../../utils/hero-resolver';
+import { resolveAflHeroState } from '../../utils/afl-hero-resolver';
+import { getAflWhatsNextTimeline } from '../../utils/league-event-resolver';
+import { getCurrentSeasonYear, getLaborDayForYear } from '../../utils/league-year';
+import {
+  getAFLPreference,
+  setAFLPreference,
+  getAFLTeamData,
+  resolveAFLTeamSelection,
+} from '../../utils/team-preferences';
+
+import '../../styles/schefter-feed.css';
+import '../../styles/schefter-feed-compact.css';
+
+// ── Team preference resolution ──────────────────────────────────────────────
+const myTeamParam = Astro.url.searchParams.get('myteam');
+const franchiseParam = Astro.url.searchParams.get('franchise');
+
 if (myTeamParam) {
   const teamData = getAFLTeamData(myTeamParam);
   if (teamData) {
     setAFLPreference(Astro.cookies, myTeamParam, teamData.conference, teamData.tier);
   }
 }
+
+const cookiePref = getAFLPreference(Astro.cookies);
+const hasExplicitTeam = !!(myTeamParam || franchiseParam || cookiePref);
+const resolvedFranchiseId = resolveAFLTeamSelection({
+  myTeamParam,
+  franchiseParam,
+  cookiePreference: cookiePref?.franchiseId,
+});
+const userFranchiseId = hasExplicitTeam ? resolvedFranchiseId : undefined;
+const userTeam = userFranchiseId ? aflConfig.teams.find(t => t.franchiseId === userFranchiseId) : undefined;
+const userConferenceId = (userTeam?.conference === '00' || userTeam?.conference === '01')
+  ? (userTeam.conference as '00' | '01')
+  : undefined;
+const userConferenceName = userConferenceId
+  ? aflConfig.conferences.find(c => c.code === userConferenceId)?.name
+  : undefined;
+
+// ── Date / hero state ───────────────────────────────────────────────────────
+const testDateParam = Astro.url.searchParams.get('testDate');
+const effectiveDate = parseTestDate(testDateParam) ?? new Date();
+const testMode = !!testDateParam;
+
+const timeline = getAflWhatsNextTimeline(effectiveDate);
+const allWhatsNew = whatsNewData as WhatsNewEntry[];
+const aflWhatsNew = allWhatsNew.filter(e => entryAppliesToLeague(e, 'afl'));
+
+const heroState = resolveAflHeroState({
+  referenceDate: effectiveDate,
+  testMode,
+  whatsNewEntries: allWhatsNew,
+  timeline,
+  userConferenceId,
+});
+
+// ── Standings + roster data ─────────────────────────────────────────────────
+const standingsFeeds = import.meta.glob('../../../data/afl-fantasy/mfl-feeds/*/standings.json', { eager: true });
+const rosterFeeds = import.meta.glob('../../../data/afl-fantasy/mfl-feeds/*/rosters.json', { eager: true });
+
+function getModule(mod: any) {
+  return mod && typeof mod === 'object' && 'default' in mod ? mod.default : mod;
+}
+
+// Resolve the AFL season year by walking from getCurrentSeasonYear backward
+// to the most recent year that actually has populated standings data.
+// (MFL rolls the year over at kickoff so the "current" season is often empty
+//  until games are played — fall back to last completed year.)
+function resolveSeasonYearWithData(): number {
+  const preferred = getCurrentSeasonYear(effectiveDate);
+  for (let y = preferred; y >= preferred - 5; y--) {
+    const feed = getModule(standingsFeeds[`../../../data/afl-fantasy/mfl-feeds/${y}/standings.json`]) as { leagueStandings?: { franchise: any[] } } | undefined;
+    if (feed?.leagueStandings?.franchise?.length) return y;
+  }
+  return preferred;
+}
+
+const seasonYear = resolveSeasonYearWithData();
+
+function pickFeed(feeds: Record<string, unknown>, suffix: string) {
+  return getModule(feeds[`../../../data/afl-fantasy/mfl-feeds/${seasonYear}/${suffix}`]);
+}
+
+const standingsFeed = pickFeed(standingsFeeds, 'standings.json') as { leagueStandings?: { franchise: any[] } } | undefined;
+const standingsFranchises: any[] = standingsFeed?.leagueStandings?.franchise ?? [];
+
+// Roster count for the user's team
+const rostersFeed = pickFeed(rosterFeeds, 'rosters.json') as { rosters?: { franchise: any | any[] } } | undefined;
+const rosterFranchises = rostersFeed?.rosters?.franchise
+  ? Array.isArray(rostersFeed.rosters.franchise) ? rostersFeed.rosters.franchise : [rostersFeed.rosters.franchise]
+  : [];
+const userRosterEntry = rosterFranchises.find((r: any) => r.id === userFranchiseId);
+const rosterCount = userRosterEntry?.player
+  ? (Array.isArray(userRosterEntry.player) ? userRosterEntry.player.length : 1)
+  : undefined;
+
+// Record from standings feed
+const userStandingsRow = standingsFranchises.find((f: any) => f.id === userFranchiseId);
+const recordParts = (userStandingsRow?.h2hwlt ?? '').split('-').map((n: string) => parseInt(n, 10));
+const record = recordParts.length === 3 && recordParts.every(Number.isFinite)
+  ? { wins: recordParts[0], losses: recordParts[1], ties: recordParts[2] }
+  : undefined;
+
+const inSeasonVariant = heroState.kind === 'regular-season' || heroState.kind === 'playoffs' || heroState.kind === 'championship';
+
+// ── Schefter feed ───────────────────────────────────────────────────────────
+const feed = feedData as FeedType;
+const compactPosts = feed.posts.slice(0, 30);
+
+// ── Conference draft preview visibility ─────────────────────────────────────
+const labor = getLaborDayForYear(effectiveDate.getFullYear());
+const alDate = new Date(labor);
+alDate.setDate(alDate.getDate() - 2);
+alDate.setHours(9, 0, 0, 0);
+const nlDate = new Date(labor);
+nlDate.setDate(nlDate.getDate() - 1);
+nlDate.setHours(9, 0, 0, 0);
+
+const draftPreviewStart = new Date(alDate);
+draftPreviewStart.setDate(draftPreviewStart.getDate() - 14); // show 2 weeks before AL draft
+const draftPreviewEnd = new Date(nlDate);
+draftPreviewEnd.setDate(draftPreviewEnd.getDate() + 7); // keep visible 1 week after NL draft
+
+const showDraftPreview = effectiveDate >= draftPreviewStart && effectiveDate <= draftPreviewEnd;
+
+// Hide the What's Next card that the hero already promotes
+const heroEventId = heroState.content.heroEventId;
 ---
 
-<TheLeagueLayout title="AFL Fantasy - American Football League">
-  <div class="landing-page">
-    <!-- Hero Section -->
-    <header class="hero-section">
-      <h1 class="league-title">{aflConfig.name}</h1>
-      <p class="league-info">
-        {aflConfig.teams.length} Teams • {aflConfig.conferences.length} Conferences • {aflConfig.draftRounds} Draft Rounds
-      </p>
-    </header>
+<TheLeagueLayout title="AFL — American Football League">
+  <div class="afl-hp">
+    <section class="afl-hp__main" aria-labelledby="afl-hp-hero-heading">
+      <h2 id="afl-hp-hero-heading" class="visually-hidden">League Overview</h2>
 
-    <!-- Quick Links -->
-    <section class="quick-links">
-      <h2>League Pages</h2>
-      <div class="links-grid">
-        <a href="/afl-fantasy/standings" class="link-card">
-          <div class="link-icon">📊</div>
-          <h3>Standings</h3>
-          <p>View current season standings by division</p>
-        </a>
+      <AflHero
+        state={heroState}
+        config={aflConfig}
+        standings={standingsFranchises}
+        userFranchiseId={userFranchiseId}
+      />
 
-        <a href="/afl-fantasy/rosters" class="link-card">
-          <div class="link-icon">👥</div>
-          <h3>Rosters</h3>
-          <p>Browse team rosters and player information</p>
-        </a>
+      <AflTeamSnapshot
+        userTeam={userTeam}
+        userConferenceName={userConferenceName}
+        record={record}
+        rosterCount={rosterCount}
+        keeperLimit={aflConfig.keepers ?? 7}
+        rosterLimit={28}
+        variant={inSeasonVariant ? 'in-season' : 'offseason'}
+      />
 
-        <a href="/afl-fantasy/playoffs" class="link-card">
-          <div class="link-icon">🏆</div>
-          <h3>Playoffs</h3>
-          <p>Playoff bracket and tournament results</p>
-        </a>
+      {showDraftPreview && (
+        <AflConferenceDraftPreview
+          alDate={alDate}
+          nlDate={nlDate}
+          referenceDate={effectiveDate}
+          userConferenceId={userConferenceId}
+        />
+      )}
 
-        <a href="/afl-fantasy/draft-predictor" class="link-card">
-          <div class="link-icon">📈</div>
-          <h3>Draft Predictor</h3>
-          <p>Projected draft order for upcoming season</p>
-        </a>
-      </div>
-    </section>
+      <AflWhatsNext demoDate={effectiveDate} maxCards={2} excludeEventId={heroEventId} />
 
-    <!-- League Info -->
-    <section class="league-info-section">
-      <h2>League Structure</h2>
-      <div class="structure-grid">
-        {aflConfig.conferences.map(conf => (
-          <div class="conference-card">
-            <h3>{conf.name}</h3>
-            <div class="divisions">
-              {conf.divisions.map(div => (
-                <div class="division-badge">{div}</div>
-              ))}
-            </div>
+      {standingsFranchises.length > 0 && (
+        <AflConferencePlayoffPreview
+          teams={aflConfig.teams}
+          standings={standingsFranchises}
+          config={aflConfig}
+          userFranchiseId={userFranchiseId}
+          conferenceCode={userConferenceId ?? '00'}
+        />
+      )}
+
+      {standingsFranchises.length > 0 && (
+        <AflStandingsCompact
+          teams={aflConfig.teams}
+          standings={standingsFranchises}
+          userFranchiseId={userFranchiseId}
+          relegationCount={4}
+        />
+      )}
+
+      <AflQuickLinks />
+
+      {testMode && (
+        <div class="afl-hp__debug" id="afl-demo-nav">
+          <div class="afl-hp__debug-phase">
+            <code>Hero: {heroState.kind} · priority {heroState.priority} · ref {effectiveDate.toISOString()}</code>
           </div>
-        ))}
-      </div>
+        </div>
+      )}
     </section>
+
+    <aside class="afl-hp__sidebar" aria-label="Schefter Report feed" tabindex="0">
+      <SchefterFeedCompact posts={compactPosts} isAuthenticated={false} />
+    </aside>
   </div>
 </TheLeagueLayout>
 
 <style>
-  .landing-page {
-    padding: 2rem 1rem;
-    max-width: 1200px;
-    margin: 0 auto;
-  }
-
-  .hero-section {
-    background: var(--hero-bg-color, #fff);
-    color: var(--hero-text-color, #002244);
-    padding: 4rem 2rem;
-    border-radius: 1rem;
-    text-align: center;
-    margin-bottom: 3rem;
-    box-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1);
-  }
-
-  .league-title {
-    font-size: 3rem;
-    font-weight: 900;
-    margin: 0 0 1rem 0;
-  }
-
-  .league-info {
-    font-size: 1.25rem;
-    margin: 0;
-    opacity: 0.95;
-  }
-
-  .quick-links {
-    margin-bottom: 3rem;
-  }
-
-  .quick-links h2 {
-    font-size: 2rem;
-    font-weight: 700;
-    margin-bottom: 1.5rem;
-    color: #1e293b;
-  }
-
-  .links-grid {
+  .afl-hp {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    grid-template-columns: 1fr 380px;
     gap: 1.5rem;
+    align-items: start;
   }
 
-  .link-card {
-    background: white;
-    padding: 2rem;
-    border-radius: 1rem;
-    border: 2px solid #e2e8f0;
-    text-decoration: none;
-    color: inherit;
-    transition: all 0.3s ease;
-    box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1);
+  .afl-hp__main {
+    min-width: 0;
   }
 
-  .link-card:hover {
-    border-color: #c41e3a;
-    box-shadow: 0 10px 15px -3px rgb(196 30 58 / 0.2);
-    transform: translateY(-2px);
+  .afl-hp__main > :global(:not(:first-child)) {
+    margin-top: 2rem;
   }
 
-  .link-icon {
-    font-size: 3rem;
-    margin-bottom: 1rem;
+  .visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
   }
 
-  .link-card h3 {
-    font-size: 1.5rem;
-    font-weight: 700;
-    margin: 0 0 0.5rem 0;
-    color: #1e293b;
+  .afl-hp__sidebar {
+    min-width: 0;
+    margin-top: 2rem;
+    position: sticky;
+    top: 2rem;
+    max-height: calc(100dvh - var(--header-height, 3.5rem) - 2rem);
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    scrollbar-width: thin;
+    scrollbar-color: var(--sf-border, #e5e7eb) transparent;
+    border-radius: var(--radius-lg, 0.75rem);
   }
 
-  .link-card p {
-    margin: 0;
-    color: #64748b;
-    line-height: 1.5;
+  .afl-hp__debug {
+    margin-top: 0.5rem;
+    padding: 0.5rem 0.75rem;
+    background: var(--color-gray-50, #f9fafb);
+    border: 1px dashed var(--content-border, #e2e8f0);
+    border-radius: var(--radius-md, 0.5rem);
+    font-size: 0.6875rem;
+    color: var(--color-gray-500, #6b7280);
   }
 
-  .league-info-section {
-    background: white;
-    padding: 2rem;
-    border-radius: 1rem;
-    box-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1);
-  }
-
-  .league-info-section h2 {
-    font-size: 2rem;
-    font-weight: 700;
-    margin: 0 0 1.5rem 0;
-    color: #1e293b;
-  }
-
-  .structure-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-    gap: 2rem;
-  }
-
-  .conference-card {
-    background: linear-gradient(135deg, #f8fafc 0%, #e2e8f0 100%);
-    padding: 1.5rem;
-    border-radius: 0.75rem;
-    border: 2px solid #cbd5e1;
-  }
-
-  .conference-card h3 {
-    font-size: 1.5rem;
-    font-weight: 700;
-    margin: 0 0 1rem 0;
-    color: #002244;
-  }
-
-  .divisions {
-    display: flex;
-    gap: 0.75rem;
-    flex-wrap: wrap;
-  }
-
-  .division-badge {
-    background: #154e87;
-    color: white;
-    padding: 0.5rem 1rem;
-    border-radius: 9999px;
-    font-size: 0.875rem;
-    font-weight: 600;
-  }
-
-  @media (max-width: 767px) {
-    .landing-page {
-      padding: 1rem 0.5rem;
+  @container (max-width: 1024px) {
+    .afl-hp {
+      grid-template-columns: 1fr 320px;
+      gap: 1rem;
     }
+  }
 
-    .hero-section {
-      padding: 3rem 1.5rem;
-    }
-
-    .league-title {
-      font-size: 2rem;
-    }
-
-    .league-info {
-      font-size: 1rem;
-    }
-
-    .links-grid {
+  @container (max-width: 880px) {
+    .afl-hp {
       grid-template-columns: 1fr;
+      gap: 1rem;
     }
 
-    .structure-grid {
-      grid-template-columns: 1fr;
+    .afl-hp__sidebar {
+      position: static;
+      max-height: none;
+      overflow-y: visible;
     }
   }
 </style>

--- a/src/pages/afl-fantasy/keepers.astro
+++ b/src/pages/afl-fantasy/keepers.astro
@@ -58,12 +58,12 @@ const teams = (aflConfig.teams ?? []).slice().sort((a, b) => {
 const hasLiveKeeperData = keeperByFranchise.size > 0;
 ---
 
-<TheLeagueLayout title="Keepers | AFL Fantasy">
+<TheLeagueLayout title="Keepers | AFL">
   <main class="afl-keepers">
     <header class="afl-keepers__hero">
       <h1>AFL Keepers</h1>
       <p>
-        AFL Fantasy is a 7-player keeper league. Each franchise picks 7
+        AFL is a 7-player keeper league. Each franchise picks 7
         players to retain into the new season; the rest are released back
         into the auction pool.
       </p>

--- a/src/pages/afl-fantasy/login.astro
+++ b/src/pages/afl-fantasy/login.astro
@@ -1,6 +1,6 @@
 ---
 /**
- * AFL Fantasy login page — mirrors /theleague/login but posts to MFL
+ * AFL login page — mirrors /theleague/login but posts to MFL
  * with leagueId=19621 so the resulting JWT scopes the user to AFL.
  *
  * Without this page, every login on the site dropped the user into
@@ -38,14 +38,14 @@ const next = Astro.url.searchParams.get('next');
 const safeNext = next && next.startsWith('/afl-fantasy') ? next : '/afl-fantasy';
 ---
 
-<TheLeagueLayout title="Sign In — AFL Fantasy">
+<TheLeagueLayout title="Sign In — AFL">
   <div class="afl-login-page">
     <LoginForm
       leagueId={AFL_LEAGUE_ID}
       seasonYear={AFL_LOGIN_YEAR}
       redirectUrl={safeNext}
       logoSrc="/assets/logos/afl-logo.svg"
-      logoAlt="AFL Fantasy logo"
+      logoAlt="AFL logo"
       subtitle="Sign in with your MFL credentials for the American Football League"
     />
   </div>

--- a/src/pages/afl-fantasy/news.astro
+++ b/src/pages/afl-fantasy/news.astro
@@ -1,6 +1,6 @@
 ---
 /**
- * The Schefter Report — AFL Fantasy News Feed
+ * The Schefter Report — AFL News Feed
  * Thin wrapper around the shared feed components for the AFL league.
  */
 export const prerender = false;

--- a/src/pages/afl-fantasy/rosters.astro
+++ b/src/pages/afl-fantasy/rosters.astro
@@ -644,7 +644,7 @@ const pageConfig = {
 };
 ---
 
-<TheLeagueLayout title={`AFL Fantasy — ${selectedTeam.name} Roster`}>
+<TheLeagueLayout title={`AFL — ${selectedTeam.name} Roster`}>
   <section class="roster-page" data-initial-view={initialView}>
     <!-- Team Header Card -->
     <div class="team-card" data-team-identity>
@@ -1200,7 +1200,7 @@ const pageConfig = {
           {!authUser && (
             <p>
               <a class="coming-soon__cta" href={`/afl-fantasy/login?next=/afl-fantasy/rosters?franchise=${selectedFranchiseId}&view=planner`}>
-                Sign in to AFL Fantasy →
+                Sign in to AFL →
               </a>
             </p>
           )}

--- a/src/pages/afl-fantasy/rules.astro
+++ b/src/pages/afl-fantasy/rules.astro
@@ -52,9 +52,9 @@ const sectionLinks = [
 <TheLeagueLayout title="AFL Constitution & Rules">
   <div class="afl-rules-page">
     <header class="afl-rules-page__hero">
-      <h1>AFL Fantasy Constitution</h1>
+      <h1>AFL Constitution</h1>
       <p>
-        The full rule set for AFL Fantasy. Use the table of contents to jump
+        The full rule set for AFL. Use the table of contents to jump
         to a section. Edits to this document live at
         <code>src/pages/afl-fantasy/docs/rules.html</code>.
       </p>

--- a/src/pages/afl-fantasy/standings.astro
+++ b/src/pages/afl-fantasy/standings.astro
@@ -155,7 +155,7 @@ const promoRegTeams = [
 });
 ---
 
-<TheLeagueLayout title="AFL Fantasy Standings" year={selectedYear}>
+<TheLeagueLayout title="AFL Standings" year={selectedYear}>
   <div class="standings-page">
     <header class="standings-hero">
       <div class="standings-hero__text">

--- a/src/pages/afl-fantasy/test-cookie.astro
+++ b/src/pages/afl-fantasy/test-cookie.astro
@@ -102,7 +102,7 @@ const resolvedTeamData = getAFLTeamData(preferredTeamId);
   </style>
 </head>
 <body>
-  <h1>🧪 AFL Fantasy Cookie Test</h1>
+  <h1>🧪 AFL Cookie Test</h1>
 
   <div class="info">
     <strong>Test URLs:</strong>

--- a/src/pages/afl-fantasy/trade-builder.astro
+++ b/src/pages/afl-fantasy/trade-builder.astro
@@ -186,7 +186,7 @@ const pageConfig = {
     {!isAflOwner ? (
       <section class="tb-gate">
         <h1>Trade Builder</h1>
-        <p>Sign in as an AFL Fantasy owner to draft trade proposals.</p>
+        <p>Sign in as an AFL owner to draft trade proposals.</p>
         <a href="/afl-fantasy/login?next=/afl-fantasy/trade-builder" class="tb-btn tb-btn--primary">Sign in</a>
       </section>
     ) : !toTeam ? (

--- a/src/pages/afl-fantasy/whats-new/[id].astro
+++ b/src/pages/afl-fantasy/whats-new/[id].astro
@@ -22,7 +22,7 @@ import { resolveLeaguePath } from '../../../utils/nav-utils';
 import { getAuthUser, isCommissionerOrAdmin } from '../../../utils/auth';
 import SchefterWidget from '../../../components/shared/SchefterWidget.astro';
 import type { SchefterFeed as FeedType } from '../../../types/schefter';
-import schefterFeedData from '../../../data/theleague/schefter-feed.json';
+import schefterFeedData from '../../../../data/afl-fantasy/schefter-feed.json';
 
 export const prerender = false;
 
@@ -34,11 +34,11 @@ const isAdmin = !!user && isCommissionerOrAdmin(user);
 
 const visible = (entries as WhatsNewEntry[])
   .filter((e) => e.visibility !== 'admin' || isAdmin)
-  .filter((e) => entryAppliesToLeague(e, 'theleague'));
+  .filter((e) => entryAppliesToLeague(e, 'afl'));
 const sorted = sortEntriesNewestFirst(visible);
 const id = Astro.params.id;
 const entry = sorted.find((e) => e.id === id);
-if (!entry) return Astro.redirect(r('/theleague/whats-new'));
+if (!entry) return Astro.redirect(r('/afl-fantasy/whats-new'));
 const { prev, next } = getAdjacentEntries(sorted, entry.id);
 
 const MULTICOLOR_ICONS = ['nfl'];
@@ -51,8 +51,8 @@ const imagePath = entry.image ? `/assets/whats-new/${entry.image}` : null;
   <main class="wn-detail">
 
     <Breadcrumbs items={[
-      { label: 'The League', href: '/theleague' },
-      { label: "What's New", href: '/theleague/whats-new' },
+      { label: 'AFL', href: '/afl-fantasy' },
+      { label: "What's New", href: '/afl-fantasy/whats-new' },
       { label: entry.title },
     ]} />
 
@@ -71,7 +71,7 @@ const imagePath = entry.image ? `/assets/whats-new/${entry.image}` : null;
                   <span class="browser-frame__dot browser-frame__dot--red"></span>
                   <span class="browser-frame__dot browser-frame__dot--yellow"></span>
                   <span class="browser-frame__dot browser-frame__dot--green"></span>
-                  <span class="browser-frame__url">{entry.link ? `theleague.us${entry.link.replace('/theleague', '')}` : 'theleague.us'}</span>
+                  <span class="browser-frame__url">{entry.link ? `afl-fantasy.com${entry.link.replace('/afl-fantasy', '')}` : 'afl-fantasy.com'}</span>
                 </div>
                 <img
                   src={imagePath}
@@ -223,8 +223,8 @@ const imagePath = entry.image ? `/assets/whats-new/${entry.image}` : null;
             <div class="wn-detail__release-card">
               <SchefterWidget
                 posts={(schefterFeedData as FeedType).posts.slice(0, 4)}
-                league="theleague"
-                allNewsLink={r('/theleague/news')}
+                league="afl"
+                allNewsLink={r('/afl-fantasy/news')}
               />
             </div>
           )}
@@ -235,7 +235,7 @@ const imagePath = entry.image ? `/assets/whats-new/${entry.image}` : null;
               <h2 class="wn-detail__section-title">More Updates</h2>
               <div class="wn-detail__nav-links">
                 {prev && (
-                  <a href={`${r('/theleague/whats-new')}/${prev.id}`} class="wn-detail__nav-link wn-detail__nav-link--prev">
+                  <a href={`${r('/afl-fantasy/whats-new')}/${prev.id}`} class="wn-detail__nav-link wn-detail__nav-link--prev">
                     <span class="wn-detail__nav-dir">
                       <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" width="12" height="12">
                         <path d="M10 3L5 8l5 5" />
@@ -246,7 +246,7 @@ const imagePath = entry.image ? `/assets/whats-new/${entry.image}` : null;
                   </a>
                 )}
                 {next && (
-                  <a href={`${r('/theleague/whats-new')}/${next.id}`} class="wn-detail__nav-link wn-detail__nav-link--next">
+                  <a href={`${r('/afl-fantasy/whats-new')}/${next.id}`} class="wn-detail__nav-link wn-detail__nav-link--next">
                     <span class="wn-detail__nav-dir">
                       Older
                       <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" width="12" height="12">

--- a/src/pages/afl-fantasy/whats-new/index.astro
+++ b/src/pages/afl-fantasy/whats-new/index.astro
@@ -23,14 +23,14 @@ import { getAuthUser, isCommissionerOrAdmin } from '../../../utils/auth';
 export const prerender = false;
 
 const hideLeaguePrefix = Astro.locals.hideLeaguePrefix ?? false;
-const basePath = hideLeaguePrefix ? '' : '/theleague';
+const basePath = hideLeaguePrefix ? '' : '/afl-fantasy';
 
 const user = getAuthUser(Astro.request);
 const isAdmin = !!user && isCommissionerOrAdmin(user);
 
 const visible = (entries as WhatsNewEntry[])
   .filter((e) => e.visibility !== 'admin' || isAdmin)
-  .filter((e) => entryAppliesToLeague(e, 'theleague'));
+  .filter((e) => entryAppliesToLeague(e, 'afl'));
 const sorted = sortEntriesNewestFirst(visible);
 
 // Read the last-visit cookie for "NEW" badge computation
@@ -51,7 +51,7 @@ Astro.cookies.set('whats_new_last_visit', new Date().toISOString().slice(0, 10),
 });
 ---
 
-<TheLeagueLayout title="What's New - The League">
+<TheLeagueLayout title="What's New — AFL">
   <main class="whats-new-page">
     <header class="whats-new-page__header">
       <h1 class="whats-new-page__title">
@@ -61,8 +61,11 @@ Astro.cookies.set('whats_new_last_visit', new Date().toISOString().slice(0, 10),
         )}
       </h1>
       <p class="whats-new-page__subtitle">
-        New features, improvements, and updates to The League.
+        New features, improvements, and updates to the AFL.
       </p>
+      {sorted.length === 0 && (
+        <p class="whats-new-page__subtitle">No AFL-specific updates yet — check back soon.</p>
+      )}
     </header>
 
     <WhatsNewListing

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -23,12 +23,12 @@ import Layout from '../layouts/Layout.astro';
         </div>
       </a>
 
-      <!-- AFL Fantasy Card -->
+      <!-- AFL Card -->
       <a
         href="/afl-fantasy"
         class="block p-8 bg-white rounded-lg shadow-lg hover:shadow-xl transition-shadow border-2 border-transparent hover:border-green-500"
       >
-        <h2 class="text-2xl font-bold mb-4 text-green-600">AFL Fantasy</h2>
+        <h2 class="text-2xl font-bold mb-4 text-green-600">AFL</h2>
         <p class="text-gray-600 mb-4">
           24 teams • 2 conferences • 9 draft rounds
         </p>

--- a/src/types/whats-new.ts
+++ b/src/types/whats-new.ts
@@ -53,6 +53,24 @@ export interface WhatsNewEntry {
   imageAlt?: string;
   /** Audience restriction — defaults to "all" if omitted. "admin" hides the entry from non-admin users in both the listing and the detail route. */
   visibility?: 'all' | 'admin';
+  /**
+   * League scope — which league(s) the entry applies to. If omitted, the entry is
+   * shown to both leagues (back-compat default). Use this to surface league-specific
+   * features only on the matching homepage / What's New page.
+   */
+  leagues?: Array<'theleague' | 'afl'>;
+}
+
+/** A league slug used by the `leagues` tagging field on What's New entries. */
+export type LeagueSlug = 'theleague' | 'afl';
+
+/**
+ * Returns true if the entry should be shown in the given league context.
+ * Missing `leagues` field = visible everywhere (back-compat default).
+ */
+export function entryAppliesToLeague(entry: WhatsNewEntry, league: LeagueSlug): boolean {
+  if (!entry.leagues || entry.leagues.length === 0) return true;
+  return entry.leagues.includes(league);
 }
 
 /** Hero content source type */

--- a/src/utils/afl-hero-resolver.ts
+++ b/src/utils/afl-hero-resolver.ts
@@ -1,0 +1,619 @@
+/**
+ * AFL Hero Resolver
+ *
+ * Determines which hero to display on the AFL homepage based on the current
+ * calendar position. Mirrors the priority structure of TheLeague's resolver
+ * but tuned to AFL's cadence:
+ *
+ *   - No auction (TheLeague has one; AFL replaces it with a single draft per conference)
+ *   - July 15 keeper deadline is the only public preseason date
+ *   - Conference drafts run the weekend before Labor Day (AL Saturday live, NL Sunday email)
+ *
+ * Hero priority (high → low):
+ *   P0++ Trade Deadline Day (24h override)
+ *   P0   Championship Week, Champion Crowned, Conference Draft Window, In-Season
+ *   P1   Keeper Deadline Day, Keeper Deadline Approaching (≤30 days out)
+ *   P2   Fresh AFL-tagged What's New entry (≤7 days)
+ *   P3   Urgent upcoming AFL event
+ *   P4   Active / upcoming AFL event
+ *   P5   Default offseason hero (no dates) or What's New fallback
+ */
+
+import type { WhatsNewEntry, HeroContent } from '../types/whats-new';
+import { entryAppliesToLeague, WHATS_NEW_CATEGORY_LABELS } from '../types/whats-new';
+import type { WhatsNextTimeline, ResolvedLeagueEvent } from '../types/league-events';
+import type { DailySlot, GameWindow } from '../types/hero-state';
+import { getNthDayOfMonth } from './league-event-resolver';
+import { getLaborDayForYear } from './league-year';
+import { getDailySlot } from './hero-resolver';
+import { getCurrentNFLWeek } from './current-week';
+
+/** How long a fresh What's New entry stays in the hero. */
+const FEATURE_HERO_DAYS = 7;
+
+const CATEGORY_COLOR: Record<string, string> = {
+  preseason: 'var(--cat-preseason, #60a5fa)',
+  draft: 'var(--cat-draft, #7c3aed)',
+  'regular-season': 'var(--cat-regular-season, #1c497c)',
+  'free-agency': 'var(--cat-free-agency, #2e8743)',
+};
+
+/** AFL hero state — discriminated by `kind`. */
+export type AflHeroState =
+  | { kind: 'conference-draft'; priority: 'P0'; content: HeroContent; al: { date: Date; live: boolean }; nl: { date: Date; live: boolean }; userConference?: '00' | '01' }
+  | { kind: 'keeper-deadline'; priority: 'P1'; content: HeroContent; deadline: Date; daysUntil: number }
+  | { kind: 'trade-deadline'; priority: 'P0++'; content: HeroContent; deadlineMidnightPT: string }
+  | { kind: 'championship'; priority: 'P0'; content: HeroContent }
+  | { kind: 'champion-crowned'; priority: 'P0'; content: HeroContent }
+  | { kind: 'playoffs'; priority: 'P0'; content: HeroContent; slot?: DailySlot; gameWindow?: GameWindow; week?: number }
+  | { kind: 'regular-season'; priority: 'P0'; content: HeroContent; slot: DailySlot; gameWindow: GameWindow; week?: number }
+  | { kind: 'event'; priority: 'P3' | 'P4'; content: HeroContent }
+  | { kind: 'feature'; priority: 'P2'; content: HeroContent }
+  | { kind: 'default'; priority: 'P5'; content: HeroContent };
+
+export interface AflHeroResolverInput {
+  referenceDate: Date;
+  testMode?: boolean;
+  whatsNewEntries?: WhatsNewEntry[];
+  timeline?: WhatsNextTimeline;
+  /** User's conference id from AFL cookie/auth ("00"=AL, "01"=NL) — for conference-aware draft hero. */
+  userConferenceId?: '00' | '01';
+}
+
+// ── Date helpers ─────────────────────────────────────────────────────────────
+
+function startOfDay(d: Date): Date {
+  const out = new Date(d);
+  out.setHours(0, 0, 0, 0);
+  return out;
+}
+
+function endOfDay(d: Date): Date {
+  const out = new Date(d);
+  out.setHours(23, 59, 59, 999);
+  return out;
+}
+
+function daysBetween(later: Date, earlier: Date): number {
+  return Math.ceil((startOfDay(later).getTime() - startOfDay(earlier).getTime()) / (1000 * 60 * 60 * 24));
+}
+
+function getKeeperDeadline(year: number): Date {
+  // July 15 @ 8pm PT (treated as local 20:00 to match the calendar entry)
+  return new Date(year, 6, 15, 20, 0, 0, 0);
+}
+
+/** Days before the keeper deadline at which the urgency hero kicks in. */
+const KEEPER_URGENCY_DAYS = 30;
+
+function getAlDraftDate(year: number): Date {
+  const labor = getLaborDayForYear(year);
+  const sat = new Date(labor);
+  sat.setDate(sat.getDate() - 2);
+  sat.setHours(9, 0, 0, 0);
+  return sat;
+}
+
+function getNlDraftDate(year: number): Date {
+  const labor = getLaborDayForYear(year);
+  const sun = new Date(labor);
+  sun.setDate(sun.getDate() - 1);
+  sun.setHours(9, 0, 0, 0);
+  return sun;
+}
+
+function getNflKickoff(year: number): Date {
+  const labor = getLaborDayForYear(year);
+  const thu = new Date(labor);
+  thu.setDate(thu.getDate() + 3);
+  return thu;
+}
+
+function getTradeDeadline(year: number): Date {
+  // AFL: Wednesday between Week 10 and Week 11 (per the constitution).
+  const labor = getLaborDayForYear(year);
+  const kickoff = new Date(labor);
+  kickoff.setDate(kickoff.getDate() + 3);
+  const wed = new Date(kickoff);
+  wed.setDate(wed.getDate() + 10 * 7 - 1); // Wed of the Week 10/11 transition
+  return wed;
+}
+
+function getPlayoffStart(year: number): Date {
+  // AFL playoffs begin Week 14 (one week earlier than TheLeague).
+  const kickoff = getNflKickoff(year);
+  const start = new Date(kickoff);
+  start.setDate(start.getDate() + 13 * 7);
+  return start;
+}
+
+function getChampionshipStart(year: number): Date {
+  // AFL World Championship is Week 16 (one week earlier than TheLeague).
+  const kickoff = getNflKickoff(year);
+  const start = new Date(kickoff);
+  start.setDate(start.getDate() + 15 * 7);
+  return start;
+}
+
+function getChampionshipEnd(year: number): Date {
+  const start = getChampionshipStart(year);
+  const end = new Date(start);
+  end.setDate(end.getDate() + 4);
+  end.setHours(23, 59, 59, 999);
+  return end;
+}
+
+// ── Phase detectors ──────────────────────────────────────────────────────────
+
+function isConferenceDraftWindow(now: Date): boolean {
+  const year = now.getFullYear();
+  // Window: 7 days before AL Saturday → end of NL Sunday
+  const al = getAlDraftDate(year);
+  const start = new Date(al);
+  start.setDate(start.getDate() - 7);
+  start.setHours(0, 0, 0, 0);
+  const nl = getNlDraftDate(year);
+  const end = endOfDay(nl);
+  return now >= start && now <= end;
+}
+
+function isKeeperDeadlineApproaching(now: Date): boolean {
+  const deadline = getKeeperDeadline(now.getFullYear());
+  if (now >= deadline) return false;
+  return daysBetween(deadline, now) <= KEEPER_URGENCY_DAYS;
+}
+
+function isKeeperDeadlineDay(now: Date): boolean {
+  return now.getMonth() === 6 && now.getDate() === 15;
+}
+
+function isTradeDeadlineDay(now: Date): boolean {
+  const year = now.getFullYear();
+  const td = getTradeDeadline(year);
+  return now.getFullYear() === td.getFullYear() && now.getMonth() === td.getMonth() && now.getDate() === td.getDate();
+}
+
+function isChampionshipWeek(now: Date): boolean {
+  const yearStart = getChampionshipStart(now.getFullYear());
+  const yearEnd = getChampionshipEnd(now.getFullYear());
+  if (now >= yearStart && now <= yearEnd) return true;
+  // Span across calendar year boundary (Dec → Jan)
+  const prevStart = getChampionshipStart(now.getFullYear() - 1);
+  const prevEnd = getChampionshipEnd(now.getFullYear() - 1);
+  return now >= prevStart && now <= prevEnd;
+}
+
+function isChampionCrownedWindow(now: Date): boolean {
+  for (const seasonYear of [now.getFullYear(), now.getFullYear() - 1]) {
+    const end = getChampionshipEnd(seasonYear);
+    const start = new Date(end);
+    start.setDate(start.getDate() + 1);
+    start.setHours(0, 0, 0, 0);
+    const crownedEnd = new Date(start);
+    crownedEnd.setDate(crownedEnd.getDate() + 7);
+    crownedEnd.setHours(23, 59, 59, 999);
+    if (now >= start && now <= crownedEnd) return true;
+  }
+  return false;
+}
+
+function isPlayoffs(now: Date): boolean {
+  const year = now.getFullYear();
+  const start = getPlayoffStart(year);
+  const champStart = getChampionshipStart(year);
+  return now >= start && now < champStart;
+}
+
+function isRegularSeason(now: Date): boolean {
+  const year = now.getFullYear();
+  const kickoff = getNflKickoff(year);
+  const playoffsStart = getPlayoffStart(year);
+  return now >= kickoff && now < playoffsStart;
+}
+
+function isQuietOffseason(now: Date): boolean {
+  // Feb 15 through the moment the keeper-deadline urgency window kicks in.
+  // We intentionally don't surface any specific date during this stretch —
+  // July 15 is the only date the site advertises.
+  const year = now.getFullYear();
+  const start = new Date(year, 1, 15); // Feb 15
+  const deadline = getKeeperDeadline(year);
+  return now >= start && now < deadline && !isKeeperDeadlineApproaching(now);
+}
+
+// ── Content builders ─────────────────────────────────────────────────────────
+
+function formatKickerDate(date: Date): string {
+  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
+function featureToHero(entry: WhatsNewEntry): HeroContent {
+  return {
+    source: 'feature',
+    title: entry.title,
+    summary: entry.summary,
+    link: entry.link,
+    linkLabel: entry.linkLabel ?? 'Check it out',
+    icon: entry.icon,
+    accentColor: 'var(--color-secondary, #2e8743)',
+    image: entry.image,
+    imageAlt: entry.imageAlt,
+    kicker: WHATS_NEW_CATEGORY_LABELS[entry.category],
+    kickerDate: formatKickerDate(new Date(entry.date + 'T00:00:00')),
+  };
+}
+
+function eventToHero(event: ResolvedLeagueEvent): HeroContent {
+  const link = event.actionLinks[0] ?? event.resultLinks[0];
+  const accent = CATEGORY_COLOR[event.definition.category] ?? 'var(--color-primary, #1c497c)';
+  return {
+    source: 'event',
+    title: event.definition.name,
+    summary: event.definition.description,
+    link: link?.url,
+    linkLabel: link?.label ?? 'Learn more',
+    icon: event.definition.icon,
+    accentColor: accent,
+    heroEventId: event.definition.id,
+    image: event.definition.image,
+    imageAlt: event.definition.imageAlt,
+    isActive: event.isActive,
+    isUrgent: event.isUrgent,
+    isExternal: link?.external,
+    kicker: event.isActive ? 'Happening Now' : event.isUrgent ? 'Coming Up' : 'League Event',
+    kickerDate: formatKickerDate(event.startDate),
+  };
+}
+
+function buildKeeperDeadlineHero(deadline: Date, daysUntil: number): HeroContent {
+  const summary =
+    daysUntil === 0
+      ? 'Today is the day — declare your 7 keepers before 8pm PT or the league picks for you.'
+      : daysUntil === 1
+        ? 'Tomorrow at 8pm PT — declare your 7 keepers. Anyone left undeclared hits the draft pool.'
+        : `${daysUntil} days until the keeper deadline. Lock in your 7 protected players before July 15 @ 8pm PT.`;
+  return {
+    source: 'event',
+    title: 'Keeper Deadline',
+    summary,
+    link: '/afl-fantasy/keepers',
+    linkLabel: 'Manage Keepers',
+    icon: 'bookmark',
+    accentColor: 'var(--cat-preseason, #60a5fa)',
+    isUrgent: true,
+    isActive: daysUntil === 0,
+    kicker: daysUntil === 0 ? 'Deadline — Today' : 'Keeper Deadline',
+    kickerDate: formatKickerDate(deadline),
+  };
+}
+
+function buildOffseasonHero(): HeroContent {
+  return {
+    source: 'default',
+    title: 'AFL Offseason',
+    summary: 'Quiet stretch on the calendar — but dynasty math never sleeps. Review rosters, scout free agents, and start lining up your keeper class.',
+    link: '/afl-fantasy/rosters',
+    linkLabel: 'Review Rosters',
+    icon: 'shield',
+    accentColor: 'var(--color-primary, #1c497c)',
+    kicker: 'Offseason',
+  };
+}
+
+function buildConferenceDraftHero(input: {
+  now: Date;
+  al: Date;
+  nl: Date;
+  userConferenceId?: '00' | '01';
+}): HeroContent {
+  const { now, al, nl, userConferenceId } = input;
+  const alLive = now >= al && now < new Date(al.getTime() + 24 * 60 * 60 * 1000);
+  const nlLive = now >= nl && now < new Date(nl.getTime() + 24 * 60 * 60 * 1000);
+  const isUserAl = userConferenceId === '00';
+  const isUserNl = userConferenceId === '01';
+
+  // Conference-aware copy
+  let title = 'Conference Drafts';
+  let summary: string;
+  let kicker = 'Draft Weekend';
+  if (alLive) {
+    kicker = 'AL Draft Under Way';
+    title = isUserAl ? 'Your Draft Is Live' : 'AL Draft Under Way';
+    summary = isUserAl
+      ? 'The American League live draft is happening right now. Make your picks before the timer expires.'
+      : 'The American League is drafting live. NL draft starts Sunday at 9am PT.';
+  } else if (nlLive) {
+    kicker = 'NL Draft Under Way';
+    title = isUserNl ? 'Your Draft Is Live' : 'NL Draft Under Way';
+    summary = isUserNl
+      ? 'The National League email draft is open. Submit your queue and watch the clock — picks tick through one at a time.'
+      : `The National League is drafting now. ${isUserAl ? 'Your AL draft wrapped yesterday — check the results.' : 'Conference Drafts are in full swing.'}`;
+  } else {
+    const daysToAl = daysBetween(al, now);
+    const daysToNl = daysBetween(nl, now);
+    if (isUserAl) {
+      summary = `Your live draft is ${daysToAl === 0 ? 'today' : daysToAl === 1 ? 'tomorrow' : `in ${daysToAl} days`} — Saturday at 9am PT. Scout the board and finalize your queue.`;
+      title = 'AL Draft Day Is Coming';
+    } else if (isUserNl) {
+      summary = `Your email draft starts ${daysToNl === 0 ? 'today' : daysToNl === 1 ? 'tomorrow' : `in ${daysToNl} days`} — Sunday at 9am PT. Set your queue before the first pick is on the clock.`;
+      title = 'NL Draft Is Coming';
+    } else {
+      summary = `AL drafts live Saturday at 9am PT, NL email draft opens Sunday at 9am PT. Conference Drafts kick off in ${daysToAl} days.`;
+    }
+  }
+
+  return {
+    source: 'draft',
+    title,
+    summary,
+    icon: 'draft-podium',
+    accentColor: 'var(--cat-draft, #7c3aed)',
+    kicker,
+    isActive: alLive || nlLive,
+    isUrgent: !alLive && !nlLive,
+    kickerDate: formatKickerDate(isUserNl ? nl : al),
+  };
+}
+
+function buildRegularSeasonHero(slot: DailySlot, week: number | undefined, gameWindow: GameWindow): HeroContent {
+  const weekLabel = week ? `Week ${week}` : 'Regular Season';
+  switch (slot) {
+    case 'live-scoring': {
+      const windowName: Record<NonNullable<GameWindow>, string> = {
+        tnf: 'Thursday Night Football',
+        sunday: 'Sunday slate',
+        snf: 'Sunday Night Football',
+        mnf: 'Monday Night Football',
+      };
+      const label = gameWindow && gameWindow in windowName ? windowName[gameWindow as NonNullable<GameWindow>] : 'live games';
+      return {
+        source: 'event',
+        title: `Games in Progress — ${weekLabel}`,
+        summary: `${label} is under way. Scoreboards update live across both conferences.`,
+        link: '/afl-fantasy/standings',
+        linkLabel: 'View Standings',
+        icon: 'nfl',
+        accentColor: 'var(--color-error, #dc2626)',
+        kicker: 'Live Now',
+        isActive: true,
+      };
+    }
+    case 'standings':
+      return {
+        source: 'event',
+        title: `Monday Standings Check — ${weekLabel}`,
+        summary: 'Where the AL and NL playoff picture stands heading into Monday Night Football.',
+        link: '/afl-fantasy/standings',
+        linkLabel: 'See the race',
+        icon: 'trophy',
+        accentColor: 'var(--cat-regular-season, #1c497c)',
+        kicker: 'Standings',
+      };
+    case 'recap':
+      return {
+        source: 'event',
+        title: `${weekLabel} Recap`,
+        summary: 'Top performances, biggest blowouts, and the AL/NL games that swung the standings.',
+        link: '/afl-fantasy/news',
+        linkLabel: 'Read the recap',
+        icon: 'commenting',
+        accentColor: 'var(--cat-regular-season, #1c497c)',
+        kicker: 'Weekly Recap',
+      };
+    case 'waiver-wire':
+      return {
+        source: 'event',
+        title: 'Waivers Process Tonight',
+        summary: 'Waiver claims run Wednesday at 9pm PT. After that, free agents go first-come, first-served through Sunday kickoff.',
+        link: '/afl-fantasy/rosters',
+        linkLabel: 'Set Your Claims',
+        icon: 'binoculars',
+        accentColor: 'var(--cat-free-agency, #2e8743)',
+        kicker: 'Waiver Day',
+      };
+    case 'game-day-preview':
+      return {
+        source: 'event',
+        title: `Game Day — ${weekLabel}`,
+        summary: 'Lineups lock at kickoff. Last call to set starters, swap injured players, and submit FCFS pickups.',
+        link: '/afl-fantasy/lineup',
+        linkLabel: 'Set Lineup',
+        icon: 'clipboard',
+        accentColor: 'var(--cat-regular-season, #1c497c)',
+        kicker: 'Game Day',
+      };
+    case 'article':
+    default:
+      return {
+        source: 'event',
+        title: `${weekLabel} — Around the AFL`,
+        summary: 'Schefter covers the moves, the matchups, and the storylines shaping the AL and NL races.',
+        link: '/afl-fantasy/news',
+        linkLabel: 'Read the latest',
+        icon: 'news',
+        accentColor: 'var(--cat-regular-season, #1c497c)',
+        kicker: 'The Beat',
+      };
+  }
+}
+
+function buildPlayoffsHero(): HeroContent {
+  return {
+    source: 'event',
+    title: 'Conference Playoffs',
+    summary: 'Conference seeds 1–4 are battling for a championship spot. NIT bracket runs alongside for everyone else.',
+    link: '/afl-fantasy/playoffs',
+    linkLabel: 'View Bracket',
+    icon: 'playoff',
+    accentColor: 'var(--cat-regular-season, #1c497c)',
+    kicker: 'Playoffs',
+    isActive: true,
+  };
+}
+
+function buildChampionshipHero(): HeroContent {
+  return {
+    source: 'event',
+    title: 'Championship Week',
+    summary: 'AL champion vs. NL champion. Winner takes the AFL crown.',
+    link: '/afl-fantasy/playoffs',
+    linkLabel: 'View Bracket',
+    icon: 'champ',
+    accentColor: 'var(--cat-regular-season, #1c497c)',
+    kicker: 'Championship',
+    isActive: true,
+  };
+}
+
+function buildChampionCrownedHero(): HeroContent {
+  return {
+    source: 'event',
+    title: 'A New Champion',
+    summary: 'The season has wrapped. View the bracket and savor the result before keeper math takes over.',
+    link: '/afl-fantasy/playoffs',
+    linkLabel: 'View Recap',
+    icon: 'trophy',
+    accentColor: 'var(--color-warning, #d97706)',
+    kicker: 'Champion Crowned',
+    isActive: true,
+  };
+}
+
+function buildTradeDeadlineHero(): HeroContent {
+  return {
+    source: 'event',
+    title: 'Trade Deadline',
+    summary: 'Last call to lock in trades for the season. After today, rosters are locked through the playoffs.',
+    link: '/afl-fantasy/rosters',
+    linkLabel: 'View Rosters',
+    icon: 'exchange',
+    accentColor: 'var(--color-error, #dc2626)',
+    isUrgent: true,
+    kicker: 'Trade Deadline — Today',
+  };
+}
+
+function buildDefaultHero(entries: WhatsNewEntry[]): HeroContent {
+  const aflEntries = entries
+    .filter((e) => entryAppliesToLeague(e, 'afl') && !e.excludeFromHero)
+    .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+  if (aflEntries.length > 0) {
+    return featureToHero(aflEntries[0]);
+  }
+  return {
+    source: 'default',
+    title: 'AFL',
+    summary: 'Two conferences, 24 teams, one champion. Welcome to the American Football League.',
+    link: '/afl-fantasy/standings',
+    linkLabel: 'View Standings',
+    icon: 'star',
+    accentColor: 'var(--color-primary, #1c497c)',
+    kicker: 'AFL',
+  };
+}
+
+// ── Main resolver ────────────────────────────────────────────────────────────
+
+export function resolveAflHeroState(input: AflHeroResolverInput): AflHeroState {
+  const now = input.referenceDate;
+  const whatsNew = input.whatsNewEntries ?? [];
+  const timeline = input.timeline;
+
+  // P0++: Trade deadline day
+  if (isTradeDeadlineDay(now)) {
+    const year = now.getFullYear();
+    return {
+      kind: 'trade-deadline',
+      priority: 'P0++',
+      content: buildTradeDeadlineHero(),
+      deadlineMidnightPT: `${year}-${String(getTradeDeadline(year).getMonth() + 1).padStart(2, '0')}-${String(getTradeDeadline(year).getDate() + 1).padStart(2, '0')}T00:00:00-08:00`,
+    };
+  }
+
+  // P0: Championship week
+  if (isChampionshipWeek(now)) {
+    return { kind: 'championship', priority: 'P0', content: buildChampionshipHero() };
+  }
+
+  // P0: Champion crowned (7-day window after championship)
+  if (isChampionCrownedWindow(now)) {
+    return { kind: 'champion-crowned', priority: 'P0', content: buildChampionCrownedHero() };
+  }
+
+  // P0: Playoffs
+  if (isPlayoffs(now)) {
+    return { kind: 'playoffs', priority: 'P0', content: buildPlayoffsHero() };
+  }
+
+  // P0: Conference Draft window
+  if (isConferenceDraftWindow(now)) {
+    const year = now.getFullYear();
+    const al = getAlDraftDate(year);
+    const nl = getNlDraftDate(year);
+    const content = buildConferenceDraftHero({ now, al, nl, userConferenceId: input.userConferenceId });
+    return {
+      kind: 'conference-draft',
+      priority: 'P0',
+      content,
+      al: { date: al, live: now >= al && now < new Date(al.getTime() + 24 * 60 * 60 * 1000) },
+      nl: { date: nl, live: now >= nl && now < new Date(nl.getTime() + 24 * 60 * 60 * 1000) },
+      userConference: input.userConferenceId,
+    };
+  }
+
+  // P1: Keeper deadline day (today is July 15) or approaching (≤30 days out)
+  if (isKeeperDeadlineDay(now) || isKeeperDeadlineApproaching(now)) {
+    const deadline = getKeeperDeadline(now.getFullYear());
+    const daysUntil = isKeeperDeadlineDay(now) ? 0 : daysBetween(deadline, now);
+    return {
+      kind: 'keeper-deadline',
+      priority: 'P1',
+      content: buildKeeperDeadlineHero(deadline, daysUntil),
+      deadline,
+      daysUntil,
+    };
+  }
+
+  // P0: Regular season — route through the daily slot rotation
+  if (isRegularSeason(now)) {
+    const { slot, gameWindow } = getDailySlot(now);
+    const week = getCurrentNFLWeek(now) ?? undefined;
+    return {
+      kind: 'regular-season',
+      priority: 'P0',
+      slot,
+      gameWindow,
+      week,
+      content: buildRegularSeasonHero(slot, week, gameWindow),
+    };
+  }
+
+  // P2: Fresh AFL-tagged What's New (≤7 days)
+  const fresh = whatsNew
+    .filter((e) => entryAppliesToLeague(e, 'afl') && !e.excludeFromHero)
+    .filter((e) => {
+      const age = daysBetween(now, new Date(e.date + 'T00:00:00'));
+      return age >= 0 && age <= FEATURE_HERO_DAYS;
+    });
+  if (fresh.length > 0) {
+    const pick = fresh[Math.floor(Math.random() * fresh.length)];
+    return { kind: 'feature', priority: 'P2', content: featureToHero(pick) };
+  }
+
+  // P3/P4: Urgent or active timeline event
+  if (timeline) {
+    if (timeline.next?.isUrgent) return { kind: 'event', priority: 'P3', content: eventToHero(timeline.next) };
+    if (timeline.current?.isActive) return { kind: 'event', priority: 'P4', content: eventToHero(timeline.current) };
+    if (timeline.next && !timeline.next.isPast && timeline.next.daysUntilStart <= 14) {
+      return { kind: 'event', priority: 'P4', content: eventToHero(timeline.next) };
+    }
+  }
+
+  // P5: Quiet offseason — no specific dates surfaced, just a "review rosters" nudge
+  if (isQuietOffseason(now)) {
+    return { kind: 'default', priority: 'P5', content: buildOffseasonHero() };
+  }
+
+  // P5: Ultimate fallback (e.g., between champion-crowned and Feb 15)
+  return { kind: 'default', priority: 'P5', content: buildDefaultHero(whatsNew) };
+}

--- a/src/utils/league-event-resolver.ts
+++ b/src/utils/league-event-resolver.ts
@@ -16,6 +16,12 @@ import type {
 import { THE_LEAGUE_EVENTS } from '../data/theleague/league-events';
 import { LEAGUE_YEAR_OVERRIDES } from '../data/theleague/league-year-config';
 import { getCurrentLeagueYear, getLaborDayForYear } from './league-year';
+import aflEventsConfig from '../data/afl-fantasy/league-events.json';
+
+/** AFL Fantasy events typed against the shared LeagueEventDefinition schema. */
+export const AFL_FANTASY_EVENTS: LeagueEventDefinition[] = (aflEventsConfig as {
+  events: LeagueEventDefinition[];
+}).events;
 
 /**
  * Get the Nth occurrence of a day-of-week in a given month.
@@ -51,6 +57,55 @@ function resolveComputedDate(rule: string, year: number): Date {
 
     case 'third-sunday-august':
       return getNthDayOfMonth(year, 7, 0, 3); // August, Sunday, 3rd
+
+    case 'saturday-before-labor-day': {
+      // AL Live Draft — Saturday immediately before Labor Day
+      const laborDay = getLaborDayForYear(year);
+      const sat = new Date(laborDay);
+      sat.setDate(sat.getDate() - 2);
+      return sat;
+    }
+
+    case 'sunday-before-labor-day': {
+      // NL Email Draft — Sunday immediately before Labor Day
+      const laborDay = getLaborDayForYear(year);
+      const sun = new Date(laborDay);
+      sun.setDate(sun.getDate() - 1);
+      return sun;
+    }
+
+    case 'afl-trade-deadline': {
+      // AFL Trade Deadline — Wednesday between Week 10 and Week 11.
+      // Week 1 Tuesday is kickoff+5 (NFL kickoff is Thursday); Week N Wed is
+      // kickoff + (N-1)*7 + 6 days. We want the Wed AFTER Week 10's Mon-Tue
+      // closes, i.e. start of Week 11 → kickoff + 10*7 - 1 days.
+      const laborDay = getLaborDayForYear(year);
+      const kickoff = new Date(laborDay);
+      kickoff.setDate(kickoff.getDate() + 3); // Thursday kickoff
+      const wed = new Date(kickoff);
+      wed.setDate(wed.getDate() + 10 * 7 - 1); // Wednesday between W10 and W11
+      return wed;
+    }
+
+    case 'afl-playoffs-start': {
+      // AFL playoffs begin NFL Week 14 (Thursday, 13 weeks after kickoff)
+      const laborDay = getLaborDayForYear(year);
+      const kickoff = new Date(laborDay);
+      kickoff.setDate(kickoff.getDate() + 3);
+      const week14 = new Date(kickoff);
+      week14.setDate(week14.getDate() + 13 * 7);
+      return week14;
+    }
+
+    case 'afl-championship-week': {
+      // AFL World Championship is NFL Week 16 (Thursday, 15 weeks after kickoff)
+      const laborDay = getLaborDayForYear(year);
+      const kickoff = new Date(laborDay);
+      kickoff.setDate(kickoff.getDate() + 3);
+      const week16 = new Date(kickoff);
+      week16.setDate(week16.getDate() + 15 * 7);
+      return week16;
+    }
 
     case 'nfl-kickoff': {
       // NFL kickoff is the Thursday after Labor Day
@@ -409,4 +464,57 @@ export function getAllResolvedEvents(options?: {
   };
 
   return resolveAllEvents(THE_LEAGUE_EVENTS, year, now, vars);
+}
+
+// ── AFL Fantasy variants ─────────────────────────────────────────────────────
+
+const AFL_LINK_VARS_DEFAULT = {
+  mflHost: 'www49.myfantasyleague.com',
+  leagueId: '19621',
+};
+
+/**
+ * Get the AFL Fantasy "What's Next" timeline.
+ * Spans current + next league year so the transition period (~Feb 14) still
+ * surfaces the upcoming year's events.
+ */
+export function getAflWhatsNextTimeline(referenceDate?: Date): WhatsNextTimeline {
+  const now = referenceDate || new Date();
+  const leagueYear = getCurrentLeagueYear(now);
+  const nextLeagueYear = leagueYear + 1;
+
+  const makeVars = (year: number): LinkTemplateVars => ({
+    ...AFL_LINK_VARS_DEFAULT,
+    year: year.toString(),
+    prevYear: (year - 1).toString(),
+  });
+
+  const currentYearEvents = resolveAllEvents(AFL_FANTASY_EVENTS, leagueYear, now, makeVars(leagueYear));
+  const nextYearEvents = resolveAllEvents(AFL_FANTASY_EVENTS, nextLeagueYear, now, makeVars(nextLeagueYear));
+
+  const currentIds = new Set(currentYearEvents.map((e) => `${e.definition.id}:${e.startDate.getTime()}`));
+  const dedupedNext = nextYearEvents.filter((e) => !currentIds.has(`${e.definition.id}:${e.startDate.getTime()}`));
+
+  const allResolved = [...currentYearEvents, ...dedupedNext].sort((a, b) => {
+    const t = a.startDate.getTime() - b.startDate.getTime();
+    if (t !== 0) return t;
+    return a.definition.sortOrder - b.definition.sortOrder;
+  });
+
+  return selectWhatsNextTimeline(allResolved, now, leagueYear);
+}
+
+/** All resolved AFL events for the full calendar page. */
+export function getAllResolvedAflEvents(options?: {
+  leagueYear?: number;
+  referenceDate?: Date;
+}): ResolvedLeagueEvent[] {
+  const now = options?.referenceDate || new Date();
+  const year = options?.leagueYear || getCurrentLeagueYear(now);
+  const vars: LinkTemplateVars = {
+    ...AFL_LINK_VARS_DEFAULT,
+    year: year.toString(),
+    prevYear: (year - 1).toString(),
+  };
+  return resolveAllEvents(AFL_FANTASY_EVENTS, year, now, vars);
 }


### PR DESCRIPTION
## Summary

Brings the AFL homepage up to parity with TheLeague — rotating hero, team snapshot, tiered standings, conference playoff preview, calendar timeline, quick links, and Schefter sidebar — tuned to AFL's actual constitution. Adds a `leagues` tagging system so What's New entries can be scoped per league.

## What changed

### AFL homepage (new)
- **Rotating hero** with a state machine encoding the full AFL calendar:
  - Long quiet offseason (Feb 15 – mid-June) → generic offseason hero, no specific dates surfaced
  - Keeper deadline window (≤30 days out) → "Keeper Deadline · N days · July 15" countdown
  - Conference Drafts (week before Labor Day) → **conference-aware** hero (NL user sees "NL Draft Is Coming", AL user sees AL angle) + AL/NL pills
  - Regular season → **daily slot rotation** through Mon standings / Tue recap / Wed waivers / Thu-Fri article / Sat-Sun game-day-preview / live-scoring during game windows
  - Trade deadline (Wed between W10-W11) → live midnight-PT countdown (reuses TheLeague's React island)
  - Playoffs (W14) → AL+NL bracket viz with seeds 1v4 / 2v3
  - Championship (W16) → AL champ vs NL champ matchup
- **Team Snapshot** — record, tier, conference, roster count; offseason variant adds keeper status
- **Tier Standings** — single tier (user's), 5-row window (2 above + user + 2 below), promotion/relegation cutline, all-play record as headline (drops H2H column)
- **Conference Playoff Standings** — seeds 1-6 for user's conference with playoff cutline
- **Conference Draft Preview** — AL Saturday + NL Sunday cards, visible ±2/+1 weeks
- **What's Next** timeline — shared `WhatsNextCard` driven by AFL events
- **Quick Links** — filtered `page-directory.json` entries scoped to `/afl-fantasy/*`
- **Schefter sidebar** — reads `data/afl-fantasy/schefter-feed.json`

### Calendar correctness (per the AFL constitution)
Three new computed rules in `league-event-resolver`:
- `saturday-before-labor-day` — AL live draft
- `sunday-before-labor-day` — NL email draft
- `afl-trade-deadline` — Wednesday between Week 10 and Week 11
- `afl-playoffs-start` — Week 14 (one week earlier than TheLeague)
- `afl-championship-week` — Week 16 World Championship

`/afl-fantasy/calendar` rewired to use `getAllResolvedAflEvents()` so it agrees with the homepage What's Next.

### `leagues` tagging system
- Added optional `leagues?: ('theleague'|'afl')[]` to `WhatsNewEntry` (missing = both, back-compat)
- Filters applied on the hero, both listing pages, and both detail routes
- All 64 existing entries pre-tagged `["theleague"]`
- New `/afl-fantasy/whats-new` page with AFL filtering, breadcrumbs, AFL feed sidebar, and an empty-state for now

### Naming
- All user-facing "AFL Fantasy" strings → "AFL" across pages, components, hero copy, nav header, league switcher, page directory, 404, root landing, and historical changelog entries. URL paths (`/afl-fantasy/`) and internal code comments unchanged.

### Page directory
- Added 12 AFL entries (Rosters, Standings, Set Lineup, Keepers, Schefter Report, Playoffs, Trade Builder, Draft Predictor, Calendar, Constitution, About, What's New) with 10+ tags each. All 373 directory tests pass.

## Test plan

- [x] All `tests/page-directory-data.test.ts` (373) and `tests/whats-new-data.test.ts` (57) pass
- [x] Quiet offseason hero (May 18 default): "AFL Offseason" generic copy, zero date mentions
- [x] Keeper window (Jul 1, 14 days out): "Keeper Season" hero with `14 days · July 15` strip
- [x] Keeper deadline urgent (Jul 13, T-2): switches to "Keeper Deadline" urgent variant
- [x] Keeper deadline day (Jul 15): "Today, 8pm PT" countdown
- [x] Conference Draft weekend (Sep 4-6, 2026, Labor Day = Sep 7): NL user sees "NL Draft Is Coming"; pills show AL Sat 9am PT / NL Sun 9am PT
- [x] Trade deadline (Wed Nov 18, 2026): live React countdown to midnight PT
- [x] Playoffs (Thu Dec 10, 2026 = Week 14): AL + NL bracket renders with real seeds
- [x] Championship (Thu Dec 24, 2026 = Week 16): "One Game. One Trophy." with AL/NL matchup
- [x] All 13 day-of-week / time-of-day windows produce distinct hero copy during regular season
- [x] Tier standings: 5-row window correct for top edge (rank 1, clamps), middle (rank 7, cutline visible), bottom of D-League (rank 5, "1 short of promotion")
- [x] AFL-tagged test entry appears on `/afl-fantasy/whats-new` and is hidden from `/theleague/whats-new`; verified end-to-end
- [x] Zero "AFL Fantasy" strings render on any user-facing surface
- [x] `/afl-fantasy/news` confirmed reading `data/afl-fantasy/schefter-feed.json` (not TheLeague's)

## Known follow-ups (intentionally out of scope)

- Populate `data/afl-fantasy/schefter-feed.json` with actual AFL transaction posts (currently has generic NFL news). Schefter agent needs an AFL mode.
- Guest "Pick your franchise" CTA currently points to `/afl-fantasy/standings`; could become a dedicated picker.
- Playoffs hero reads from regular-season seeds; once MFL publishes the actual bracket feed, switch to live advancement data.
- No unit tests yet for `resolveAflHeroState` / `getAflWhatsNextTimeline`.
- Internal "AFL Fantasy" strings in JSDoc / SCSS / type comments left alone (not user-facing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)