### PR TITLE
fix(afl): personalize homepage on login, remove team-picker prompt

### DIFF
--- a/src/components/afl/hp-sections/AflTeamSnapshot.astro
+++ b/src/components/afl/hp-sections/AflTeamSnapshot.astro
@@ -157,16 +157,16 @@ const metrics: MetricDef[] = inferredVariant === 'in-season'
     </div>
   </section>
 ) : (
-  <section class="afl-snapshot afl-snapshot--guest" aria-label="Team selector prompt">
+  <section class="afl-snapshot afl-snapshot--guest" aria-label="Login prompt">
     <div class="afl-snapshot__guest-inner">
       <svg class="afl-snapshot__guest-icon" width="24" height="24" aria-hidden="true">
         <use href={`${spriteUrl}#icon-shield`} />
       </svg>
       <div class="afl-snapshot__guest-text">
-        <p class="afl-snapshot__guest-heading">Pick your franchise</p>
-        <p class="afl-snapshot__guest-desc">Choose your team to personalize standings, keepers, and the rotating hero.</p>
+        <p class="afl-snapshot__guest-heading">Sign in to personalize</p>
+        <p class="afl-snapshot__guest-desc">Log in with your MFL account to unlock standings, keepers, and the rotating hero tailored to your franchise.</p>
       </div>
-      <a href="/afl-fantasy/standings" class="afl-snapshot__guest-btn">Choose team</a>
+      <a href="/afl-fantasy/login" class="afl-snapshot__guest-btn">Log in</a>
     </div>
   </section>
 )}

--- a/src/pages/afl-fantasy/index.astro
+++ b/src/pages/afl-fantasy/index.astro
@@ -43,6 +43,7 @@ import {
   getAFLTeamData,
   resolveAFLTeamSelection,
 } from '../../utils/team-preferences';
+import { getAuthUser } from '../../utils/auth';
 
 import '../../styles/schefter-feed.css';
 import '../../styles/schefter-feed-compact.css';
@@ -59,11 +60,14 @@ if (myTeamParam) {
 }
 
 const cookiePref = getAFLPreference(Astro.cookies);
-const hasExplicitTeam = !!(myTeamParam || franchiseParam || cookiePref);
+const authUser = getAuthUser(Astro.request);
+const authAflFranchiseId =
+  authUser?.leagueId === '19621' && authUser.franchiseId ? authUser.franchiseId : null;
+const hasExplicitTeam = !!(myTeamParam || franchiseParam || cookiePref || authAflFranchiseId);
 const resolvedFranchiseId = resolveAFLTeamSelection({
   myTeamParam,
   franchiseParam,
-  cookiePreference: cookiePref?.franchiseId,
+  cookiePreference: cookiePref?.franchiseId ?? authAflFranchiseId ?? undefined,
 });
 const userFranchiseId = hasExplicitTeam ? resolvedFranchiseId : undefined;
 const userTeam = userFranchiseId ? aflConfig.teams.find(t => t.franchiseId === userFranchiseId) : undefined;


### PR DESCRIPTION
## Summary

- The AFL homepage now personalizes itself from the authenticated AFL session (JWT `leagueId === '19621'`), not just from URL params + the AFL preference cookie.
- The guest card on the homepage now prompts **Sign in to personalize / Log in** (routes to `/afl-fantasy/login`) instead of **Pick your franchise / Choose team**. Personalization is no longer a separate step from logging in.

## Why

A signed-in AFL owner was still seeing "Pick your franchise" on the homepage even though the team drawer already knew which franchise was theirs. The page was reading from the AFL preference cookie only, while the surrounding layout already considered the JWT — so the homepage felt out of sync with the rest of the site. The prior CTA also implied that picking a team was something users did *instead of* logging in, which isn't the model we want.

## Test plan

- [x] Unauthenticated, no cookie → guest card with **Sign in to personalize / Log in** (button → `/afl-fantasy/login`).
- [x] Authenticated to AFL (`leagueId 19621`, franchise `0001`) via `x-user-context` header → renders "My Team" (Smokane FC), no guest prompt.
- [x] Existing AFL preference cookie → still renders the personalized snapshot (existing behavior preserved).
- [x] URL `?myteam=` / `?franchise=` still work as overrides.
- [ ] Smoke test in a real signed-in AFL session after deploy.

## Notes for reviewer

- URL params and the AFL preference cookie are still honored as escape hatches for sharing/previewing other teams — they're just not the surfaced path for first-time users anymore.
- Did **not** wire cross-league mapping (TheLeague auth → AFL franchise via `CROSS_LEAGUE_TEAM_MAP`). That can be a follow-up if we want TheLeague-only authenticated users to also auto-personalize the AFL homepage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)