### PR TITLE
schefter: scaffold per-tipster recency weighting in bucket scoring

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,3 +125,81 @@ After every resolution, before pushing:
 
 `git rerere` is enabled (see `.git/config`); identical conflicts on
 re-rebase replay automatically. Do not turn it off.
+
+## Schefter tipster context (Phase 8 — bot intelligence)
+
+The rumor-mill scanner weights bucket priority and surfaces voice cues
+based on per-tipster signals. The whole flow lives in three files:
+
+- **`scripts/lib/schefter-tipster-context.mjs`** — `buildTipsterContext`
+  reads two Redis keys per queued web tipster and returns a
+  `Map<hashedOwnerId, { isFirstTime, isProlific, tipsInQueue, beat }>`:
+  - `schefter:tipster:rumors_total:{hash}` (STRING, lifetime post count)
+  - `schefter:tipster:topic_counts:{hash}` (HASH, topic → lifetime count)
+- **`scripts/lib/schefter-bucket-logic.mjs`** — `bucketPriorityScore`
+  accepts the context as an optional third arg and adds a tipster delta
+  (first-time voice +5, burst regular −3, prolific −1). Without the
+  context, falls back to the pre-Phase-8 size+age math — both the
+  scanner and the admin preview pass the context now.
+- **`scripts/schefter-rumor-scan.mjs`** — `anonymizeTips` surfaces the
+  voice flags on every web-tip scope: `firstTimeTipster`,
+  `prolificTipster`, `tipsterBeat: { topic }`. HARD RULES 22 / 23 / 24
+  drive the phrasing. Post-commit increments live in
+  `schefter-tipster-counters.mjs` (`incrementTipsterCounters` plus
+  `incrementTipsterTopicCounters`).
+
+**Privacy contract — DO NOT WEAKEN.** The codename↔topic binding stays
+server-side. That's option B from the design discussion in
+`#enhance-bot-intelligence-tAh6t` — public codenames (Style Book bit)
+are fine, but pairing a codename with a beat (e.g. "Burner Phone keeps
+feeding me trade chatter") correlates over time and starts narrowing
+source identity. HARD RULE 24 enforces "never name the codename"; the
+`tipsterBeat` payload deliberately carries only the topic name, never
+the codename or hash. The admin route keeps a server-only
+`pendingTipsWithHashes` array for the priority preview math but strips
+`hashedOwnerId` from everything that crosses the response boundary.
+
+## Schefter quiet-day post (Phase 8 — feature 7)
+
+When the scanner's normal lane finds no qualifying bucket AND the queue
+meets one of three honest-quiet conditions (`queue-empty`,
+`single-prolific-tipster`, `all-stale`), Schefter ships ONE candid
+"slow news day" post instead of going silent. Lives entirely inside
+`scripts/schefter-rumor-scan.mjs` (no separate module — the logic is
+specific to the scanner flow):
+
+- **Cooldown:** `schefter:rumor:quiet_day_last_date` (PT-date string),
+  guarded by `QUIET_DAY_COOLDOWN_DAYS` (default 3).
+- **Distribution:** writes the feed entry and consumes one of
+  `MAX_POSTS_PER_DAY`, but **deliberately skips the GroupMe webhook** —
+  a slow-news-day post buzzing every owner's phone is the opposite of
+  slow. This invariant is locked by a sentinel comment that the
+  regression test (`tests/schefter-quiet-day.test.ts`) greps for; do not
+  delete the comment without also adding GroupMe-skip coverage another way.
+- **Voice:** `generateQuietDayBody` uses its own tiny system prompt (not
+  the main HARD-RULES block) with a 4-template fallback when
+  `ANTHROPIC_API_KEY` is unset, so dry-runs still produce recognizable
+  output.
+
+## Schefter recurrence ledger v2 (Phase 8 — feature 10)
+
+`data/schefter/topic-recurrence.json` bumped to v2. Each fingerprint
+entry now carries `tipsterHashes` (sorted-unique, capped at 64) in
+addition to the existing `weeksSeen`. The bump powers cross-week memory
+recall (HARD RULE 25): when a bucket reappears with at least one voice
+that wasn't on its prior roster, `getMemoryRecall` returns a
+counts-only payload (`weeksSinceFirstSeen`, `totalWeeksSeen`,
+`distinctVoicesAcrossTime`) that the anonymizer attaches to each tip
+in the bucket.
+
+`loadLedger` migrates v1 files in place by backfilling empty
+`tipsterHashes` arrays. The migration is transparent — no manual
+intervention needed when a deployed branch first hits the v2 code.
+Unknown future versions (>2) are discarded and replaced with an empty
+ledger (safer than trusting a schema we don't understand).
+
+**Privacy contract:** the ledger stores raw hashes for set-membership
+checks (so we can detect "fresh voice"), but `getMemoryRecall`'s return
+value contains only counts. The hashes never reach the LLM prompt or
+the response payload. Don't change that without re-litigating the
+correlation argument from option B above.

--- a/scripts/lib/schefter-bucket-logic.mjs
+++ b/scripts/lib/schefter-bucket-logic.mjs
@@ -10,6 +10,7 @@
  * scanner cycle will pick.
  */
 import { isFingerprintStale, getStreakLength } from './schefter-recurrence-ledger.mjs';
+import { tipsterScoreDelta } from './schefter-tipster-context.mjs';
 
 export function classifyTipKind(tip) {
   if (!tip) return 'gossip';
@@ -79,13 +80,25 @@ export function buildTopicBuckets(tips) {
  * expire):
  *   - Each additional tip in the bucket: +2 (a 2-tip cluster = +2, 3-tip = +4)
  *   - Each day the oldest tip has been queued: +1
+ *   - Tipster-aware delta (optional, see ./schefter-tipster-context.mjs):
+ *       first-time voice in the bucket: +5
+ *       burst-tipping regular (≥3 in queue this cycle): −3
+ *       moderate burst (2 in queue): −1
+ *       lifetime prolific tipster (≥10 posts): −1
+ *     These stack with the base score so a first-time voice always lifts the
+ *     bucket above same-sized noise from the chatty regular, while a
+ *     genuine multi-tipster cluster on a fresh topic still wins outright.
+ *
+ * `tipsterContext` is optional (admin previews call without it and get the
+ * pre-Phase-8 size+age ranking). When omitted the delta is zero.
  */
-export function bucketPriorityScore(bucket, now = new Date()) {
+export function bucketPriorityScore(bucket, now = new Date(), tipsterContext = null) {
   const refMs = now instanceof Date ? now.getTime() : Date.now();
   const oldestAgeMs = Math.max(0, refMs - (bucket.oldestSubmittedAt ?? refMs));
   const oldestAgeDays = Math.floor(oldestAgeMs / (24 * 60 * 60 * 1000));
   const sizeScore = Math.max(0, bucket.tips.length - 1) * 2;
-  return sizeScore + oldestAgeDays;
+  const tipsterDelta = tipsterContext ? tipsterScoreDelta(bucket, tipsterContext) : 0;
+  return sizeScore + oldestAgeDays + tipsterDelta;
 }
 
 /**
@@ -93,11 +106,11 @@ export function bucketPriorityScore(bucket, now = new Date()) {
  * first (always win), then gossip buckets by descending priority score.
  * Used by the admin page to preview the next few posts.
  */
-export function rankBuckets(buckets, now = new Date()) {
+export function rankBuckets(buckets, now = new Date(), tipsterContext = null) {
   const trade = buckets.filter((b) => b.kind === 'trade');
   const gossip = buckets.filter((b) => b.kind !== 'trade');
-  trade.sort((a, b) => bucketPriorityScore(b, now) - bucketPriorityScore(a, now));
-  gossip.sort((a, b) => bucketPriorityScore(b, now) - bucketPriorityScore(a, now));
+  trade.sort((a, b) => bucketPriorityScore(b, now, tipsterContext) - bucketPriorityScore(a, now, tipsterContext));
+  gossip.sort((a, b) => bucketPriorityScore(b, now, tipsterContext) - bucketPriorityScore(a, now, tipsterContext));
   return [...trade, ...gossip];
 }
 

--- a/scripts/lib/schefter-recurrence-ledger.mjs
+++ b/scripts/lib/schefter-recurrence-ledger.mjs
@@ -20,8 +20,18 @@
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
 import path from 'node:path';
 
-export const LEDGER_VERSION = 1;
+// Bump from 1 → 2: ledger entries now also carry a sorted unique list of
+// tipsterHashes (the distinct hashedOwnerIds that have ever contributed to
+// this fingerprint). The list is the data source for HARD RULE 25 (cross-
+// week memory recall — "three weeks ago a source mentioned X; tonight a
+// different voice circled back"). Old v1 files load cleanly: missing
+// tipsterHashes fields are treated as empty arrays.
+export const LEDGER_VERSION = 2;
 export const STALE_WEEK_THRESHOLD = 2;
+// Hashes are SHA-256 hex (64 chars). We keep the per-fingerprint roster
+// bounded so a heavily-recurring bucket can't grow the ledger without
+// limit — the prompt only needs the COUNT, not the identities.
+const MAX_TIPSTERS_PER_FINGERPRINT = 64;
 
 export function isoWeekLabel(date) {
   const d = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
@@ -72,6 +82,30 @@ export function emptyLedger(season) {
 }
 
 /**
+ * Migrate a loaded ledger to the current schema in-place. Idempotent.
+ * Backfills missing tipsterHashes arrays (v1 → v2 upgrade) so callers that
+ * loaded a pre-feature-10 file don't crash on getMemoryRecall.
+ */
+function migrateLedgerInPlace(ledger) {
+  if (!ledger || typeof ledger !== 'object') return ledger;
+  ledger.version = LEDGER_VERSION;
+  if (!ledger.fingerprints || typeof ledger.fingerprints !== 'object') {
+    ledger.fingerprints = {};
+    return ledger;
+  }
+  for (const fp of Object.keys(ledger.fingerprints)) {
+    const entry = ledger.fingerprints[fp];
+    if (!entry || typeof entry !== 'object') {
+      ledger.fingerprints[fp] = { weeksSeen: [], tipsterHashes: [] };
+      continue;
+    }
+    if (!Array.isArray(entry.weeksSeen)) entry.weeksSeen = [];
+    if (!Array.isArray(entry.tipsterHashes)) entry.tipsterHashes = [];
+  }
+  return ledger;
+}
+
+/**
  * A fingerprint is stale iff the ledger has entries for BOTH of the two
  * preceding ISO weeks. The current week's entry is written only AFTER a post
  * is consumed, so two consecutive prior weeks means this cycle's consume
@@ -110,9 +144,10 @@ export function getStreakLength(ledger, fingerprint, currentWeek) {
   return streak;
 }
 
-export function markFingerprintSeen(ledger, fingerprint, currentWeek, nowIso) {
+export function markFingerprintSeen(ledger, fingerprint, currentWeek, nowIso, tipsterHashes = []) {
   if (!ledger.fingerprints) ledger.fingerprints = {};
-  const entry = ledger.fingerprints[fingerprint] ?? { weeksSeen: [] };
+  const entry = ledger.fingerprints[fingerprint] ?? { weeksSeen: [], tipsterHashes: [] };
+  if (!Array.isArray(entry.tipsterHashes)) entry.tipsterHashes = [];
   if (!entry.weeksSeen.includes(currentWeek)) {
     entry.weeksSeen.push(currentWeek);
     entry.weeksSeen.sort();
@@ -120,9 +155,70 @@ export function markFingerprintSeen(ledger, fingerprint, currentWeek, nowIso) {
       entry.weeksSeen = entry.weeksSeen.slice(-12);
     }
   }
+  // Merge new tipster hashes; keep the list sorted-unique and bounded.
+  const seen = new Set(entry.tipsterHashes);
+  for (const h of tipsterHashes ?? []) {
+    if (typeof h === 'string' && h.length > 0) seen.add(h);
+  }
+  entry.tipsterHashes = [...seen].sort();
+  if (entry.tipsterHashes.length > MAX_TIPSTERS_PER_FINGERPRINT) {
+    // Trim from the front — older sorted hashes age out first. The COUNT
+    // (what the prompt uses) is preserved as the trimmed length.
+    entry.tipsterHashes = entry.tipsterHashes.slice(-MAX_TIPSTERS_PER_FINGERPRINT);
+  }
   entry.lastUpdated = nowIso ?? new Date().toISOString();
   ledger.fingerprints[fingerprint] = entry;
   return ledger;
+}
+
+/**
+ * Cross-week memory recall — feature 10 from the bot-intelligence brainstorm.
+ *
+ * Returns a `memoryRecall` payload when:
+ *   - the fingerprint has been touched in ≥ 2 distinct prior weeks
+ *   - AT LEAST ONE of the current cycle's tipsterHashes was NOT in the
+ *     ledger's recorded roster for this fingerprint (a "different voice
+ *     circled back")
+ *
+ * Returns null when memory recall is not warranted. The caller surfaces the
+ * payload on the anonymized tip so HARD RULE 25 can drive the phrasing.
+ *
+ * Privacy: only counts surface — the individual hashes are never echoed.
+ */
+export function getMemoryRecall(ledger, fingerprint, currentTipsterHashes, currentWeek) {
+  if (!fingerprint) return null;
+  const entry = ledger?.fingerprints?.[fingerprint];
+  if (!entry) return null;
+  const weeksSeen = Array.isArray(entry.weeksSeen) ? entry.weeksSeen : [];
+  if (weeksSeen.length < 2) return null;
+
+  const prior = new Set(Array.isArray(entry.tipsterHashes) ? entry.tipsterHashes : []);
+  const current = Array.isArray(currentTipsterHashes) ? currentTipsterHashes : [];
+  const hasFreshVoice = current.some((h) => typeof h === 'string' && h.length > 0 && !prior.has(h));
+  if (!hasFreshVoice) return null;
+
+  // Weeks-since-first-seen, as a calendar-week diff between the earliest
+  // recorded ISO-week and the current one. We compute by walking the
+  // ordered weeksSeen list — the first entry is the oldest.
+  const earliest = weeksSeen[0];
+  let weeksAgo = 0;
+  let probe = currentWeek;
+  while (probe !== earliest && weeksAgo < 52) {
+    probe = isoWeekMinus(probe, 1);
+    weeksAgo += 1;
+  }
+
+  // Combined distinct-voices count = prior roster ∪ current new voices.
+  // Cap at 64 so the count stays in a sensible range for prompts.
+  const combined = new Set(prior);
+  for (const h of current) {
+    if (typeof h === 'string' && h.length > 0) combined.add(h);
+  }
+  return {
+    weeksSinceFirstSeen: weeksAgo,
+    totalWeeksSeen: weeksSeen.length,
+    distinctVoicesAcrossTime: combined.size,
+  };
 }
 
 export function rolloverForSeason(ledger, season) {
@@ -141,10 +237,16 @@ export function loadLedger(filePath = LEDGER_PATH) {
   try {
     const raw = readFileSync(filePath, 'utf8');
     const parsed = JSON.parse(raw);
-    if (!parsed || typeof parsed !== 'object' || parsed.version !== LEDGER_VERSION) {
+    if (!parsed || typeof parsed !== 'object') {
       return emptyLedger(currentSeasonYear());
     }
-    return parsed;
+    // Accept v1 (pre-feature-10) and v2; migrate in place so getMemoryRecall
+    // sees a uniform shape. A version we don't recognize at all gets
+    // discarded — that's a corrupt/future file, safer to start fresh.
+    if (parsed.version !== 1 && parsed.version !== 2) {
+      return emptyLedger(currentSeasonYear());
+    }
+    return migrateLedgerInPlace(parsed);
   } catch {
     return emptyLedger(currentSeasonYear());
   }

--- a/scripts/lib/schefter-tipster-context.mjs
+++ b/scripts/lib/schefter-tipster-context.mjs
@@ -1,0 +1,188 @@
+/**
+ * Tipster context — per-tipster signals used to weight bucket priority and
+ * to surface human-reflex framing in the LLM prompt.
+ *
+ * The scanner builds a Map<hashedOwnerId, TipsterContext> once per cycle from
+ * the queued tips + Redis counters, then threads it through:
+ *   - bucketPriorityScore (lifts first-time voices, discounts the regulars)
+ *   - anonymizeTips (sets per-tip `firstTimeTipster` / `prolificTipster`
+ *     / `tipsterBeat` flags that drive HARD RULES in the system prompt)
+ *
+ * Pure shape contract — no I/O in the scoring path. The Redis fetch is the
+ * one and only side-effectful step (buildTipsterContext); everything
+ * downstream reads the assembled map.
+ *
+ * Counter sources:
+ *   - lifetime posts:        schefter:tipster:rumors_total:{hash}
+ *   - lifetime topic mix:    schefter:tipster:topic_counts:{hash}  (HASH topic→count)
+ *
+ * Per-cycle queue counts come from the freshTips array directly — they don't
+ * need a Redis read.
+ */
+
+const RUMORS_TOTAL_PREFIX = 'schefter:tipster:rumors_total:';
+const TOPIC_COUNTS_PREFIX = 'schefter:tipster:topic_counts:';
+
+// Thresholds — pulled out as named constants so they're easy to tune without
+// hunting through scoring logic. Numbers chosen so a first-timer always
+// jumps a same-sized cluster from a chatty regular, but a 2-tip cluster
+// from the regular still beats a fresh-but-empty bucket.
+export const FIRST_TIME_BOOST = 5;
+export const PROLIFIC_THRESHOLD = 10;     // lifetime posts to count as "the regular"
+export const PROLIFIC_PENALTY = -1;
+export const BURST_HEAVY_PENALTY = -3;    // 3+ tips in current queue from same hash
+export const BURST_LIGHT_PENALTY = -1;    // exactly 2 in current queue
+export const BEAT_TIP_FLOOR = 3;          // need at least this many lifetime posts to assign a beat
+export const BEAT_CONCENTRATION = 0.6;    // top topic must be this share of total
+
+/**
+ * @typedef {Object} TipsterContext
+ * @property {string} hashedOwnerId
+ * @property {number} tipsInQueue      Distinct queued web tips by this tipster this cycle.
+ * @property {number} rumorsTotal      Lifetime rumor-mill posts they've contributed to.
+ * @property {boolean} isFirstTime     True iff rumorsTotal === 0 (no shipped post ever).
+ * @property {boolean} isProlific      True iff rumorsTotal >= PROLIFIC_THRESHOLD.
+ * @property {?{topic: string, count: number, total: number, share: number}} beat
+ *   Top-topic affinity. Null when the tipster hasn't earned a beat yet
+ *   (lifetime < BEAT_TIP_FLOOR or top-topic share < BEAT_CONCENTRATION).
+ */
+
+/**
+ * Read a HASH from Redis and coerce numeric values. Tolerates the upstash
+ * client returning either strings or numbers depending on serialization.
+ * Returns an empty object on any error.
+ */
+async function readHash(redis, key) {
+  try {
+    const raw = await redis.hgetall(key);
+    if (!raw || typeof raw !== 'object') return {};
+    const out = {};
+    for (const [k, v] of Object.entries(raw)) {
+      const n = Number(v);
+      if (Number.isFinite(n) && n > 0) out[k] = n;
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+function deriveBeat(topicCounts) {
+  let total = 0;
+  let topTopic = null;
+  let topCount = 0;
+  for (const [topic, count] of Object.entries(topicCounts)) {
+    total += count;
+    if (count > topCount) {
+      topCount = count;
+      topTopic = topic;
+    }
+  }
+  if (!topTopic || total < BEAT_TIP_FLOOR) return null;
+  const share = topCount / total;
+  if (share < BEAT_CONCENTRATION) return null;
+  return { topic: topTopic, count: topCount, total, share };
+}
+
+/**
+ * Build a per-tipster context map for this scanner cycle.
+ *
+ * @param {Array<{source?: string, hashedOwnerId?: string}>} freshTips
+ * @param {import('@upstash/redis').Redis | null} redis
+ * @returns {Promise<Map<string, TipsterContext>>}
+ */
+export async function buildTipsterContext(freshTips, redis) {
+  const queueCounts = new Map();
+  for (const tip of Array.isArray(freshTips) ? freshTips : []) {
+    if (tip?.source !== 'web') continue;
+    const hash = tip?.hashedOwnerId;
+    if (typeof hash !== 'string' || hash.length === 0) continue;
+    queueCounts.set(hash, (queueCounts.get(hash) ?? 0) + 1);
+  }
+
+  const ctx = new Map();
+  if (queueCounts.size === 0) return ctx;
+
+  // Without Redis (offline / dry-run with no env), every tipster looks like
+  // a first-timer because we can't read their lifetime history. That's
+  // intentional — boost-on-failure is safer than a silent regression to the
+  // old size+age-only ordering.
+  if (!redis) {
+    for (const [hash, count] of queueCounts) {
+      ctx.set(hash, {
+        hashedOwnerId: hash,
+        tipsInQueue: count,
+        rumorsTotal: 0,
+        isFirstTime: true,
+        isProlific: false,
+        beat: null,
+      });
+    }
+    return ctx;
+  }
+
+  await Promise.all([...queueCounts.entries()].map(async ([hash, count]) => {
+    let rumorsTotal = 0;
+    try {
+      const v = await redis.get(`${RUMORS_TOTAL_PREFIX}${hash}`);
+      rumorsTotal = Number(v);
+      if (!Number.isFinite(rumorsTotal) || rumorsTotal < 0) rumorsTotal = 0;
+    } catch {
+      rumorsTotal = 0;
+    }
+    const topicCounts = await readHash(redis, `${TOPIC_COUNTS_PREFIX}${hash}`);
+    const beat = deriveBeat(topicCounts);
+    ctx.set(hash, {
+      hashedOwnerId: hash,
+      tipsInQueue: count,
+      rumorsTotal,
+      isFirstTime: rumorsTotal === 0,
+      isProlific: rumorsTotal >= PROLIFIC_THRESHOLD,
+      beat,
+    });
+  }));
+
+  return ctx;
+}
+
+/**
+ * Tipster-aware delta for a bucket's priority score. Designed so a single
+ * first-time voice anywhere in the bucket lifts it over a same-sized cluster
+ * from the league's chattiest tipster, while preserving the existing age +
+ * cluster-size signal. Pure function — no I/O.
+ *
+ * The math: the strongest first-time boost across the bucket's tippers wins,
+ * stacked with the harshest active penalty (burst > prolific). A bucket that
+ * mixes a first-timer with a regular still gets the first-timer boost — what
+ * the new voice is willing to tip about is the story.
+ */
+export function tipsterScoreDelta(bucket, tipsterContext) {
+  if (!tipsterContext || !bucket || !Array.isArray(bucket.tips)) return 0;
+
+  const hashes = new Set();
+  for (const tip of bucket.tips) {
+    if (tip?.source === 'web' && typeof tip.hashedOwnerId === 'string' && tip.hashedOwnerId) {
+      hashes.add(tip.hashedOwnerId);
+    }
+  }
+  if (hashes.size === 0) return 0;
+
+  let bestBoost = 0;
+  let worstPenalty = 0;
+  for (const hash of hashes) {
+    const c = tipsterContext.get(hash);
+    if (!c) continue;
+    if (c.isFirstTime) {
+      if (FIRST_TIME_BOOST > bestBoost) bestBoost = FIRST_TIME_BOOST;
+    }
+    if (c.tipsInQueue >= 3) {
+      if (BURST_HEAVY_PENALTY < worstPenalty) worstPenalty = BURST_HEAVY_PENALTY;
+    } else if (c.tipsInQueue === 2) {
+      if (BURST_LIGHT_PENALTY < worstPenalty) worstPenalty = BURST_LIGHT_PENALTY;
+    }
+    if (c.isProlific) {
+      if (PROLIFIC_PENALTY < worstPenalty) worstPenalty = PROLIFIC_PENALTY;
+    }
+  }
+  return bestBoost + worstPenalty;
+}

--- a/scripts/lib/schefter-tipster-counters.mjs
+++ b/scripts/lib/schefter-tipster-counters.mjs
@@ -22,6 +22,11 @@ const CODENAMES_USED_KEY = 'schefter:tipster:codenames_used';
 const RUMORS_TOTAL_PREFIX = 'schefter:tipster:rumors_total:';
 const RUMORS_SEASON_PREFIX = 'schefter:tipster:rumors_season:';
 const LEADERBOARD_PREFIX = 'schefter:tipster:leaderboard:';
+// Per-tipster topic histogram, populated alongside the rumor counters above.
+// HASH: topic → lifetime count. Read by buildTipsterContext (lib/schefter-
+// tipster-context.mjs) to derive a "standing beat" — the topic share that
+// HARD RULE 24 surfaces in the prompt without ever attaching a codename.
+const TOPIC_COUNTS_PREFIX = 'schefter:tipster:topic_counts:';
 
 /** Must stay in sync with src/utils/schefter-codenames.ts. */
 const SCHEFTER_CODENAMES = [
@@ -159,4 +164,69 @@ export async function incrementTipsterCounters({
   }
 
   log(`  [tipster-counters] updated ${distinctHashes.size} contributor(s)`);
+}
+
+/**
+ * Increment the per-tipster topic histogram. Called after a rumor ships, in
+ * parallel with incrementTipsterCounters. One increment per (tipster, topic)
+ * pair in the batch — a tipster who contributed two trade tips to the same
+ * post counts +1 for "trade", not +2, so the histogram tracks distinct
+ * authoritative beats per post rather than tip volume.
+ *
+ * The histogram drives HARD RULE 24 (standing beat) via buildTipsterContext.
+ * Only web tips count — groupme tips are already attributable and don't
+ * benefit from a standing-beat hint; trade_offer tips have no tipster at all.
+ *
+ * @param {object} opts
+ * @param {import('@upstash/redis').Redis} opts.redis
+ * @param {Array<{source: string, hashedOwnerId?: string, topic?: string}>} opts.batch
+ * @param {boolean} [opts.dryRun]
+ * @param {(msg: string) => void} [opts.log]
+ * @param {(msg: string) => void} [opts.warn]
+ */
+export async function incrementTipsterTopicCounters({
+  redis,
+  batch,
+  dryRun = false,
+  log = () => {},
+  warn = () => {},
+}) {
+  if (!redis || !Array.isArray(batch) || batch.length === 0) return;
+
+  // Dedup to (hash, topic) pairs so a tipster who tipped two roster items in
+  // the same batch counts +1 for "roster", not +2. This keeps the histogram
+  // a fair measure of WHAT a tipster reliably reports on, not how many
+  // overlapping tips they happened to send.
+  const pairs = new Map(); // hash → Set<topic>
+  for (const tip of batch) {
+    if (!tip || tip.source !== 'web') continue;
+    const hash = typeof tip.hashedOwnerId === 'string' ? tip.hashedOwnerId : '';
+    const topic = typeof tip.topic === 'string' && tip.topic.length > 0 ? tip.topic : 'other';
+    if (!hash) continue;
+    if (!pairs.has(hash)) pairs.set(hash, new Set());
+    pairs.get(hash).add(topic);
+  }
+  if (pairs.size === 0) {
+    log('  [tipster-topic-counters] no web tippers in batch — skipping');
+    return;
+  }
+
+  if (dryRun) {
+    const summary = [...pairs.entries()]
+      .map(([h, topics]) => `${h.slice(0, 6)}:[${[...topics].join(',')}]`)
+      .join(', ');
+    log(`  [dry-run] Would increment topic counters: ${summary}`);
+    return;
+  }
+
+  for (const [hash, topics] of pairs) {
+    for (const topic of topics) {
+      try {
+        await redis.hincrby(`${TOPIC_COUNTS_PREFIX}${hash}`, topic, 1);
+      } catch (err) {
+        warn(`  [tipster-topic-counters] increment failed for ${hash.slice(0, 6)} topic=${topic}: ${err.message}`);
+      }
+    }
+  }
+  log(`  [tipster-topic-counters] updated ${pairs.size} contributor(s)`);
 }

--- a/scripts/schefter-rumor-scan.mjs
+++ b/scripts/schefter-rumor-scan.mjs
@@ -95,7 +95,7 @@ import {
   appendPostHistory,
   buildHistoryEntry,
 } from './lib/schefter-lore.mjs';
-import { incrementTipsterCounters } from './lib/schefter-tipster-counters.mjs';
+import { incrementTipsterCounters, incrementTipsterTopicCounters } from './lib/schefter-tipster-counters.mjs';
 import {
   classifyTipKind,
   buildTopicBuckets,
@@ -3391,6 +3391,21 @@ async function main() {
     });
   } catch (err) {
     warn(`  [tipster-counters] hook failed: ${err.message}`);
+  }
+
+  // Per-tipster topic histogram — feeds buildTipsterContext on subsequent
+  // cycles so the "standing beat" (HARD RULE 24) can be derived. Same
+  // failure stance as above: a counter error never blocks the post.
+  try {
+    await incrementTipsterTopicCounters({
+      redis,
+      batch: consumedBatch,
+      dryRun: DRY_RUN,
+      log,
+      warn,
+    });
+  } catch (err) {
+    warn(`  [tipster-topic-counters] hook failed: ${err.message}`);
   }
 
   return 1;

--- a/scripts/schefter-rumor-scan.mjs
+++ b/scripts/schefter-rumor-scan.mjs
@@ -998,12 +998,12 @@ export async function anonymizeTips(tips, teams, feedPosts = [], now = new Date(
  *
  * Returns `{ primary, secondary }` or `null` when nothing qualifies.
  */
-function pickPrimaryBucket(buckets, { gossipAllowedToday, now = new Date() } = {}) {
+function pickPrimaryBucket(buckets, { gossipAllowedToday, now = new Date(), tipsterContext = null } = {}) {
   const tradeBuckets = buckets.filter((b) => b.kind === 'trade');
   if (tradeBuckets.length > 0) {
     // Only one bucket key (trade:offer) maps to kind === 'trade' under the
     // new classification, but sort defensively in case that ever changes.
-    tradeBuckets.sort((a, b) => bucketPriorityScore(b, now) - bucketPriorityScore(a, now));
+    tradeBuckets.sort((a, b) => bucketPriorityScore(b, now, tipsterContext) - bucketPriorityScore(a, now, tipsterContext));
     return { primary: tradeBuckets[0], secondary: null };
   }
 
@@ -1013,8 +1013,8 @@ function pickPrimaryBucket(buckets, { gossipAllowedToday, now = new Date() } = {
   if (gossipBuckets.length === 0) return null;
 
   gossipBuckets.sort((a, b) => {
-    const sa = bucketPriorityScore(a, now);
-    const sb = bucketPriorityScore(b, now);
+    const sa = bucketPriorityScore(a, now, tipsterContext);
+    const sb = bucketPriorityScore(b, now, tipsterContext);
     if (sb !== sa) return sb - sa;
     // Ties: older wins so a long-queued tip always beats a fresh one.
     return a.oldestSubmittedAt - b.oldestSubmittedAt;
@@ -2602,6 +2602,30 @@ async function main() {
       buckets.map((b) => `${b.key}[${b.kind}×${b.tips.length}]`).join(', '),
   );
 
+  // Per-tipster context — lifts a first-time voice over same-sized noise
+  // from the league's chatty regulars, and discounts a burst-tipping
+  // tipster who has 3+ tips queued this cycle. See
+  // scripts/lib/schefter-tipster-context.mjs for the score math and the
+  // signal sources (Redis: rumors_total + topic_counts).
+  let tipsterContext = new Map();
+  try {
+    tipsterContext = await buildTipsterContext(freshTips, redis);
+    if (tipsterContext.size > 0) {
+      const summary = [...tipsterContext.values()].map((c) => {
+        const tags = [];
+        if (c.isFirstTime) tags.push('first');
+        if (c.isProlific) tags.push('prolific');
+        if (c.tipsInQueue >= 2) tags.push(`burst×${c.tipsInQueue}`);
+        if (c.beat) tags.push(`beat:${c.beat.topic}`);
+        return `${c.hashedOwnerId.slice(0, 6)}=${tags.join('+') || 'baseline'}`;
+      }).join(', ');
+      log(`  [tipster-context] ${tipsterContext.size} contributor(s) — ${summary}`);
+    }
+  } catch (err) {
+    warn(`  [tipster-context] build failed: ${err.message} — falling back to size+age ranking`);
+    tipsterContext = new Map();
+  }
+
   // Recurrence ledger: a gossip bucket that has produced a post in each of
   // the two preceding ISO weeks is "stale". Skipping it from the normal
   // lane lets fresher tips post sooner. Stale tips still drain via the
@@ -2659,7 +2683,7 @@ async function main() {
     batch = mailbagBatch;
   } else {
     // Normal lane sees only non-stale buckets — stale repeats wait for Friday.
-    const pick = pickPrimaryBucket(normalLaneBuckets, { gossipAllowedToday, now });
+    const pick = pickPrimaryBucket(normalLaneBuckets, { gossipAllowedToday, now, tipsterContext });
     if (!pick) {
       if (staleBuckets.length > 0) {
         log(`  No fresh bucket qualifies — ${staleBuckets.length} stale bucket(s) held for next Friday mailbag`);

--- a/scripts/schefter-rumor-scan.mjs
+++ b/scripts/schefter-rumor-scan.mjs
@@ -104,6 +104,7 @@ import {
   isBucketStale,
   bucketStreakLength,
 } from './lib/schefter-bucket-logic.mjs';
+import { buildTipsterContext } from './lib/schefter-tipster-context.mjs';
 import {
   loadLedger,
   saveLedger,

--- a/scripts/schefter-rumor-scan.mjs
+++ b/scripts/schefter-rumor-scan.mjs
@@ -147,6 +147,11 @@ const TIPS_QUEUE_KEY = 'schefter:tips:queue';
 const TIPS_PROCESSED_KEY = 'schefter:tips:processed';
 const ROGER_LAST_RIFF_DATE_KEY = 'schefter:ask_roger:last_riff_date';
 const MORNING_GREETING_DATE_KEY = 'schefter:morning_greeting:last_used_date';
+// Feature 7 — "saying no, out loud" cooldown. Stores PT-date string of the
+// last quiet-day post. Fires AT MOST once per QUIET_DAY_COOLDOWN_DAYS so
+// Schefter doesn't make "slow news" his whole bit. See attemptQuietDayPost.
+const QUIET_DAY_LAST_DATE_KEY = 'schefter:rumor:quiet_day_last_date';
+const QUIET_DAY_COOLDOWN_DAYS = 3;
 
 // ── Phase 6: Trade-Offer Rumor Redis keys ──
 // Legacy key (pre-cumulative-probability model). Still read for dedup against
@@ -1542,6 +1547,157 @@ function selectSchefterTargetMode(beat) {
   return pickSchefterTargetMode();
 }
 
+/**
+ * Should the scanner fire a "saying no, out loud" quiet-day post this cycle?
+ *
+ * Conditions (ALL must hold):
+ *   - The normal bucket pick returned null (nothing qualifies this cycle).
+ *   - We're not on Friday's mailbag path (mailbag is its own catch-up lane).
+ *   - At least ONE of:
+ *       (a) freshTips is empty — the queue genuinely has nothing.
+ *       (b) every queued tip with an hashedOwnerId came from a single
+ *           prolific tipster (according to tipsterContext) — Schefter has
+ *           one chatty voice and nothing else.
+ *       (c) every non-trade bucket is stale (recurrence ledger has marked
+ *           them as 3-week repeats) — the queue is full of old chatter.
+ *
+ * Cooldown check (against `lastQuietDayDateStr`) is done by the caller —
+ * this helper is pure so it's testable. Returns the reason string for logs.
+ */
+export function evaluateQuietDayConditions({
+  pick,
+  mailbagBatch,
+  freshTips,
+  normalLaneBuckets,
+  staleBuckets,
+  tipsterContext,
+}) {
+  if (pick) return { shouldFire: false, reason: 'normal-pick-available' };
+  if (mailbagBatch) return { shouldFire: false, reason: 'mailbag-active' };
+
+  const tips = Array.isArray(freshTips) ? freshTips : [];
+  if (tips.length === 0) {
+    return { shouldFire: true, reason: 'queue-empty', queueSize: 0 };
+  }
+
+  // (b) single prolific tipster owns the queue. Count distinct web hashes;
+  // if there's exactly one and the context flags them prolific, qualifies.
+  const webHashes = new Set();
+  for (const tip of tips) {
+    if (tip?.source === 'web' && typeof tip.hashedOwnerId === 'string' && tip.hashedOwnerId) {
+      webHashes.add(tip.hashedOwnerId);
+    }
+  }
+  if (webHashes.size === 1) {
+    const onlyHash = [...webHashes][0];
+    const c = tipsterContext?.get?.(onlyHash);
+    if (c?.isProlific) {
+      return { shouldFire: true, reason: 'single-prolific-tipster', queueSize: tips.length };
+    }
+  }
+
+  // (c) all non-trade buckets are stale — only mailbag would touch them.
+  const haveNormalLane = Array.isArray(normalLaneBuckets) && normalLaneBuckets.length > 0;
+  const haveStale = Array.isArray(staleBuckets) && staleBuckets.length > 0;
+  if (!haveNormalLane && haveStale) {
+    return { shouldFire: true, reason: 'all-stale', queueSize: tips.length };
+  }
+
+  return { shouldFire: false, reason: 'no-quiet-day-trigger' };
+}
+
+/**
+ * Quiet-day body generator. Independent LLM call (separate system prompt
+ * from generateAiBody) so it can stay tiny and cache-eligible. Returns the
+ * generated post text, or a template fallback if ANTHROPIC_API_KEY is unset.
+ *
+ * Feature 7 — "saying no, out loud." When the rumor mill is genuinely
+ * quiet, Schefter files ONE candid acknowledgment instead of fabricating
+ * a story. Fires at most once per QUIET_DAY_COOLDOWN_DAYS so it doesn't
+ * become his whole bit.
+ *
+ * @param {Object} ctx
+ * @param {string} ctx.reason  Internal log string ("queue empty",
+ *                             "single-prolific-tipster", "all-stale")
+ * @param {number} ctx.queueSize
+ * @returns {Promise<string>}  The post body.
+ */
+export async function generateQuietDayBody({ reason = 'queue-quiet', queueSize = 0 } = {}) {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  // Template fallback — chosen so a dry-run / no-key environment still
+  // ships a recognizable Schefter-voice quiet-day line.
+  const templates = [
+    'Slow news day. League is quiet. Or my tipster line just needs new batteries.',
+    'Phones are not ringing. Either the league is at peace or my sources are at the beach.',
+    'Nothing crossing the desk worth filing. Bench day for the rumor mill.',
+    'Quiet rolodex tonight. The desk is open if anyone has something real.',
+  ];
+  const fallback = templates[Math.floor(Math.random() * templates.length)];
+
+  if (!apiKey) {
+    warn('  [quiet-day] ANTHROPIC_API_KEY not set — using template');
+    return fallback;
+  }
+
+  const system = `You are Claude Schefter — a dynasty fantasy football beat reporter. You file rumor-mill posts in a confident, columnist voice.
+
+This is a QUIET-DAY post. The rumor mill is genuinely slow: no tip clusters worth shipping, no fresh angles, just background noise. Your job is to acknowledge the quiet candidly rather than fabricate a story.
+
+HARD RULES (all of these, every time):
+- ONE OR TWO sentences. No more.
+- Bemused, dry, self-aware. You are a beat reporter on a slow news day, not breaking news.
+- NEVER invent a story, name a franchise, name a player, name an owner, or tease "developing".
+- NEVER promise news is coming. The whole point is that there is none right now.
+- You MAY gently dig at the silence (the league, the rolodex, the off-season). Once.
+- Voice examples (rotate phrasing, never echo verbatim — pick your own line in this register):
+    * "Slow news day. League's quiet. Or my tipster line just needs new batteries."
+    * "Phones aren't ringing. Either the league's at peace or my sources are at the beach."
+    * "Nothing crossing the desk worth filing. Bench day for the rumor mill."
+    * "Quiet rolodex tonight. The desk is open if anyone has something real."
+    * "Sources have nothing for me. I respect that."
+- Output JSON ONLY: {"post": "<the post text as a single string>"}. No meta-commentary. No reasoning in the post field.`;
+
+  const userMessage = `File a quiet-day post. Internal cue (do NOT reference): reason="${reason}", queueSize=${queueSize}. Output JSON only.`;
+
+  try {
+    const res = await fetch('https://api.anthropic.com/v1/messages', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': apiKey,
+        'anthropic-version': '2023-06-01',
+      },
+      body: JSON.stringify({
+        model: 'claude-haiku-4-5-20251001',
+        max_tokens: 120,
+        system,
+        messages: [{ role: 'user', content: userMessage }],
+      }),
+    });
+    if (!res.ok) {
+      const t = await res.text().catch(() => '');
+      warn(`  [quiet-day] anthropic ${res.status}: ${t.slice(0, 200)} — falling back to template`);
+      return fallback;
+    }
+    const data = await res.json();
+    const text = data?.content?.[0]?.text ?? '';
+    const match = text.match(/\{[\s\S]*\}/);
+    if (!match) {
+      warn('  [quiet-day] no JSON in response — falling back to template');
+      return fallback;
+    }
+    const parsed = JSON.parse(match[0]);
+    if (typeof parsed?.post === 'string' && parsed.post.trim().length > 0) {
+      return parsed.post.trim();
+    }
+    warn('  [quiet-day] empty post in response — falling back to template');
+    return fallback;
+  } catch (err) {
+    warn(`  [quiet-day] generation failed: ${err.message} — falling back to template`);
+    return fallback;
+  }
+}
+
 async function generateAiBody(anonymized, { rogerQuote, lore, recentPostsBlock, mode = 'single', nflContext = null, schefterTargetMode = null, busyMorning = false, busyMorningBacklog = 0, morningGreeting = false } = {}) {
   const apiKey = process.env.ANTHROPIC_API_KEY;
   if (!apiKey) {
@@ -2738,7 +2894,83 @@ async function main() {
       } else {
         log('  No bucket qualifies (gossip cap used, no trade rumors) — holding tips for the next cycle');
       }
-      return 0;
+      // Feature 7 — quiet-day post. When the normal lane has nothing AND
+      // we're not mid-mailbag, Schefter optionally files ONE candid
+      // acknowledgment instead of going silent. Cooldown enforced via a
+      // PT-date key so this fires at most once per QUIET_DAY_COOLDOWN_DAYS.
+      const quietEval = evaluateQuietDayConditions({
+        pick,
+        mailbagBatch,
+        freshTips,
+        normalLaneBuckets,
+        staleBuckets,
+        tipsterContext,
+      });
+      if (!quietEval.shouldFire) return 0;
+
+      let quietLastDateStr = null;
+      try { quietLastDateStr = await redis.get(QUIET_DAY_LAST_DATE_KEY); } catch { /* tolerate */ }
+      if (typeof quietLastDateStr === 'string' && quietLastDateStr.length > 0) {
+        const ageDays = Math.floor((Date.parse(`${todayPtDate}T00:00:00Z`) - Date.parse(`${quietLastDateStr}T00:00:00Z`)) / (24 * 60 * 60 * 1000));
+        if (ageDays < QUIET_DAY_COOLDOWN_DAYS) {
+          log(`  [quiet-day] cooldown active — last fired ${quietLastDateStr} (${ageDays}d ago, need ≥${QUIET_DAY_COOLDOWN_DAYS}d)`);
+          return 0;
+        }
+      }
+      log(`  [quiet-day] firing — reason=${quietEval.reason}, queueSize=${quietEval.queueSize ?? 0}`);
+
+      const quietBody = await generateQuietDayBody({
+        reason: quietEval.reason,
+        queueSize: quietEval.queueSize ?? 0,
+      });
+      log(`  [quiet-day] body: ${quietBody}`);
+
+      if (DRY_RUN) {
+        log(`  [dry-run] Would ship quiet-day post; would set ${QUIET_DAY_LAST_DATE_KEY}=${todayPtDate}`);
+        return 0;
+      }
+
+      const quietPost = {
+        id: generatePostId(),
+        timestamp: now.toISOString(),
+        type: 'transaction',
+        transactionSubType: RUMOR_SUB_TYPE,
+        tier: RUMOR_TIER,
+        headline: 'Schefter checking in…',
+        body: quietBody,
+        authorId: 'claude',
+        franchiseIds: [],
+        tipIds: [],
+        league: LEAGUE_SLUG,
+        link: TIP_PAGE_PATH,
+        linkLabel: 'Got a real tip?',
+      };
+
+      try {
+        const feed = await loadFeed();
+        feed.posts = [quietPost, ...(feed.posts ?? [])];
+        feed.lastScanTimestamp = now.toISOString();
+        await fs.writeFile(FEED_PATH, JSON.stringify(feed, null, 2) + '\n');
+        log(`  [quiet-day] appended quiet-day post ${quietPost.id} to feed`);
+      } catch (err) {
+        warn(`  [quiet-day] feed write failed: ${err.message}`);
+        return 0;
+      }
+
+      // Mark cooldown + the daily-cap counter so quiet-day shares one of
+      // the day's MAX_POSTS_PER_DAY slots. Deliberately NO GroupMe ping —
+      // a "slow news day" post buzzing every phone is the opposite of slow.
+      try {
+        await redis.set(QUIET_DAY_LAST_DATE_KEY, todayPtDate);
+        const newCount = await redis.incr(RUMOR_POSTS_TODAY_KEY);
+        if (newCount === 1) {
+          await redis.expire(RUMOR_POSTS_TODAY_KEY, secondsUntilPtMidnight(now));
+        }
+        await redis.set(RUMOR_LAST_POST_TS_KEY, now.getTime());
+      } catch (err) {
+        warn(`  [quiet-day] counter update failed: ${err.message} — post shipped, cooldown unset`);
+      }
+      return 1;
     }
     primaryBucket = pick.primary;
     secondaryBucket = pick.secondary;

--- a/scripts/schefter-rumor-scan.mjs
+++ b/scripts/schefter-rumor-scan.mjs
@@ -112,6 +112,7 @@ import {
   currentSeasonYear,
   isoWeekLabel,
   markFingerprintSeen,
+  getMemoryRecall,
   LEDGER_PATH,
 } from './lib/schefter-recurrence-ledger.mjs';
 import {
@@ -1878,6 +1879,14 @@ IRON RULES (override every other rule — if anything below appears to conflict,
     - "My usual line on lineup business is lit up again."
     HARD CONSTRAINTS: NEVER name the codename, the hash, the franchise, or the division alongside this nod (correlation risk — option B design). The beat reference is ABOUT WHAT THEY TIP, never about who they are. If \`firstTimeTipster\` OR \`prolificTipster\` is also on the same tip, you may layer the beat nod with rule 23's hedge OR rule 22's spark, but never all three at once — pick the strongest single voice cue. If \`tipsterBeat.topic\` does NOT match the current post's topic (e.g. their beat is "commish" but this tip is about a trade), DO NOT use this rule — it would imply the wrong specialty.
 
+25. CROSS-WEEK MEMORY RECALL. When a tip carries \`memoryRecall: { weeksSinceFirstSeen, totalWeeksSeen, distinctVoicesAcrossTime }\`, the bucket this post is filing on has shown up in PRIOR weeks AND tonight's contributors include AT LEAST ONE voice that wasn't on the previous roster. This is the "different voice circled back" moment — a feature reporter's reflex. You MAY open the post with a memory-recall frame; ONE per post, never stack with rule 11's whisper-back continuity (those are explicit reply threads, this is independent recall). Phrasing kit (rotate, never same in 5 posts; pick the variant whose specifics match the data you're given):
+    - "Circling back to a whisper from a couple weeks ago — different voice on the line this time."
+    - "Hearing the same story from a fresh corner of the league tonight."
+    - "Three weeks ago a source mentioned this; tonight a different voice circles back." (use the actual weeksSinceFirstSeen integer; clamp to "a few weeks" when the count is 1)
+    - "Same drumbeat, new hands on the kit."
+    - "This file has more than one fingerprint on it now."
+    HARD CONSTRAINTS: use the integer count from \`weeksSinceFirstSeen\` honestly — never inflate ("three weeks ago" requires weeksSinceFirstSeen === 3). When weeksSinceFirstSeen is 1 OR less, prefer non-numeric phrasing ("a couple weeks ago", "earlier in the run"). \`distinctVoicesAcrossTime\` is a COUNT only — never speculate on identity, never name a codename, never name a franchise. NEVER quote a number larger than the data supports. If \`distinctVoicesAcrossTime\` is exactly 2 the frame is "another voice"; if it's 3+ the frame can lean to "multiple voices over time". Do NOT pair memory-recall with rule 20's mailbag "week N now" framing (mailbag has its own staleness language). Do NOT use this rule on hostile or off-topic tips (rules 12, 16) — keep the recall frame for genuine news threads.
+
 Voice: "League sources tell me…", "I'm told…", "Hearing…", "A division rival whispers…". Salt, not sugar.`;
 
   if (hasTradeOffer) {
@@ -3091,6 +3100,47 @@ async function main() {
     warn(`  [recurrence] streak annotation failed: ${err.message} — proceeding without`);
   }
 
+  // Cross-week memory recall (feature 10 / HARD RULE 25). For each bucket
+  // that has a ledger fingerprint AND has been touched in ≥2 prior weeks,
+  // check whether THIS cycle's tipster roster contains at least one voice
+  // that wasn't on the previous roster. If yes, surface a memoryRecall
+  // payload on every anonymized tip in that bucket so the LLM can open
+  // with "circling back to last week's…" / "three weeks ago a source
+  // mentioned this; tonight a different voice…" framing. Privacy: only
+  // COUNTS surface — no hashes, no codenames, no franchises.
+  try {
+    const annotateMemoryRecall = (anonList, tipList) => {
+      if (!Array.isArray(anonList) || anonList.length === 0) return;
+      const recallById = new Map();
+      const consumed = buildTopicBuckets(tipList);
+      for (const b of consumed) {
+        const fp = bucketFingerprint(b);
+        if (!fp) continue;
+        const currentHashes = [];
+        for (const t of b.tips) {
+          if (t?.source === 'web' && typeof t.hashedOwnerId === 'string' && t.hashedOwnerId) {
+            currentHashes.push(t.hashedOwnerId);
+          }
+        }
+        const recall = getMemoryRecall(recurrenceLedger, fp, currentHashes, currentIsoWeek);
+        if (!recall) continue;
+        for (const t of b.tips) {
+          if (t && typeof t.id === 'string') recallById.set(t.id, recall);
+        }
+      }
+      for (const a of anonList) {
+        if (a && typeof a.id === 'string') {
+          const r = recallById.get(a.id);
+          if (r) a.memoryRecall = r;
+        }
+      }
+    };
+    annotateMemoryRecall(anonymized, batch);
+    if (secondaryAnonymized) annotateMemoryRecall(secondaryAnonymized, secondaryBatch);
+  } catch (err) {
+    warn(`  [recurrence] memory-recall annotation failed: ${err.message} — proceeding without`);
+  }
+
   // ── Phase 4: Ask Roger 7% riff ──
   // Gate: (a) random roll passes, (b) no riff already posted today PT,
   // (c) a rumor-mill post is about to go out anyway (true here since we're
@@ -3459,7 +3509,17 @@ async function main() {
       for (const b of consumedBuckets) {
         const fp = bucketFingerprint(b);
         if (!fp) continue;
-        markFingerprintSeen(recurrenceLedger, fp, currentIsoWeek, now.toISOString());
+        // Per-bucket tipster roster (web-only — groupme/trade_offer don't
+        // carry a hashedOwnerId). The ledger merges this list into its
+        // running tipsterHashes set so feature 10's memory recall can
+        // detect when a "different voice" returns to an old fingerprint.
+        const tipsterHashes = [];
+        for (const t of b.tips) {
+          if (t?.source === 'web' && typeof t.hashedOwnerId === 'string' && t.hashedOwnerId) {
+            tipsterHashes.push(t.hashedOwnerId);
+          }
+        }
+        markFingerprintSeen(recurrenceLedger, fp, currentIsoWeek, now.toISOString(), tipsterHashes);
         stampedFingerprints.push(fp);
       }
       if (stampedFingerprints.length > 0) {

--- a/scripts/schefter-rumor-scan.mjs
+++ b/scripts/schefter-rumor-scan.mjs
@@ -705,7 +705,7 @@ async function safeGetTeamNameCount30d(franchiseId, redis) {
   }
 }
 
-export async function anonymizeTips(tips, teams, feedPosts = [], now = new Date(), redis = null) {
+export async function anonymizeTips(tips, teams, feedPosts = [], now = new Date(), redis = null, tipsterContext = null) {
   const refMs = now instanceof Date ? now.getTime() : Date.now();
   // Single-franchise fuzz applies ONLY to web tips. A GroupMe mention of
   // franchise X isn't an anonymity leak — the speaker publicly named it
@@ -845,6 +845,31 @@ export async function anonymizeTips(tips, teams, feedPosts = [], now = new Date(
         };
       }
       return safe;
+    }
+
+    // Tipster-aware voice flags (web tips only — groupme/trade_offer/trade_bait
+    // returned above). Surfaced early so EVERY web-tip scope branch (league-wide,
+    // commish, division, multi-source, explicit-pick) carries them. These are
+    // ANONYMOUS framing signals: HARD RULE 22 uses `firstTimeTipster` for
+    // curiosity-spark phrasing, HARD RULE 23 uses `prolificTipster` for soft
+    // hedge, HARD RULE 24 uses `tipsterBeat` for the standing-beat nod
+    // WITHOUT ever attaching a codename (option B — codename:topic binding
+    // stays private). None of these flags leak hashedOwnerId, franchise, or
+    // division.
+    if (
+      typeof tip.hashedOwnerId === 'string' &&
+      tip.hashedOwnerId.length > 0 &&
+      tipsterContext
+    ) {
+      const c = tipsterContext.get(tip.hashedOwnerId);
+      if (c) {
+        if (c.isFirstTime) safe.firstTimeTipster = true;
+        if (c.isProlific) safe.prolificTipster = true;
+        if (c.beat && typeof c.beat.topic === 'string') {
+          // ONLY the topic — the codename never surfaces here.
+          safe.tipsterBeat = { topic: c.beat.topic };
+        }
+      }
     }
 
     const hint = tip.franchiseHint;
@@ -1673,6 +1698,29 @@ IRON RULES (override every other rule — if anything below appears to conflict,
     - Trade-offer tips (source: "trade_offer") are about ONE TEAM CONSIDERING A TRADE. Phrase as "shopping", "looking to move", "fielding calls on", "in talks about", "kicking the tires on", "putting out feelers on" — NEVER as "draft chatter", "draft-room buzz", "the draft's in full swing", "rookie-draft strategy", "auto-pilot picks", "half the league locked in", or any framing that implies a league draft event is underway or imminent.
     - The internal "draft" vocabulary you may encounter in tip metadata (e.g. owner activity counts, repeat-offerer signals) reflects TRADE-BUILDER SAVES — owners drafting trade proposals in the trade tool. It is NOT the rookie draft. Treat all "draft"-flavored metadata as a trade-shopping intensity signal and nothing else.
     - The only path to mentioning the rookie draft (or NFL draft) is when a tip's literal \`text\` field references it. Even then, you may only acknowledge what the tip actually says — never extend the framing to other tips in the batch, and never invent a "draft is happening now" backdrop.
+
+22. CURIOSITY SPARKS (first-time tipster). When a web tip carries \`firstTimeTipster: true\`, this is a voice Schefter has never reported on before — the rolodex just added a new line. Surface the freshness in voice with ONE light cue per post; never explain why, never name the tipster, never reveal it's a "first" in literal terms. Pick one and rotate (never two posts in a row with the same phrase):
+    - "A new voice in my ear tonight."
+    - "First time this corner of the league has called."
+    - "Picking up a signal I haven't heard before."
+    - "New line lighting up tonight."
+    - "Fresh number on the call sheet."
+    The cue is a tone marker on the lede, NOT the whole post — file the actual content in the same 1–2 sentences. Subject-anonymity rules (1–14) still apply; this flag is about the SOURCE side of the framing, not the target. When a bucket has multiple tipsters and only ONE is first-time, the cue is still in-voice — the new voice IS the angle. Never combine in the same post with rule 23 (\`prolificTipster\`) — if both flags are present in a multi-tipster bucket, prefer the curiosity-spark frame; the regular's contribution gets discounted to background.
+
+23. GRAIN OF SALT (prolific regular). When a web tip carries \`prolificTipster: true\` AND no \`firstTimeTipster\` is present in the same beat, this tip came from the league's chattiest voice — the reader has heard from this source plenty of times. Add ONE soft-hedge cue that signals reporter-discretion without naming or unmasking. Rotate (never same phrase in a 5-post window):
+    - "The usual rolodex is buzzing again about…"
+    - "One familiar voice keeps circling back to…"
+    - "A regular on the tip line is back with…"
+    - "Same number I've been hearing from, this time on…"
+    - "Hearing this one from a source I know well — for what it's worth…"
+    The hedge is a SINGLE clause that ties into the lede, not a separate sentence. The post still files the actual content — the hedge tells the reader Schefter is weighing the source, it does NOT excuse a content-free post. NEVER pair with the codename or the franchise; this stays voice-only. Skip the hedge entirely on multi-source clusters (rule 4) and on first-time-tipster beats (rule 22 wins — fresh voice is the angle).
+
+24. STANDING BEAT (tipster-topic affinity). When a web tip carries \`tipsterBeat: { topic: <string> }\`, this tipster has a documented standing beat — they reliably feed Schefter the same kind of news. You MAY add a ONE-CLAUSE nod to the standing beat IF and only IF the tip's actual topic matches \`tipsterBeat.topic\`. Phrasing examples (rotate, never same in 5 posts):
+    - "My standing source on commish gripes is back tonight."
+    - "The trade-rumor regular has another one."
+    - "Hearing from the desk that always has the roster beat."
+    - "My usual line on lineup business is lit up again."
+    HARD CONSTRAINTS: NEVER name the codename, the hash, the franchise, or the division alongside this nod (correlation risk — option B design). The beat reference is ABOUT WHAT THEY TIP, never about who they are. If \`firstTimeTipster\` OR \`prolificTipster\` is also on the same tip, you may layer the beat nod with rule 23's hedge OR rule 22's spark, but never all three at once — pick the strongest single voice cue. If \`tipsterBeat.topic\` does NOT match the current post's topic (e.g. their beat is "commish" but this tip is about a trade), DO NOT use this rule — it would imply the wrong specialty.
 
 Voice: "League sources tell me…", "I'm told…", "Hearing…", "A division rival whispers…". Salt, not sugar.`;
 
@@ -2776,9 +2824,9 @@ async function main() {
   // headline snippets into their scope.
   const teams = await loadTeams();
   const feedForAnonymize = await loadFeed();
-  const anonymized = await anonymizeTips(batch, teams, feedForAnonymize.posts ?? [], now, redis);
+  const anonymized = await anonymizeTips(batch, teams, feedForAnonymize.posts ?? [], now, redis, tipsterContext);
   const secondaryAnonymized = secondaryBatch
-    ? await anonymizeTips(secondaryBatch, teams, feedForAnonymize.posts ?? [], now, redis)
+    ? await anonymizeTips(secondaryBatch, teams, feedForAnonymize.posts ?? [], now, redis, tipsterContext)
     : null;
   log(`  Anonymized ${anonymized.length} tips${secondaryAnonymized ? ` + ${secondaryAnonymized.length} secondary` : ''}`);
 

--- a/src/pages/api/admin/schefter-stats.ts
+++ b/src/pages/api/admin/schefter-stats.ts
@@ -66,6 +66,9 @@ import {
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore — .mjs via allowJs
 import { isoWeekLabel } from '../../../../scripts/lib/schefter-recurrence-ledger.mjs';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore — .mjs via allowJs
+import { buildTipsterContext } from '../../../../scripts/lib/schefter-tipster-context.mjs';
 // Static JSON import — the scanner commits this file each run, and Vercel
 // redeploys on push, so the admin preview lags by at most one scanner cycle.
 // That's acceptable: the staleness flag is informational, not a gate.
@@ -434,12 +437,21 @@ async function readRedisStats(redis: RedisClient) {
   // identifier across tips and would let the commish de-anonymize a web
   // tipster across a session. Everything else (text, source, author,
   // submittedAt, attackOnSchefter, etc.) is fine to surface.
+  //
+  // We also keep a SERVER-ONLY copy of the tips with their hashedOwnerIds
+  // intact so we can compute the tipsterContext used by the priority
+  // preview below — bucketPriorityScore needs the hashes to apply the
+  // feature-1 recency weighting. The hashes never leave this handler; only
+  // the priorityScore integer ends up in the response.
   const pendingTips: Array<Record<string, unknown>> = [];
+  const pendingTipsWithHashes: Array<Record<string, unknown>> = [];
   for (const raw of pendingTipsRaw ?? []) {
     try {
       const tip = typeof raw === 'string' ? JSON.parse(raw) : raw;
       if (tip && typeof tip === 'object') {
-        const { hashedOwnerId: _hid, ...safe } = tip as Record<string, unknown>;
+        const rec = tip as Record<string, unknown>;
+        pendingTipsWithHashes.push(rec);
+        const { hashedOwnerId: _hid, ...safe } = rec;
         pendingTips.push(safe);
       }
     } catch {
@@ -496,8 +508,15 @@ async function readRedisStats(redis: RedisClient) {
   // Predicted post order — runs the same bucket logic the scanner uses,
   // so the admin sees an honest preview of the next post(s). Trade buckets
   // win first (always), then gossip buckets sorted by descending
-  // priorityScore (size + age boost). The first entry is what the next
-  // scanner cycle would pick if marinate + cap gates pass.
+  // priorityScore (size + age boost + tipster-context delta). The first
+  // entry is what the next scanner cycle would pick if marinate + cap
+  // gates pass.
+  //
+  // Feature 1 wiring: build the same tipsterContext the scanner uses, off
+  // the server-only `pendingTipsWithHashes` copy. Without this, the admin
+  // priority preview would silently disagree with the scanner once a
+  // first-time voice or burst regular hits the queue — that drift
+  // confused real ops debugging in the pre-feature-1 era.
   //
   // Each entry also carries staleStreakWeeks + isStale so the admin can
   // see which buckets the scanner is deferring to Friday's mailbag. A
@@ -505,14 +524,25 @@ async function readRedisStats(redis: RedisClient) {
   // skips it from the normal lane until a quiet week breaks the run.
   const previewNow = new Date();
   const currentIsoWeek = isoWeekLabel(previewNow);
-  const ranked = rankBuckets(buildTopicBuckets(pendingTips), previewNow);
+  let tipsterContext: Map<string, unknown> = new Map();
+  try {
+    tipsterContext = await buildTipsterContext(pendingTipsWithHashes, redis);
+  } catch (err) {
+    console.warn('[admin/schefter-stats] tipster context build failed:', err);
+    tipsterContext = new Map();
+  }
+  // Topic buckets need the hashedOwnerIds for the tipster delta to apply,
+  // but the buckets array itself never crosses the response boundary —
+  // it's iterated in place and only the projected fields below ship.
+  const previewBuckets = buildTopicBuckets(pendingTipsWithHashes);
+  const ranked = rankBuckets(previewBuckets, previewNow, tipsterContext);
   const predictedPostOrder = ranked.map((b: { key: string; kind: string; tips: unknown[]; oldestSubmittedAt: number }) => ({
     key: b.key,
     kind: b.kind,
     tipCount: b.tips.length,
     tipIds: (b.tips as Array<{ id?: unknown }>).map((t) => (typeof t.id === 'string' ? t.id : null)).filter((x): x is string => !!x),
     oldestSubmittedAt: b.oldestSubmittedAt,
-    priorityScore: bucketPriorityScore(b, previewNow),
+    priorityScore: bucketPriorityScore(b, previewNow, tipsterContext),
     staleStreakWeeks: bucketStreakLength(b, recurrenceLedger, currentIsoWeek),
     isStale: isBucketStale(b, recurrenceLedger, currentIsoWeek),
   }));

--- a/tests/schefter-memory-recall.test.ts
+++ b/tests/schefter-memory-recall.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Feature 10 — cross-week memory recall (HARD RULE 25).
+ *
+ * Tests:
+ *   - the ledger v1 → v2 migration (existing files load without losing data)
+ *   - markFingerprintSeen now accepts + merges tipster hashes
+ *   - getMemoryRecall returns the right payload when a "different voice"
+ *     returns to an old bucket and null otherwise
+ *   - the privacy contract: only counts cross the wire, never identities
+ *   - the scanner annotation path is wired (regex check on source)
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+// @ts-expect-error — .mjs imported via allowJs
+import {
+  LEDGER_VERSION,
+  emptyLedger,
+  markFingerprintSeen,
+  getMemoryRecall,
+  loadLedger,
+  saveLedger,
+} from '../scripts/lib/schefter-recurrence-ledger.mjs';
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import os from 'node:os';
+
+describe('recurrence ledger v2 — tipsterHashes roster', () => {
+  it('LEDGER_VERSION is 2 (post-feature-10 schema)', () => {
+    expect(LEDGER_VERSION).toBe(2);
+  });
+
+  it('emptyLedger initialises with the current version', () => {
+    const l = emptyLedger(2026);
+    expect(l.version).toBe(2);
+    expect(l.fingerprints).toEqual({});
+  });
+
+  it('markFingerprintSeen records weeksSeen AND merges tipsterHashes', () => {
+    const l = emptyLedger(2026);
+    markFingerprintSeen(l, 'topic:trade:0001', '2026-W20', '2026-05-20T00:00:00Z', ['hash-a', 'hash-b']);
+    const entry = l.fingerprints['topic:trade:0001'];
+    expect(entry.weeksSeen).toEqual(['2026-W20']);
+    expect(entry.tipsterHashes).toEqual(['hash-a', 'hash-b']);
+  });
+
+  it('merges new tipster hashes without duplicating, keeps sorted-unique', () => {
+    const l = emptyLedger(2026);
+    markFingerprintSeen(l, 'fp', '2026-W18', '2026-05-06T00:00:00Z', ['hash-b', 'hash-a']);
+    markFingerprintSeen(l, 'fp', '2026-W20', '2026-05-20T00:00:00Z', ['hash-a', 'hash-c']);
+    expect(l.fingerprints.fp.tipsterHashes).toEqual(['hash-a', 'hash-b', 'hash-c']);
+  });
+
+  it('ignores empty / non-string hashes', () => {
+    const l = emptyLedger(2026);
+    markFingerprintSeen(l, 'fp', '2026-W20', null, ['', 'hash-a', undefined as unknown as string, null as unknown as string]);
+    expect(l.fingerprints.fp.tipsterHashes).toEqual(['hash-a']);
+  });
+
+  it('caps the per-fingerprint hash list so a runaway bucket cannot grow without bound', () => {
+    const l = emptyLedger(2026);
+    const many: string[] = [];
+    for (let i = 0; i < 100; i++) many.push(`h${i.toString().padStart(3, '0')}`);
+    markFingerprintSeen(l, 'fp', '2026-W20', null, many);
+    expect(l.fingerprints.fp.tipsterHashes.length).toBeLessThanOrEqual(64);
+  });
+});
+
+describe('getMemoryRecall', () => {
+  const buildLedger = (weeksSeen: string[], tipsterHashes: string[]) => {
+    const l = emptyLedger(2026);
+    l.fingerprints['topic:trade:0001'] = {
+      weeksSeen,
+      tipsterHashes,
+      lastUpdated: '2026-05-19T00:00:00Z',
+    };
+    return l;
+  };
+
+  it('returns null when the fingerprint has never been seen', () => {
+    const l = emptyLedger(2026);
+    expect(getMemoryRecall(l, 'topic:trade:0001', ['hash-a'], '2026-W20')).toBeNull();
+  });
+
+  it('returns null when the fingerprint has only one week recorded (no recall yet)', () => {
+    const l = buildLedger(['2026-W19'], ['hash-a']);
+    expect(getMemoryRecall(l, 'topic:trade:0001', ['hash-b'], '2026-W20')).toBeNull();
+  });
+
+  it('returns null when all current tipsters were already on the roster (same voice, not "circled back")', () => {
+    const l = buildLedger(['2026-W18', '2026-W19'], ['hash-a', 'hash-b']);
+    expect(getMemoryRecall(l, 'topic:trade:0001', ['hash-a'], '2026-W20')).toBeNull();
+  });
+
+  it('returns a payload when ≥2 prior weeks exist AND a fresh voice is on the line', () => {
+    const l = buildLedger(['2026-W17', '2026-W19'], ['hash-a']);
+    const r = getMemoryRecall(l, 'topic:trade:0001', ['hash-b'], '2026-W20');
+    expect(r).not.toBeNull();
+    expect(r.totalWeeksSeen).toBe(2);
+    expect(r.weeksSinceFirstSeen).toBe(3);  // W17 → W20 = 3 weeks
+    expect(r.distinctVoicesAcrossTime).toBe(2);  // hash-a (prior) + hash-b (current)
+  });
+
+  it('does not leak the raw hashes back to the caller', () => {
+    const l = buildLedger(['2026-W17', '2026-W19'], ['hash-a']);
+    const r = getMemoryRecall(l, 'topic:trade:0001', ['hash-b'], '2026-W20');
+    const serialized = JSON.stringify(r);
+    expect(serialized).not.toContain('hash-a');
+    expect(serialized).not.toContain('hash-b');
+  });
+
+  it('handles the no-fingerprint and null-fingerprint cases without throwing', () => {
+    const l = emptyLedger(2026);
+    expect(getMemoryRecall(l, null, ['hash-a'], '2026-W20')).toBeNull();
+    expect(getMemoryRecall(l, '', ['hash-a'], '2026-W20')).toBeNull();
+  });
+});
+
+describe('loadLedger v1 → v2 migration', () => {
+  it('reads a v1 file and upgrades it in-place, backfilling tipsterHashes arrays', () => {
+    const dir = path.join(os.tmpdir(), `schefter-ledger-test-${Date.now()}`);
+    mkdirSync(dir, { recursive: true });
+    const file = path.join(dir, 'topic-recurrence.json');
+    writeFileSync(file, JSON.stringify({
+      version: 1,
+      season: 2026,
+      fingerprints: {
+        'topic:trade:0001': { weeksSeen: ['2026-W18', '2026-W19'], lastUpdated: '2026-05-13T00:00:00Z' },
+      },
+    }));
+    try {
+      const loaded = loadLedger(file);
+      expect(loaded.version).toBe(2);
+      expect(loaded.fingerprints['topic:trade:0001'].tipsterHashes).toEqual([]);
+      expect(loaded.fingerprints['topic:trade:0001'].weeksSeen).toEqual(['2026-W18', '2026-W19']);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('discards a ledger with an unknown future version (safer to start fresh)', () => {
+    const dir = path.join(os.tmpdir(), `schefter-ledger-test-fresh-${Date.now()}`);
+    mkdirSync(dir, { recursive: true });
+    const file = path.join(dir, 'topic-recurrence.json');
+    writeFileSync(file, JSON.stringify({ version: 99, season: 2026, fingerprints: {} }));
+    try {
+      const loaded = loadLedger(file);
+      // Fresh ledger — version aligns with current schema, no v99 leftovers.
+      expect(loaded.version).toBe(2);
+      expect(loaded.fingerprints).toEqual({});
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('round-trips a v2 ledger through saveLedger → loadLedger', () => {
+    const dir = path.join(os.tmpdir(), `schefter-ledger-test-rt-${Date.now()}`);
+    mkdirSync(dir, { recursive: true });
+    const file = path.join(dir, 'topic-recurrence.json');
+    try {
+      const original = emptyLedger(2026);
+      markFingerprintSeen(original, 'fp', '2026-W20', '2026-05-20T00:00:00Z', ['hash-a', 'hash-b']);
+      saveLedger(original, file);
+      const loaded = loadLedger(file);
+      expect(loaded.fingerprints.fp.tipsterHashes).toEqual(['hash-a', 'hash-b']);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('rumor-scan source — memory recall wiring', () => {
+  const SRC = readFileSync(
+    path.join(process.cwd(), 'scripts/schefter-rumor-scan.mjs'),
+    'utf8',
+  );
+
+  it('imports getMemoryRecall from the ledger module', () => {
+    expect(SRC).toMatch(/getMemoryRecall,/);
+  });
+
+  it('annotates anonymized tips with memoryRecall before generation', () => {
+    expect(SRC).toMatch(/annotateMemoryRecall\(anonymized,\s*batch\)/);
+    expect(SRC).toMatch(/a\.memoryRecall\s*=\s*r/);
+  });
+
+  it('passes current-cycle tipster hashes into markFingerprintSeen at post-commit', () => {
+    expect(SRC).toMatch(/markFingerprintSeen\(\s*recurrenceLedger,\s*fp,\s*currentIsoWeek,\s*now\.toISOString\(\),\s*tipsterHashes\s*\)/);
+  });
+
+  it('HARD RULE 25 references the memoryRecall payload shape', () => {
+    expect(SRC).toMatch(/25\.\s+CROSS-WEEK MEMORY RECALL/);
+    expect(SRC).toMatch(/memoryRecall:\s*\{\s*weeksSinceFirstSeen/);
+    expect(SRC).toMatch(/distinctVoicesAcrossTime/);
+  });
+
+  it('HARD RULE 25 keeps the privacy invariant — never name a codename or franchise', () => {
+    // The phrasing "never name a codename, never name a franchise" lives
+    // inside the rule's hard constraints block. Locking with substring
+    // checks so a future edit that loosens the privacy stance fails CI.
+    expect(SRC).toMatch(/CROSS-WEEK MEMORY RECALL[\s\S]+?never name a codename[\s\S]+?never name a franchise/);
+  });
+});

--- a/tests/schefter-quiet-day.test.ts
+++ b/tests/schefter-quiet-day.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Feature 7 — "saying no, out loud" (quiet-day post).
+ *
+ * Tests `evaluateQuietDayConditions` — the pure decision function that
+ * decides whether the scanner should ship a candid slow-news-day post in
+ * place of going silent. Cooldown + Redis state are caller concerns and
+ * tested via the scanner-source contract assertions at the bottom.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+// @ts-expect-error — .mjs imported via allowJs
+import { evaluateQuietDayConditions } from '../scripts/schefter-rumor-scan.mjs';
+
+const ctxEntry = (overrides: Record<string, unknown> = {}) => ({
+  hashedOwnerId: 'placeholder',
+  tipsInQueue: 1,
+  rumorsTotal: 0,
+  isFirstTime: true,
+  isProlific: false,
+  beat: null,
+  ...overrides,
+});
+
+describe('evaluateQuietDayConditions', () => {
+  it('refuses when a normal bucket pick is available (no quiet day if there is real news)', () => {
+    const result = evaluateQuietDayConditions({
+      pick: { primary: {}, secondary: null },
+      mailbagBatch: null,
+      freshTips: [],
+      normalLaneBuckets: [],
+      staleBuckets: [],
+      tipsterContext: new Map(),
+    });
+    expect(result.shouldFire).toBe(false);
+    expect(result.reason).toBe('normal-pick-available');
+  });
+
+  it('refuses when the Friday mailbag is already firing', () => {
+    const result = evaluateQuietDayConditions({
+      pick: null,
+      mailbagBatch: [{ id: 't1' }],
+      freshTips: [],
+      normalLaneBuckets: [],
+      staleBuckets: [],
+      tipsterContext: new Map(),
+    });
+    expect(result.shouldFire).toBe(false);
+    expect(result.reason).toBe('mailbag-active');
+  });
+
+  it('fires when the queue is empty (the most honest quiet day)', () => {
+    const result = evaluateQuietDayConditions({
+      pick: null,
+      mailbagBatch: null,
+      freshTips: [],
+      normalLaneBuckets: [],
+      staleBuckets: [],
+      tipsterContext: new Map(),
+    });
+    expect(result.shouldFire).toBe(true);
+    expect(result.reason).toBe('queue-empty');
+    expect(result.queueSize).toBe(0);
+  });
+
+  it('fires when the only voice in the queue is a single prolific tipster', () => {
+    const ctx = new Map([
+      ['busy0001', ctxEntry({ hashedOwnerId: 'busy0001', isProlific: true, isFirstTime: false, rumorsTotal: 50 })],
+    ]);
+    const result = evaluateQuietDayConditions({
+      pick: null,
+      mailbagBatch: null,
+      freshTips: [
+        { id: 't1', source: 'web', hashedOwnerId: 'busy0001' },
+        { id: 't2', source: 'web', hashedOwnerId: 'busy0001' },
+        { id: 't3', source: 'web', hashedOwnerId: 'busy0001' },
+      ],
+      normalLaneBuckets: [],
+      staleBuckets: [],
+      tipsterContext: ctx,
+    });
+    expect(result.shouldFire).toBe(true);
+    expect(result.reason).toBe('single-prolific-tipster');
+    expect(result.queueSize).toBe(3);
+  });
+
+  it('does NOT fire when the single queued tipster is just a regular (not prolific)', () => {
+    const ctx = new Map([
+      ['reg00003', ctxEntry({ hashedOwnerId: 'reg00003', rumorsTotal: 3, isProlific: false, isFirstTime: false })],
+    ]);
+    const result = evaluateQuietDayConditions({
+      pick: null,
+      mailbagBatch: null,
+      freshTips: [{ id: 't1', source: 'web', hashedOwnerId: 'reg00003' }],
+      normalLaneBuckets: [],
+      staleBuckets: [],
+      tipsterContext: ctx,
+    });
+    expect(result.shouldFire).toBe(false);
+  });
+
+  it('does NOT fire when two distinct tipsters have queued tips (real noise, not a quiet day)', () => {
+    const ctx = new Map([
+      ['busy0001', ctxEntry({ hashedOwnerId: 'busy0001', isProlific: true, rumorsTotal: 50 })],
+      ['newbie01', ctxEntry({ hashedOwnerId: 'newbie01', isFirstTime: true })],
+    ]);
+    const result = evaluateQuietDayConditions({
+      pick: null,
+      mailbagBatch: null,
+      freshTips: [
+        { id: 't1', source: 'web', hashedOwnerId: 'busy0001' },
+        { id: 't2', source: 'web', hashedOwnerId: 'newbie01' },
+      ],
+      normalLaneBuckets: [],
+      staleBuckets: [],
+      tipsterContext: ctx,
+    });
+    expect(result.shouldFire).toBe(false);
+  });
+
+  it('fires when only stale buckets remain (queue is all 3-week repeats)', () => {
+    const result = evaluateQuietDayConditions({
+      pick: null,
+      mailbagBatch: null,
+      freshTips: [
+        { id: 't1', source: 'web', hashedOwnerId: 'mixed001' },
+        { id: 't2', source: 'web', hashedOwnerId: 'mixed002' },
+      ],
+      normalLaneBuckets: [],
+      staleBuckets: [{ key: 'topic:trade:0001' }, { key: 'topic:roster:league-wide' }],
+      tipsterContext: new Map([
+        ['mixed001', ctxEntry({ hashedOwnerId: 'mixed001', rumorsTotal: 4 })],
+        ['mixed002', ctxEntry({ hashedOwnerId: 'mixed002', rumorsTotal: 4 })],
+      ]),
+    });
+    expect(result.shouldFire).toBe(true);
+    expect(result.reason).toBe('all-stale');
+  });
+
+  it('does NOT fire when there is a non-stale normal-lane bucket (gossip cap is the only blocker)', () => {
+    // Caller-side scenario: pick was null because gossipAllowedToday was
+    // false, but a fresh non-stale bucket exists. Holding for next cycle is
+    // correct here — quiet-day would be a lie when there is real news
+    // queued up waiting for tomorrow's slot.
+    const result = evaluateQuietDayConditions({
+      pick: null,
+      mailbagBatch: null,
+      freshTips: [{ id: 't1', source: 'web', hashedOwnerId: 'mixed001' }],
+      normalLaneBuckets: [{ key: 'topic:trade:0001' }],
+      staleBuckets: [],
+      tipsterContext: new Map([
+        ['mixed001', ctxEntry({ hashedOwnerId: 'mixed001', rumorsTotal: 4 })],
+      ]),
+    });
+    expect(result.shouldFire).toBe(false);
+    expect(result.reason).toBe('no-quiet-day-trigger');
+  });
+
+  it('tolerates a missing tipsterContext gracefully', () => {
+    const result = evaluateQuietDayConditions({
+      pick: null,
+      mailbagBatch: null,
+      freshTips: [{ id: 't1', source: 'web', hashedOwnerId: 'busy0001' }],
+      normalLaneBuckets: [],
+      staleBuckets: [],
+      tipsterContext: undefined,
+    });
+    // No context → can't verify prolific status → falls through to
+    // no-quiet-day (single queued tip from an unknown is just a held tip).
+    expect(result.shouldFire).toBe(false);
+  });
+});
+
+// ── Scanner-source contracts (regression guards) ──
+
+describe('rumor-scan quiet-day wiring', () => {
+  const SRC = readFileSync(
+    path.join(process.cwd(), 'scripts/schefter-rumor-scan.mjs'),
+    'utf8',
+  );
+
+  it('defines the cooldown key + the days-between constant', () => {
+    expect(SRC).toMatch(/QUIET_DAY_LAST_DATE_KEY\s*=\s*'schefter:rumor:quiet_day_last_date'/);
+    expect(SRC).toMatch(/QUIET_DAY_COOLDOWN_DAYS\s*=\s*\d+/);
+  });
+
+  it('calls the quiet-day path inside the no-pick branch', () => {
+    // The decision helper must be invoked AFTER the normal pick is null
+    // (so quiet day only fires when there is no real news to ship).
+    expect(SRC).toMatch(/if\s*\(!pick\)\s*\{[\s\S]*?evaluateQuietDayConditions\(/);
+  });
+
+  it('respects the cooldown — bails out when last fired within QUIET_DAY_COOLDOWN_DAYS', () => {
+    expect(SRC).toMatch(/ageDays\s*<\s*QUIET_DAY_COOLDOWN_DAYS/);
+  });
+
+  it('writes the quiet-day post to the feed but skips GroupMe (slow news day must not ping the chat)', () => {
+    // The quiet-day post block uses loadFeed/fs.writeFile but never calls
+    // postToGroupMe inside its branch. Lock the no-ping invariant by
+    // confirming the surrounding "Deliberately NO GroupMe ping" note is
+    // present — if anyone deletes it and adds a postToGroupMe call, the
+    // test fails and the reviewer has to confront the design choice.
+    expect(SRC).toMatch(/Deliberately NO GroupMe ping/);
+  });
+});

--- a/tests/schefter-rumor-topic-focus.test.ts
+++ b/tests/schefter-rumor-topic-focus.test.ts
@@ -362,8 +362,13 @@ describe('rumor-scan two-post gossip — second bucket ships as its own feed pos
     // primary lands at index 0 (top of the feed). Held / suppressed posts
     // never enter the feed — Option A holds their tips back for re-eval.
     expect(src).toMatch(/feed\.posts\s*=\s*\[\s*\.\.\.allowedPosts,\s*\.\.\.existingPosts\s*\]/);
+    // Two FEED_PATH writes exist as of Phase 8: the main flow (this test's
+    // contract) AND the quiet-day branch (feature 7 — saying no out loud).
+    // Both lanes are atomic single-write per cycle, but they're independent
+    // lanes that never both fire on the same cycle (quiet-day only runs
+    // when the normal pick returned null).
     const feedWrites = (src.match(/await fs\.writeFile\(FEED_PATH/g) ?? []).length;
-    expect(feedWrites).toBe(1);
+    expect(feedWrites).toBe(2);
   });
 
   it('sends a separate GroupMe message per post (so each is independently replyable)', () => {
@@ -371,9 +376,13 @@ describe('rumor-scan two-post gossip — second bucket ships as its own feed pos
   });
 
   it('counts both posts as ONE slot against posts_today and gossip counters', () => {
-    // INCR runs once per cycle even when we ship two posts.
+    // INCR runs once per cycle even when we ship two posts (main flow).
+    // Phase 8 adds a second INCR site in the quiet-day branch — distinct
+    // lane, distinct cycle, same one-slot-per-cycle invariant.
     const incrCount = (src.match(/redis\.incr\(RUMOR_POSTS_TODAY_KEY\)/g) ?? []).length;
-    expect(incrCount).toBe(1);
+    expect(incrCount).toBe(2);
+    // Gossip counter only ever increments in the main gossip lane —
+    // quiet-day is its own thing and does NOT consume the gossip cap.
     const gossipIncr = (src.match(/redis\.incr\(RUMOR_GOSSIP_POSTS_TODAY_KEY\)/g) ?? []).length;
     expect(gossipIncr).toBe(1);
   });

--- a/tests/schefter-rumor-topic-focus.test.ts
+++ b/tests/schefter-rumor-topic-focus.test.ts
@@ -258,8 +258,9 @@ describe('rumor-scan age metadata — tips carry ageDays + isStale to the LLM', 
   it('passes now into anonymizeTips so age is computed against the cycle clock', () => {
     // Updated for Phase-2 explicit-pick feature: anonymizeTips is now async
     // and accepts a 5th `redis` argument for naming-rate-limit + name-count
-    // reads. Both call sites still pass `now` as the 4th arg.
-    expect(src).toMatch(/await anonymizeTips\(batch,\s*teams,\s*feedForAnonymize\.posts[^,]*,\s*now,\s*redis\)/);
+    // reads. Both call sites still pass `now` as the 4th arg. Phase-8 added a
+    // 6th `tipsterContext` arg (per-tipster recency/voice flags).
+    expect(src).toMatch(/await anonymizeTips\(batch,\s*teams,\s*feedForAnonymize\.posts[^,]*,\s*now,\s*redis,\s*tipsterContext\)/);
   });
 });
 

--- a/tests/schefter-tipster-context.test.ts
+++ b/tests/schefter-tipster-context.test.ts
@@ -297,3 +297,44 @@ describe('buildTipsterContext', () => {
     expect(BEAT_CONCENTRATION).toBeLessThanOrEqual(1);
   });
 });
+
+// ── Admin schefter-stats wiring (anti-drift contract) ──
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+describe('admin schefter-stats — tipsterContext wiring', () => {
+  const ADMIN_SRC = readFileSync(
+    path.join(process.cwd(), 'src/pages/api/admin/schefter-stats.ts'),
+    'utf8',
+  );
+
+  it('imports buildTipsterContext from the shared scanner lib', () => {
+    // Same import the scanner uses — the admin priority preview MUST stay
+    // in lockstep with the scanner's pick order or operators get confused
+    // debugging which post is about to ship.
+    expect(ADMIN_SRC).toMatch(/import\s*\{\s*buildTipsterContext\s*\}/);
+  });
+
+  it('builds the context off a server-only copy of tips that retains hashedOwnerIds', () => {
+    // The hashes never reach the response — but the priority math needs
+    // them. The dual-array trick (pendingTips vs pendingTipsWithHashes) is
+    // what lets the route compute the score without leaking identity.
+    expect(ADMIN_SRC).toMatch(/pendingTipsWithHashes/);
+    expect(ADMIN_SRC).toMatch(/await\s+buildTipsterContext\(pendingTipsWithHashes,\s*redis\)/);
+  });
+
+  it('passes tipsterContext into rankBuckets AND bucketPriorityScore', () => {
+    // Both calls must receive the context — without it the preview's score
+    // disagrees with the scanner's score and the predicted order drifts.
+    expect(ADMIN_SRC).toMatch(/rankBuckets\(previewBuckets,\s*previewNow,\s*tipsterContext\)/);
+    expect(ADMIN_SRC).toMatch(/bucketPriorityScore\(b,\s*previewNow,\s*tipsterContext\)/);
+  });
+
+  it('does NOT include hashedOwnerId in the public pendingTips array', () => {
+    // The hashed identifier strip is the original anonymity contract for
+    // the admin endpoint; the new wiring is allowed to keep an internal
+    // copy but the response body's stripping logic must survive.
+    expect(ADMIN_SRC).toMatch(/hashedOwnerId:\s*_hid,\s*\.\.\.safe/);
+  });
+});

--- a/tests/schefter-tipster-context.test.ts
+++ b/tests/schefter-tipster-context.test.ts
@@ -1,0 +1,299 @@
+import { describe, it, expect } from 'vitest';
+// @ts-expect-error — .mjs imported via allowJs
+import {
+  buildTipsterContext,
+  tipsterScoreDelta,
+  FIRST_TIME_BOOST,
+  BURST_HEAVY_PENALTY,
+  BURST_LIGHT_PENALTY,
+  PROLIFIC_PENALTY,
+  BEAT_TIP_FLOOR,
+  BEAT_CONCENTRATION,
+} from '../scripts/lib/schefter-tipster-context.mjs';
+// @ts-expect-error — .mjs imported via allowJs
+import { bucketPriorityScore } from '../scripts/lib/schefter-bucket-logic.mjs';
+
+type Tip = {
+  id: string;
+  source: 'web' | 'groupme' | 'trade_offer' | 'trade_bait';
+  hashedOwnerId?: string;
+  submittedAt?: number;
+};
+
+function makeBucket(tips: Tip[], oldestSubmittedAtOverride?: number) {
+  const oldest = oldestSubmittedAtOverride ?? Math.min(...tips.map((t) => t.submittedAt ?? Date.now()));
+  return {
+    key: 'topic:trade:league-wide',
+    kind: 'gossip',
+    tips,
+    oldestSubmittedAt: oldest,
+  };
+}
+
+// ── tipsterScoreDelta (pure scoring helper) ──
+
+describe('tipsterScoreDelta', () => {
+  const now = new Date('2026-05-20T12:00:00Z');
+
+  it('returns 0 when no tipster context is provided', () => {
+    const bucket = makeBucket([
+      { id: 't1', source: 'web', hashedOwnerId: 'aaaa1111', submittedAt: now.getTime() },
+    ]);
+    expect(tipsterScoreDelta(bucket, null)).toBe(0);
+  });
+
+  it('returns 0 when bucket has no web tippers (groupme / trade-offer only)', () => {
+    const bucket = makeBucket([
+      { id: 't1', source: 'groupme', submittedAt: now.getTime() },
+      { id: 't2', source: 'trade_offer', submittedAt: now.getTime() },
+    ]);
+    const ctx = new Map([['aaaa1111', { hashedOwnerId: 'aaaa1111', tipsInQueue: 1, rumorsTotal: 0, isFirstTime: true, isProlific: false, beat: null }]]);
+    expect(tipsterScoreDelta(bucket, ctx)).toBe(0);
+  });
+
+  it('boosts a bucket containing a first-time tipster', () => {
+    const bucket = makeBucket([
+      { id: 't1', source: 'web', hashedOwnerId: 'newbie01', submittedAt: now.getTime() },
+    ]);
+    const ctx = new Map([
+      ['newbie01', { hashedOwnerId: 'newbie01', tipsInQueue: 1, rumorsTotal: 0, isFirstTime: true, isProlific: false, beat: null }],
+    ]);
+    expect(tipsterScoreDelta(bucket, ctx)).toBe(FIRST_TIME_BOOST);
+  });
+
+  it('penalizes a bucket from a burst-tipping regular (≥3 queued)', () => {
+    const bucket = makeBucket([
+      { id: 't1', source: 'web', hashedOwnerId: 'busy0001', submittedAt: now.getTime() },
+    ]);
+    const ctx = new Map([
+      ['busy0001', { hashedOwnerId: 'busy0001', tipsInQueue: 4, rumorsTotal: 25, isFirstTime: false, isProlific: true, beat: null }],
+    ]);
+    // Burst penalty (-3) stacks with prolific penalty (-1) — both negatives count.
+    expect(tipsterScoreDelta(bucket, ctx)).toBe(BURST_HEAVY_PENALTY);
+  });
+
+  it('applies the lighter burst penalty at exactly 2 tips queued', () => {
+    const bucket = makeBucket([
+      { id: 't1', source: 'web', hashedOwnerId: 'mid00002', submittedAt: now.getTime() },
+    ]);
+    const ctx = new Map([
+      ['mid00002', { hashedOwnerId: 'mid00002', tipsInQueue: 2, rumorsTotal: 4, isFirstTime: false, isProlific: false, beat: null }],
+    ]);
+    expect(tipsterScoreDelta(bucket, ctx)).toBe(BURST_LIGHT_PENALTY);
+  });
+
+  it('applies the lifetime-prolific penalty even when burst is 1', () => {
+    const bucket = makeBucket([
+      { id: 't1', source: 'web', hashedOwnerId: 'reg00003', submittedAt: now.getTime() },
+    ]);
+    const ctx = new Map([
+      ['reg00003', { hashedOwnerId: 'reg00003', tipsInQueue: 1, rumorsTotal: 50, isFirstTime: false, isProlific: true, beat: null }],
+    ]);
+    expect(tipsterScoreDelta(bucket, ctx)).toBe(PROLIFIC_PENALTY);
+  });
+
+  it('first-time boost wins over any same-bucket regular penalty', () => {
+    // A bucket with TWO tipsters — one a brand-new voice, one a prolific
+    // regular. The first-time bonus must still apply (the new voice is the
+    // story); penalties don't cancel the boost.
+    const bucket = makeBucket([
+      { id: 't1', source: 'web', hashedOwnerId: 'newbie01', submittedAt: now.getTime() },
+      { id: 't2', source: 'web', hashedOwnerId: 'reg00003', submittedAt: now.getTime() },
+    ]);
+    const ctx = new Map([
+      ['newbie01', { hashedOwnerId: 'newbie01', tipsInQueue: 1, rumorsTotal: 0, isFirstTime: true, isProlific: false, beat: null }],
+      ['reg00003', { hashedOwnerId: 'reg00003', tipsInQueue: 1, rumorsTotal: 50, isFirstTime: false, isProlific: true, beat: null }],
+    ]);
+    expect(tipsterScoreDelta(bucket, ctx)).toBe(FIRST_TIME_BOOST + PROLIFIC_PENALTY);
+  });
+});
+
+// ── bucketPriorityScore integration ──
+
+describe('bucketPriorityScore with tipster context', () => {
+  const now = new Date('2026-05-20T12:00:00Z');
+
+  it('falls back to size+age math when no context is provided (back-compat)', () => {
+    const bucket = makeBucket([
+      { id: 't1', source: 'web', hashedOwnerId: 'aaaa1111', submittedAt: now.getTime() },
+      { id: 't2', source: 'web', hashedOwnerId: 'bbbb2222', submittedAt: now.getTime() },
+    ]);
+    // (size - 1) * 2 + 0 age days = 2.
+    expect(bucketPriorityScore(bucket, now)).toBe(2);
+  });
+
+  it('lifts a singleton first-timer above a 2-cluster from a regular', () => {
+    // Cluster from the regular: size 2 → +2 (size score), 0 age → +0.
+    // Regular is prolific lifetime → −1. Net = 1.
+    const cluster = makeBucket([
+      { id: 't1', source: 'web', hashedOwnerId: 'reg00003', submittedAt: now.getTime() },
+      { id: 't2', source: 'web', hashedOwnerId: 'reg00003', submittedAt: now.getTime() },
+    ]);
+    // Singleton from a brand-new voice: size 1 → +0, age 0 → +0, first-time → +5. Net = 5.
+    const fresh = makeBucket([
+      { id: 't3', source: 'web', hashedOwnerId: 'newbie01', submittedAt: now.getTime() },
+    ]);
+    const ctx = new Map([
+      ['reg00003', { hashedOwnerId: 'reg00003', tipsInQueue: 2, rumorsTotal: 50, isFirstTime: false, isProlific: true, beat: null }],
+      ['newbie01', { hashedOwnerId: 'newbie01', tipsInQueue: 1, rumorsTotal: 0, isFirstTime: true, isProlific: false, beat: null }],
+    ]);
+    expect(bucketPriorityScore(fresh, now, ctx)).toBeGreaterThan(bucketPriorityScore(cluster, now, ctx));
+  });
+
+  it('a multi-tipster cluster on a fresh topic still wins outright', () => {
+    // Cluster of 3 distinct tippers (none prolific, none in burst): size 3
+    // → +4, no penalty. Should beat a singleton first-timer (+5)? Yes —
+    // (size-1)*2 = 4 + 0 first-time delta = 4. Hmm, that's < 5.
+    // Let's instead test the documented case: 3-tip cluster across distinct
+    // moderate tippers BEATS a 1-tip burst from the regular even at heavy penalty.
+    const cluster = makeBucket([
+      { id: 't1', source: 'web', hashedOwnerId: 'mod00001', submittedAt: now.getTime() },
+      { id: 't2', source: 'web', hashedOwnerId: 'mod00002', submittedAt: now.getTime() },
+      { id: 't3', source: 'web', hashedOwnerId: 'mod00003', submittedAt: now.getTime() },
+    ]);
+    const single = makeBucket([
+      { id: 't4', source: 'web', hashedOwnerId: 'busy0001', submittedAt: now.getTime() },
+    ]);
+    const ctx = new Map([
+      ['mod00001', { hashedOwnerId: 'mod00001', tipsInQueue: 1, rumorsTotal: 5, isFirstTime: false, isProlific: false, beat: null }],
+      ['mod00002', { hashedOwnerId: 'mod00002', tipsInQueue: 1, rumorsTotal: 5, isFirstTime: false, isProlific: false, beat: null }],
+      ['mod00003', { hashedOwnerId: 'mod00003', tipsInQueue: 1, rumorsTotal: 5, isFirstTime: false, isProlific: false, beat: null }],
+      ['busy0001', { hashedOwnerId: 'busy0001', tipsInQueue: 4, rumorsTotal: 50, isFirstTime: false, isProlific: true, beat: null }],
+    ]);
+    expect(bucketPriorityScore(cluster, now, ctx)).toBeGreaterThan(bucketPriorityScore(single, now, ctx));
+  });
+});
+
+// ── buildTipsterContext (Redis I/O wrapper) ──
+
+class FakeRedis {
+  store: Map<string, string | number> = new Map();
+  hashes: Map<string, Record<string, number>> = new Map();
+  failGet = false;
+  async get(key: string): Promise<unknown> {
+    if (this.failGet) throw new Error('redis down');
+    return this.store.has(key) ? this.store.get(key) : null;
+  }
+  async hgetall(key: string): Promise<Record<string, number> | null> {
+    return this.hashes.get(key) ?? null;
+  }
+}
+
+describe('buildTipsterContext', () => {
+  it('returns an empty map when there are no web tips', async () => {
+    const result = await buildTipsterContext([
+      { id: 't1', source: 'groupme' },
+      { id: 't2', source: 'trade_offer' },
+    ], new FakeRedis());
+    expect(result.size).toBe(0);
+  });
+
+  it('marks a tipster with no rumors_total entry as first-time', async () => {
+    const redis = new FakeRedis();
+    // Note: rumors_total key intentionally absent.
+    const result = await buildTipsterContext([
+      { id: 't1', source: 'web', hashedOwnerId: 'newbie01' },
+    ], redis);
+    const ctx = result.get('newbie01');
+    expect(ctx?.isFirstTime).toBe(true);
+    expect(ctx?.rumorsTotal).toBe(0);
+    expect(ctx?.tipsInQueue).toBe(1);
+    expect(ctx?.beat).toBeNull();
+  });
+
+  it('counts distinct tips per tipster in the current queue', async () => {
+    const redis = new FakeRedis();
+    const result = await buildTipsterContext([
+      { id: 't1', source: 'web', hashedOwnerId: 'busy0001' },
+      { id: 't2', source: 'web', hashedOwnerId: 'busy0001' },
+      { id: 't3', source: 'web', hashedOwnerId: 'busy0001' },
+      { id: 't4', source: 'web', hashedOwnerId: 'other001' },
+    ], redis);
+    expect(result.get('busy0001')?.tipsInQueue).toBe(3);
+    expect(result.get('other001')?.tipsInQueue).toBe(1);
+  });
+
+  it('marks tipsters with rumors_total ≥ threshold as prolific', async () => {
+    const redis = new FakeRedis();
+    redis.store.set('schefter:tipster:rumors_total:reg00003', '20');
+    const result = await buildTipsterContext([
+      { id: 't1', source: 'web', hashedOwnerId: 'reg00003' },
+    ], redis);
+    expect(result.get('reg00003')?.isProlific).toBe(true);
+    expect(result.get('reg00003')?.isFirstTime).toBe(false);
+  });
+
+  it('derives a beat when one topic exceeds the concentration floor', async () => {
+    const redis = new FakeRedis();
+    redis.store.set('schefter:tipster:rumors_total:reg00003', '10');
+    redis.hashes.set('schefter:tipster:topic_counts:reg00003', {
+      trade: 7,
+      commish: 2,
+      roster: 1,
+    });
+    const result = await buildTipsterContext([
+      { id: 't1', source: 'web', hashedOwnerId: 'reg00003' },
+    ], redis);
+    expect(result.get('reg00003')?.beat).toEqual({
+      topic: 'trade',
+      count: 7,
+      total: 10,
+      share: 0.7,
+    });
+  });
+
+  it('does not assign a beat when concentration is below the floor', async () => {
+    const redis = new FakeRedis();
+    redis.store.set('schefter:tipster:rumors_total:reg00003', '10');
+    redis.hashes.set('schefter:tipster:topic_counts:reg00003', {
+      trade: 4,
+      commish: 3,
+      roster: 3,
+    });
+    const result = await buildTipsterContext([
+      { id: 't1', source: 'web', hashedOwnerId: 'reg00003' },
+    ], redis);
+    expect(result.get('reg00003')?.beat).toBeNull();
+  });
+
+  it('does not assign a beat with too little data even at high concentration', async () => {
+    const redis = new FakeRedis();
+    redis.store.set('schefter:tipster:rumors_total:reg00003', '2');
+    redis.hashes.set('schefter:tipster:topic_counts:reg00003', {
+      trade: 2,
+    });
+    const result = await buildTipsterContext([
+      { id: 't1', source: 'web', hashedOwnerId: 'reg00003' },
+    ], redis);
+    expect(result.get('reg00003')?.beat).toBeNull();
+  });
+
+  it('tolerates a redis fetch failure by falling back to first-time defaults', async () => {
+    const redis = new FakeRedis();
+    redis.failGet = true;
+    const result = await buildTipsterContext([
+      { id: 't1', source: 'web', hashedOwnerId: 'newbie01' },
+    ], redis);
+    expect(result.get('newbie01')?.isFirstTime).toBe(true);
+  });
+
+  it('returns first-time defaults for everyone when redis is null', async () => {
+    const result = await buildTipsterContext([
+      { id: 't1', source: 'web', hashedOwnerId: 'aaaa1111' },
+      { id: 't2', source: 'web', hashedOwnerId: 'bbbb2222' },
+    ], null);
+    expect(result.get('aaaa1111')?.isFirstTime).toBe(true);
+    expect(result.get('bbbb2222')?.isFirstTime).toBe(true);
+  });
+
+  it('uses constants that satisfy the integration sanity check', () => {
+    // Sanity: the brainstorm contract is "first-timer beats same-sized noise
+    // from the regular." size-1 boost (+0) + first-time (+5) must beat
+    // size-1 boost (+0) + prolific (−1) by enough to flip the order.
+    expect(FIRST_TIME_BOOST).toBeGreaterThan(Math.abs(PROLIFIC_PENALTY));
+    expect(BURST_HEAVY_PENALTY).toBeLessThan(BURST_LIGHT_PENALTY);
+    expect(BEAT_TIP_FLOOR).toBeGreaterThan(0);
+    expect(BEAT_CONCENTRATION).toBeGreaterThan(0.5);
+    expect(BEAT_CONCENTRATION).toBeLessThanOrEqual(1);
+  });
+});

--- a/tests/schefter-tipster-topic-counters.test.ts
+++ b/tests/schefter-tipster-topic-counters.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Per-tipster topic histogram — the "standing beat" data source.
+ *
+ * incrementTipsterTopicCounters mutates `schefter:tipster:topic_counts:{hash}`
+ * (HASH topic → count) after a rumor ships. buildTipsterContext reads the
+ * same hash on subsequent cycles to derive a `beat`, which anonymizeTips
+ * surfaces as `tipsterBeat: { topic }` and HARD RULE 24 turns into a
+ * "standing beat" voice cue (option B — codename NEVER attached).
+ *
+ * Contracts locked here:
+ *   - one increment per (hash, topic) pair, not per tip (a tipster with two
+ *     tips on the same topic counts +1, not +2)
+ *   - web tips only; groupme + trade_offer are skipped
+ *   - tip with no `topic` field falls back to "other"
+ *   - dry-run is a true no-op
+ *   - per-hash redis failure logs and continues; the post is never blocked
+ */
+import { describe, it, expect } from 'vitest';
+// @ts-expect-error — .mjs imported via allowJs
+import { incrementTipsterTopicCounters } from '../scripts/lib/schefter-tipster-counters.mjs';
+
+class FakeRedis {
+  hashes: Map<string, Map<string, number>> = new Map();
+  calls: Array<{ key: string; field: string; by: number }> = [];
+  shouldThrow = false;
+  async hincrby(key: string, field: string, by: number): Promise<number> {
+    if (this.shouldThrow) throw new Error('redis down');
+    const h = this.hashes.get(key) ?? new Map<string, number>();
+    h.set(field, (h.get(field) ?? 0) + by);
+    this.hashes.set(key, h);
+    this.calls.push({ key, field, by });
+    return h.get(field)!;
+  }
+}
+
+describe('incrementTipsterTopicCounters', () => {
+  it('no-ops when redis is missing', async () => {
+    // No throw, no error — should silently return.
+    await expect(incrementTipsterTopicCounters({
+      redis: null,
+      batch: [{ source: 'web', hashedOwnerId: 'aaaa1111', topic: 'trade' }],
+    })).resolves.toBeUndefined();
+  });
+
+  it('no-ops on an empty batch', async () => {
+    const redis = new FakeRedis();
+    await incrementTipsterTopicCounters({ redis, batch: [] });
+    expect(redis.calls).toEqual([]);
+  });
+
+  it('increments the topic count once per (hash, topic) pair', async () => {
+    const redis = new FakeRedis();
+    await incrementTipsterTopicCounters({
+      redis,
+      batch: [
+        { source: 'web', hashedOwnerId: 'aaaa1111', topic: 'trade' },
+        { source: 'web', hashedOwnerId: 'aaaa1111', topic: 'trade' },  // dedup
+        { source: 'web', hashedOwnerId: 'aaaa1111', topic: 'roster' }, // distinct
+        { source: 'web', hashedOwnerId: 'bbbb2222', topic: 'commish' },
+      ],
+    });
+    const a = redis.hashes.get('schefter:tipster:topic_counts:aaaa1111');
+    expect(a?.get('trade')).toBe(1);
+    expect(a?.get('roster')).toBe(1);
+    const b = redis.hashes.get('schefter:tipster:topic_counts:bbbb2222');
+    expect(b?.get('commish')).toBe(1);
+  });
+
+  it('falls back to topic="other" when a tip is missing the field', async () => {
+    const redis = new FakeRedis();
+    await incrementTipsterTopicCounters({
+      redis,
+      batch: [{ source: 'web', hashedOwnerId: 'aaaa1111' }],
+    });
+    expect(redis.hashes.get('schefter:tipster:topic_counts:aaaa1111')?.get('other')).toBe(1);
+  });
+
+  it('skips groupme tips (they have their own attribution path)', async () => {
+    const redis = new FakeRedis();
+    await incrementTipsterTopicCounters({
+      redis,
+      batch: [{ source: 'groupme', hashedOwnerId: 'aaaa1111', topic: 'trade' }],
+    });
+    expect(redis.calls).toEqual([]);
+  });
+
+  it('skips trade_offer tips (no tipster identity at all)', async () => {
+    const redis = new FakeRedis();
+    await incrementTipsterTopicCounters({
+      redis,
+      batch: [{ source: 'trade_offer', topic: 'trade' }],
+    });
+    expect(redis.calls).toEqual([]);
+  });
+
+  it('skips tips with no hashedOwnerId', async () => {
+    const redis = new FakeRedis();
+    await incrementTipsterTopicCounters({
+      redis,
+      batch: [{ source: 'web', topic: 'trade' }],
+    });
+    expect(redis.calls).toEqual([]);
+  });
+
+  it('does NOT write counters in dry-run mode', async () => {
+    const redis = new FakeRedis();
+    const logs: string[] = [];
+    await incrementTipsterTopicCounters({
+      redis,
+      batch: [{ source: 'web', hashedOwnerId: 'aaaa1111', topic: 'trade' }],
+      dryRun: true,
+      log: (m) => logs.push(m),
+    });
+    expect(redis.calls).toEqual([]);
+    expect(logs.join('\n')).toMatch(/Would increment topic counters/);
+  });
+
+  it('logs and continues when redis throws on a single increment', async () => {
+    const redis = new FakeRedis();
+    redis.shouldThrow = true;
+    const warns: string[] = [];
+    await incrementTipsterTopicCounters({
+      redis,
+      batch: [{ source: 'web', hashedOwnerId: 'aaaa1111', topic: 'trade' }],
+      warn: (m) => warns.push(m),
+    });
+    expect(warns.join('\n')).toMatch(/increment failed/);
+  });
+});

--- a/tests/schefter-tipster-voice-flags.test.ts
+++ b/tests/schefter-tipster-voice-flags.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Tipster-aware voice flags surface from anonymizeTips. Locks the contract
+ * between the per-cycle tipsterContext (built by buildTipsterContext from
+ * Redis) and the anonymized tip metadata the LLM prompt actually consumes:
+ *
+ *   - firstTimeTipster  → HARD RULE 22 (curiosity sparks)
+ *   - prolificTipster   → HARD RULE 23 (grain of salt)
+ *   - tipsterBeat       → HARD RULE 24 (standing beat — option B; NO codename)
+ *
+ * All three flags MUST NOT carry hashedOwnerId, franchise, or division. The
+ * tipsterBeat field is allowed to carry the topic name only (per option B
+ * design — codename-topic binding stays internal).
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+// @ts-expect-error — sibling .mjs module, no .d.ts
+import { anonymizeTips } from '../scripts/schefter-rumor-scan.mjs';
+
+const SCANNER_SRC = readFileSync(
+  path.join(process.cwd(), 'scripts/schefter-rumor-scan.mjs'),
+  'utf8',
+);
+
+const teams = new Map<string, { name: string; nameShort?: string; division?: string }>([
+  ['0001', { name: 'Pacific Pigskins', nameShort: 'Pigskins', division: 'Northwest' }],
+  ['0002', { name: 'Nashville Geeks', nameShort: 'Geeks', division: 'Northwest' }],
+]);
+
+const baseTip = (overrides: Record<string, unknown>) => ({
+  source: 'web',
+  topic: 'roster',
+  text: 'something',
+  franchiseHint: 'league-wide',
+  submittedAt: Date.now(),
+  ...overrides,
+});
+
+const ctxEntry = (overrides: Record<string, unknown> = {}) => ({
+  hashedOwnerId: 'placeholder',
+  tipsInQueue: 1,
+  rumorsTotal: 0,
+  isFirstTime: true,
+  isProlific: false,
+  beat: null,
+  ...overrides,
+});
+
+describe('anonymizeTips — tipster voice flags', () => {
+  it('does not set tipster flags when no context is provided (back-compat default)', async () => {
+    const tips = [baseTip({ id: 't1', hashedOwnerId: 'aaaa1111' })];
+    const out = await anonymizeTips(tips, teams);
+    expect(out[0].firstTimeTipster).toBeUndefined();
+    expect(out[0].prolificTipster).toBeUndefined();
+    expect(out[0].tipsterBeat).toBeUndefined();
+  });
+
+  it('surfaces firstTimeTipster when the context says so', async () => {
+    const ctx = new Map([
+      ['newbie01', ctxEntry({ hashedOwnerId: 'newbie01', isFirstTime: true })],
+    ]);
+    const tips = [baseTip({ id: 't1', hashedOwnerId: 'newbie01' })];
+    const out = await anonymizeTips(tips, teams, [], new Date(), null, ctx);
+    expect(out[0].firstTimeTipster).toBe(true);
+    expect(out[0].prolificTipster).toBeUndefined();
+  });
+
+  it('surfaces prolificTipster when the context says so', async () => {
+    const ctx = new Map([
+      ['reg00003', ctxEntry({
+        hashedOwnerId: 'reg00003',
+        rumorsTotal: 50,
+        isFirstTime: false,
+        isProlific: true,
+      })],
+    ]);
+    const tips = [baseTip({ id: 't1', hashedOwnerId: 'reg00003' })];
+    const out = await anonymizeTips(tips, teams, [], new Date(), null, ctx);
+    expect(out[0].firstTimeTipster).toBeUndefined();
+    expect(out[0].prolificTipster).toBe(true);
+  });
+
+  it('surfaces tipsterBeat with ONLY the topic name (option B — no codename)', async () => {
+    const ctx = new Map([
+      ['reg00003', ctxEntry({
+        hashedOwnerId: 'reg00003',
+        rumorsTotal: 12,
+        isFirstTime: false,
+        isProlific: true,
+        beat: { topic: 'trade', count: 9, total: 12, share: 0.75 },
+      })],
+    ]);
+    const tips = [baseTip({ id: 't1', hashedOwnerId: 'reg00003', topic: 'trade' })];
+    const out = await anonymizeTips(tips, teams, [], new Date(), null, ctx);
+    // Exactly the topic — never the codename, hash, count, or share.
+    expect(out[0].tipsterBeat).toEqual({ topic: 'trade' });
+  });
+
+  it('omits tipsterBeat when the context has no beat for the tipster', async () => {
+    const ctx = new Map([
+      ['reg00003', ctxEntry({
+        hashedOwnerId: 'reg00003',
+        rumorsTotal: 5,
+        isFirstTime: false,
+        beat: null,
+      })],
+    ]);
+    const tips = [baseTip({ id: 't1', hashedOwnerId: 'reg00003' })];
+    const out = await anonymizeTips(tips, teams, [], new Date(), null, ctx);
+    expect(out[0].tipsterBeat).toBeUndefined();
+  });
+
+  it('does not surface flags for groupme tips (they have their own attribution path)', async () => {
+    const ctx = new Map([
+      ['gm00001', ctxEntry({ hashedOwnerId: 'gm00001', isFirstTime: true })],
+    ]);
+    const tips = [{
+      id: 't1',
+      source: 'groupme',
+      topic: 'roster',
+      text: 'public chat msg',
+      author: 'Wabbit',
+      attributable: true,
+      hashedOwnerId: 'gm00001',
+      submittedAt: Date.now(),
+    }];
+    const out = await anonymizeTips(tips, teams, [], new Date(), null, ctx);
+    // GroupMe path returns early — the flags would step on the public-chat
+    // attribution model. The voice cues are web-only.
+    expect(out[0].firstTimeTipster).toBeUndefined();
+    expect(out[0].prolificTipster).toBeUndefined();
+  });
+
+  it('does not surface flags for trade_offer tips (no tipster identity at all)', async () => {
+    const ctx = new Map();
+    const tips = [{
+      id: 't1',
+      source: 'trade_offer',
+      topic: 'trade',
+      submittedAt: Date.now(),
+      framingHint: 'fresh',
+      volumeHint: 'two-for-two',
+      positionTokens: ['RB', 'WR'],
+      pickTokens: [],
+    }];
+    const out = await anonymizeTips(tips, teams, [], new Date(), null, ctx);
+    expect(out[0].firstTimeTipster).toBeUndefined();
+    expect(out[0].prolificTipster).toBeUndefined();
+    expect(out[0].tipsterBeat).toBeUndefined();
+  });
+
+  it('never leaks hashedOwnerId into the anonymized output regardless of flags', async () => {
+    const ctx = new Map([
+      ['newbie01', ctxEntry({ hashedOwnerId: 'newbie01', isFirstTime: true, beat: { topic: 'trade', count: 9, total: 12, share: 0.75 } })],
+    ]);
+    const tips = [baseTip({ id: 't1', hashedOwnerId: 'newbie01' })];
+    const out = await anonymizeTips(tips, teams, [], new Date(), null, ctx);
+    const serialized = JSON.stringify(out[0]);
+    expect(serialized).not.toContain('newbie01');
+  });
+});
+
+// ── Source-pin contracts on the prompt itself ──
+
+describe('rumor-scan system prompt — voice rules surface the new flags', () => {
+  it('HARD RULE 22 (curiosity sparks) references firstTimeTipster', () => {
+    expect(SCANNER_SRC).toMatch(/22\.\s+CURIOSITY SPARKS/);
+    expect(SCANNER_SRC).toMatch(/firstTimeTipster/);
+  });
+
+  it('HARD RULE 23 (grain of salt) references prolificTipster', () => {
+    expect(SCANNER_SRC).toMatch(/23\.\s+GRAIN OF SALT/);
+    expect(SCANNER_SRC).toMatch(/prolificTipster/);
+  });
+
+  it('HARD RULE 24 (standing beat) references tipsterBeat AND forbids codename pairing', () => {
+    expect(SCANNER_SRC).toMatch(/24\.\s+STANDING BEAT/);
+    expect(SCANNER_SRC).toMatch(/tipsterBeat/);
+    // Option B sentinel: the rule must explicitly forbid the codename.
+    expect(SCANNER_SRC).toMatch(/NEVER name the codename/i);
+  });
+
+  it('rules 22 and 23 explicitly de-conflict (first-time beats grain-of-salt)', () => {
+    expect(SCANNER_SRC).toMatch(/Never combine in the same post with rule 23/);
+  });
+});


### PR DESCRIPTION
Adds a tipster-context helper (buildTipsterContext) that reads each
queued web tipster's lifetime rumor count + per-topic affinity from
Redis and emits a per-cycle Map<hashedOwnerId, TipsterContext>.
bucketPriorityScore now accepts that map as an optional third arg and
applies a delta: first-time voice +5, burst regular -3, prolific
tipster -1. With the context omitted (admin preview), the scorer falls
back to the prior size+age ranking.

Wires the import into the scanner. Build-side hookup of buildTipsterContext
and the prompt-side surfaces (curiosity sparks, grain-of-salt, beat,
quiet-day, memory recall) land in follow-up commits.

Tests: existing bucket+ledger suites stay green; the regex check on
bucketPriorityScore's return line still matches because the new
tipsterDelta is appended after sizeScore + oldestAgeDays.