### PR TITLE
Fix AFL draft dates to the Saturday before Labor Day weekend

### DIFF
--- a/src/data/afl-fantasy/league-events.json
+++ b/src/data/afl-fantasy/league-events.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "AFL league calendar events. Mirrors TheLeague's shape (see src/data/theleague/league-events.ts and src/types/league-events.ts). Custom computed rules used here: 'saturday-before-labor-day' (AL Live Draft), 'sunday-before-labor-day' (NL Email Draft, 9am PT). Keeper deadline is fixed July 15.",
+  "$comment": "AFL league calendar events. Mirrors TheLeague's shape (see src/data/theleague/league-events.ts and src/types/league-events.ts). Custom computed rules used here: 'saturday-before-labor-day-weekend' (AL Live Draft — the Saturday a week before Labor Day, NOT on the holiday weekend), 'sunday-before-labor-day-weekend' (NL Email Draft, 9am PT — the next day). Keeper deadline is fixed July 15.",
   "events": [
     {
       "id": "afl-new-season-starts",
@@ -29,7 +29,7 @@
       "description": "AL teams meet live for the conference draft — veterans and rookies on the same board.",
       "category": "draft",
       "icon": "draft-podium",
-      "startDate": { "type": "computed", "rule": "saturday-before-labor-day", "time": "09:00" },
+      "startDate": { "type": "computed", "rule": "saturday-before-labor-day-weekend", "time": "09:00" },
       "urgencyDays": 7,
       "sortOrder": 4
     },
@@ -39,7 +39,7 @@
       "description": "NL teams begin the email draft at 9am PT Sunday. Slow draft, but the clock matters.",
       "category": "draft",
       "icon": "draft-podium",
-      "startDate": { "type": "computed", "rule": "sunday-before-labor-day", "time": "09:00" },
+      "startDate": { "type": "computed", "rule": "sunday-before-labor-day-weekend", "time": "09:00" },
       "urgencyDays": 7,
       "sortOrder": 5
     },

--- a/src/utils/league-event-resolver.ts
+++ b/src/utils/league-event-resolver.ts
@@ -58,19 +58,23 @@ function resolveComputedDate(rule: string, year: number): Date {
     case 'third-sunday-august':
       return getNthDayOfMonth(year, 7, 0, 3); // August, Sunday, 3rd
 
-    case 'saturday-before-labor-day': {
-      // AL Live Draft — Saturday immediately before Labor Day
+    case 'saturday-before-labor-day-weekend': {
+      // AL Live Draft — Saturday a full week before Labor Day, i.e. the
+      // Saturday BEFORE the Labor Day holiday weekend (not the Saturday of it).
+      // Labor Day is Monday, so the Saturday of LD weekend is laborDay - 2;
+      // one week earlier is laborDay - 9.
       const laborDay = getLaborDayForYear(year);
       const sat = new Date(laborDay);
-      sat.setDate(sat.getDate() - 2);
+      sat.setDate(sat.getDate() - 9);
       return sat;
     }
 
-    case 'sunday-before-labor-day': {
-      // NL Email Draft — Sunday immediately before Labor Day
+    case 'sunday-before-labor-day-weekend': {
+      // NL Email Draft — the Sunday right after the AL Draft Saturday above,
+      // i.e. the day before the Labor Day holiday weekend (laborDay - 8).
       const laborDay = getLaborDayForYear(year);
       const sun = new Date(laborDay);
-      sun.setDate(sun.getDate() - 1);
+      sun.setDate(sun.getDate() - 8);
       return sun;
     }
 

--- a/tests/league-event-resolver.test.ts
+++ b/tests/league-event-resolver.test.ts
@@ -83,6 +83,28 @@ describe('resolveDateForYear', () => {
     expect(date.getDate()).toBe(10);
   });
 
+  it('should resolve AL draft to the Saturday a week before Labor Day weekend', () => {
+    // Labor Day 2026 is Mon Sep 7. The draft is NOT on the holiday weekend —
+    // it is the Saturday a full week earlier: Aug 29, 2026.
+    const date = resolveDateForYear(
+      { type: 'computed', rule: 'saturday-before-labor-day-weekend' },
+      2026,
+    );
+    expect(date.getDay()).toBe(6); // Saturday
+    expect(date.getMonth()).toBe(7); // August
+    expect(date.getDate()).toBe(29);
+  });
+
+  it('should resolve NL draft to the Sunday after the AL draft Saturday', () => {
+    const date = resolveDateForYear(
+      { type: 'computed', rule: 'sunday-before-labor-day-weekend' },
+      2026,
+    );
+    expect(date.getDay()).toBe(0); // Sunday
+    expect(date.getMonth()).toBe(7); // August
+    expect(date.getDate()).toBe(30);
+  });
+
   it('should resolve computed day-before-nfl-kickoff', () => {
     const date = resolveDateForYear({ type: 'computed', rule: 'day-before-nfl-kickoff' }, 2026);
     expect(date.getDay()).toBe(3); // Wednesday


### PR DESCRIPTION
The AL/NL conference drafts are held the Saturday/Sunday a full week
before Labor Day, not on the holiday weekend itself. The computed rules
were landing on the Saturday OF Labor Day weekend (laborDay - 2), e.g.
Sep 5/6 in 2026 instead of Aug 29/30.

Rename the rules to 'saturday-before-labor-day-weekend' /
'sunday-before-labor-day-weekend' and shift the offsets to laborDay - 9
/ -8 so the names stay accurate. Add regression coverage.