### PR TITLE
security: remove header auth bypass, add SSRF guard and LLM rate limits

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,26 @@ A few legacy vars predate this rule (`SCHEFTER_RUMOR_MILL_ENABLED`,
 `SCHEFTER_TRADE_OFFER_RUMORS_ENABLED`). Don't add more, and prefer
 moving the existing ones into code if you're already touching the file.
 
+## League registry — never hardcode league constants
+
+`src/config/leagues-data.mjs` (data) + `src/config/leagues.ts` (types/helpers)
+are the single source of truth for per-league constants: MFL id, slug, name,
+MFL host, data path, apex domains, and feature flags. Do not write `'13522'`,
+`'19621'`, `'data/theleague'`, etc. inline — import from the registry.
+App code imports `../config/leagues`; node scripts import
+`src/config/leagues-data.mjs` directly. Gate league-specific UI with
+`leagueHasFeature(slug, 'contracts' | 'keepers' | ...)`. Adding a league or
+domain is a one-entry change in `leagues-data.mjs`.
+
+## Auth — session JWT only
+
+`getAuthUser()` (src/utils/auth.ts) trusts only the signed session cookie.
+The old `X-User-Context` / `X-Auth-User` header fallbacks were removed in
+June 2026 — they allowed full auth bypass. Never re-add unsigned identity
+sources. Rate-limit any new LLM-backed endpoint with
+`src/utils/rate-limit.ts`, and run any server-side fetch of a user-supplied
+URL through `src/utils/url-guard.ts#validatePublicUrl`.
+
 ## Roger date-handling gotchas
 
 There are **two** independent code paths named "Roger". Both have hallucinated

--- a/docs/claude/auth.md
+++ b/docs/claude/auth.md
@@ -2,20 +2,15 @@
 
 ## Overview
 
-Authentication supports multiple methods for flexibility across different integration contexts:
-- Session JWT (primary)
-- Authorization header
-- X-User-Context header
-- X-Auth-User header
+The **session JWT in the httpOnly cookie is the only identity source.**
 
-## Auth Priority Order
-
-When checking authentication, sources are tried in order:
-
-1. **Session JWT from httpOnly cookie** (primary method)
-2. **Authorization header** with Bearer token
-3. **X-User-Context header** (JSON format, for message board integration)
-4. **X-Auth-User header** (colon-delimited, for testing)
+> ⚠️ **Removed (June 2026):** the `X-User-Context` and `X-Auth-User` header
+> fallbacks were deleted from `getAuthUser()`. They accepted unsigned identity
+> from any client, which allowed full auth bypass / privilege escalation
+> (claim any franchise or the admin role with a curl header). Any docs or
+> examples below that still show those headers are historical — they no longer
+> work. For local testing, log in through the normal flow or mint a session
+> token with `createSessionToken()` from `src/utils/session.ts`.
 
 ## Core Auth Utilities
 

--- a/docs/features/authentication-testing.md
+++ b/docs/features/authentication-testing.md
@@ -1,5 +1,10 @@
 # Contract Management - Authentication & Testing Guide
 
+> ⚠️ **OUTDATED (June 2026):** the `X-User-Context` / `X-Auth-User` header auth
+> shown throughout this guide was removed for security (unsigned headers =
+> full auth bypass). Authenticate with a real session cookie instead. See
+> `docs/claude/auth.md`.
+
 ## Overview
 
 The contract management feature now pulls **real player data** from your live site and implements **real authentication** support. Here's how to test and use it.

--- a/docs/features/quick-start-testing.md
+++ b/docs/features/quick-start-testing.md
@@ -1,5 +1,10 @@
 # Quick Start - Contract Management Testing
 
+> ⚠️ **OUTDATED (June 2026):** the `X-User-Context` / `X-Auth-User` header auth
+> shown in this guide was removed for security (unsigned headers = full auth
+> bypass). Authenticate with a real session cookie instead. See
+> `docs/claude/auth.md`.
+
 ## View All Eligible Players
 
 ### Option 1: Browser (Easiest)

--- a/packages/shared-utils/src/auth.ts
+++ b/packages/shared-utils/src/auth.ts
@@ -22,79 +22,26 @@ const normalizeFranchise = (value: string | null | undefined): string => {
 };
 
 /**
- * Get authenticated user from request
- * Checks multiple sources for authentication (in priority order):
- * 1. Session JWT from httpOnly cookie (primary auth method)
- * 2. Authorization header with Bearer token
- * 3. X-User-Context header (sent by message board or test harness)
- * 4. X-Auth-User header (colon-delimited format for test)
+ * Get authenticated user from request.
+ * The session JWT in the httpOnly cookie is the only accepted identity source.
+ * Unsigned identity headers (X-User-Context / X-Auth-User) were removed — they
+ * let any client claim any franchise or the admin role. Do not re-add them.
  */
 export function getAuthUser(request: Request): AuthUser | null {
-
-  // Priority 1: Check for session JWT in cookies
   const cookieHeader = request.headers.get('cookie');
-  console.log('[auth.ts] cookieHeader present?', !!cookieHeader);
   const sessionToken = getSessionTokenFromCookie(cookieHeader);
-  console.log('[auth.ts] sessionToken found?', !!sessionToken);
+  if (!sessionToken) return null;
 
-  if (sessionToken) {
-    const sessionData = validateSessionToken(sessionToken);
-    console.log('[auth.ts] sessionData valid?', !!sessionData);
-    if (sessionData) {
-      return {
-        id: sessionData.userId,
-        name: sessionData.username,
-        franchiseId: normalizeFranchise(sessionData.franchiseId),
-        leagueId: sessionData.leagueId,
-        role: sessionData.role,
-      };
-    }
-  }
+  const sessionData = validateSessionToken(sessionToken);
+  if (!sessionData) return null;
 
-  // Priority 2: Check Authorization header with Bearer token
-  const authHeader = request.headers.get('authorization');
-  // TODO: Implement JWT token validation from Authorization header
-  // if (authHeader?.startsWith('Bearer ')) {
-  //   const token = authHeader.substring(7);
-  //   return validateJWT(token);
-  // }
-
-  // Priority 3: Check for user context header (sent by message board or test harness)
-  const userContextHeader = request.headers.get('x-user-context');
-  if (userContextHeader) {
-    try {
-      const rawUser = JSON.parse(userContextHeader) as AuthUser;
-      const user = {
-        id: rawUser.id,
-        name: rawUser.name,
-        franchiseId: normalizeFranchise(rawUser.franchiseId),
-        leagueId: rawUser.leagueId,
-        role: rawUser.role,
-      };
-      if (user.id && user.franchiseId && user.leagueId) {
-        return user;
-      }
-    } catch {
-      // Invalid JSON in header, continue checking
-    }
-  }
-
-  // Priority 4: Check for X-Auth-User header with format: "id:franchiseId:leagueId:name:role"
-  const userHeader = request.headers.get('x-auth-user');
-  if (userHeader) {
-    const parts = userHeader.split(':');
-    if (parts.length >= 3) {
-      return {
-        id: parts[0],
-        franchiseId: normalizeFranchise(parts[1]),
-        leagueId: parts[2],
-        name: parts[3] || 'User',
-        role: (parts[4] as any) || 'owner',
-      };
-    }
-  }
-
-  return null;
+  return {
+    id: sessionData.userId,
+    name: sessionData.username,
+    franchiseId: normalizeFranchise(sessionData.franchiseId),
+    leagueId: sessionData.leagueId,
+    role: sessionData.role,
+  };
 }
 
 /**

--- a/src/config/leagues-data.mjs
+++ b/src/config/leagues-data.mjs
@@ -1,0 +1,92 @@
+/**
+ * League registry — the single source of truth for every per-league constant.
+ *
+ * Plain .mjs so both the Astro app (via src/config/leagues.ts, which adds
+ * types) and node cron scripts (import '../src/config/leagues-data.mjs') can use
+ * it. Never hardcode a league id, slug, data path, or domain anywhere else —
+ * look it up here. Adding a league = adding one entry to LEAGUES (plus DNS /
+ * Vercel domain attachment for its apex domains).
+ */
+
+export const LEAGUES = {
+  theleague: {
+    /** MFL numeric league id */
+    id: '13522',
+    /** Canonical slug: path segment under src/pages/ and in URLs */
+    slug: 'theleague',
+    /** Short slug used by nav config / styles (LeagueSlug type) */
+    navSlug: 'theleague',
+    name: 'The League',
+    /** MFL server hostname for this league */
+    mflHost: 'www49.myfantasyleague.com',
+    /** Repo-relative data directory written by the fetch pipelines */
+    dataPath: 'data/theleague',
+    /** Apex domains that serve this league (bare + www) */
+    domains: ['theleague.us', 'www.theleague.us'],
+    features: {
+      contracts: true,
+      salaryCap: true,
+      keepers: false,
+      powerRankings: true,
+      liveLineups: true,
+      schefterFeed: true,
+    },
+  },
+  'afl-fantasy': {
+    id: '19621',
+    slug: 'afl-fantasy',
+    navSlug: 'afl',
+    name: 'American Football League',
+    mflHost: 'www44.myfantasyleague.com',
+    dataPath: 'data/afl-fantasy',
+    domains: ['afl-fantasy.com', 'www.afl-fantasy.com'],
+    features: {
+      contracts: false,
+      salaryCap: false,
+      keepers: true,
+      powerRankings: false,
+      liveLineups: false,
+      schefterFeed: false,
+    },
+  },
+};
+
+export const DEFAULT_LEAGUE_SLUG = 'theleague';
+
+export const ALL_LEAGUES = Object.values(LEAGUES);
+
+/** @param {string} slug Canonical slug ('theleague' | 'afl-fantasy') */
+export function getLeagueBySlug(slug) {
+  return LEAGUES[slug] ?? null;
+}
+
+/** @param {string} id MFL numeric league id */
+export function getLeagueById(id) {
+  return ALL_LEAGUES.find((l) => l.id === id) ?? null;
+}
+
+/**
+ * Resolve a URL pathname to its league (e.g. '/afl-fantasy/rosters').
+ * Falls back to the default league for unprefixed paths.
+ * @param {string} pathname
+ */
+export function getLeagueByPath(pathname) {
+  for (const league of ALL_LEAGUES) {
+    if (pathname === `/${league.slug}` || pathname.startsWith(`/${league.slug}/`)) {
+      return league;
+    }
+  }
+  return LEAGUES[DEFAULT_LEAGUE_SLUG];
+}
+
+/** Apex hostname → canonical slug map, derived from each league's domains. */
+export function buildHostToSlugMap() {
+  /** @type {Record<string, string>} */
+  const map = {};
+  for (const league of ALL_LEAGUES) {
+    for (const domain of league.domains) {
+      map[domain] = league.slug;
+    }
+  }
+  return map;
+}

--- a/src/config/leagues.ts
+++ b/src/config/leagues.ts
@@ -1,0 +1,65 @@
+/**
+ * Typed wrapper around the league registry (src/config/leagues.mjs).
+ *
+ * App code should import from here; node scripts import the .mjs directly.
+ * The registry is the single source of truth for league ids, slugs, names,
+ * MFL hosts, data paths, domains, and feature flags.
+ */
+
+import type { LeagueSlug } from '../types/nav';
+import {
+  LEAGUES as RAW_LEAGUES,
+  DEFAULT_LEAGUE_SLUG as RAW_DEFAULT,
+  getLeagueBySlug as rawGetBySlug,
+  getLeagueById as rawGetById,
+  getLeagueByPath as rawGetByPath,
+  buildHostToSlugMap,
+} from './leagues-data.mjs';
+
+/** Canonical slug: the path segment under src/pages/ */
+export type CanonicalLeagueSlug = 'theleague' | 'afl-fantasy';
+
+export interface LeagueFeatures {
+  contracts: boolean;
+  salaryCap: boolean;
+  keepers: boolean;
+  powerRankings: boolean;
+  liveLineups: boolean;
+  schefterFeed: boolean;
+}
+
+export interface LeagueDefinition {
+  id: string;
+  slug: CanonicalLeagueSlug;
+  /** Short slug used by nav config / styles */
+  navSlug: LeagueSlug;
+  name: string;
+  mflHost: string;
+  dataPath: string;
+  domains: string[];
+  features: LeagueFeatures;
+}
+
+export const LEAGUES = RAW_LEAGUES as Record<CanonicalLeagueSlug, LeagueDefinition>;
+export const DEFAULT_LEAGUE_SLUG = RAW_DEFAULT as CanonicalLeagueSlug;
+export const ALL_LEAGUES: LeagueDefinition[] = Object.values(LEAGUES);
+
+export function getLeagueBySlug(slug: string): LeagueDefinition | null {
+  return rawGetBySlug(slug) as LeagueDefinition | null;
+}
+
+export function getLeagueById(id: string): LeagueDefinition | null {
+  return rawGetById(id) as LeagueDefinition | null;
+}
+
+/** Resolve a URL pathname to its league; defaults to theleague. */
+export function getLeagueByPath(pathname: string): LeagueDefinition {
+  return rawGetByPath(pathname) as LeagueDefinition;
+}
+
+/** Whether a feature is enabled for the given league slug. */
+export function leagueHasFeature(slug: string, feature: keyof LeagueFeatures): boolean {
+  return getLeagueBySlug(slug)?.features[feature] ?? false;
+}
+
+export { buildHostToSlugMap };

--- a/src/pages/api/groupme/rewrite.ts
+++ b/src/pages/api/groupme/rewrite.ts
@@ -11,7 +11,11 @@
 
 import type { APIRoute } from 'astro';
 import { getAuthUser } from '../../../utils/auth';
+import { checkRateLimit } from '../../../utils/rate-limit';
 import { loadTeamConfig } from '../../../utils/groupme-storage';
+
+const RATE_LIMIT_MAX = 20;
+const RATE_LIMIT_WINDOW = 3600; // 1 hour
 
 function json(data: unknown, status = 200): Response {
   return new Response(JSON.stringify(data), {
@@ -37,6 +41,11 @@ RULES:
 export const POST: APIRoute = async ({ request }) => {
   const user = getAuthUser(request);
   if (!user?.franchiseId) return json({ error: 'Authentication required' }, 401);
+
+  const limit = await checkRateLimit('groupme-rewrite', user.franchiseId, RATE_LIMIT_MAX, RATE_LIMIT_WINDOW);
+  if (!limit.allowed) {
+    return json({ error: 'Slow down — too many rewrites this hour. Try again later.' }, 429);
+  }
 
   if (!process.env.ANTHROPIC_API_KEY) {
     return json({ error: 'AI not configured' }, 503);

--- a/src/pages/api/og-preview.ts
+++ b/src/pages/api/og-preview.ts
@@ -1,5 +1,6 @@
 import type { APIRoute } from 'astro';
 import { getOgPreview } from '../../utils/og-preview';
+import { validatePublicUrl } from '../../utils/url-guard';
 
 export const prerender = false;
 
@@ -7,6 +8,15 @@ export const GET: APIRoute = async ({ request }) => {
   const url = new URL(request.url).searchParams.get('url');
   if (!url || !/^https?:\/\//i.test(url)) {
     return new Response(JSON.stringify({ error: 'Invalid or missing url param' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // SSRF guard — refuse URLs that point at internal/private address space
+  const blocked = await validatePublicUrl(url);
+  if (blocked) {
+    return new Response(JSON.stringify({ error: blocked }), {
       status: 400,
       headers: { 'Content-Type': 'application/json' },
     });

--- a/src/pages/api/schefter-replies/[postId]/ai-reply.ts
+++ b/src/pages/api/schefter-replies/[postId]/ai-reply.ts
@@ -9,6 +9,7 @@
 
 import type { APIRoute } from 'astro';
 import { getAuthUser } from '../../../../utils/auth';
+import { checkRateLimit } from '../../../../utils/rate-limit';
 import type { SchefterReply, AiReplyRequest } from '../../../../types/schefter-replies';
 import {
   getReplyById,
@@ -75,9 +76,17 @@ function chooseCharacter(post: SchefterPost | null): 'claude' | 'roger' {
   return 'claude';
 }
 
+const RATE_LIMIT_MAX = 30;
+const RATE_LIMIT_WINDOW = 3600; // 1 hour
+
 export const POST: APIRoute = async ({ params, request }) => {
   const user = getAuthUser(request);
   if (!user?.franchiseId) return json({ error: 'Authentication required' }, 401);
+
+  const limit = await checkRateLimit('ai-reply', user.franchiseId, RATE_LIMIT_MAX, RATE_LIMIT_WINDOW);
+  if (!limit.allowed) {
+    return json({ error: 'Too many AI replies this hour — give Schefter a breather.' }, 429);
+  }
 
   const postId = params.postId;
   if (!postId) return json({ error: 'postId required' }, 400);

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,7 +1,11 @@
 /**
  * Authentication Utilities
  * Handles user authentication and authorization
- * Currently supports franchise/league context from message board or external auth
+ *
+ * Identity comes exclusively from the signed session JWT. Unsigned identity
+ * headers (X-User-Context / X-Auth-User) were removed — they let any client
+ * claim any franchise or the admin role. Do not re-add them; for local
+ * testing, mint a real session via the login flow or createSessionToken().
  */
 
 import { getSessionTokenFromCookie, validateSessionToken } from './session';
@@ -23,76 +27,24 @@ const normalizeFranchise = (value: string | null | undefined): string => {
 };
 
 /**
- * Get authenticated user from request
- * Checks multiple sources for authentication (in priority order):
- * 1. Session JWT from httpOnly cookie (primary auth method)
- * 2. Authorization header with Bearer token
- * 3. X-User-Context header (sent by message board or test harness)
- * 4. X-Auth-User header (colon-delimited format for test)
+ * Get authenticated user from request.
+ * The session JWT in the httpOnly cookie is the only accepted identity source.
  */
 export function getAuthUser(request: Request): AuthUser | null {
-
-  // Priority 1: Check for session JWT in cookies
   const cookieHeader = request.headers.get('cookie');
   const sessionToken = getSessionTokenFromCookie(cookieHeader);
+  if (!sessionToken) return null;
 
-  if (sessionToken) {
-    const sessionData = validateSessionToken(sessionToken);
-    if (sessionData) {
-      return {
-        id: sessionData.userId,
-        name: sessionData.username,
-        franchiseId: normalizeFranchise(sessionData.franchiseId),
-        leagueId: sessionData.leagueId,
-        role: sessionData.role,
-      };
-    }
-  }
+  const sessionData = validateSessionToken(sessionToken);
+  if (!sessionData) return null;
 
-  // Priority 2: Check Authorization header with Bearer token
-  const authHeader = request.headers.get('authorization');
-  // TODO: Implement JWT token validation from Authorization header
-  // if (authHeader?.startsWith('Bearer ')) {
-  //   const token = authHeader.substring(7);
-  //   return validateJWT(token);
-  // }
-
-  // Priority 3: Check for user context header (sent by message board or test harness)
-  const userContextHeader = request.headers.get('x-user-context');
-  if (userContextHeader) {
-    try {
-      const rawUser = JSON.parse(userContextHeader) as AuthUser;
-      const user = {
-        id: rawUser.id,
-        name: rawUser.name,
-        franchiseId: normalizeFranchise(rawUser.franchiseId),
-        leagueId: rawUser.leagueId,
-        role: rawUser.role,
-      };
-      if (user.id && user.franchiseId && user.leagueId) {
-        return user;
-      }
-    } catch {
-      // Invalid JSON in header, continue checking
-    }
-  }
-
-  // Priority 4: Check for X-Auth-User header with format: "id:franchiseId:leagueId:name:role"
-  const userHeader = request.headers.get('x-auth-user');
-  if (userHeader) {
-    const parts = userHeader.split(':');
-    if (parts.length >= 3) {
-      return {
-        id: parts[0],
-        franchiseId: normalizeFranchise(parts[1]),
-        leagueId: parts[2],
-        name: parts[3] || 'User',
-        role: (parts[4] as any) || 'owner',
-      };
-    }
-  }
-
-  return null;
+  return {
+    id: sessionData.userId,
+    name: sessionData.username,
+    franchiseId: normalizeFranchise(sessionData.franchiseId),
+    leagueId: sessionData.leagueId,
+    role: sessionData.role,
+  };
 }
 
 /**

--- a/src/utils/contract-validation.ts
+++ b/src/utils/contract-validation.ts
@@ -5,6 +5,7 @@
 
 import type { ContractValidationResult, ContractValidationError } from '../types/contracts';
 import type { DeclarationType } from '../types/contract-eligibility';
+import { LEAGUES } from '../config/leagues';
 
 // League season starts on February 15th
 const SEASON_START_MONTH = 2; // February (0-indexed would be 1, but JS uses 0-indexed, so 2 for March would be 2... actually Feb is 1)
@@ -129,7 +130,7 @@ function validateLeagueId(leagueId: string): ContractValidationError[] {
   const errors: ContractValidationError[] = [];
 
   // Allow both production league and test league
-  const ALLOWED_LEAGUES = ['13522', '18202', '36189'];
+  const ALLOWED_LEAGUES = [LEAGUES.theleague.id, '18202', '36189'];
   if (!ALLOWED_LEAGUES.includes(leagueId)) {
     errors.push({
       field: 'leagueId',

--- a/src/utils/league-context.ts
+++ b/src/utils/league-context.ts
@@ -1,7 +1,10 @@
 /**
  * League context utilities
- * Determines which league context we're in based on URL path
+ * Determines which league context we're in based on URL path.
+ * All per-league constants come from the registry in src/config/leagues.ts.
  */
+
+import { getLeagueByPath } from '../config/leagues';
 
 export interface LeagueContext {
   host: string;
@@ -10,9 +13,6 @@ export interface LeagueContext {
   slug: string; // 'theleague' or 'afl-fantasy'
   dataPath: string; // 'data/theleague' or 'data/afl-fantasy'
 }
-
-const defaultMflHost =
-  (import.meta.env.PUBLIC_MFL_HOST as string | undefined) || 'www49.myfantasyleague.com/';
 
 const normalizeHost = (value: string) =>
   value.replace(/^https?:\/\//, '').replace(/\/+$/, '');
@@ -23,38 +23,19 @@ const normalizeHost = (value: string) =>
  * @returns League context information
  */
 export function getLeagueContext(url: URL): LeagueContext {
-  const pathname = url.pathname;
-  const host = normalizeHost(defaultMflHost);
+  const league = getLeagueByPath(url.pathname);
+  // PUBLIC_MFL_HOST overrides for all leagues (legacy behavior); otherwise
+  // each league uses its own MFL server from the registry.
+  const host = normalizeHost(
+    (import.meta.env.PUBLIC_MFL_HOST as string | undefined) || league.mflHost
+  );
 
-  // Check if URL starts with /afl-fantasy
-  if (pathname.startsWith('/afl-fantasy')) {
-    return {
-      host,
-      leagueId: '19621',
-      name: 'American Football League',
-      slug: 'afl-fantasy',
-      dataPath: 'data/afl-fantasy',
-    };
-  }
-
-  // Check if URL starts with /theleague
-  if (pathname.startsWith('/theleague')) {
-    return {
-      host,
-      leagueId: '13522',
-      name: 'The League',
-      slug: 'theleague',
-      dataPath: 'data/theleague',
-    };
-  }
-
-  // Default to The League for backward compatibility
   return {
     host,
-    leagueId: '13522',
-    name: 'The League',
-    slug: 'theleague',
-    dataPath: 'data/theleague',
+    leagueId: league.id,
+    name: league.name,
+    slug: league.slug,
+    dataPath: league.dataPath,
   };
 }
 

--- a/src/utils/league-host-map.ts
+++ b/src/utils/league-host-map.ts
@@ -5,22 +5,20 @@
  * pulls in astro:middleware and can't be unit-tested directly) and by
  * vitest.
  *
- * Adding a new league domain: extend HOST_TO_SLUG. The afl-fantasy.com
- * entry is wired in but dormant — flipping live requires DNS + Vercel
- * domain attachment (AFL_DUPLICATION_PLAN §2.3, Phase 7).
+ * Adding a new league domain: add it to the league's `domains` array in
+ * src/config/leagues-data.mjs. The afl-fantasy.com entries are wired in but
+ * dormant — flipping live requires DNS + Vercel domain attachment
+ * (AFL_DUPLICATION_PLAN §2.3, Phase 7).
  */
+
+import { buildHostToSlugMap } from '../config/leagues';
 
 /**
  * Map of apex hostnames → league slug (the path segment under src/pages/).
- * Both the bare host and `www.` variant should be present.
+ * Derived from the league registry; both bare host and `www.` variants are
+ * listed there.
  */
-export const HOST_TO_SLUG: Readonly<Record<string, string>> = {
-  'theleague.us': 'theleague',
-  'www.theleague.us': 'theleague',
-  // Dormant until afl-fantasy.com is pointed at this Vercel project.
-  'afl-fantasy.com': 'afl-fantasy',
-  'www.afl-fantasy.com': 'afl-fantasy',
-};
+export const HOST_TO_SLUG: Readonly<Record<string, string>> = buildHostToSlugMap();
 
 // Slug prefixes get a trailing slash so /theleagueX doesn't match /theleague
 // as a substring. The exact path /theleague (no trailing slash) is caught

--- a/src/utils/lineup-optimizer.ts
+++ b/src/utils/lineup-optimizer.ts
@@ -2,6 +2,7 @@
  * LineupOptimizer
  * Detects bench upgrades and lineup optimization opportunities
  */
+import { LEAGUES, DEFAULT_LEAGUE_SLUG } from '../config/leagues';
 
 import type { 
   FantasyPlayer, 
@@ -43,7 +44,7 @@ export class LineupOptimizer {
   private leagueId: string;
   private year: string;
 
-  constructor(leagueId: string = '13522', year: string = new Date().getFullYear().toString()) {
+  constructor(leagueId: string = LEAGUES[DEFAULT_LEAGUE_SLUG].id, year: string = new Date().getFullYear().toString()) {
     this.leagueId = leagueId;
     this.year = year;
   }

--- a/src/utils/live-auctions.ts
+++ b/src/utils/live-auctions.ts
@@ -9,9 +9,10 @@
  * homepage SSR loader so we don't pay for a self-fetch round-trip.
  */
 import { getCurrentLeagueYear } from './league-year';
+import { LEAGUES, DEFAULT_LEAGUE_SLUG } from '../config/leagues';
 
 const DEFAULT_HOST = 'https://api.myfantasyleague.com';
-const DEFAULT_LEAGUE_ID = '13522';
+const DEFAULT_LEAGUE_ID = LEAGUES[DEFAULT_LEAGUE_SLUG].id;
 
 export interface LiveAuctionEntry {
   bid: number;

--- a/src/utils/mfl-contract-writer.ts
+++ b/src/utils/mfl-contract-writer.ts
@@ -10,11 +10,12 @@
 import { readFileSync, writeFileSync, mkdirSync, existsSync, readdirSync, unlinkSync } from 'node:fs';
 import { join, basename } from 'node:path';
 import { mflFetch } from './mfl-fetch';
+import { LEAGUES, DEFAULT_LEAGUE_SLUG } from '../config/leagues';
 
 // Reads use api.myfantasyleague.com; writes MUST use www49 (commissioner writes fail on the api subdomain)
 const MFL_READ_HOST = process.env.MFL_HOST || 'https://api.myfantasyleague.com';
 const MFL_WRITE_HOST = process.env.MFL_WRITE_HOST || 'https://www49.myfantasyleague.com';
-const MFL_LEAGUE_ID = process.env.MFL_LEAGUE_ID || '13522';
+const MFL_LEAGUE_ID = process.env.MFL_LEAGUE_ID || LEAGUES[DEFAULT_LEAGUE_SLUG].id;
 // Cookie names match the actual MFL cookie names for clarity
 const MFL_USER_ID = process.env.MFL_USER_ID || '';
 const MFL_IS_COMMISH = process.env.MFL_IS_COMMISH || '';

--- a/src/utils/mfl-matchup-api.ts
+++ b/src/utils/mfl-matchup-api.ts
@@ -5,6 +5,7 @@
 
 import type { FantasyPlayer, StartingLineup, PlayerStatus, FantasyTeam } from '../types/matchup-previews';
 import { mflFetch } from './mfl-fetch';
+import { LEAGUES, DEFAULT_LEAGUE_SLUG } from '../config/leagues';
 
 /**
  * MFL API configuration
@@ -718,7 +719,7 @@ export class MFLMatchupApiClient {
  */
 export function createMFLApiClient(config: Partial<MFLApiConfig> = {}): MFLMatchupApiClient {
   const defaultConfig: MFLApiConfig = {
-    leagueId: config.leagueId || process.env.MFL_LEAGUE_ID || '13522',
+    leagueId: config.leagueId || process.env.MFL_LEAGUE_ID || LEAGUES[DEFAULT_LEAGUE_SLUG].id,
     year: config.year || new Date().getFullYear().toString(),
     host: config.host || process.env.MFL_HOST || 'https://api.myfantasyleague.com',
     mflUserId: config.mflUserId || process.env.MFL_USER_ID,

--- a/src/utils/offseason-hero-data.ts
+++ b/src/utils/offseason-hero-data.ts
@@ -311,10 +311,11 @@ export function getCutCandidates(leagueYear: number): CutCandidateRaw[] {
 // ── Draft Completion ──
 
 /**
- * Check if the rookie draft is complete by verifying all picks have players.
+ * Pure check: do the parsed MFL draft results contain picks and is every
+ * pick filled with a player? Exported separately so tests can cover the
+ * empty/partial-pick logic with fixtures instead of live repo data.
  */
-export function isDraftComplete(leagueYear: number): boolean {
-  const data = readJsonFile(`data/theleague/mfl-feeds/${leagueYear}/draftResults.json`);
+export function areAllDraftPicksFilled(data: any): boolean {
   if (!data?.draftResults?.draftUnit?.draftPick) return false;
 
   const picks = Array.isArray(data.draftResults.draftUnit.draftPick)
@@ -324,6 +325,15 @@ export function isDraftComplete(leagueYear: number): boolean {
   if (picks.length === 0) return false;
 
   return picks.every((p: any) => p.player && p.player.trim() !== '');
+}
+
+/**
+ * Check if the rookie draft is complete by verifying all picks have players.
+ */
+export function isDraftComplete(leagueYear: number): boolean {
+  return areAllDraftPicksFilled(
+    readJsonFile(`data/theleague/mfl-feeds/${leagueYear}/draftResults.json`)
+  );
 }
 
 // ── Player Lookup ──

--- a/src/utils/og-preview.ts
+++ b/src/utils/og-preview.ts
@@ -7,6 +7,8 @@
  * Used to render link-preview cards in the Schefter feed for GroupMe posts.
  */
 
+import { validatePublicUrl } from './url-guard';
+
 type RedisClient = {
   get: <T>(key: string) => Promise<T | null>;
   set: (key: string, value: unknown, opts?: { ex?: number }) => Promise<string>;
@@ -52,6 +54,39 @@ const CACHE_KEY_PREFIX = 'og:preview:';
 const CACHE_TTL_SECONDS = 7 * 24 * 60 * 60; // 7 days
 const FAILED_CACHE_TTL_SECONDS = 60 * 60; // 1 hour for failures (retry sooner)
 const FETCH_TIMEOUT_MS = 5000;
+const MAX_REDIRECTS = 3;
+
+/**
+ * Fetch with manual redirect following, validating every hop against the
+ * SSRF guard — `redirect: 'follow'` would let a public URL bounce us into
+ * private address space.
+ */
+async function fetchWithGuardedRedirects(url: string, signal: AbortSignal): Promise<Response> {
+  let current = url;
+  for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
+    const reason = await validatePublicUrl(current);
+    if (reason) throw new Error(`Blocked URL (${reason}): ${current}`);
+
+    const res = await fetch(current, {
+      signal,
+      headers: {
+        // Masquerade as a regular browser — many sites block bots
+        'User-Agent': 'Mozilla/5.0 (compatible; MFLFootballBot/1.0; +https://theleague.football)',
+        Accept: 'text/html,application/xhtml+xml',
+      },
+      redirect: 'manual',
+    });
+
+    if (res.status >= 300 && res.status < 400) {
+      const location = res.headers.get('location');
+      if (!location) return res;
+      current = new URL(location, current).toString();
+      continue;
+    }
+    return res;
+  }
+  throw new Error('Too many redirects');
+}
 
 /** Fetch and parse OG/Twitter meta tags from a URL */
 async function fetchAndParse(url: string): Promise<OgPreview> {
@@ -62,15 +97,7 @@ async function fetchAndParse(url: string): Promise<OgPreview> {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
 
-    const res = await fetch(url, {
-      signal: controller.signal,
-      headers: {
-        // Masquerade as a regular browser — many sites block bots
-        'User-Agent': 'Mozilla/5.0 (compatible; MFLFootballBot/1.0; +https://theleague.football)',
-        Accept: 'text/html,application/xhtml+xml',
-      },
-      redirect: 'follow',
-    });
+    const res = await fetchWithGuardedRedirects(url, controller.signal);
     clearTimeout(timeout);
 
     if (!res.ok) {

--- a/src/utils/playoffs.ts
+++ b/src/utils/playoffs.ts
@@ -4,12 +4,14 @@
 
 import type { TeamStanding } from '../types/standings';
 import { chooseTeamName } from './team-names';
+import { LEAGUES, DEFAULT_LEAGUE_SLUG } from '../config/leagues';
 
 const DEFAULT_HOST =
   (import.meta.env.PUBLIC_MFL_HOST as string | undefined) ||
   'https://www49.myfantasyleague.com';
 const DEFAULT_LEAGUE_ID =
-  (import.meta.env.PUBLIC_MFL_LEAGUE_ID as string | undefined) || '13522';
+  (import.meta.env.PUBLIC_MFL_LEAGUE_ID as string | undefined) ||
+  LEAGUES[DEFAULT_LEAGUE_SLUG].id;
 
 const trimHost = (host: string) => host.replace(/\/+$/, '');
 

--- a/src/utils/rate-limit.ts
+++ b/src/utils/rate-limit.ts
@@ -1,0 +1,68 @@
+/**
+ * Shared per-franchise rate limiter (Redis fixed window).
+ *
+ * Mirrors the pattern proven in api/rules-qa.ts: INCR a per-franchise key,
+ * set the TTL on first increment, reject once the count exceeds the cap.
+ * Fails open if Redis is unavailable — these limits protect LLM spend,
+ * not data integrity, and the endpoints already require authentication.
+ */
+
+type RedisClient = {
+  incr: (key: string) => Promise<number>;
+  expire: (key: string, seconds: number) => Promise<number>;
+};
+
+let loggedMissingRedis = false;
+
+async function getRedis(): Promise<RedisClient | null> {
+  const url = process.env.UPSTASH_REDIS_REST_URL || process.env.KV_REST_API_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN || process.env.KV_REST_API_TOKEN;
+  if (!url || !token) return null;
+
+  try {
+    const { Redis } = await import('@upstash/redis');
+    return new Redis({ url, token }) as unknown as RedisClient;
+  } catch (error) {
+    if (!loggedMissingRedis) {
+      loggedMissingRedis = true;
+      console.warn('[rate-limit] Redis unavailable:', error);
+    }
+    return null;
+  }
+}
+
+export interface RateLimitResult {
+  allowed: boolean;
+  /** Requests made in the current window (0 if Redis unavailable) */
+  count: number;
+}
+
+/**
+ * Check and consume one request against a fixed-window rate limit.
+ *
+ * @param scope    Namespace for the limit, e.g. 'ai-reply' or 'groupme-rewrite'
+ * @param id       Caller identity — use the franchiseId from the session
+ * @param max      Max requests per window
+ * @param windowSeconds  Window length in seconds
+ */
+export async function checkRateLimit(
+  scope: string,
+  id: string,
+  max: number,
+  windowSeconds: number,
+): Promise<RateLimitResult> {
+  try {
+    const redis = await getRedis();
+    if (!redis) return { allowed: true, count: 0 };
+
+    const key = `rate:${scope}:${id}`;
+    const count = await redis.incr(key);
+    if (count === 1) {
+      await redis.expire(key, windowSeconds);
+    }
+    return { allowed: count <= max, count };
+  } catch (e) {
+    console.warn(`[rate-limit] check failed for ${scope}:`, e);
+    return { allowed: true, count: 0 };
+  }
+}

--- a/src/utils/url-guard.ts
+++ b/src/utils/url-guard.ts
@@ -1,0 +1,96 @@
+/**
+ * SSRF guard for server-side fetches of user-supplied URLs.
+ *
+ * Blocks requests that could reach internal infrastructure: non-http(s)
+ * schemes, non-default ports, localhost-style hostnames, and IP literals or
+ * DNS results in private / loopback / link-local / metadata ranges.
+ */
+
+/** Returns true if the IPv4/IPv6 address is private, loopback, link-local, or otherwise non-public. */
+export function isPrivateAddress(addr: string): boolean {
+  const ip = addr.trim().toLowerCase();
+
+  // IPv6 (including IPv4-mapped)
+  if (ip.includes(':')) {
+    if (ip === '::' || ip === '::1') return true;
+    if (ip.startsWith('fe80:') || ip.startsWith('fc') || ip.startsWith('fd')) return true;
+    const mapped = ip.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/);
+    if (mapped) return isPrivateAddress(mapped[1]);
+    return false;
+  }
+
+  const parts = ip.split('.').map(Number);
+  if (parts.length !== 4 || parts.some((p) => Number.isNaN(p) || p < 0 || p > 255)) {
+    // Not a valid IPv4 literal — treat as "not an IP" (caller handles hostnames)
+    return false;
+  }
+  const [a, b] = parts;
+  if (a === 0 || a === 10 || a === 127) return true;
+  if (a === 169 && b === 254) return true; // link-local + cloud metadata (169.254.169.254)
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  if (a === 192 && b === 168) return true;
+  if (a === 100 && b >= 64 && b <= 127) return true; // CGNAT
+  return false;
+}
+
+function looksLikeIpLiteral(hostname: string): boolean {
+  return /^\d+\.\d+\.\d+\.\d+$/.test(hostname) || hostname.includes(':');
+}
+
+/**
+ * Validate that a URL is safe to fetch server-side.
+ * Returns null if OK, or a human-readable rejection reason.
+ */
+export async function validatePublicUrl(rawUrl: string): Promise<string | null> {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return 'Invalid URL';
+  }
+
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    return 'Only http(s) URLs are allowed';
+  }
+  if (url.port && url.port !== '80' && url.port !== '443') {
+    return 'Non-standard ports are not allowed';
+  }
+  if (url.username || url.password) {
+    return 'URLs with credentials are not allowed';
+  }
+
+  // Strip IPv6 brackets for address checks
+  const hostname = url.hostname.replace(/^\[|\]$/g, '').toLowerCase();
+
+  if (
+    hostname === 'localhost' ||
+    !hostname.includes('.') || // single-label internal names (and bracketless edge cases)
+    hostname.endsWith('.local') ||
+    hostname.endsWith('.internal') ||
+    hostname.endsWith('.localhost')
+  ) {
+    // IPv6 literals contain ':' but no '.', so re-check before rejecting
+    if (!hostname.includes(':')) return 'Internal hostnames are not allowed';
+  }
+
+  if (looksLikeIpLiteral(hostname)) {
+    if (isPrivateAddress(hostname)) return 'Private IP addresses are not allowed';
+    return null;
+  }
+
+  // Resolve DNS and verify every address is public. Degrade gracefully in
+  // runtimes without node:dns (the literal/hostname checks above still apply).
+  try {
+    const dns = await import('node:dns/promises');
+    const results = await dns.lookup(hostname, { all: true });
+    for (const r of results) {
+      if (isPrivateAddress(r.address)) return 'Hostname resolves to a private address';
+    }
+  } catch (e) {
+    const code = (e as NodeJS.ErrnoException)?.code;
+    if (code === 'ENOTFOUND' || code === 'EAI_AGAIN') return 'Hostname does not resolve';
+    // dns module unavailable or transient failure — fall through
+  }
+
+  return null;
+}

--- a/tests/global-setup-timezone.ts
+++ b/tests/global-setup-timezone.ts
@@ -1,0 +1,15 @@
+/**
+ * Pin the test suite to Pacific Time.
+ *
+ * Hero/matchup date logic operates in PT and many tests construct PT
+ * wall-clock Dates with `new Date(y, m, d, h)`. Without this pin the suite
+ * fails on UTC runners (GitHub Actions, cloud containers).
+ *
+ * This must run as vitest `globalSetup` — it executes in the main process
+ * before worker threads spawn, so each worker's V8 isolate initializes its
+ * timezone from the already-updated TZ. Setting TZ inside `setupFiles`
+ * (in the worker) is too late: the isolate has already cached the zone.
+ */
+export default function setup(): void {
+  process.env.TZ = 'America/Los_Angeles';
+}

--- a/tests/leagues-registry.test.ts
+++ b/tests/leagues-registry.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+import {
+  LEAGUES,
+  ALL_LEAGUES,
+  DEFAULT_LEAGUE_SLUG,
+  getLeagueBySlug,
+  getLeagueById,
+  getLeagueByPath,
+  leagueHasFeature,
+  buildHostToSlugMap,
+} from '../src/config/leagues';
+import { HOST_TO_SLUG } from '../src/utils/league-host-map';
+import { getLeagueContext } from '../src/utils/league-context';
+
+describe('league registry', () => {
+  it('has unique ids and slugs', () => {
+    const ids = ALL_LEAGUES.map((l) => l.id);
+    const slugs = ALL_LEAGUES.map((l) => l.slug);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(new Set(slugs).size).toBe(slugs.length);
+  });
+
+  it('keys match each entry slug', () => {
+    for (const [key, league] of Object.entries(LEAGUES)) {
+      expect(league.slug).toBe(key);
+    }
+  });
+
+  it('every league lists bare and www domain variants', () => {
+    for (const league of ALL_LEAGUES) {
+      const bare = league.domains.filter((d) => !d.startsWith('www.'));
+      for (const d of bare) {
+        expect(league.domains, `${league.slug} missing www.${d}`).toContain(`www.${d}`);
+      }
+    }
+  });
+
+  it('resolves known leagues', () => {
+    expect(getLeagueBySlug('theleague')?.id).toBe('13522');
+    expect(getLeagueBySlug('afl-fantasy')?.id).toBe('19621');
+    expect(getLeagueById('13522')?.slug).toBe('theleague');
+    expect(getLeagueById('19621')?.slug).toBe('afl-fantasy');
+    expect(getLeagueBySlug('nope')).toBeNull();
+    expect(getLeagueById('0000')).toBeNull();
+  });
+
+  it('resolves paths with prefix-boundary safety', () => {
+    expect(getLeagueByPath('/afl-fantasy/rosters').slug).toBe('afl-fantasy');
+    expect(getLeagueByPath('/afl-fantasy').slug).toBe('afl-fantasy');
+    expect(getLeagueByPath('/afl-fantasyX').slug).toBe(DEFAULT_LEAGUE_SLUG);
+    expect(getLeagueByPath('/theleague/rosters').slug).toBe('theleague');
+    expect(getLeagueByPath('/').slug).toBe(DEFAULT_LEAGUE_SLUG);
+  });
+
+  it('exposes feature flags', () => {
+    expect(leagueHasFeature('theleague', 'contracts')).toBe(true);
+    expect(leagueHasFeature('afl-fantasy', 'contracts')).toBe(false);
+    expect(leagueHasFeature('afl-fantasy', 'keepers')).toBe(true);
+    expect(leagueHasFeature('nope', 'contracts')).toBe(false);
+  });
+});
+
+describe('host map derived from registry', () => {
+  it('preserves the pre-registry HOST_TO_SLUG entries', () => {
+    expect(HOST_TO_SLUG['theleague.us']).toBe('theleague');
+    expect(HOST_TO_SLUG['www.theleague.us']).toBe('theleague');
+    expect(HOST_TO_SLUG['afl-fantasy.com']).toBe('afl-fantasy');
+    expect(HOST_TO_SLUG['www.afl-fantasy.com']).toBe('afl-fantasy');
+  });
+
+  it('buildHostToSlugMap covers every league domain', () => {
+    const map = buildHostToSlugMap();
+    for (const league of ALL_LEAGUES) {
+      for (const d of league.domains) {
+        expect(map[d]).toBe(league.slug);
+      }
+    }
+  });
+});
+
+describe('getLeagueContext via registry', () => {
+  it('returns the same shape and values as before the refactor', () => {
+    const tl = getLeagueContext(new URL('https://theleague.us/theleague/rosters'));
+    expect(tl).toMatchObject({
+      leagueId: '13522',
+      name: 'The League',
+      slug: 'theleague',
+      dataPath: 'data/theleague',
+    });
+
+    const afl = getLeagueContext(new URL('https://example.com/afl-fantasy/lineup'));
+    expect(afl).toMatchObject({
+      leagueId: '19621',
+      name: 'American Football League',
+      slug: 'afl-fantasy',
+      dataPath: 'data/afl-fantasy',
+    });
+
+    // Unprefixed paths default to theleague (backward compatibility)
+    const root = getLeagueContext(new URL('https://example.com/'));
+    expect(root.slug).toBe('theleague');
+  });
+});

--- a/tests/offseason-hero-data.test.ts
+++ b/tests/offseason-hero-data.test.ts
@@ -4,11 +4,12 @@ import {
   getTaggedPlayers,
   getCutCandidates,
   isDraftComplete,
+  areAllDraftPicksFilled,
 } from '../src/utils/offseason-hero-data';
 
-// These tests use real data files from the repo.
-// 2025 season has completed playoff brackets and a full draft.
-// 2026 season has empty draft results and current rosters.
+// These tests use real data files from the repo for FROZEN historical years
+// only (their feeds never change). Anything about the current/in-progress
+// year must use fixtures — live data flips state as the season advances.
 
 describe('getChampionshipResult', () => {
   it('returns null for a non-existent year', () => {
@@ -81,13 +82,28 @@ describe('isDraftComplete', () => {
     expect(isDraftComplete(1999)).toBe(false);
   });
 
-  it('returns false for 2026 (draft has not started)', () => {
-    // 2026 draft picks all have empty player fields
-    expect(isDraftComplete(2026)).toBe(false);
+  it('returns true for 2025 (completed draft, frozen data)', () => {
+    expect(isDraftComplete(2025)).toBe(true);
+  });
+});
+
+describe('areAllDraftPicksFilled (fixtures)', () => {
+  const wrap = (draftPick: unknown) => ({ draftResults: { draftUnit: { draftPick } } });
+
+  it('returns false for missing or empty data', () => {
+    expect(areAllDraftPicksFilled(null)).toBe(false);
+    expect(areAllDraftPicksFilled({})).toBe(false);
+    expect(areAllDraftPicksFilled(wrap([]))).toBe(false);
   });
 
-  it('returns true for 2025 (completed draft)', () => {
-    // 2025 draft should be complete (all picks filled)
-    expect(isDraftComplete(2025)).toBe(true);
+  it('returns false when any pick has an empty player field', () => {
+    expect(areAllDraftPicksFilled(wrap([{ player: '12345' }, { player: '' }]))).toBe(false);
+    expect(areAllDraftPicksFilled(wrap([{ player: '   ' }]))).toBe(false);
+    expect(areAllDraftPicksFilled(wrap({ player: '' }))).toBe(false); // single pick, not array
+  });
+
+  it('returns true when every pick is filled', () => {
+    expect(areAllDraftPicksFilled(wrap([{ player: '12345' }, { player: '67890' }]))).toBe(true);
+    expect(areAllDraftPicksFilled(wrap({ player: '12345' }))).toBe(true);
   });
 });

--- a/tests/url-guard.test.ts
+++ b/tests/url-guard.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { isPrivateAddress, validatePublicUrl } from '../src/utils/url-guard';
+
+describe('isPrivateAddress', () => {
+  it('flags loopback, private, link-local, and CGNAT ranges', () => {
+    for (const ip of [
+      '127.0.0.1',
+      '10.0.0.1',
+      '172.16.0.1',
+      '172.31.255.255',
+      '192.168.1.1',
+      '169.254.169.254',
+      '0.0.0.0',
+      '100.64.0.1',
+      '::1',
+      '::',
+      'fe80::1',
+      'fc00::1',
+      'fd12:3456::1',
+      '::ffff:10.0.0.1',
+      '::ffff:127.0.0.1',
+    ]) {
+      expect(isPrivateAddress(ip), ip).toBe(true);
+    }
+  });
+
+  it('allows public addresses', () => {
+    for (const ip of ['8.8.8.8', '1.1.1.1', '172.32.0.1', '172.15.0.1', '100.128.0.1', '2607:f8b0::1', '::ffff:8.8.8.8']) {
+      expect(isPrivateAddress(ip), ip).toBe(false);
+    }
+  });
+});
+
+describe('validatePublicUrl', () => {
+  it('rejects non-http schemes', async () => {
+    expect(await validatePublicUrl('file:///etc/passwd')).toBeTruthy();
+    expect(await validatePublicUrl('ftp://example.com/x')).toBeTruthy();
+    expect(await validatePublicUrl('gopher://example.com')).toBeTruthy();
+  });
+
+  it('rejects non-standard ports and embedded credentials', async () => {
+    expect(await validatePublicUrl('http://example.com:8080/')).toBeTruthy();
+    expect(await validatePublicUrl('http://example.com:6379/')).toBeTruthy();
+    expect(await validatePublicUrl('http://user:pass@example.com/')).toBeTruthy();
+    expect(await validatePublicUrl('https://example.com:443/')).toBeNull();
+  });
+
+  it('rejects localhost-style and single-label hostnames', async () => {
+    expect(await validatePublicUrl('http://localhost/')).toBeTruthy();
+    expect(await validatePublicUrl('http://localhost:80/')).toBeTruthy();
+    expect(await validatePublicUrl('http://intranet/')).toBeTruthy();
+    expect(await validatePublicUrl('http://foo.local/')).toBeTruthy();
+    expect(await validatePublicUrl('http://db.internal/')).toBeTruthy();
+  });
+
+  it('rejects private IP literals including the cloud metadata endpoint', async () => {
+    expect(await validatePublicUrl('http://169.254.169.254/latest/meta-data/')).toBeTruthy();
+    expect(await validatePublicUrl('http://127.0.0.1/')).toBeTruthy();
+    expect(await validatePublicUrl('http://10.1.2.3/')).toBeTruthy();
+    expect(await validatePublicUrl('http://192.168.0.10/')).toBeTruthy();
+    expect(await validatePublicUrl('http://[::1]/')).toBeTruthy();
+    expect(await validatePublicUrl('http://[fe80::1]/')).toBeTruthy();
+  });
+
+  it('allows public IP literals', async () => {
+    expect(await validatePublicUrl('http://8.8.8.8/')).toBeNull();
+  });
+
+  it('rejects malformed URLs', async () => {
+    expect(await validatePublicUrl('not a url')).toBeTruthy();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
+    globalSetup: ['tests/global-setup-timezone.ts'],
     include: ['tests/**/*.test.ts', 'tests/**/*.test.js'],
     // Requires MFL API credentials — run separately via pnpm test:mfl-integration
     exclude: ['tests/mfl-write-integration.test.ts'],


### PR DESCRIPTION
- getAuthUser() now trusts only the signed session JWT; the unsigned
  X-User-Context / X-Auth-User header fallbacks allowed any client to
  impersonate any franchise or the admin role
- new src/utils/url-guard.ts validates user-supplied URLs (scheme, port,
  internal hostnames, private/link-local/metadata IPs, DNS resolution);
  og-preview now validates the initial URL and every redirect hop
- new src/utils/rate-limit.ts (Redis fixed window, same pattern as
  rules-qa); applied to /api/groupme/rewrite (20/hr) and
  /api/schefter-replies/:id/ai-reply (30/hr) to cap LLM spend abuse
- docs updated to mark header-auth instructions as removed