### PR TITLE
fix(rosters): space team nav chevron from teams, trim card bottom padding

### DIFF
--- a/src/pages/theleague/rosters.astro
+++ b/src/pages/theleague/rosters.astro
@@ -3205,7 +3205,7 @@ const defaultLastSeenText = formatLastSeen(defaultLastSeen);
 .team-nav-accordion__content.expanded {
   max-height: 600px;
   opacity: 1;
-  margin-top: var(--padding-sm);
+  margin-top: var(--padding-lg);
 }
 
 .team-nav-accordion__content.collapsed {
@@ -3269,7 +3269,7 @@ const defaultLastSeenText = formatLastSeen(defaultLastSeen);
     .team-card {
       display:grid;
       padding-top: 1rem;
-      padding-bottom: var(--padding-xxl);/* Make room for tabs below */
+      padding-bottom: var(--padding-md);
       justify-items: center;
       gap: var(--padding-sm);
       border-radius: var(--radius-lg, 1rem);


### PR DESCRIPTION
The absolutely-positioned chevron overlapped the NORTHWEST division
label when expanded, and the mobile team-card had 48px of dead space
at the bottom. Bump expanded margin-top to --padding-lg and replace
the --padding-xxl mobile bottom with --padding-md.